### PR TITLE
Change layout of MPS plugin to avoid double zip problem

### DIFF
--- a/build-tests.xml
+++ b/build-tests.xml
@@ -581,13 +581,20 @@
   <target name="test" depends="classes, module-tests, fetchDependencies, declare-mps-tasks">
     <echo message="testing generation" />
     <gentest parallelMode="true" fork="true" showdiff="true" logLevel="${mps.ant.log}">
+      <plugin path="${artifacts.io.lionweb.mps}/io.lionweb.mps" />
       <plugin path="${artifacts.mps}/lib/mps-workbench.jar" />
       <plugin path="${artifacts.mps}/plugins/mps-build" />
       <plugin path="${artifacts.mps}/plugins/mps-core" />
       <plugin path="${artifacts.mps}/plugins/mps-httpsupport" />
       <plugin path="${artifacts.mps}/plugins/mps-testing" />
-      <plugin path="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps" />
       
+      <library file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.lioncore.java.jar" />
+      <library file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.converter.jar" />
+      <library file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.jar" />
+      <library file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.runtime.jar" />
+      <library file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.json.jar" />
+      <library file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.m3.jar" />
+      <library file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.structure.attribute.jar" />
       <library file="${artifacts.mps}/languages/baseLanguage/closures.runtime.jar" />
       <library file="${artifacts.mps}/languages/baseLanguage/collections.runtime.jar" />
       <library file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.blTypes.jar" />
@@ -706,13 +713,6 @@
       <library file="${artifacts.mps}/plugins/mps-testing/languages/languageDesign/jetbrains.mps.lang.test.jar" />
       <library file="${artifacts.mps}/plugins/mps-testing/languages/languageDesign/jetbrains.mps.lang.test.matcher.jar" />
       <library file="${artifacts.mps}/plugins/mps-testing/languages/languageDesign/jetbrains.mps.lang.test.runtime.jar" />
-      <library file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.lioncore.java.jar" />
-      <library file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.jar" />
-      <library file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.jar" />
-      <library file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.runtime.jar" />
-      <library file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.json.jar" />
-      <library file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.m3.jar" />
-      <library file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.structure.attribute.jar" />
       
       <module file="${lioncore-mps.home}/languages/io.lionweb.mps.converter.TestLang/io.lionweb.mps.converter.TestLang.mpl" />
       <module file="${lioncore-mps.home}/languages/io.lionweb.mps.converter.TestLang2/io.lionweb.mps.converter.TestLang2.mpl" />
@@ -735,12 +735,12 @@
   <target name="generate" depends="declare-mps-tasks, fetchDependencies">
     <echo message="generating" />
     <generate strictMode="true" parallelMode="true" parallelThreads="8" useInplaceTransform="false" hideWarnings="false" createStaticRefs="true" fork="true" skipUnmodifiedModels="${mps.generator.skipUnmodifiedModels}" logLevel="${mps.ant.log}">
+      <plugin path="${artifacts.io.lionweb.mps}/io.lionweb.mps" />
       <plugin path="${artifacts.mps}/lib/mps-workbench.jar" />
       <plugin path="${artifacts.mps}/plugins/mps-build" />
       <plugin path="${artifacts.mps}/plugins/mps-core" />
       <plugin path="${artifacts.mps}/plugins/mps-httpsupport" />
       <plugin path="${artifacts.mps}/plugins/mps-testing" />
-      <plugin path="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps" />
       <library file="${artifacts.mps}/languages/baseLanguage/closures.runtime.jar" />
       <library file="${artifacts.mps}/languages/baseLanguage/collections.runtime.jar" />
       <library file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.blTypes.jar" />
@@ -1044,11 +1044,11 @@
         <fileset file="${artifacts.mps}/lib/jdom.jar" />
         <fileset file="${artifacts.mps}/lib/trove4j.jar" />
         <fileset file="${artifacts.mps}/lib/ecj-4.16.jar" />
-        <fileset file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.jar" />
-        <fileset file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.jar" />
-        <fileset file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.runtime.jar" />
-        <fileset file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.json.jar" />
-        <fileset file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.m3.jar" />
+        <fileset file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.converter.jar" />
+        <fileset file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.jar" />
+        <fileset file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.runtime.jar" />
+        <fileset file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.json.jar" />
+        <fileset file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.m3.jar" />
         <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.jar" />
         <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.classifiers.jar" />
         <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.scopes.jar" />
