### PR TITLE
Ensure that the version of LIonCore Builtins is correct

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 
 dependencies {
     "mps"("com.jetbrains:mps:2021.1.4")
-    "libs"("io.lionweb.lioncore-java:lioncore-java-core:0.0.24")
+    "libs"("io.lionweb.lioncore-java:lioncore-java-core:0.0.28")
 }
 
 configurations.getByName("libs") {

--- a/solutions/io.lionweb.mps.build/models/io.lionweb.mps.build.mps
+++ b/solutions/io.lionweb.mps.build/models/io.lionweb.mps.build.mps
@@ -599,8 +599,8 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="1f4Qr8WT8nG" role="3bR37C">
-          <node concept="3bR9La" id="1f4Qr8WT8nH" role="1SiIV1">
+        <node concept="1SiIV0" id="fKtnirpu2p" role="3bR37C">
+          <node concept="3bR9La" id="fKtnirpu2q" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
           </node>
         </node>
@@ -765,14 +765,14 @@
             <ref role="3bR37D" node="5wsogBcGDM7" resolve="io.lionweb.lioncore.java" />
           </node>
         </node>
-        <node concept="1SiIV0" id="5AGBwuFPhf0" role="3bR37C">
-          <node concept="3bR9La" id="5AGBwuFPhf1" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
+        <node concept="1SiIV0" id="fKtnirpu2F" role="3bR37C">
+          <node concept="3bR9La" id="fKtnirpu2G" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
           </node>
         </node>
-        <node concept="1SiIV0" id="1f4Qr8WT8o0" role="3bR37C">
-          <node concept="3bR9La" id="1f4Qr8WT8o1" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
+        <node concept="1SiIV0" id="fKtnirpu2H" role="3bR37C">
+          <node concept="3bR9La" id="fKtnirpu2I" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
           </node>
         </node>
       </node>
@@ -943,13 +943,13 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="5AGBwuFPhfu" role="3bR37C">
-          <node concept="3bR9La" id="5AGBwuFPhfv" role="1SiIV1">
+        <node concept="1SiIV0" id="fKtnirpu3b" role="3bR37C">
+          <node concept="3bR9La" id="fKtnirpu3c" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
           </node>
         </node>
-        <node concept="1SiIV0" id="5M3rB6Csebt" role="3bR37C">
-          <node concept="3bR9La" id="5M3rB6Csebu" role="1SiIV1">
+        <node concept="1SiIV0" id="fKtnirpu3d" role="3bR37C">
+          <node concept="3bR9La" id="fKtnirpu3e" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.mps2lionweb.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.mps2lionweb.mps
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:42e59ade-052b-4e0d-b0f5-6d4ec03ed4f0(io.lionweb.mps.json.instance.mps2lionweb)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
@@ -20,6 +21,7 @@
     <import index="xx25" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter.structure.types(MPS.Core/)" />
     <import index="apzt" ref="r:ea3bdd37-0680-4524-8252-d8093e3b6903(io.lionweb.mps.converter.util)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="imb3" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.language(io.lionweb.lioncore.java/)" />
     <import index="teza" ref="r:84248d29-a48a-459b-8ba9-05c71de1fb63(io.lionweb.mps.converter.m2.idmapper)" implicit="true" />
   </imports>
   <registry>
@@ -102,6 +104,7 @@
       <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_">
         <property id="1178608670077" name="isAbstract" index="1EzhhJ" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -2808,21 +2811,76 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="5$DmpJ4hujY" role="3cqZAp" />
+        <node concept="3cpWs8" id="5$DmpJ4k8iE" role="3cqZAp">
+          <node concept="3cpWsn" id="5$DmpJ4k8iH" role="3cpWs9">
+            <property role="TrG5h" value="langKey" />
+            <node concept="17QB3L" id="5$DmpJ4k8iC" role="1tU5fm" />
+            <node concept="1rXfSq" id="5$DmpJ4k9Ro" role="33vP2m">
+              <ref role="37wK5l" node="5s4Z0e0go9v" resolve="extractLanguageKey" />
+              <node concept="37vLTw" id="5$DmpJ4k9Rp" role="37wK5m">
+                <ref role="3cqZAo" node="5s4Z0e0lZGb" resolve="owner" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5$DmpJ4kbV0" role="3cqZAp">
+          <node concept="3cpWsn" id="5$DmpJ4kbV3" role="3cpWs9">
+            <property role="TrG5h" value="langVersion" />
+            <node concept="17QB3L" id="5$DmpJ4kbUY" role="1tU5fm" />
+            <node concept="1rXfSq" id="5$DmpJ4kdUp" role="33vP2m">
+              <ref role="37wK5l" node="5s4Z0e0gpy9" resolve="extractLanguageVersion" />
+              <node concept="37vLTw" id="5$DmpJ4kdUq" role="37wK5m">
+                <ref role="3cqZAo" node="5s4Z0e0lZGb" resolve="owner" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5$DmpJ4kgpm" role="3cqZAp" />
+        <node concept="3clFbJ" id="5$DmpJ4khD$" role="3cqZAp">
+          <node concept="3clFbS" id="5$DmpJ4khDA" role="3clFbx">
+            <node concept="3clFbF" id="5$DmpJ4kmLo" role="3cqZAp">
+              <node concept="37vLTI" id="5$DmpJ4koCF" role="3clFbG">
+                <node concept="37vLTw" id="5$DmpJ4kmLm" role="37vLTJ">
+                  <ref role="3cqZAo" node="5$DmpJ4kbV3" resolve="langVersion" />
+                </node>
+                <node concept="2OqwBi" id="5$DmpJ4ksOY" role="37vLTx">
+                  <node concept="2YIFZM" id="5$DmpJ4krMw" role="2Oq$k0">
+                    <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
+                    <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                  </node>
+                  <node concept="liA8E" id="5$DmpJ4ktD_" role="2OqNvi">
+                    <ref role="37wK5l" to="imb3:~Language.getVersion()" resolve="getVersion" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="5$DmpJ4kiFw" role="3clFbw">
+            <node concept="2OqwBi" id="5$DmpJ4kltw" role="3uHU7w">
+              <node concept="2YIFZM" id="5$DmpJ4kkhU" role="2Oq$k0">
+                <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
+                <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+              </node>
+              <node concept="liA8E" id="5$DmpJ4kmhD" role="2OqNvi">
+                <ref role="37wK5l" to="imb3:~Language.getKey()" resolve="getKey" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="5$DmpJ4ki3E" role="3uHU7B">
+              <ref role="3cqZAo" node="5$DmpJ4k8iH" resolve="langKey" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5$DmpJ4gRhT" role="3cqZAp" />
         <node concept="3clFbF" id="5s4Z0e0fjL3" role="3cqZAp">
           <node concept="2ShNRf" id="5s4Z0e0fjL4" role="3clFbG">
             <node concept="1pGfFk" id="5s4Z0e0fjL5" role="2ShVmc">
               <ref role="37wK5l" to="xfsv:~MetaPointer.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String)" resolve="MetaPointer" />
-              <node concept="1rXfSq" id="5s4Z0e0gqIz" role="37wK5m">
-                <ref role="37wK5l" node="5s4Z0e0go9v" resolve="extractLanguageKey" />
-                <node concept="37vLTw" id="5s4Z0e0lZGf" role="37wK5m">
-                  <ref role="3cqZAo" node="5s4Z0e0lZGb" resolve="owner" />
-                </node>
+              <node concept="37vLTw" id="5$DmpJ4kfZ7" role="37wK5m">
+                <ref role="3cqZAo" node="5$DmpJ4k8iH" resolve="langKey" />
               </node>
-              <node concept="1rXfSq" id="5s4Z0e0gqI_" role="37wK5m">
-                <ref role="37wK5l" node="5s4Z0e0gpy9" resolve="extractLanguageVersion" />
-                <node concept="37vLTw" id="5s4Z0e0lZGg" role="37wK5m">
-                  <ref role="3cqZAo" node="5s4Z0e0lZGb" resolve="owner" />
-                </node>
+              <node concept="37vLTw" id="5$DmpJ4kf9s" role="37wK5m">
+                <ref role="3cqZAo" node="5$DmpJ4kbV3" resolve="langVersion" />
               </node>
               <node concept="2OqwBi" id="5s4Z0e0fjLd" role="37wK5m">
                 <node concept="37vLTw" id="5s4Z0e0fjLe" role="2Oq$k0">

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.lioncore.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.lioncore.mps
@@ -22,6 +22,7 @@
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="imb3" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.language(io.lionweb.lioncore.java/)" />
     <import index="teza" ref="r:84248d29-a48a-459b-8ba9-05c71de1fb63(io.lionweb.mps.converter.m2.idmapper)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -58,6 +59,9 @@
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
       <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
@@ -95,6 +99,7 @@
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
       <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -112,6 +117,7 @@
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -207,6 +213,7 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
@@ -4453,6 +4460,50 @@
             </node>
           </node>
           <node concept="3clFbS" id="5sACIIsA0x9" role="2LFqv$">
+            <node concept="3cpWs8" id="5$DmpJ47TMM" role="3cqZAp">
+              <node concept="3cpWsn" id="5$DmpJ47TMP" role="3cpWs9">
+                <property role="TrG5h" value="languageWeDependOn" />
+                <node concept="3uibUv" id="5$DmpJ487yR" role="1tU5fm">
+                  <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+                </node>
+                <node concept="1rXfSq" id="5sACIIsJV43" role="33vP2m">
+                  <ref role="37wK5l" node="5sACIIsA0EW" resolve="lookupLanguage" />
+                  <node concept="2GrUjf" id="5sACIIsJZEl" role="37wK5m">
+                    <ref role="2Gs0qQ" node="5sACIIsA0x5" resolve="depends" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="5$DmpJ48BCA" role="3cqZAp">
+              <node concept="3clFbS" id="5$DmpJ48BCC" role="3clFbx">
+                <node concept="YS8fn" id="5$DmpJ48QV0" role="3cqZAp">
+                  <node concept="2ShNRf" id="5$DmpJ48Ukn" role="YScLw">
+                    <node concept="1pGfFk" id="5$DmpJ48Zck" role="2ShVmc">
+                      <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
+                      <node concept="3cpWs3" id="5$DmpJ49d6C" role="37wK5m">
+                        <node concept="Xl_RD" id="5$DmpJ492gU" role="3uHU7B">
+                          <property role="Xl_RC" value="Unable to resolve language dependency to " />
+                        </node>
+                        <node concept="2OqwBi" id="5$DmpJ49kf_" role="3uHU7w">
+                          <node concept="2GrUjf" id="5$DmpJ49guR" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="5sACIIsA0x5" resolve="depends" />
+                          </node>
+                          <node concept="2qgKlT" id="5$DmpJ49kfA" role="2OqNvi">
+                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbC" id="5$DmpJ48JBq" role="3clFbw">
+                <node concept="10Nm6u" id="5$DmpJ48MC9" role="3uHU7w" />
+                <node concept="37vLTw" id="5$DmpJ48EX_" role="3uHU7B">
+                  <ref role="3cqZAo" node="5$DmpJ47TMP" resolve="languageWeDependOn" />
+                </node>
+              </node>
+            </node>
             <node concept="3clFbF" id="5sACIIsJLo2" role="3cqZAp">
               <node concept="2OqwBi" id="5sACIIsJNgi" role="3clFbG">
                 <node concept="37vLTw" id="5sACIIsJLo0" role="2Oq$k0">
@@ -4460,11 +4511,8 @@
                 </node>
                 <node concept="liA8E" id="5sACIIsJQ4c" role="2OqNvi">
                   <ref role="37wK5l" to="imb3:~Language.addDependency(io.lionweb.lioncore.java.language.Language)" resolve="addDependency" />
-                  <node concept="1rXfSq" id="5sACIIsJV43" role="37wK5m">
-                    <ref role="37wK5l" node="5sACIIsA0EW" resolve="lookupLanguage" />
-                    <node concept="2GrUjf" id="5sACIIsJZEl" role="37wK5m">
-                      <ref role="2Gs0qQ" node="5sACIIsA0x5" resolve="depends" />
-                    </node>
+                  <node concept="37vLTw" id="5$DmpJ48x5W" role="37wK5m">
+                    <ref role="3cqZAo" node="5$DmpJ47TMP" resolve="languageWeDependOn" />
                   </node>
                 </node>
               </node>


### PR DESCRIPTION
Fix #34 

The key point is this:
<img width="868" alt="Screenshot 2023-08-04 at 10 33 58" src="https://github.com/LIonWeb-org/lioncore-mps/assets/439078/08fdd396-0174-45ae-9d45-830bdd2d302d">
Without this change the language version was 2, as it was derived from jetbrains.mps.lang.core, as INamedConcept is mapped to INamed:
<img width="994" alt="Screenshot 2023-08-04 at 10 35 04" src="https://github.com/LIonWeb-org/lioncore-mps/assets/439078/352614da-c2fa-4493-8dcb-f804a04390f8">
