### PR TITLE
Configure signing and setup the release plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.specificlanguages.mps") version "1.5.0"
     `maven-publish`
+    id("signing")
 }
 
 val libs by configurations.creating
@@ -135,4 +136,13 @@ tasks{
     checkMps {
         buildScript.set(file("build-tests.xml"))
     }
+}
+
+if (isReleaseVersion) {
+    tasks.withType(Sign::class) {
+    }
+}
+
+signing {
+    sign(publishing.publications["mpsPlugin"])
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.specificlanguages.mps") version "1.5.0"
     `maven-publish`
     id("signing")
+    id("net.researchgate.release") version "3.0.2"
 }
 
 val libs by configurations.creating
@@ -25,7 +26,8 @@ configurations.getByName("libs") {
 }
 
 group = "io.lionweb"
-version = "0.0.9-SNAPSHOT"
+
+val isReleaseVersion = !(version as String).endsWith("SNAPSHOT")
 
 
 task<Jar>("sourcesJar") {
@@ -61,8 +63,6 @@ publishing {
             artifact(tasks.getByName("javadocJar"))
             // Put resolved versions of dependencies into POM files -- uncomment as soon as we have any dependencies
             // versionMapping { usage("java-runtime") { fromResolutionOf("generation") } }
-
-            println("VERSION ${project.version}")
 
             pom {
                 name.set("lionweb-mps")
@@ -145,4 +145,12 @@ if (isReleaseVersion) {
 
 signing {
     sign(publishing.publications["mpsPlugin"])
+}
+
+release {
+    buildTasks.set(listOf("publish"))
+    git {
+        requireBranch.set("")
+        pushToRemote.set("origin")
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version="experimental-release-a"
+version=0.0.9-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+version="experimental-release-a"


### PR DESCRIPTION
This PR set up signing, and configure it only for the release versions (the ones not ending with `-SNAPSHOT`).
It also configures the release plugin.

Now when running `./gradlew release` gradle will perform some checks, then move from `0.0.9-SNAPSHOT` to `0.0.9`, create and push a tag, perform the release, and then move to `0.0.10-SNAPSHOT`. I find it very convenient.

For the release plugin to work the version needs to be moved to gradle.properties.

One would still need to login into https://s01.oss.sonatype.org/#stagingRepositories for closing & releasing, and one still needs to configure their own GPG keys on their machines.