@@ -1060,8 +1060,8 @@
         <fileset file="${artifacts.mps}/plugins/mps-testing/languages/languageDesign/jetbrains.mps.lang.test.matcher.jar" />
         <fileset file="${artifacts.mps}/plugins/mps-testing/languages/languageDesign/jetbrains.mps.lang.test.runtime.jar" />
         <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.traceable.jar" />
-        <fileset file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/gson.jar" />
-        <fileset file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/lioncore-java-core.jar" />
+        <fileset file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/gson.jar" />
+        <fileset file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/lioncore-java-core.jar" />
       </classpath>
     </javac>
   </target>
@@ -1108,11 +1108,11 @@
         <fileset file="${artifacts.mps}/lib/jdom.jar" />
         <fileset file="${artifacts.mps}/lib/trove4j.jar" />
         <fileset file="${artifacts.mps}/lib/ecj-4.16.jar" />
-        <fileset file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.jar" />
-        <fileset file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.jar" />
-        <fileset file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.runtime.jar" />
-        <fileset file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.json.jar" />
-        <fileset file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.m3.jar" />
+        <fileset file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.converter.jar" />
+        <fileset file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.jar" />
+        <fileset file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.runtime.jar" />
+        <fileset file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.json.jar" />
+        <fileset file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.m3.jar" />
         <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.jar" />
         <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.classifiers.jar" />
         <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.scopes.jar" />
@@ -1122,8 +1122,8 @@
         <fileset file="${artifacts.mps}/plugins/mps-testing/languages/languageDesign/jetbrains.mps.lang.test.matcher.jar" />
         <fileset file="${artifacts.mps}/plugins/mps-testing/languages/languageDesign/jetbrains.mps.lang.test.runtime.jar" />
         <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.traceable.jar" />
-        <fileset file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/gson.jar" />
-        <fileset file="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/lioncore-java-core.jar" />
+        <fileset file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/gson.jar" />
+        <fileset file="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/lioncore-java-core.jar" />
       </classpath>
     </javac>
   </target>
@@ -1275,6 +1275,13 @@
   
   <target name="test.lionweb-mps.build.tests" depends="assemble">
     <path id="mps.libraries.path">
+      <pathelement location="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.lioncore.java.jar" />
+      <pathelement location="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.converter.jar" />
+      <pathelement location="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.jar" />
+      <pathelement location="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.runtime.jar" />
+      <pathelement location="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.json.jar" />
+      <pathelement location="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.m3.jar" />
+      <pathelement location="${artifacts.io.lionweb.mps}/io.lionweb.mps/lib/io.lionweb.mps.structure.attribute.jar" />
       <pathelement location="${artifacts.mps}/languages/baseLanguage/closures.runtime.jar" />
       <pathelement location="${artifacts.mps}/languages/baseLanguage/collections.runtime.jar" />
       <pathelement location="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.blTypes.jar" />
@@ -1390,22 +1397,15 @@
       <pathelement location="${artifacts.mps}/plugins/mps-testing/languages/languageDesign/jetbrains.mps.lang.test.jar" />
       <pathelement location="${artifacts.mps}/plugins/mps-testing/languages/languageDesign/jetbrains.mps.lang.test.matcher.jar" />
       <pathelement location="${artifacts.mps}/plugins/mps-testing/languages/languageDesign/jetbrains.mps.lang.test.runtime.jar" />
-      <pathelement location="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.lioncore.java.jar" />
-      <pathelement location="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.jar" />
-      <pathelement location="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.jar" />
-      <pathelement location="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.runtime.jar" />
-      <pathelement location="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.json.jar" />
-      <pathelement location="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.m3.jar" />
-      <pathelement location="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.structure.attribute.jar" />
     </path>
     <pathconvert pathsep="${path.separator}" property="mps.libraries.path.string" refid="mps.libraries.path" />
     <path id="mps.plugins.path">
+      <pathelement location="${artifacts.io.lionweb.mps}/io.lionweb.mps" />
       <pathelement location="${artifacts.mps}/lib/mps-workbench.jar" />
       <pathelement location="${artifacts.mps}/plugins/mps-build" />
       <pathelement location="${artifacts.mps}/plugins/mps-core" />
       <pathelement location="${artifacts.mps}/plugins/mps-httpsupport" />
       <pathelement location="${artifacts.mps}/plugins/mps-testing" />
-      <pathelement location="${build.tmp}/deps/io.lionweb.mps/lionweb-mps.zip/io.lionweb.mps" />
     </path>
     <pathconvert pathsep="${path.separator}" property="mps.plugins.path.string" refid="mps.plugins.path" />
     <path id="mps.tests.path">

--- a/build.xml
+++ b/build.xml
@@ -35,10 +35,12 @@
   </path>
   
   <target name="assemble" depends="classes, declare-mps-tasks">
-    <mkdir dir="${build.layout}" />
-    <mkdir dir="${build.tmp}/default/lionweb-mps.zip" />
-    <mkdir dir="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps" />
-    <mkdir dir="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib" />
+    <mkdir dir="${build.layout}/io.lionweb.mps" />
+    <mkdir dir="${build.layout}/io.lionweb.mps/META-INF" />
+    <copy todir="${build.layout}/io.lionweb.mps/META-INF">
+      <fileset file="${basedir}/solutions/io.lionweb.mps.client.ideaPlugin/source_gen/io/lionweb/mps/client/ideaPlugin/plugin.xml" />
+    </copy>
+    <mkdir dir="${build.layout}/io.lionweb.mps/lib" />
     <mkdir dir="${build.tmp}/default/io.lionweb.mps.client.persistence.jar" />
     <mkdir dir="${build.tmp}/default/io.lionweb.mps.client.persistence.jar/META-INF" />
     <echoxml file="${build.tmp}/default/io.lionweb.mps.client.persistence.jar/META-INF/module.xml">
@@ -69,7 +71,7 @@
         <sources jar="io.lionweb.mps.client.persistence-src.jar" descriptor="io.lionweb.mps.client.persistence.msd" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.client.persistence.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.client.persistence.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/io.lionweb.mps.client.persistence" />
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.client.persistence/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
       <fileset dir="${build.tmp}/default/io.lionweb.mps.client.persistence.jar" />
@@ -77,7 +79,7 @@
     <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-io.lionweb.mps.client.persistence-models">
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.client.persistence/models" includes="**/*.mps, **/*.mpsr, **/.model" />
     </copyModels>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.client.persistence-src.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.client.persistence-src.jar" duplicate="preserve">
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.client.persistence/source_gen">
         <exclude name="**/trace.info" />
         <exclude name="**/exports" />
@@ -114,7 +116,7 @@
         <sources jar="io.lionweb.mps.client.connector-src.jar" descriptor="io.lionweb.mps.client.connector.msd" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.client.connector.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.client.connector.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/io.lionweb.mps.client.connector" />
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.client.connector/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
       <fileset dir="${build.tmp}/default/io.lionweb.mps.client.connector.jar" />
@@ -122,7 +124,7 @@
     <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-io.lionweb.mps.client.connector-models">
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.client.connector/models" includes="**/*.mps, **/*.mpsr, **/.model" />
     </copyModels>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.client.connector-src.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.client.connector-src.jar" duplicate="preserve">
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.client.connector/source_gen">
         <exclude name="**/trace.info" />
         <exclude name="**/exports" />
@@ -146,7 +148,7 @@
         <sources jar="io.lionweb.mps.client.ideaPlugin-src.jar" descriptor="io.lionweb.mps.client.ideaPlugin.msd" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.client.ideaPlugin.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.client.ideaPlugin.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/io.lionweb.mps.client.ideaPlugin" />
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.client.ideaPlugin/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
       <fileset dir="${build.tmp}/default/io.lionweb.mps.client.ideaPlugin.jar" />
@@ -154,7 +156,7 @@
     <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-io.lionweb.mps.client.ideaPlugin-models">
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.client.ideaPlugin/models" includes="**/*.mps, **/*.mpsr, **/.model" />
     </copyModels>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.client.ideaPlugin-src.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.client.ideaPlugin-src.jar" duplicate="preserve">
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.client.ideaPlugin/source_gen">
         <exclude name="**/trace.info" />
         <exclude name="**/exports" />
@@ -227,7 +229,7 @@
         <sources jar="io.lionweb.mps.structure.attribute-src.jar" descriptor="io.lionweb.mps.structure.attribute.mpl" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.structure.attribute.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.structure.attribute.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/io.lionweb.mps.structure.attribute" />
       <fileset dir="${lioncore-mps.home}/languages/io.lionweb.mps.structure.attribute" includes="icons/**, resources/**" />
       <fileset dir="${lioncore-mps.home}/languages/io.lionweb.mps.structure.attribute/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
@@ -236,7 +238,7 @@
     <copyModels todir="${build.tmp}/customProcessors/copyModels/languages-io.lionweb.mps.structure.attribute-models">
       <fileset dir="${lioncore-mps.home}/languages/io.lionweb.mps.structure.attribute/models" includes="**/*.mps, **/*.mpsr, **/.model" />
     </copyModels>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.structure.attribute-src.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.structure.attribute-src.jar" duplicate="preserve">
       <fileset dir="${lioncore-mps.home}/languages/io.lionweb.mps.structure.attribute/source_gen">
         <exclude name="**/trace.info" />
         <exclude name="**/exports" />
@@ -284,7 +286,7 @@
         <sources jar="io.lionweb.mps.server.plugin-src.jar" descriptor="io.lionweb.mps.server.plugin.msd" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.server.plugin.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.server.plugin.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/io.lionweb.mps.server.plugin" />
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.server.plugin/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
       <fileset dir="${build.tmp}/default/io.lionweb.mps.server.plugin.jar" />
@@ -292,7 +294,7 @@
     <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-io.lionweb.mps.server.plugin-models">
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.server.plugin/models" includes="**/*.mps, **/*.mpsr, **/.model" />
     </copyModels>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.server.plugin-src.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.server.plugin-src.jar" duplicate="preserve">
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.server.plugin/source_gen">
         <exclude name="**/trace.info" />
         <exclude name="**/exports" />
@@ -349,7 +351,7 @@
         <sources jar="io.lionweb.mps.converter-src.jar" descriptor="io.lionweb.mps.converter.msd" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.converter.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/io.lionweb.mps.converter" />
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.converter/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
       <fileset dir="${build.tmp}/default/io.lionweb.mps.converter.jar" />
@@ -357,7 +359,7 @@
     <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-io.lionweb.mps.converter-models">
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.converter/models" includes="**/*.mps, **/*.mpsr, **/.model" />
     </copyModels>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter-src.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.converter-src.jar" duplicate="preserve">
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.converter/source_gen">
         <exclude name="**/trace.info" />
         <exclude name="**/exports" />
@@ -407,7 +409,7 @@
         <sources jar="io.lionweb.mps.json-src.jar" descriptor="io.lionweb.mps.json.msd" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.json.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.json.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/io.lionweb.mps.json" />
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.json/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
       <fileset dir="${build.tmp}/default/io.lionweb.mps.json.jar" />
@@ -415,7 +417,7 @@
     <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-io.lionweb.mps.json-models">
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.json/models" includes="**/*.mps, **/*.mpsr, **/.model" />
     </copyModels>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.json-src.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.json-src.jar" duplicate="preserve">
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.json/source_gen">
         <exclude name="**/trace.info" />
         <exclude name="**/exports" />
@@ -438,7 +440,7 @@
         <sources jar="." descriptor="io.lionweb.lioncore.java.msd" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.lioncore.java.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.lioncore.java.jar" duplicate="preserve">
       <zipfileset file="${lioncore-mps.home}/solutions/io.lionweb.lioncore.java/io.lionweb.lioncore.java.msd" prefix="module" />
       <fileset dir="${build.tmp}/default/io.lionweb.lioncore.java.jar" />
     </jar>
@@ -512,7 +514,7 @@
         <sources jar="io.lionweb.mps.converter.lang-src.jar" descriptor="io.lionweb.mps.converter.lang.mpl" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/io.lionweb.mps.converter.lang" />
       <fileset dir="${lioncore-mps.home}/languages/io.lionweb.mps.converter.lang" includes="icons/**, resources/**" />
       <fileset dir="${lioncore-mps.home}/languages/io.lionweb.mps.converter.lang/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
@@ -521,7 +523,7 @@
     <copyModels todir="${build.tmp}/customProcessors/copyModels/languages-io.lionweb.mps.converter.lang-models">
       <fileset dir="${lioncore-mps.home}/languages/io.lionweb.mps.converter.lang/models" includes="**/*.mps, **/*.mpsr, **/.model" />
     </copyModels>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.lang-src.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.converter.lang-src.jar" duplicate="preserve">
       <fileset dir="${lioncore-mps.home}/languages/io.lionweb.mps.converter.lang/source_gen">
         <exclude name="**/trace.info" />
         <exclude name="**/exports" />
@@ -569,7 +571,7 @@
         <sources jar="io.lionweb.mps.converter.lang.runtime-src.jar" descriptor="io.lionweb.mps.converter.lang.runtime.msd" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.runtime.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.runtime.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/io.lionweb.mps.converter.lang.runtime" />
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.converter.lang.runtime/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
       <fileset dir="${build.tmp}/default/io.lionweb.mps.converter.lang.runtime.jar" />
@@ -577,7 +579,7 @@
     <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-io.lionweb.mps.converter.lang.runtime-models">
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.converter.lang.runtime/models" includes="**/*.mps, **/*.mpsr, **/.model" />
     </copyModels>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.runtime-src.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.converter.lang.runtime-src.jar" duplicate="preserve">
       <fileset dir="${lioncore-mps.home}/solutions/io.lionweb.mps.converter.lang.runtime/source_gen">
         <exclude name="**/trace.info" />
         <exclude name="**/exports" />
@@ -649,7 +651,7 @@
         <sources jar="io.lionweb.mps.m3-src.jar" descriptor="io.lionweb.mps.m3.mpl" />
       </module>
     </echoxml>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.m3.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.m3.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/io.lionweb.mps.m3" />
       <fileset dir="${lioncore-mps.home}/languages/io.lionweb.mps.m3" includes="icons/**, resources/**" />
       <fileset dir="${lioncore-mps.home}/languages/io.lionweb.mps.m3/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
@@ -658,7 +660,7 @@
     <copyModels todir="${build.tmp}/customProcessors/copyModels/languages-io.lionweb.mps.m3-models">
       <fileset dir="${lioncore-mps.home}/languages/io.lionweb.mps.m3/models" includes="**/*.mps, **/*.mpsr, **/.model" />
     </copyModels>
-    <jar destfile="${build.tmp}/default/lionweb-mps.zip/io.lionweb.mps/lib/io.lionweb.mps.m3-src.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/io.lionweb.mps/lib/io.lionweb.mps.m3-src.jar" duplicate="preserve">
       <fileset dir="${lioncore-mps.home}/languages/io.lionweb.mps.m3/source_gen">
         <exclude name="**/trace.info" />
         <exclude name="**/exports" />
@@ -668,12 +670,12 @@
       <zipfileset file="${lioncore-mps.home}/languages/io.lionweb.mps.m3/io.lionweb.mps.m3.mpl" prefix="module" />
       <zipfileset dir="${build.tmp}/customProcessors/copyModels/languages-io.lionweb.mps.m3-models" prefix="module/models" />
     </jar>
-    <zip destfile="${build.layout}/lionweb-mps.zip">
-      <zipfileset file="${basedir}/solutions/io.lionweb.mps.client.ideaPlugin/source_gen/io/lionweb/mps/client/ideaPlugin/plugin.xml" prefix="io.lionweb.mps/META-INF" />
-      <zipfileset file="${lioncore-mps.home}/solutions/io.lionweb.lioncore.java/libs/lioncore-java-core.jar" prefix="io.lionweb.mps/lib" />
-      <zipfileset file="${lioncore-mps.home}/solutions/io.lionweb.lioncore.java/libs/gson.jar" prefix="io.lionweb.mps/lib" />
-      <fileset dir="${build.tmp}/default/lionweb-mps.zip" />
-    </zip>
+    <copy todir="${build.layout}/io.lionweb.mps/lib">
+      <fileset file="${lioncore-mps.home}/solutions/io.lionweb.lioncore.java/libs/lioncore-java-core.jar" />
+    </copy>
+    <copy todir="${build.layout}/io.lionweb.mps/lib">
+      <fileset file="${lioncore-mps.home}/solutions/io.lionweb.lioncore.java/libs/gson.jar" />
+    </copy>
     <echo file="${build.layout}/build.properties">io.lionweb.mps.version=${version}${line.separator}mps.build.number=${mps.build.number}${line.separator}mps.date=${mps.date}${line.separator}mps.build.vcs.number=${mps.build.vcs.number}${line.separator}mps.teamcity.buildConfName=${mps.teamcity.buildConfName}${line.separator}mps.idea.platform.build.number=${mps.idea.platform.build.number}${line.separator}mps.mps.build.counter=${mps.mps.build.counter}${line.separator}mpsBootstrapCore.version.major=${mpsBootstrapCore.version.major}${line.separator}mpsBootstrapCore.version.minor=${mpsBootstrapCore.version.minor}${line.separator}mpsBootstrapCore.version.bugfixNr=${mpsBootstrapCore.version.bugfixNr}${line.separator}mpsBootstrapCore.version.eap=${mpsBootstrapCore.version.eap}${line.separator}mpsBootstrapCore.version=${mpsBootstrapCore.version}</echo>
   </target>
   

--- a/solutions/io.lionweb.mps.build/models/io.lionweb.mps.build.mps
+++ b/solutions/io.lionweb.mps.build/models/io.lionweb.mps.build.mps
@@ -54,7 +54,6 @@
         <reference id="7181125477683417255" name="layout" index="13uUGO" />
         <child id="7181125477683417254" name="artifacts" index="13uUGP" />
       </concept>
-      <concept id="7389400916848050071" name="jetbrains.mps.build.structure.BuildLayout_Zip" flags="ng" index="3981dG" />
       <concept id="7389400916848050060" name="jetbrains.mps.build.structure.BuildLayout_NamedContainer" flags="ng" index="3981dR">
         <child id="4380385936562148502" name="containerName" index="Nbhlr" />
       </concept>
@@ -228,90 +227,83 @@
       </node>
     </node>
     <node concept="1l3spV" id="5wsogBcGDKo" role="1l3spN">
-      <node concept="3981dG" id="7jdzMamlULD" role="39821P">
-        <node concept="m$_wl" id="5wsogBcGDKp" role="39821P">
-          <ref role="m_rDy" node="5wsogBcGDKB" resolve="io.lionweb.mps" />
-          <node concept="398223" id="7jdzMamlUPJ" role="39821P">
-            <node concept="3_J27D" id="7jdzMamlUPL" role="Nbhlr">
-              <node concept="3Mxwew" id="7jdzMamlUQl" role="3MwsjC">
-                <property role="3MwjfP" value="lib" />
-              </node>
+      <node concept="m$_wl" id="5wsogBcGDKp" role="39821P">
+        <ref role="m_rDy" node="5wsogBcGDKB" resolve="io.lionweb.mps" />
+        <node concept="398223" id="7jdzMamlUPJ" role="39821P">
+          <node concept="3_J27D" id="7jdzMamlUPL" role="Nbhlr">
+            <node concept="3Mxwew" id="7jdzMamlUQl" role="3MwsjC">
+              <property role="3MwjfP" value="lib" />
             </node>
-            <node concept="L2wRC" id="7jdzMamlUQn" role="39821P">
-              <ref role="L2wRA" node="7jdzMamjptg" resolve="io.lionweb.mps.client.persistence" />
-            </node>
-            <node concept="L2wRC" id="3CCFwIJPdCr" role="39821P">
-              <ref role="L2wRA" node="7jdzMamjpom" resolve="io.lionweb.mps.client.connector" />
-            </node>
-            <node concept="L2wRC" id="3CCFwIJPdDb" role="39821P">
-              <ref role="L2wRA" node="7jdzMamjpqS" resolve="io.lionweb.mps.client.ideaPlugin" />
-            </node>
-            <node concept="L2wRC" id="3CCFwIJPdEh" role="39821P">
-              <ref role="L2wRA" node="6fYiNFaW8NT" resolve="io.lionweb.mps.structure.attribute" />
-            </node>
-            <node concept="L2wRC" id="3CCFwIJPdGf" role="39821P">
-              <ref role="L2wRA" node="4OO9PkkNNvE" resolve="io.lionweb.mps.server.plugin" />
-            </node>
-            <node concept="L2wRC" id="3CCFwIJPdHr" role="39821P">
-              <ref role="L2wRA" node="5wsogBcGDLk" resolve="io.lionweb.mps.converter" />
-            </node>
-            <node concept="L2wRC" id="3CCFwIJPdIl" role="39821P">
-              <ref role="L2wRA" node="5wsogBcGDLJ" resolve="io.lionweb.mps.json" />
-            </node>
-            <node concept="L2wRC" id="3CCFwIJPdJ_" role="39821P">
-              <ref role="L2wRA" node="5wsogBcGDM7" resolve="io.lionweb.lioncore.java" />
-            </node>
-            <node concept="L2wRC" id="3CCFwIJPgh6" role="39821P">
-              <ref role="L2wRA" node="5wsogBcGDM$" resolve="io.lionweb.mps.converter.lang" />
-            </node>
-            <node concept="L2wRC" id="3CCFwIJPgio" role="39821P">
-              <ref role="L2wRA" node="5wsogBcGDNb" resolve="io.lionweb.mps.converter.lang.runtime" />
-            </node>
-            <node concept="L2wRC" id="3CCFwIJPi9R" role="39821P">
-              <ref role="L2wRA" node="5wsogBcGDKV" resolve="io.lionweb.mps.m3" />
-            </node>
-            <node concept="28jJK3" id="5wsogBcGDKr" role="39821P">
-              <node concept="398BVA" id="5wsogBcGDKs" role="28jJRO">
-                <ref role="398BVh" node="5wsogBcGDKe" resolve="lioncore-mps.home" />
-                <node concept="2Ry0Ak" id="5wsogBcGDKt" role="iGT6I">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="5wsogBcGDKu" role="2Ry0An">
-                    <property role="2Ry0Am" value="io.lionweb.lioncore.java" />
-                    <node concept="2Ry0Ak" id="5wsogBcGDKv" role="2Ry0An">
-                      <property role="2Ry0Am" value="libs" />
-                      <node concept="2Ry0Ak" id="36dvFBW80LB" role="2Ry0An">
-                        <property role="2Ry0Am" value="lioncore-java-core.jar" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="28jJK3" id="5wsogBcGDKx" role="39821P">
-              <node concept="398BVA" id="5wsogBcGDKy" role="28jJRO">
-                <ref role="398BVh" node="5wsogBcGDKe" resolve="lioncore-mps.home" />
-                <node concept="2Ry0Ak" id="5wsogBcGDKz" role="iGT6I">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="5wsogBcGDK$" role="2Ry0An">
-                    <property role="2Ry0Am" value="io.lionweb.lioncore.java" />
-                    <node concept="2Ry0Ak" id="5wsogBcGDK_" role="2Ry0An">
-                      <property role="2Ry0Am" value="libs" />
-                      <node concept="2Ry0Ak" id="36dvFBW80Lh" role="2Ry0An">
-                        <property role="2Ry0Am" value="gson.jar" />
-                      </node>
+          </node>
+          <node concept="L2wRC" id="7jdzMamlUQn" role="39821P">
+            <ref role="L2wRA" node="7jdzMamjptg" resolve="io.lionweb.mps.client.persistence" />
+          </node>
+          <node concept="L2wRC" id="3CCFwIJPdCr" role="39821P">
+            <ref role="L2wRA" node="7jdzMamjpom" resolve="io.lionweb.mps.client.connector" />
+          </node>
+          <node concept="L2wRC" id="3CCFwIJPdDb" role="39821P">
+            <ref role="L2wRA" node="7jdzMamjpqS" resolve="io.lionweb.mps.client.ideaPlugin" />
+          </node>
+          <node concept="L2wRC" id="3CCFwIJPdEh" role="39821P">
+            <ref role="L2wRA" node="6fYiNFaW8NT" resolve="io.lionweb.mps.structure.attribute" />
+          </node>
+          <node concept="L2wRC" id="3CCFwIJPdGf" role="39821P">
+            <ref role="L2wRA" node="4OO9PkkNNvE" resolve="io.lionweb.mps.server.plugin" />
+          </node>
+          <node concept="L2wRC" id="3CCFwIJPdHr" role="39821P">
+            <ref role="L2wRA" node="5wsogBcGDLk" resolve="io.lionweb.mps.converter" />
+          </node>
+          <node concept="L2wRC" id="3CCFwIJPdIl" role="39821P">
+            <ref role="L2wRA" node="5wsogBcGDLJ" resolve="io.lionweb.mps.json" />
+          </node>
+          <node concept="L2wRC" id="3CCFwIJPdJ_" role="39821P">
+            <ref role="L2wRA" node="5wsogBcGDM7" resolve="io.lionweb.lioncore.java" />
+          </node>
+          <node concept="L2wRC" id="3CCFwIJPgh6" role="39821P">
+            <ref role="L2wRA" node="5wsogBcGDM$" resolve="io.lionweb.mps.converter.lang" />
+          </node>
+          <node concept="L2wRC" id="3CCFwIJPgio" role="39821P">
+            <ref role="L2wRA" node="5wsogBcGDNb" resolve="io.lionweb.mps.converter.lang.runtime" />
+          </node>
+          <node concept="L2wRC" id="3CCFwIJPi9R" role="39821P">
+            <ref role="L2wRA" node="5wsogBcGDKV" resolve="io.lionweb.mps.m3" />
+          </node>
+          <node concept="28jJK3" id="5wsogBcGDKr" role="39821P">
+            <node concept="398BVA" id="5wsogBcGDKs" role="28jJRO">
+              <ref role="398BVh" node="5wsogBcGDKe" resolve="lioncore-mps.home" />
+              <node concept="2Ry0Ak" id="5wsogBcGDKt" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="5wsogBcGDKu" role="2Ry0An">
+                  <property role="2Ry0Am" value="io.lionweb.lioncore.java" />
+                  <node concept="2Ry0Ak" id="5wsogBcGDKv" role="2Ry0An">
+                    <property role="2Ry0Am" value="libs" />
+                    <node concept="2Ry0Ak" id="36dvFBW80LB" role="2Ry0An">
+                      <property role="2Ry0Am" value="lioncore-java-core.jar" />
                     </node>
                   </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="pUk6w" id="7jdzMamlUOQ" role="pUk7w" />
-        </node>
-        <node concept="3_J27D" id="7jdzMamlULF" role="Nbhlr">
-          <node concept="3Mxwew" id="7jdzMamlUMh" role="3MwsjC">
-            <property role="3MwjfP" value="lionweb-mps.zip" />
+          <node concept="28jJK3" id="5wsogBcGDKx" role="39821P">
+            <node concept="398BVA" id="5wsogBcGDKy" role="28jJRO">
+              <ref role="398BVh" node="5wsogBcGDKe" resolve="lioncore-mps.home" />
+              <node concept="2Ry0Ak" id="5wsogBcGDKz" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="5wsogBcGDK$" role="2Ry0An">
+                  <property role="2Ry0Am" value="io.lionweb.lioncore.java" />
+                  <node concept="2Ry0Ak" id="5wsogBcGDK_" role="2Ry0An">
+                    <property role="2Ry0Am" value="libs" />
+                    <node concept="2Ry0Ak" id="36dvFBW80Lh" role="2Ry0An">
+                      <property role="2Ry0Am" value="gson.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
           </node>
         </node>
+        <node concept="pUk6w" id="7jdzMamlUOQ" role="pUk7w" />
       </node>
     </node>
     <node concept="m$_wf" id="5wsogBcGDKB" role="3989C9">


### PR DESCRIPTION
See issue #38 

This seems to solve the problem for me, when I import lioncore-mps in the lionweb-pricing-demo it now works when running `./gradlew setup` without the need to manually unzip anything