### PR TITLE
fix export M2 annotations

### DIFF
--- a/.mps/modules.xml
+++ b/.mps/modules.xml
@@ -13,6 +13,7 @@
       <modulePath path="$PROJECT_DIR$/languages/io.lionweb.mps.converter.TestLang2/io.lionweb.mps.converter.TestLang2.mpl" folder="test.langs" />
       <modulePath path="$PROJECT_DIR$/languages/io.lionweb.mps.converter.TestLang3/io.lionweb.mps.converter.TestLang3.mpl" folder="test.langs" />
       <modulePath path="$PROJECT_DIR$/languages/io.lionweb.mps.converter.TestLangBroken/io.lionweb.mps.converter.TestLangBroken.mpl" folder="xx_broken" />
+      <modulePath path="$PROJECT_DIR$/languages/io.lionweb.mps.converter.TestLanguageAnnotation/io.lionweb.mps.converter.TestLanguageAnnotation.mpl" folder="test.langs" />
       <modulePath path="$PROJECT_DIR$/languages/io.lionweb.mps.converter.TestRefs/io.lionweb.mps.converter.TestRefs.mpl" folder="test.langs" />
       <modulePath path="$PROJECT_DIR$/languages/io.lionweb.mps.converter.deps.AnnotationAnnotates/io.lionweb.mps.converter.deps.AnnotationAnnotates.mpl" folder="test.dependencies" />
       <modulePath path="$PROJECT_DIR$/languages/io.lionweb.mps.converter.deps.AnnotationAnnotates_Node/io.lionweb.mps.converter.deps.AnnotationAnnotates_Node.mpl" folder="test.dependencies" />

--- a/build.xml
+++ b/build.xml
@@ -507,7 +507,6 @@
           <module ref="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" kind="rt" />
           <module ref="d936855b-48da-4812-a8a0-2bfddd633ac4(jetbrains.mps.lang.behavior.runtime)" kind="rt" />
           <module ref="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" kind="rt" />
-          <module ref="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" kind="cl" />
           <module ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" kind="cl" />
           <module ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" kind="cl" />
           <module ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" kind="cl" />

--- a/build.xml
+++ b/build.xml
@@ -2700,6 +2700,66 @@
       <zipfileset file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestComputedProperty/io.lionweb.mps.converter.TestComputedProperty.mpl" prefix="module" />
       <zipfileset dir="${build.tmp}/customProcessors/copyModels/languages-io.lionweb.mps.converter.TestComputedProperty-models" prefix="module/models" />
     </jar>
+    <mkdir dir="${build.tmp}/default/io.lionweb.mps.converter.TestLanguageAnnotation.jar" />
+    <mkdir dir="${build.tmp}/default/io.lionweb.mps.converter.TestLanguageAnnotation.jar/META-INF" />
+    <echoxml file="${build.tmp}/default/io.lionweb.mps.converter.TestLanguageAnnotation.jar/META-INF/module.xml">
+      <module namespace="io.lionweb.mps.converter.TestLanguageAnnotation" type="language" uuid="d8685aa4-94a0-46f9-a14e-818bb12c5c50">
+        <dependencies>
+          <module ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" kind="rt" />
+          <module ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" kind="rt" />
+          <module ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" kind="rt" />
+          <module ref="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" kind="rt" />
+          <module ref="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" kind="rt" />
+          <module ref="a3e4657f-a76c-45bb-bbda-c764596ecc65(jetbrains.mps.baseLanguage.logging.runtime)" kind="rt" />
+          <module ref="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" kind="rt" />
+          <module ref="d44dab97-aaac-44cb-9745-8a14db674c03(jetbrains.mps.baseLanguage.tuples.runtime)" kind="rt" />
+          <module ref="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" kind="rt" />
+          <module ref="d936855b-48da-4812-a8a0-2bfddd633ac4(jetbrains.mps.lang.behavior.runtime)" kind="rt" />
+          <module ref="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" kind="rt" />
+          <module ref="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" kind="cl" />
+          <module ref="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" kind="cl" />
+        </dependencies>
+        <uses>
+          <language id="l:d8685aa4-94a0-46f9-a14e-818bb12c5c50:io.lionweb.mps.converter.TestLanguageAnnotation" />
+          <language id="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" />
+          <language id="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" />
+          <language id="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" />
+          <language id="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" />
+          <language id="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" />
+          <language id="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" />
+          <language id="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" />
+          <language id="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" />
+          <language id="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" />
+          <language id="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" />
+          <language id="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" />
+          <language id="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" />
+          <language id="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" />
+        </uses>
+        <classpath>
+          <entry path="." />
+        </classpath>
+        <sources jar="io.lionweb.mps.converter.TestLanguageAnnotation-src.jar" descriptor="io.lionweb.mps.converter.TestLanguageAnnotation.mpl" />
+      </module>
+    </echoxml>
+    <jar destfile="${build.layout}/io.lionweb.mps.tests.contributions/languages/lionweb-mps-tests.contributions/io.lionweb.mps.converter.TestLanguageAnnotation.jar" duplicate="preserve">
+      <fileset dir="${build.tmp}/java/out/io.lionweb.mps.converter.TestLanguageAnnotation" />
+      <fileset dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLanguageAnnotation" includes="icons/**" />
+      <fileset dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLanguageAnnotation/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
+      <fileset dir="${build.tmp}/default/io.lionweb.mps.converter.TestLanguageAnnotation.jar" />
+    </jar>
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/languages-io.lionweb.mps.converter.TestLanguageAnnotation-models">
+      <fileset dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLanguageAnnotation/models" includes="**/*.mps, **/*.mpsr, **/.model" />
+    </copyModels>
+    <jar destfile="${build.layout}/io.lionweb.mps.tests.contributions/languages/lionweb-mps-tests.contributions/io.lionweb.mps.converter.TestLanguageAnnotation-src.jar" duplicate="preserve">
+      <fileset dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLanguageAnnotation/source_gen">
+        <exclude name="**/trace.info" />
+        <exclude name="**/exports" />
+        <exclude name="**/checkpoints" />
+        <exclude name="**/*.mps" />
+      </fileset>
+      <zipfileset file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLanguageAnnotation/io.lionweb.mps.converter.TestLanguageAnnotation.mpl" prefix="module" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/languages-io.lionweb.mps.converter.TestLanguageAnnotation-models" prefix="module/models" />
+    </jar>
     <mkdir dir="${build.tmp}/default/io.lionweb.mps.converter.test.support.jar" />
     <mkdir dir="${build.tmp}/default/io.lionweb.mps.converter.test.support.jar/META-INF" />
     <echoxml file="${build.tmp}/default/io.lionweb.mps.converter.test.support.jar/META-INF/module.xml">
@@ -3051,7 +3111,7 @@
     <delete dir="${build.layout}" />
   </target>
   
-  <target name="compileJava" depends="java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.m3.runtime, java.compile.io.lionweb.mps.structure.attribute, java.compile.io.lionweb.mps.specific, java.compile.io.lionweb.mps.server.plugin, java.compile.io.lionweb.mps.converter, java.compile.io.lionweb.mps.json, java.compile.java.modules.cycle.1, java.compile.io.lionweb.mps.converter.lang, java.compile.io.lionweb.mps.converter.lang.runtime, java.compile.io.lionweb.mps.client.connector, java.compile.io.lionweb.mps.client.ideaPlugin, java.compile.io.lionweb.mps.client.persistence, java.compile.io.lionweb.mps.cmdline, java.compile.io.lionweb.mps.build, java.compile.io.lionweb.mps.converter.TestAllBuiltins, java.compile.io.lionweb.mps.testsupport, java.compile.io.lionweb.mps.testsupport.generator, java.compile.io.lionweb.mps.converter.TestLang, java.compile.io.lionweb.mps.converter.TestLang2, java.compile.io.lionweb.mps.converter.TestLang3, java.compile.library, java.compile.MultiRefLang, java.compile.io.lionweb.mps.converter.TestCoreRefLang, java.compile.io.lionweb.mps.converter.TestCustomDatatype, java.compile.io.lionweb.mps.converter.TestAnnotation, java.compile.io.lionweb.mps.converter.TestRefs, java.compile.io.lionweb.mps.converter.deps.AnnotationAnnotates, java.compile.io.lionweb.mps.converter.deps.AnnotationAnnotates_Node, java.compile.io.lionweb.mps.converter.deps.AnnotationExtends, java.compile.io.lionweb.mps.converter.deps.AnnotationImplements, java.compile.io.lionweb.mps.converter.deps.ConceptExtends, java.compile.io.lionweb.mps.converter.deps.ConceptImplements, java.compile.io.lionweb.mps.converter.deps.ContainmentType, java.compile.io.lionweb.mps.converter.deps.InterfaceExtends, java.compile.io.lionweb.mps.converter.deps.LanguageDepends, java.compile.io.lionweb.mps.converter.deps.OnlyBuiltins, java.compile.io.lionweb.mps.converter.deps.PropertyType, java.compile.io.lionweb.mps.converter.deps.ReferenceType, java.compile.io.lionweb.mps.converter.deps.SmartReferenceType, java.compile.io.lionweb.mps.converter.deps.Standalone, java.compile.io.lionweb.mps.converter.deps.AvoidMultipleConcepts, java.compile.io.lionweb.mps.converter.TestAbstract, java.compile.io.lionweb.mps.converter.TestComputedProperty, java.compile.io.lionweb.mps.converter.test.support, java.compile.io.lionweb.mps.json.test.support, java.compile.io.lionweb.mps.lang.test, java.compile.io.lionweb.mps.json.test, java.compile.io.lionweb.mps.converter.test" />
+  <target name="compileJava" depends="java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.m3.runtime, java.compile.io.lionweb.mps.structure.attribute, java.compile.io.lionweb.mps.specific, java.compile.io.lionweb.mps.server.plugin, java.compile.io.lionweb.mps.converter, java.compile.io.lionweb.mps.json, java.compile.java.modules.cycle.1, java.compile.io.lionweb.mps.converter.lang, java.compile.io.lionweb.mps.converter.lang.runtime, java.compile.io.lionweb.mps.client.connector, java.compile.io.lionweb.mps.client.ideaPlugin, java.compile.io.lionweb.mps.client.persistence, java.compile.io.lionweb.mps.cmdline, java.compile.io.lionweb.mps.build, java.compile.io.lionweb.mps.converter.TestAllBuiltins, java.compile.io.lionweb.mps.testsupport, java.compile.io.lionweb.mps.testsupport.generator, java.compile.io.lionweb.mps.converter.TestLang, java.compile.io.lionweb.mps.converter.TestLang2, java.compile.io.lionweb.mps.converter.TestLang3, java.compile.library, java.compile.MultiRefLang, java.compile.io.lionweb.mps.converter.TestCoreRefLang, java.compile.io.lionweb.mps.converter.TestCustomDatatype, java.compile.io.lionweb.mps.converter.TestAnnotation, java.compile.io.lionweb.mps.converter.TestRefs, java.compile.io.lionweb.mps.converter.deps.AnnotationAnnotates, java.compile.io.lionweb.mps.converter.deps.AnnotationAnnotates_Node, java.compile.io.lionweb.mps.converter.deps.AnnotationExtends, java.compile.io.lionweb.mps.converter.deps.AnnotationImplements, java.compile.io.lionweb.mps.converter.deps.ConceptExtends, java.compile.io.lionweb.mps.converter.deps.ConceptImplements, java.compile.io.lionweb.mps.converter.deps.ContainmentType, java.compile.io.lionweb.mps.converter.deps.InterfaceExtends, java.compile.io.lionweb.mps.converter.deps.LanguageDepends, java.compile.io.lionweb.mps.converter.deps.OnlyBuiltins, java.compile.io.lionweb.mps.converter.deps.PropertyType, java.compile.io.lionweb.mps.converter.deps.ReferenceType, java.compile.io.lionweb.mps.converter.deps.SmartReferenceType, java.compile.io.lionweb.mps.converter.deps.Standalone, java.compile.io.lionweb.mps.converter.deps.AvoidMultipleConcepts, java.compile.io.lionweb.mps.converter.TestAbstract, java.compile.io.lionweb.mps.converter.TestComputedProperty, java.compile.io.lionweb.mps.converter.TestLanguageAnnotation, java.compile.io.lionweb.mps.converter.test.support, java.compile.io.lionweb.mps.json.test.support, java.compile.io.lionweb.mps.lang.test, java.compile.io.lionweb.mps.json.test, java.compile.io.lionweb.mps.converter.test" />
   
   <target name="processResources" />
   
@@ -3188,12 +3248,13 @@
       <library file="${artifacts.mps}/languages/util/jetbrains.mps.runtime.jar" />
       <library file="${artifacts.mps}/languages/workbench-stub.jar" />
       <library file="${artifacts.mps}/languages/xml/jetbrains.mps.core.xml.jar" />
-      <chunk>
+      <chunk bootstrap="true">
         <module file="${lionweb-mps.home}/solutions/io.lionweb.lionweb.java/io.lionweb.lionweb.java.msd" />
         <module file="${basedir}/solutions/io.lionweb.mps.build/io.lionweb.mps.build.msd" />
         <module file="${basedir}/solutions/io.lionweb.mps.client.ideaPlugin/io.lionweb.mps.client.ideaPlugin.msd" />
         <module file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestCoreRefLang/io.lionweb.mps.converter.TestCoreRefLang.mpl" />
         <module file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLang/io.lionweb.mps.converter.TestLang.mpl" />
+        <module file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLanguageAnnotation/io.lionweb.mps.converter.TestLanguageAnnotation.mpl" bootstrap="true" />
         <module file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.deps.AvoidMultipleConcepts/io.lionweb.mps.converter.deps.AvoidMultipleConcepts.mpl" />
         <module file="${lionweb-mps.home}/languages/io.lionweb.mps.structure.attribute/io.lionweb.mps.structure.attribute.mpl" />
         <module file="${lionweb-mps.home}/languages/io.lionweb.mps.testsupport/io.lionweb.mps.testsupport.mpl" />
@@ -5384,6 +5445,51 @@
     </copy>
   </target>
   
+  <target name="java.compile.io.lionweb.mps.converter.TestLanguageAnnotation" depends="fetchDependencies">
+    <mkdir dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLanguageAnnotation/source_gen" />
+    <mkdir dir="${build.tmp}/java/out/io.lionweb.mps.converter.TestLanguageAnnotation" />
+    <javac destdir="${build.tmp}/java/out/io.lionweb.mps.converter.TestLanguageAnnotation" fork="false" encoding="utf8" includeantruntime="false" debug="true">
+      <compilerarg value="-Xlint:none" />
+      <src>
+        <path location="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLanguageAnnotation/source_gen" />
+      </src>
+      <classpath>
+        <fileset file="${artifacts.mps}/lib/mps-core.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-annotations.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-behavior-api.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-behavior-runtime.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-closures.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-collections.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-generator.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-openapi.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-logging.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-tuples.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-references.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-messaging.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-boot-util.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-context.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-constraints-runtime.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-persistence.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-project-check.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-textgen.jar" />
+        <fileset file="${artifacts.IDEA}/lib/annotations.jar" />
+        <fileset file="${artifacts.IDEA}/lib/log4j.jar" />
+        <fileset file="${artifacts.IDEA}/lib/jdom.jar" />
+        <fileset file="${artifacts.IDEA}/lib/trove4j.jar" />
+        <fileset file="${artifacts.IDEA}/lib/ecj-4.16.jar" />
+        <fileset file="${artifacts.IDEA}/plugins/java/lib/ecj-4.16.jar" />
+        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.logging.runtime.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.core.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.descriptor.aspects.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.scopes.runtime.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.structure.jar" />
+      </classpath>
+    </javac>
+    <copy todir="${build.tmp}/java/out/io.lionweb.mps.converter.TestLanguageAnnotation">
+      <fileset dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLanguageAnnotation/source_gen" excludes="**/*.java" />
+    </copy>
+  </target>
+  
   <target name="java.compile.io.lionweb.mps.converter.test.support" depends="java.compile.io.lionweb.mps.converter, java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.m3.runtime, fetchDependencies">
     <mkdir dir="${lionweb-mps.home}/solutions/io.lionweb.mps.converter.test.support/source_gen" />
     <mkdir dir="${build.tmp}/java/out/io.lionweb.mps.converter.test.support" />
@@ -5936,15 +6042,6 @@
   </target>
   
   <target name="cleanSources">
-    <delete dir="${lionweb-mps.home}/solutions/io.lionweb.mps.build/source_gen" />
-    <delete dir="${lionweb-mps.home}/solutions/io.lionweb.mps.client.ideaPlugin/source_gen" />
-    <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestCoreRefLang/source_gen" />
-    <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLang/source_gen" />
-    <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.deps.AvoidMultipleConcepts/source_gen" />
-    <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.structure.attribute/source_gen" />
-    <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.testsupport/source_gen" />
-    <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.testsupport/generator/source_gen" />
-    <delete dir="${lionweb-mps.home}/languages/library/source_gen" />
     <delete dir="${lionweb-mps.home}/languages/MultiRefLang/source_gen" />
     <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestAbstract/source_gen" />
     <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestAllBuiltins/source_gen" />

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## Next
 * Optionally export computed property values of instances to LionWeb JSON.
 
-* For concepts with alias and/or short description, export annotation with that information.  
+* For concepts with alias and/or short description, optinally export annotation with that information.  
 
 * Filter nodes of abstract concepts or interfaces from exporting to LionWeb JSON. 
 

--- a/languages/io.lionweb.mps.converter.TestComputedProperty/io.lionweb.mps.converter.TestComputedProperty.mpl
+++ b/languages/io.lionweb.mps.converter.TestComputedProperty/io.lionweb.mps.converter.TestComputedProperty.mpl
@@ -19,13 +19,11 @@
   <languageVersions>
     <language slang="l:411e5b27-8a76-482e-8af8-1704262b4468:io.lionweb.mps.structure.attribute" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-    <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
     <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
     <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
     <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
@@ -36,10 +34,8 @@
     <language slang="l:ea3159bf-f48e-4720-bde2-86dba75f0d34:jetbrains.mps.lang.context.defs" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
-    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:ad93155d-79b2-4759-b10c-55123e763903:jetbrains.mps.lang.messages" version="0" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-    <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
@@ -49,7 +45,6 @@
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-    <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/languages/io.lionweb.mps.converter.TestLanguageAnnotation/io.lionweb.mps.converter.TestLanguageAnnotation.mpl
+++ b/languages/io.lionweb.mps.converter.TestLanguageAnnotation/io.lionweb.mps.converter.TestLanguageAnnotation.mpl
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language namespace="io.lionweb.mps.converter.TestLanguageAnnotation" uuid="d8685aa4-94a0-46f9-a14e-818bb12c5c50" languageVersion="0" moduleVersion="0">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <accessoryModels />
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:d8685aa4-94a0-46f9-a14e-818bb12c5c50:io.lionweb.mps.converter.TestLanguageAnnotation" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
+    <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="d8685aa4-94a0-46f9-a14e-818bb12c5c50(io.lionweb.mps.converter.TestLanguageAnnotation)" version="0" />
+    <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+  </dependencyVersions>
+  <extendedLanguages />
+</language>
+

--- a/languages/io.lionweb.mps.converter.TestLanguageAnnotation/models/io.lionweb.mps.converter.TestLanguageAnnotation.behavior.mps
+++ b/languages/io.lionweb.mps.converter.TestLanguageAnnotation/models/io.lionweb.mps.converter.TestLanguageAnnotation.behavior.mps
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:c43d05c7-a28f-40fd-aad6-ae97e551873d(io.lionweb.mps.converter.TestLanguageAnnotation.behavior)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/languages/io.lionweb.mps.converter.TestLanguageAnnotation/models/io.lionweb.mps.converter.TestLanguageAnnotation.structure.mps
+++ b/languages/io.lionweb.mps.converter.TestLanguageAnnotation/models/io.lionweb.mps.converter.TestLanguageAnnotation.structure.mps
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:396581f8-7dd1-4d93-b5e1-f371d80f0697(io.lionweb.mps.converter.TestLanguageAnnotation.structure)">
+  <persistence version="9" />
+  <languages>
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <use id="d8685aa4-94a0-46f9-a14e-818bb12c5c50" name="io.lionweb.mps.converter.TestLanguageAnnotation" version="0" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
+  </languages>
+  <imports>
+    <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="d8685aa4-94a0-46f9-a14e-818bb12c5c50" name="io.lionweb.mps.converter.TestLanguageAnnotation">
+      <concept id="6667649974498560080" name="io.lionweb.mps.converter.TestLanguageAnnotation.structure.ClassifierAnnotation" flags="ng" index="1$akw3" />
+      <concept id="6667649974498560192" name="io.lionweb.mps.converter.TestLanguageAnnotation.structure.InterfaceAnnotation" flags="ng" index="1$akyj" />
+      <concept id="6667649974498560197" name="io.lionweb.mps.converter.TestLanguageAnnotation.structure.AnnotationAnnotation" flags="ng" index="1$akym" />
+      <concept id="6667649974498560187" name="io.lionweb.mps.converter.TestLanguageAnnotation.structure.ConceptAnnotation" flags="ng" index="1$akzC" />
+    </language>
+    <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="6054523464627964745" name="jetbrains.mps.lang.structure.structure.AttributeInfo_AttributedConcept" flags="ng" index="trNpa">
+        <reference id="6054523464627965081" name="concept" index="trN6q" />
+      </concept>
+      <concept id="2992811758677295509" name="jetbrains.mps.lang.structure.structure.AttributeInfo" flags="ng" index="M6xJ_">
+        <child id="7588428831947959310" name="attributed" index="EQaZv" />
+      </concept>
+      <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+      </concept>
+      <concept id="1169125989551" name="jetbrains.mps.lang.structure.structure.InterfaceConceptDeclaration" flags="ig" index="PlHQZ" />
+      <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <reference id="1071489389519" name="extends" index="1TJDcQ" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1TIwiD" id="5M8g5cSCgxg">
+    <property role="EcuMT" value="6667649974498560080" />
+    <property role="TrG5h" value="ClassifierAnnotation" />
+    <ref role="1TJDcQ" to="tpck:2ULFgo8_XDk" resolve="NodeAttribute" />
+    <node concept="M6xJ_" id="5M8g5cSCgxh" role="lGtFl">
+      <node concept="trNpa" id="5M8g5cSCgxj" role="EQaZv">
+        <ref role="trN6q" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+      </node>
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5M8g5cSCgyV">
+    <property role="EcuMT" value="6667649974498560187" />
+    <property role="TrG5h" value="ConceptAnnotation" />
+    <ref role="1TJDcQ" to="tpck:2ULFgo8_XDk" resolve="NodeAttribute" />
+    <node concept="M6xJ_" id="5M8g5cSCgyW" role="lGtFl">
+      <node concept="trNpa" id="5M8g5cSCgyY" role="EQaZv">
+        <ref role="trN6q" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+      </node>
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5M8g5cSCgz0">
+    <property role="EcuMT" value="6667649974498560192" />
+    <property role="TrG5h" value="InterfaceAnnotation" />
+    <ref role="1TJDcQ" to="tpck:2ULFgo8_XDk" resolve="NodeAttribute" />
+    <node concept="M6xJ_" id="5M8g5cSCgz1" role="lGtFl">
+      <node concept="trNpa" id="5M8g5cSCgz3" role="EQaZv">
+        <ref role="trN6q" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
+      </node>
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5M8g5cSCgz5">
+    <property role="EcuMT" value="6667649974498560197" />
+    <property role="TrG5h" value="AnnotationAnnotation" />
+    <ref role="1TJDcQ" to="tpck:2ULFgo8_XDk" resolve="NodeAttribute" />
+    <node concept="M6xJ_" id="5M8g5cSCgz6" role="lGtFl">
+      <node concept="trNpa" id="5M8g5cSCgz8" role="EQaZv">
+        <ref role="trN6q" to="tpck:2ULFgo8_XDk" resolve="NodeAttribute" />
+      </node>
+    </node>
+    <node concept="1$akym" id="5M8g5cSCl$V" role="lGtFl" />
+    <node concept="1$akw3" id="5M8g5cSCm4i" role="lGtFl" />
+  </node>
+  <node concept="1TIwiD" id="5M8g5cSCm6N">
+    <property role="EcuMT" value="6667649974498582963" />
+    <property role="TrG5h" value="TrialConcept" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1$akw3" id="5M8g5cSCo9B" role="lGtFl" />
+    <node concept="1$akzC" id="5M8g5cSCoSU" role="lGtFl" />
+  </node>
+  <node concept="PlHQZ" id="5M8g5cSCm6O">
+    <property role="EcuMT" value="6667649974498582964" />
+    <property role="TrG5h" value="TrialInterface" />
+    <node concept="1$akw3" id="5M8g5cSCmBc" role="lGtFl" />
+    <node concept="1$akyj" id="5M8g5cSCnmm" role="lGtFl" />
+  </node>
+</model>
+

--- a/languages/io.lionweb.mps.converter.lang/io.lionweb.mps.converter.lang.mpl
+++ b/languages/io.lionweb.mps.converter.lang/io.lionweb.mps.converter.lang.mpl
@@ -24,7 +24,6 @@
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">7350a1d7-537e-4f0d-9965-e91c82522d7d(io.lionweb.mps.m3.runtime)</dependency>
-    <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.editor.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.editor.mps
@@ -248,6 +248,15 @@
             <ref role="1NtTu8" to="d0tf:utjSYFId7H" resolve="scope" />
           </node>
         </node>
+        <node concept="3EZMnI" id="5M8g5cT5W13" role="3EZMnx">
+          <node concept="3F0ifn" id="5M8g5cT5W14" role="3EZMnx">
+            <property role="3F0ifm" value="Export description annotations:" />
+          </node>
+          <node concept="2iRfu4" id="5M8g5cT5W15" role="2iSdaV" />
+          <node concept="3F0A7n" id="5M8g5cT5W16" role="3EZMnx">
+            <ref role="1NtTu8" to="d0tf:utjSYFId7H" resolve="scope" />
+          </node>
+        </node>
       </node>
       <node concept="3F0ifn" id="1q44RFSZQQ1" role="3EZMnx" />
       <node concept="3F0ifn" id="4Yo3buYkNTb" role="3EZMnx">

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.intentions.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.intentions.mps
@@ -17,10 +17,10 @@
     <import index="d0tf" ref="r:087ec845-a235-4ffb-80e5-329ef8e66943(io.lionweb.mps.converter.lang.structure)" />
     <import index="j5yh" ref="r:137003c8-aa9f-4bda-ae9b-f5d7ec2da82c(io.lionweb.mps.json.idmapper)" />
     <import index="h3y3" ref="r:11596e6a-4231-47c9-b3df-0dcce1111a54(io.lionweb.mps.m3.structure)" />
-    <import index="xfsv" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.serialization.data(io.lionweb.lioncore.java/)" />
+    <import index="xfsv" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.serialization.data(io.lionweb.lionweb.java/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
-    <import index="imb3" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.language(io.lionweb.lioncore.java/)" />
+    <import index="imb3" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.language(io.lionweb.lionweb.java/)" />
     <import index="y7p" ref="r:3303ef0b-a58e-4f50-b3cb-bd3d7aaf3653(io.lionweb.mps.m3.runtime)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
@@ -2141,6 +2141,22 @@
                         <ref role="Rm8GQ" to="6peh:utjSYFI7F7" resolve="fineGrainedClosure" />
                         <ref role="1Px2BO" to="6peh:24j7TNH1AVU" resolve="M2ToJson.Scope" />
                       </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5M8g5cT5X24" role="3cqZAp">
+              <node concept="2OqwBi" id="5M8g5cT5Xu5" role="3clFbG">
+                <node concept="37vLTw" id="5M8g5cT5X22" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1q44RFT01lB" resolve="converter" />
+                </node>
+                <node concept="liA8E" id="5M8g5cT5XDx" role="2OqNvi">
+                  <ref role="37wK5l" to="6peh:5M8g5cT5Ngm" resolve="setExportDescriptionAnnotations" />
+                  <node concept="2OqwBi" id="5M8g5cT5XS1" role="37wK5m">
+                    <node concept="2Sf5sV" id="5M8g5cT5XG_" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="5M8g5cT5Y8A" role="2OqNvi">
+                      <ref role="3TsBF5" to="d0tf:5M8g5cT5W10" resolve="exportDescriptionAnnotations" />
                     </node>
                   </node>
                 </node>

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.intentions.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.intentions.mps
@@ -23,7 +23,6 @@
     <import index="imb3" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.language(io.lionweb.lionweb.java/)" />
     <import index="y7p" ref="r:3303ef0b-a58e-4f50-b3cb-bd3d7aaf3653(io.lionweb.mps.m3.runtime)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
-    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.intentions.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.intentions.mps
@@ -44,6 +44,9 @@
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -655,6 +658,11 @@
                           <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                           <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
                         </node>
+                        <node concept="2ShNRf" id="7weWCFlyStI" role="37wK5m">
+                          <node concept="HV5vD" id="7weWCFlyStJ" role="2ShVmc">
+                            <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -712,6 +720,11 @@
                         <node concept="2YIFZM" id="5TNjoy1zul5" role="37wK5m">
                           <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
                           <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
+                        </node>
+                        <node concept="2ShNRf" id="7weWCFlySHz" role="37wK5m">
+                          <node concept="HV5vD" id="7weWCFlySH$" role="2ShVmc">
+                            <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -1198,6 +1211,11 @@
                         <node concept="2YIFZM" id="5sACIIt1V85" role="37wK5m">
                           <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                           <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                        </node>
+                        <node concept="2ShNRf" id="7weWCFlyI7w" role="37wK5m">
+                          <node concept="HV5vD" id="7weWCFlyJjA" role="2ShVmc">
+                            <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -1757,6 +1775,11 @@
                         <node concept="2YIFZM" id="5hsSXrmDfRt" role="37wK5m">
                           <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                           <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                        </node>
+                        <node concept="2ShNRf" id="7weWCFlyTup" role="37wK5m">
+                          <node concept="HV5vD" id="7weWCFlyTuq" role="2ShVmc">
+                            <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                          </node>
                         </node>
                       </node>
                     </node>

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.structure.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.structure.mps
@@ -223,6 +223,11 @@
       <property role="TrG5h" value="scope" />
       <ref role="AX2Wp" node="utjSYFIbxq" resolve="LanguageExportScope" />
     </node>
+    <node concept="1TJgyi" id="5M8g5cT5W10" role="1TKVEl">
+      <property role="IQ2nx" value="6667649974506340416" />
+      <property role="TrG5h" value="exportDescriptionAnnotations" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
     <node concept="PrWs8" id="1q44RFSZQBV" role="PzmwI">
       <ref role="PrY4T" node="1q44RFSZQFB" resolve="ILanguageIdentityContainer" />
     </node>

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.typesystem.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.typesystem.mps
@@ -20,6 +20,9 @@
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -231,7 +234,23 @@
           </node>
         </node>
       </node>
-      <node concept="3clFbH" id="3M8YG$aAF5O" role="3cqZAp" />
+      <node concept="3cpWs8" id="5M8g5cSLsEu" role="3cqZAp">
+        <node concept="3cpWsn" id="5M8g5cSLsEv" role="3cpWs9">
+          <property role="TrG5h" value="constants" />
+          <node concept="3uibUv" id="5M8g5cSLsqA" role="1tU5fm">
+            <ref role="3uigEE" to="y7p:DUXtGZOlwJ" resolve="LionCoreConstants" />
+          </node>
+          <node concept="2ShNRf" id="5M8g5cSLsEw" role="33vP2m">
+            <node concept="1pGfFk" id="5M8g5cSLsEx" role="2ShVmc">
+              <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+              <node concept="37vLTw" id="5M8g5cSLsEy" role="37wK5m">
+                <ref role="3cqZAo" node="3M8YG$9ZiF3" resolve="repository" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="5M8g5cSLt51" role="3cqZAp" />
       <node concept="3cpWs8" id="4pht$XswCmL" role="3cqZAp">
         <node concept="3cpWsn" id="4pht$XswCmM" role="3cpWs9">
           <property role="TrG5h" value="finder" />
@@ -244,11 +263,22 @@
             <node concept="37vLTw" id="3M8YG$9ZptS" role="37wK5m">
               <ref role="3cqZAo" node="3M8YG$9ZiF3" resolve="repository" />
             </node>
-            <node concept="2ShNRf" id="24j7TNHjR6f" role="37wK5m">
-              <node concept="1pGfFk" id="24j7TNHjRoe" role="2ShVmc">
-                <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
-                <node concept="37vLTw" id="3M8YG$9ZiFa" role="37wK5m">
+            <node concept="37vLTw" id="5M8g5cSLsEz" role="37wK5m">
+              <ref role="3cqZAo" node="5M8g5cSLsEv" resolve="constants" />
+            </node>
+            <node concept="2ShNRf" id="5M8g5cSLrFC" role="37wK5m">
+              <node concept="1pGfFk" id="5M8g5cSLs17" role="2ShVmc">
+                <ref role="37wK5l" to="apzt:5AGBwuFEKL7" resolve="AnnotationFinder" />
+                <node concept="37vLTw" id="5M8g5cSLscx" role="37wK5m">
                   <ref role="3cqZAo" node="3M8YG$9ZiF3" resolve="repository" />
+                </node>
+                <node concept="2ShNRf" id="5M8g5cSLvad" role="37wK5m">
+                  <node concept="HV5vD" id="5M8g5cSLvI1" role="2ShVmc">
+                    <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="5M8g5cSLttR" role="37wK5m">
+                  <ref role="3cqZAo" node="5M8g5cSLsEv" resolve="constants" />
                 </node>
               </node>
             </node>
@@ -437,6 +467,22 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="5M8g5cSLwDs" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cSLwDt" role="3cpWs9">
+            <property role="TrG5h" value="constants" />
+            <node concept="3uibUv" id="5M8g5cSLwon" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:DUXtGZOlwJ" resolve="LionCoreConstants" />
+            </node>
+            <node concept="2ShNRf" id="5M8g5cSLwDu" role="33vP2m">
+              <node concept="1pGfFk" id="5M8g5cSLwDv" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                <node concept="37vLTw" id="5M8g5cSLwDw" role="37wK5m">
+                  <ref role="3cqZAo" node="3M8YG$9Zq3f" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbH" id="3M8YG$aAKnh" role="3cqZAp" />
         <node concept="3cpWs8" id="39$JcGGC7Fw" role="3cqZAp">
           <node concept="3cpWsn" id="39$JcGGC7Fx" role="3cpWs9">
@@ -450,11 +496,22 @@
               <node concept="37vLTw" id="3M8YG$aAKwB" role="37wK5m">
                 <ref role="3cqZAo" node="3M8YG$9Zq3f" resolve="repository" />
               </node>
-              <node concept="2ShNRf" id="3M8YG$aAKwC" role="37wK5m">
-                <node concept="1pGfFk" id="3M8YG$aAKwD" role="2ShVmc">
-                  <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
-                  <node concept="37vLTw" id="3M8YG$aAKwE" role="37wK5m">
+              <node concept="37vLTw" id="5M8g5cSLwDx" role="37wK5m">
+                <ref role="3cqZAo" node="5M8g5cSLwDt" resolve="constants" />
+              </node>
+              <node concept="2ShNRf" id="5M8g5cSLx06" role="37wK5m">
+                <node concept="1pGfFk" id="5M8g5cSLx07" role="2ShVmc">
+                  <ref role="37wK5l" to="apzt:5AGBwuFEKL7" resolve="AnnotationFinder" />
+                  <node concept="37vLTw" id="5M8g5cSLx08" role="37wK5m">
                     <ref role="3cqZAo" node="3M8YG$9Zq3f" resolve="repository" />
+                  </node>
+                  <node concept="2ShNRf" id="5M8g5cSLx09" role="37wK5m">
+                    <node concept="HV5vD" id="5M8g5cSLx0a" role="2ShVmc">
+                      <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="5M8g5cSLx0b" role="37wK5m">
+                    <ref role="3cqZAo" node="5M8g5cSLwDt" resolve="constants" />
                   </node>
                 </node>
               </node>

--- a/solutions/io.lionweb.mps.build/models/io.lionweb.mps.build.mps
+++ b/solutions/io.lionweb.mps.build/models/io.lionweb.mps.build.mps
@@ -1131,11 +1131,6 @@
             <ref role="3bR37D" node="6jI_U5e9kIC" resolve="io.lionweb.mps.m3.runtime" />
           </node>
         </node>
-        <node concept="1SiIV0" id="34Q84zMMDxU" role="3bR37C">
-          <node concept="3bR9La" id="34Q84zMMDxV" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
-          </node>
-        </node>
       </node>
       <node concept="1E1JtA" id="5wsogBcGDNb" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/solutions/io.lionweb.mps.build/models/io.lionweb.mps.build.mps
+++ b/solutions/io.lionweb.mps.build/models/io.lionweb.mps.build.mps
@@ -104,6 +104,7 @@
     </language>
     <language id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps">
       <concept id="6503355885715333289" name="jetbrains.mps.build.mps.structure.BuildMpsAspect" flags="ng" index="2igEWh">
+        <property id="6503355885715353788" name="bootstrap" index="2igJW4" />
         <property id="7981469545489178349" name="generationMaxHeapSizeInMb" index="3UIfUI" />
       </concept>
       <concept id="7832771629084799699" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginVendor" flags="ng" index="2iUeEo">
@@ -190,6 +191,7 @@
     <property role="2DA0ip" value="../.." />
     <node concept="2igEWh" id="1r9ZEnp6m1g" role="1hWBAP">
       <property role="3UIfUI" value="4096" />
+      <property role="2igJW4" value="true" />
     </node>
     <node concept="22LTRH" id="24OSoZ61D0h" role="1hWBAP">
       <property role="TrG5h" value="tests" />
@@ -3454,6 +3456,66 @@
             </node>
             <node concept="3qWCbU" id="nWBHrKVRae" role="3LXTna">
               <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="5M8g5cTbOnE" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="io.lionweb.mps.converter.TestLanguageAnnotation" />
+        <property role="3LESm3" value="d8685aa4-94a0-46f9-a14e-818bb12c5c50" />
+        <node concept="398BVA" id="5M8g5cTbOy0" role="3LF7KH">
+          <ref role="398BVh" node="5wsogBcGDKe" resolve="lionweb-mps.home" />
+          <node concept="2Ry0Ak" id="5M8g5cTbOyN" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="5M8g5cTbO_G" role="2Ry0An">
+              <property role="2Ry0Am" value="io.lionweb.mps.converter.TestLanguageAnnotation" />
+              <node concept="2Ry0Ak" id="5M8g5cTbOBb" role="2Ry0An">
+                <property role="2Ry0Am" value="io.lionweb.mps.converter.TestLanguageAnnotation.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5M8g5cTbOKy" role="3bR37C">
+          <node concept="3bR9La" id="5M8g5cTbOKz" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="5M8g5cTbOKK" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="5M8g5cTbOKL" role="1HemKq">
+            <node concept="398BVA" id="5M8g5cTbOK$" role="3LXTmr">
+              <ref role="398BVh" node="5wsogBcGDKe" resolve="lionweb-mps.home" />
+              <node concept="2Ry0Ak" id="5M8g5cTbOK_" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="5M8g5cTbOKA" role="2Ry0An">
+                  <property role="2Ry0Am" value="io.lionweb.mps.converter.TestLanguageAnnotation" />
+                  <node concept="2Ry0Ak" id="5M8g5cTbOKB" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="5M8g5cTbOKM" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5M8g5cTbOMW" role="3bR31x">
+          <node concept="3LXTmp" id="5M8g5cTbOMX" role="3rtmxm">
+            <node concept="398BVA" id="5M8g5cTbOMY" role="3LXTmr">
+              <ref role="398BVh" node="5wsogBcGDKe" resolve="lionweb-mps.home" />
+              <node concept="2Ry0Ak" id="5M8g5cTbOMZ" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="5M8g5cTbON0" role="2Ry0An">
+                  <property role="2Ry0Am" value="io.lionweb.mps.converter.TestLanguageAnnotation" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="5M8g5cTbON2" role="3LXTna">
+              <property role="3qWCbO" value="icons/**" />
             </node>
           </node>
         </node>

--- a/solutions/io.lionweb.mps.client.connector/models/io.lionweb.mps.client.connector.impl.mps
+++ b/solutions/io.lionweb.mps.client.connector/models/io.lionweb.mps.client.connector.impl.mps
@@ -22,6 +22,7 @@
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="imb3" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.language(io.lionweb.lionweb.java/)" />
+    <import index="cz4z" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.self(io.lionweb.lionweb.java/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -41,6 +42,9 @@
       </concept>
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
@@ -1480,6 +1484,11 @@
                         <node concept="2YIFZM" id="5hsSXrmDeQ3" role="37wK5m">
                           <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                           <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                        </node>
+                        <node concept="2ShNRf" id="7weWCFlyMiW" role="37wK5m">
+                          <node concept="HV5vD" id="7weWCFlyMiX" role="2ShVmc">
+                            <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                          </node>
                         </node>
                       </node>
                     </node>

--- a/solutions/io.lionweb.mps.converter.test.support/models/io.lionweb.mps.converter.test.support.mps
+++ b/solutions/io.lionweb.mps.converter.test.support/models/io.lionweb.mps.converter.test.support.mps
@@ -1792,6 +1792,15 @@
           <ref role="3uigEE" to="y7p:5JNiskhxHcX" resolve="ILionCoreConstants" />
         </node>
       </node>
+      <node concept="37vLTG" id="5M8g5cSCOGJ" role="3clF46">
+        <property role="TrG5h" value="annotationFinder" />
+        <node concept="3uibUv" id="5M8g5cSCOP8" role="1tU5fm">
+          <ref role="3uigEE" to="apzt:18UigYQMpCK" resolve="AnnotationFinder" />
+        </node>
+        <node concept="2AHcQZ" id="5M8g5cSCQ3d" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
       <node concept="3cqZAl" id="3M8YG$9VNCL" role="3clF45" />
       <node concept="3Tm1VV" id="3M8YG$9VNCM" role="1B3o_S" />
       <node concept="3clFbS" id="3M8YG$9VNCU" role="3clF47">
@@ -1799,6 +1808,9 @@
           <ref role="37wK5l" to="apzt:24j7TNHl1J_" resolve="BuiltinsUsage" />
           <node concept="37vLTw" id="3M8YG$9VNCW" role="37wK5m">
             <ref role="3cqZAo" node="3M8YG$9VNCI" resolve="constants" />
+          </node>
+          <node concept="37vLTw" id="5M8g5cSDtBv" role="37wK5m">
+            <ref role="3cqZAo" node="5M8g5cSCOGJ" resolve="annotationFinder" />
           </node>
         </node>
       </node>

--- a/solutions/io.lionweb.mps.converter.test/models/io.lionweb.mps.converter.test.languagedependsonfinder@tests.mps
+++ b/solutions/io.lionweb.mps.converter.test/models/io.lionweb.mps.converter.test.languagedependsonfinder@tests.mps
@@ -30,6 +30,9 @@
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -158,6 +161,12 @@
                         <ref role="2WH_rO" node="3M8YG$a_1L3" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="5M8g5cT1WgD" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT1WgG" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT1WgI" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1Ujs" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$Sab" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$Sac" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$Sad" role="2OqNvi">
@@ -195,6 +204,12 @@
                         <ref role="2WH_rO" node="3M8YG$a_1L3" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="5M8g5cT1Wnb" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT1Wnc" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT1Wnd" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1Ujs" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$VWY" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$VWZ" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$VX0" role="2OqNvi">
@@ -227,6 +242,12 @@
                       <node concept="2WthIp" id="3M8YG$a$WU8" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$WU9" role="2OqNvi">
                         <ref role="2WH_rO" node="3M8YG$a_1L3" resolve="constants" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="5M8g5cT1Wts" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT1Wtt" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT1Wtu" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1Ujs" resolve="annotationFinder" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="3M8YG$a$WUa" role="37wK5m">
@@ -273,6 +294,12 @@
                         <ref role="2WH_rO" node="3M8YG$a_1L3" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="5M8g5cT1WBc" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT1WBd" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT1WBe" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1Ujs" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$X1t" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$X1u" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$X1v" role="2OqNvi">
@@ -308,6 +335,12 @@
                       <node concept="2WthIp" id="3M8YG$a_0qp" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a_0qq" role="2OqNvi">
                         <ref role="2WH_rO" node="3M8YG$a_1L3" resolve="constants" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="5M8g5cT1WHh" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT1WHi" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT1WHj" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1Ujs" resolve="annotationFinder" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="3M8YG$a_0qr" role="37wK5m">
@@ -427,6 +460,12 @@
                         <ref role="2WH_rO" node="3M8YG$a_1L3" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="5M8g5cT1WWS" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT1WWT" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT1WWU" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1Ujs" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a_16z" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a_16$" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a_16_" role="2OqNvi">
@@ -468,6 +507,12 @@
                       <node concept="2WthIp" id="3M8YG$a$YDj" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$YDk" role="2OqNvi">
                         <ref role="2WH_rO" node="3M8YG$a_1L3" resolve="constants" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="5M8g5cT1X5C" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT1X5D" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT1X5E" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1Ujs" resolve="annotationFinder" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="3M8YG$a$YDl" role="37wK5m">
@@ -513,6 +558,12 @@
                         <ref role="2WH_rO" node="3M8YG$a_1L3" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="5M8g5cT1X9X" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT1X9Y" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT1X9Z" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1Ujs" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$YNn" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$YNo" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$YNp" role="2OqNvi">
@@ -554,6 +605,12 @@
                       <node concept="2WthIp" id="3M8YG$a$ZT_" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$ZTA" role="2OqNvi">
                         <ref role="2WH_rO" node="3M8YG$a_1L3" resolve="constants" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="5M8g5cT1Xem" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT1Xen" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT1Xeo" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1Ujs" resolve="annotationFinder" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="3M8YG$a$ZTB" role="37wK5m">
@@ -614,6 +671,39 @@
       <node concept="3uibUv" id="5JNiskhCD8G" role="3clF45">
         <ref role="3uigEE" to="y7p:5JNiskhxHcX" resolve="ILionCoreConstants" />
       </node>
+    </node>
+    <node concept="2XrIbr" id="5M8g5cT1Ujs" role="1qtyYc">
+      <property role="TrG5h" value="annotationFinder" />
+      <node concept="3uibUv" id="5M8g5cT1Vxk" role="3clF45">
+        <ref role="3uigEE" to="apzt:18UigYQMpCK" resolve="AnnotationFinder" />
+      </node>
+      <node concept="3clFbS" id="5M8g5cT1Uju" role="3clF47">
+        <node concept="3clFbF" id="5M8g5cT1Vz9" role="3cqZAp">
+          <node concept="2ShNRf" id="5M8g5cT1Vz7" role="3clFbG">
+            <node concept="1pGfFk" id="5M8g5cT1VGY" role="2ShVmc">
+              <ref role="37wK5l" to="apzt:5AGBwuFEKL7" resolve="AnnotationFinder" />
+              <node concept="2OqwBi" id="5M8g5cT1VHj" role="37wK5m">
+                <node concept="2WthIp" id="5M8g5cT1VHm" role="2Oq$k0" />
+                <node concept="2XshWL" id="5M8g5cT1VHo" role="2OqNvi">
+                  <ref role="2WH_rO" node="3M8YG$a_1KV" resolve="repository" />
+                </node>
+              </node>
+              <node concept="2ShNRf" id="5M8g5cT1VMF" role="37wK5m">
+                <node concept="HV5vD" id="5M8g5cT1VXI" role="2ShVmc">
+                  <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5M8g5cT1W9W" role="37wK5m">
+                <node concept="2WthIp" id="5M8g5cT1W9Z" role="2Oq$k0" />
+                <node concept="2XshWL" id="5M8g5cT1Wa1" role="2OqNvi">
+                  <ref role="2WH_rO" node="3M8YG$a_1L3" resolve="constants" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="5M8g5cT1UCm" role="1B3o_S" />
     </node>
     <node concept="2XrIbr" id="3M8YG$a$PST" role="1qtyYc">
       <property role="TrG5h" value="languages" />
@@ -683,6 +773,39 @@
         <ref role="3uigEE" to="y7p:5JNiskhxHcX" resolve="ILionCoreConstants" />
       </node>
     </node>
+    <node concept="2XrIbr" id="5M8g5cT1XJL" role="1qtyYc">
+      <property role="TrG5h" value="annotationFinder" />
+      <node concept="3uibUv" id="5M8g5cT1XJM" role="3clF45">
+        <ref role="3uigEE" to="apzt:18UigYQMpCK" resolve="AnnotationFinder" />
+      </node>
+      <node concept="3clFbS" id="5M8g5cT1XJN" role="3clF47">
+        <node concept="3clFbF" id="5M8g5cT1XJO" role="3cqZAp">
+          <node concept="2ShNRf" id="5M8g5cT1XJP" role="3clFbG">
+            <node concept="1pGfFk" id="5M8g5cT1XJQ" role="2ShVmc">
+              <ref role="37wK5l" to="apzt:5AGBwuFEKL7" resolve="AnnotationFinder" />
+              <node concept="2OqwBi" id="5M8g5cT1XJR" role="37wK5m">
+                <node concept="2WthIp" id="5M8g5cT1XJS" role="2Oq$k0" />
+                <node concept="2XshWL" id="5M8g5cT1XJT" role="2OqNvi">
+                  <ref role="2WH_rO" node="3M8YG$a_29V" resolve="repository" />
+                </node>
+              </node>
+              <node concept="2ShNRf" id="5M8g5cT1XJU" role="37wK5m">
+                <node concept="HV5vD" id="5M8g5cT1XJV" role="2ShVmc">
+                  <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5M8g5cT1XJW" role="37wK5m">
+                <node concept="2WthIp" id="5M8g5cT1XJX" role="2Oq$k0" />
+                <node concept="2XshWL" id="5M8g5cT1XJY" role="2OqNvi">
+                  <ref role="2WH_rO" node="3M8YG$a_2a3" resolve="constants" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="5M8g5cT1XJZ" role="1B3o_S" />
+    </node>
     <node concept="2XrIbr" id="3M8YG$a$OU$" role="1qtyYc">
       <property role="TrG5h" value="languages" />
       <node concept="A3Dl8" id="3M8YG$a$OU_" role="3clF45">
@@ -742,6 +865,12 @@
                         <ref role="2WH_rO" node="3M8YG$a_2a3" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="5M8g5cT23Pw" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT23Px" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT23Py" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1XJL" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$Sr6" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$Sr7" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$Sr8" role="2OqNvi">
@@ -779,6 +908,12 @@
                         <ref role="2WH_rO" node="3M8YG$a_2a3" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="5M8g5cT23XX" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT23XY" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT23XZ" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1XJL" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$Wna" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$Wnb" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$Wnc" role="2OqNvi">
@@ -811,6 +946,12 @@
                       <node concept="2WthIp" id="3M8YG$a$WzI" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$WzJ" role="2OqNvi">
                         <ref role="2WH_rO" node="3M8YG$a_2a3" resolve="constants" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="5M8g5cT2422" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT2423" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT2424" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1XJL" resolve="annotationFinder" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="3M8YG$a$WzK" role="37wK5m">
@@ -863,6 +1004,12 @@
                         <ref role="2WH_rO" node="3M8YG$a_2a3" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="5M8g5cT2467" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT2468" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT2469" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1XJL" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$XuG" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$XuH" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$XuI" role="2OqNvi">
@@ -898,6 +1045,12 @@
                       <node concept="2WthIp" id="3M8YG$a$XFM" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$XFN" role="2OqNvi">
                         <ref role="2WH_rO" node="3M8YG$a_2a3" resolve="constants" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="5M8g5cT24ag" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT24ah" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT24ai" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1XJL" resolve="annotationFinder" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="3M8YG$a$XFO" role="37wK5m">
@@ -941,6 +1094,12 @@
                       <node concept="2WthIp" id="3M8YG$a$Yg8" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$Yg9" role="2OqNvi">
                         <ref role="2WH_rO" node="3M8YG$a_2a3" resolve="constants" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="5M8g5cT24es" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT24et" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT24eu" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1XJL" resolve="annotationFinder" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="3M8YG$a$Yga" role="37wK5m">
@@ -993,6 +1152,12 @@
                         <ref role="2WH_rO" node="3M8YG$a_2a3" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="5M8g5cT24iL" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT24iM" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT24iN" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1XJL" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$Zg_" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$ZgA" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$ZgB" role="2OqNvi">
@@ -1034,6 +1199,12 @@
                       <node concept="2WthIp" id="3M8YG$a$Zqv" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$Zqw" role="2OqNvi">
                         <ref role="2WH_rO" node="3M8YG$a_2a3" resolve="constants" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="5M8g5cT24ti" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT24tj" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT24tk" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1XJL" resolve="annotationFinder" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="3M8YG$a$Zqx" role="37wK5m">
@@ -1098,6 +1269,39 @@
         <ref role="3uigEE" to="y7p:5JNiskhxHcX" resolve="ILionCoreConstants" />
       </node>
     </node>
+    <node concept="2XrIbr" id="5M8g5cT1YwP" role="1qtyYc">
+      <property role="TrG5h" value="annotationFinder" />
+      <node concept="3uibUv" id="5M8g5cT1YwQ" role="3clF45">
+        <ref role="3uigEE" to="apzt:18UigYQMpCK" resolve="AnnotationFinder" />
+      </node>
+      <node concept="3clFbS" id="5M8g5cT1YwR" role="3clF47">
+        <node concept="3clFbF" id="5M8g5cT1YwS" role="3cqZAp">
+          <node concept="2ShNRf" id="5M8g5cT1YwT" role="3clFbG">
+            <node concept="1pGfFk" id="5M8g5cT1YwU" role="2ShVmc">
+              <ref role="37wK5l" to="apzt:5AGBwuFEKL7" resolve="AnnotationFinder" />
+              <node concept="2OqwBi" id="5M8g5cT1YwV" role="37wK5m">
+                <node concept="2WthIp" id="5M8g5cT1YwW" role="2Oq$k0" />
+                <node concept="2XshWL" id="5M8g5cT1YwX" role="2OqNvi">
+                  <ref role="2WH_rO" node="3M8YG$a$Tp7" resolve="repository" />
+                </node>
+              </node>
+              <node concept="2ShNRf" id="5M8g5cT1YwY" role="37wK5m">
+                <node concept="HV5vD" id="5M8g5cT1YwZ" role="2ShVmc">
+                  <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5M8g5cT1Yx0" role="37wK5m">
+                <node concept="2WthIp" id="5M8g5cT1Yx1" role="2Oq$k0" />
+                <node concept="2XshWL" id="5M8g5cT1Yx2" role="2OqNvi">
+                  <ref role="2WH_rO" node="3M8YG$a$N2g" resolve="constants" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="5M8g5cT1Yx3" role="1B3o_S" />
+    </node>
     <node concept="2XrIbr" id="3M8YG$a$Ni0" role="1qtyYc">
       <property role="TrG5h" value="languages" />
       <node concept="A3Dl8" id="3M8YG$a$NvN" role="3clF45">
@@ -1157,6 +1361,12 @@
                         <ref role="2WH_rO" node="3M8YG$a$N2g" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="5M8g5cT2365" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT2368" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT236a" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$Ov$" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$OvB" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$OvD" role="2OqNvi">
@@ -1194,6 +1404,12 @@
                         <ref role="2WH_rO" node="3M8YG$a$N2g" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="5M8g5cT23cB" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT23cC" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT23cD" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$Ugz" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$UgA" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$UgC" role="2OqNvi">
@@ -1226,6 +1442,12 @@
                       <node concept="2WthIp" id="3M8YG$a$UkU" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$UkV" role="2OqNvi">
                         <ref role="2WH_rO" node="3M8YG$a$N2g" resolve="constants" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="5M8g5cT23iS" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT23iT" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT23iU" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="3M8YG$a$UkW" role="37wK5m">
@@ -1272,6 +1494,12 @@
                         <ref role="2WH_rO" node="3M8YG$a$N2g" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="5M8g5cT23mX" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT23mY" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT23mZ" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$Uxc" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$Uxd" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$Uxe" role="2OqNvi">
@@ -1307,6 +1535,12 @@
                       <node concept="2WthIp" id="3M8YG$a$UD2" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$UD3" role="2OqNvi">
                         <ref role="2WH_rO" node="3M8YG$a$N2g" resolve="constants" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="5M8g5cT23t3" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT23t4" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT23t5" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="3M8YG$a$UD4" role="37wK5m">
@@ -1352,6 +1586,12 @@
                         <ref role="2WH_rO" node="3M8YG$a$N2g" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="5M8g5cT23xd" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT23xe" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT23xf" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$UO4" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$UO5" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$UO6" role="2OqNvi">
@@ -1395,6 +1635,12 @@
                         <ref role="2WH_rO" node="3M8YG$a$N2g" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="5M8g5cT23By" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT23Bz" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT23B$" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$V3M" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$V3N" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$V3O" role="2OqNvi">
@@ -1436,6 +1682,12 @@
                       <node concept="2WthIp" id="3M8YG$a$Vhi" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$Vhj" role="2OqNvi">
                         <ref role="2WH_rO" node="3M8YG$a$N2g" resolve="constants" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="5M8g5cT23FT" role="37wK5m">
+                      <node concept="2WthIp" id="5M8g5cT23FU" role="2Oq$k0" />
+                      <node concept="2XshWL" id="5M8g5cT23FV" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="3M8YG$a$Vhk" role="37wK5m">

--- a/solutions/io.lionweb.mps.converter.test/models/io.lionweb.mps.converter.test.util@tests.mps
+++ b/solutions/io.lionweb.mps.converter.test/models/io.lionweb.mps.converter.test.util@tests.mps
@@ -13,8 +13,9 @@
     <import index="pzsh" ref="r:3aa80522-f200-442e-b2fa-4548c1197635(io.lionweb.mps.converter.TestCoreRefLang.structure)" />
     <import index="h2gc" ref="r:c9b5090c-7263-4642-b8f4-1265e3a15687(library.structure)" />
     <import index="jfqc" ref="r:6e560006-b8bd-4479-9a0e-1c215f48423a(io.lionweb.mps.converter.test.support)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
-    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -30,6 +31,9 @@
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -44,6 +48,15 @@
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
         <child id="1068580123133" name="returnType" index="3clF45" />
         <child id="1068580123135" name="body" index="3clF47" />
@@ -54,6 +67,10 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -298,18 +315,56 @@
         <ref role="3uigEE" to="jfqc:3M8YG$9VNA$" resolve="TestBuiltinsUsage" />
       </node>
       <node concept="3clFbS" id="24j7TNHmbEn" role="3clF47">
+        <node concept="3cpWs8" id="5M8g5cT1ZHU" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cT1ZHV" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="5M8g5cT1Z3g" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="5M8g5cT1ZHW" role="33vP2m">
+              <node concept="1jGwE1" id="5M8g5cT1ZHX" role="2Oq$k0" />
+              <node concept="liA8E" id="5M8g5cT1ZHY" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5M8g5cT1ZQa" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cT1ZQb" role="3cpWs9">
+            <property role="TrG5h" value="constants" />
+            <node concept="3uibUv" id="5M8g5cT1ZM1" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:DUXtGZOlwJ" resolve="LionCoreConstants" />
+            </node>
+            <node concept="2ShNRf" id="5M8g5cT1ZQc" role="33vP2m">
+              <node concept="1pGfFk" id="5M8g5cT1ZQd" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                <node concept="37vLTw" id="5M8g5cT1ZQe" role="37wK5m">
+                  <ref role="3cqZAo" node="5M8g5cT1ZHV" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="24j7TNHmbEF" role="3cqZAp">
           <node concept="2ShNRf" id="24j7TNHmbED" role="3clFbG">
             <node concept="1pGfFk" id="24j7TNHmbTu" role="2ShVmc">
               <ref role="37wK5l" to="jfqc:3M8YG$9VNCH" resolve="TestBuiltinsUsage" />
-              <node concept="2ShNRf" id="24j7TNHmbTF" role="37wK5m">
-                <node concept="1pGfFk" id="24j7TNHmc9w" role="2ShVmc">
-                  <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
-                  <node concept="2OqwBi" id="24j7TNHmclQ" role="37wK5m">
-                    <node concept="1jGwE1" id="24j7TNHmc9P" role="2Oq$k0" />
-                    <node concept="liA8E" id="24j7TNHmcvZ" role="2OqNvi">
-                      <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              <node concept="37vLTw" id="5M8g5cT1ZQf" role="37wK5m">
+                <ref role="3cqZAo" node="5M8g5cT1ZQb" resolve="constants" />
+              </node>
+              <node concept="2ShNRf" id="5M8g5cT20P6" role="37wK5m">
+                <node concept="1pGfFk" id="5M8g5cT219B" role="2ShVmc">
+                  <ref role="37wK5l" to="apzt:5AGBwuFEKL7" resolve="AnnotationFinder" />
+                  <node concept="37vLTw" id="5M8g5cT21h5" role="37wK5m">
+                    <ref role="3cqZAo" node="5M8g5cT1ZHV" resolve="repository" />
+                  </node>
+                  <node concept="2ShNRf" id="5M8g5cT21$h" role="37wK5m">
+                    <node concept="HV5vD" id="5M8g5cT22$z" role="2ShVmc">
+                      <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
                     </node>
+                  </node>
+                  <node concept="37vLTw" id="5M8g5cT22OK" role="37wK5m">
+                    <ref role="3cqZAo" node="5M8g5cT1ZQb" resolve="constants" />
                   </node>
                 </node>
               </node>
@@ -573,18 +628,56 @@
         <ref role="3uigEE" to="jfqc:3M8YG$9VNA$" resolve="TestBuiltinsUsage" />
       </node>
       <node concept="3clFbS" id="4$L4A$sXH28" role="3clF47">
+        <node concept="3cpWs8" id="5M8g5cT2b_B" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cT2b_C" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="5M8g5cT2beM" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="5M8g5cT2b_D" role="33vP2m">
+              <node concept="1jGwE1" id="5M8g5cT2b_E" role="2Oq$k0" />
+              <node concept="liA8E" id="5M8g5cT2b_F" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5M8g5cT2bEE" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cT2bEF" role="3cpWs9">
+            <property role="TrG5h" value="constants" />
+            <node concept="3uibUv" id="5M8g5cT2bCN" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:DUXtGZOlwJ" resolve="LionCoreConstants" />
+            </node>
+            <node concept="2ShNRf" id="5M8g5cT2bEG" role="33vP2m">
+              <node concept="1pGfFk" id="5M8g5cT2bEH" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                <node concept="37vLTw" id="5M8g5cT2bEI" role="37wK5m">
+                  <ref role="3cqZAo" node="5M8g5cT2b_C" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="4$L4A$sXH29" role="3cqZAp">
           <node concept="2ShNRf" id="4$L4A$sXH2a" role="3clFbG">
             <node concept="1pGfFk" id="4$L4A$sXH2b" role="2ShVmc">
               <ref role="37wK5l" to="jfqc:3M8YG$9VNCH" resolve="TestBuiltinsUsage" />
-              <node concept="2ShNRf" id="4$L4A$sXH2c" role="37wK5m">
-                <node concept="1pGfFk" id="4$L4A$sXH2d" role="2ShVmc">
-                  <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
-                  <node concept="2OqwBi" id="4$L4A$sXH2e" role="37wK5m">
-                    <node concept="1jGwE1" id="4$L4A$sXH2f" role="2Oq$k0" />
-                    <node concept="liA8E" id="4$L4A$sXH2g" role="2OqNvi">
-                      <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              <node concept="37vLTw" id="5M8g5cT2bEJ" role="37wK5m">
+                <ref role="3cqZAo" node="5M8g5cT2bEF" resolve="constants" />
+              </node>
+              <node concept="2ShNRf" id="5M8g5cT2bPB" role="37wK5m">
+                <node concept="1pGfFk" id="5M8g5cT2ccV" role="2ShVmc">
+                  <ref role="37wK5l" to="apzt:5AGBwuFEKL7" resolve="AnnotationFinder" />
+                  <node concept="37vLTw" id="5M8g5cT2cBH" role="37wK5m">
+                    <ref role="3cqZAo" node="5M8g5cT2b_C" resolve="repository" />
+                  </node>
+                  <node concept="2ShNRf" id="5M8g5cT2cKv" role="37wK5m">
+                    <node concept="HV5vD" id="5M8g5cT3kR$" role="2ShVmc">
+                      <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
                     </node>
+                  </node>
+                  <node concept="37vLTw" id="5M8g5cT3lre" role="37wK5m">
+                    <ref role="3cqZAo" node="5M8g5cT2bEF" resolve="constants" />
                   </node>
                 </node>
               </node>

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.language2lioncore.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.language2lioncore.mps
@@ -373,7 +373,7 @@
     <node concept="312cEg" id="18UigYQMTew" role="jymVt">
       <property role="TrG5h" value="annotationFinder" />
       <property role="3TUv4t" value="true" />
-      <node concept="3Tm6S6" id="18UigYQMTex" role="1B3o_S" />
+      <node concept="3Tmbuc" id="5M8g5cSKLH7" role="1B3o_S" />
       <node concept="3uibUv" id="18UigYQMTez" role="1tU5fm">
         <ref role="3uigEE" to="apzt:18UigYQMpCK" resolve="AnnotationFinder" />
       </node>
@@ -1773,6 +1773,9 @@
               </node>
               <node concept="37vLTw" id="3M8YG$aA7XW" role="37wK5m">
                 <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+              </node>
+              <node concept="37vLTw" id="5M8g5cSL0j8" role="37wK5m">
+                <ref role="3cqZAo" node="18UigYQMTew" resolve="annotationFinder" />
               </node>
               <node concept="2ShNRf" id="3M8YG$aA7XX" role="37wK5m">
                 <node concept="2HTt$P" id="3M8YG$aA7XY" role="2ShVmc">
@@ -5075,6 +5078,9 @@
               </node>
               <node concept="37vLTw" id="24j7TNHeeJT" role="37wK5m">
                 <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+              </node>
+              <node concept="37vLTw" id="5M8g5cSKRSn" role="37wK5m">
+                <ref role="3cqZAo" node="18UigYQMTew" resolve="annotationFinder" />
               </node>
               <node concept="2ShNRf" id="5M3rB6BoNER" role="37wK5m">
                 <node concept="2HTt$P" id="5M3rB6BoNYC" role="2ShVmc">

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.mps2lioncore.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.mps2lioncore.mps
@@ -1711,6 +1711,9 @@
               <node concept="37vLTw" id="3M8YG$aA7XW" role="37wK5m">
                 <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
               </node>
+              <node concept="37vLTw" id="5M8g5cSLlQs" role="37wK5m">
+                <ref role="3cqZAo" node="18UigYQMTew" resolve="annotationFinder" />
+              </node>
               <node concept="2ShNRf" id="3M8YG$aA7XX" role="37wK5m">
                 <node concept="2HTt$P" id="3M8YG$aA7XY" role="2ShVmc">
                   <node concept="3uibUv" id="3M8YG$aA7XZ" role="2HTBi0">

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.util.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.util.mps
@@ -9,6 +9,7 @@
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
     <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
   </languages>
   <imports>
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
@@ -291,6 +292,11 @@
     <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
       <concept id="4733039728785194814" name="jetbrains.mps.lang.modelapi.structure.NamedNodeReference" flags="ng" index="ZC_QK">
         <reference id="7256306938026143658" name="target" index="2aWVGs" />
+      </concept>
+    </language>
+    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="6332851714983831325" name="jetbrains.mps.baseLanguage.logging.structure.MsgStatement" flags="ng" index="2xdQw9">
+        <child id="5721587534047265374" name="message" index="9lYJi" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
@@ -2735,6 +2741,14 @@
         <ref role="3uigEE" to="y7p:5JNiskhxHcX" resolve="ILionCoreConstants" />
       </node>
     </node>
+    <node concept="312cEg" id="5M8g5cSCOQD" role="jymVt">
+      <property role="TrG5h" value="annotationFinder" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="5M8g5cSCOQE" role="1B3o_S" />
+      <node concept="3uibUv" id="5M8g5cSCOQG" role="1tU5fm">
+        <ref role="3uigEE" node="18UigYQMpCK" resolve="AnnotationFinder" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="24j7TNHl1lP" role="jymVt" />
     <node concept="3clFbW" id="24j7TNHl1J_" role="jymVt">
       <node concept="37vLTG" id="24j7TNHl1JA" role="3clF46">
@@ -2744,6 +2758,15 @@
         </node>
         <node concept="3uibUv" id="5JNiskhBOYC" role="1tU5fm">
           <ref role="3uigEE" to="y7p:5JNiskhxHcX" resolve="ILionCoreConstants" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5M8g5cSCOGJ" role="3clF46">
+        <property role="TrG5h" value="annotationFinder" />
+        <node concept="3uibUv" id="5M8g5cSCOP8" role="1tU5fm">
+          <ref role="3uigEE" node="18UigYQMpCK" resolve="AnnotationFinder" />
+        </node>
+        <node concept="2AHcQZ" id="5M8g5cSCQ3d" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
       <node concept="3cqZAl" id="24j7TNHl1JF" role="3clF45" />
@@ -2759,6 +2782,19 @@
             </node>
             <node concept="37vLTw" id="24j7TNHl1JN" role="37vLTx">
               <ref role="3cqZAo" node="24j7TNHl1JA" resolve="constants" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cSCOQH" role="3cqZAp">
+          <node concept="37vLTI" id="5M8g5cSCOQJ" role="3clFbG">
+            <node concept="2OqwBi" id="5M8g5cSCPHw" role="37vLTJ">
+              <node concept="Xjq3P" id="5M8g5cSCPPK" role="2Oq$k0" />
+              <node concept="2OwXpG" id="5M8g5cSCPHz" role="2OqNvi">
+                <ref role="2Oxat5" node="5M8g5cSCOQD" resolve="annotationFinder" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="5M8g5cSCOQN" role="37vLTx">
+              <ref role="3cqZAo" node="5M8g5cSCOGJ" resolve="annotationFinder" />
             </node>
           </node>
         </node>
@@ -2950,47 +2986,65 @@
         </node>
       </node>
       <node concept="3clFbS" id="24j7TNHlXr6" role="3clF47">
+        <node concept="2xdQw9" id="5M8g5cSY3aB" role="3cqZAp">
+          <node concept="3cpWs3" id="5M8g5cSY5wh" role="9lYJi">
+            <node concept="37vLTw" id="5M8g5cSY6fm" role="3uHU7w">
+              <ref role="3cqZAo" node="24j7TNHlXsl" resolve="abstractConcept" />
+            </node>
+            <node concept="Xl_RD" id="5M8g5cSY3aD" role="3uHU7B">
+              <property role="Xl_RC" value="bla: " />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="3M8YG$9TnVR" role="3cqZAp">
-          <node concept="22lmx$" id="3M8YG$9TtV0" role="3clFbG">
-            <node concept="22lmx$" id="3M8YG$9TrQf" role="3uHU7B">
-              <node concept="22lmx$" id="3M8YG$9Tpyi" role="3uHU7B">
-                <node concept="1rXfSq" id="3M8YG$9TnVP" role="3uHU7B">
-                  <ref role="37wK5l" node="3M8YG$9SVBL" resolve="extendsBuiltins" />
-                  <node concept="37vLTw" id="3M8YG$9ToyQ" role="37wK5m">
-                    <ref role="3cqZAo" node="24j7TNHlXsl" resolve="abstractConcept" />
+          <node concept="22lmx$" id="5M8g5cSDq7h" role="3clFbG">
+            <node concept="22lmx$" id="3M8YG$9TtV0" role="3uHU7B">
+              <node concept="22lmx$" id="3M8YG$9TrQf" role="3uHU7B">
+                <node concept="22lmx$" id="3M8YG$9Tpyi" role="3uHU7B">
+                  <node concept="1rXfSq" id="3M8YG$9TnVP" role="3uHU7B">
+                    <ref role="37wK5l" node="3M8YG$9SVBL" resolve="extendsBuiltins" />
+                    <node concept="37vLTw" id="3M8YG$9ToyQ" role="37wK5m">
+                      <ref role="3cqZAo" node="24j7TNHlXsl" resolve="abstractConcept" />
+                    </node>
+                  </node>
+                  <node concept="1rXfSq" id="3M8YG$9Tqah" role="3uHU7w">
+                    <ref role="37wK5l" node="39$JcGGMh$D" resolve="implementsBuiltinsInterfaces" />
+                    <node concept="37vLTw" id="3M8YG$9TqTP" role="37wK5m">
+                      <ref role="3cqZAo" node="24j7TNHlXsl" resolve="abstractConcept" />
+                    </node>
                   </node>
                 </node>
-                <node concept="1rXfSq" id="3M8YG$9Tqah" role="3uHU7w">
-                  <ref role="37wK5l" node="39$JcGGMh$D" resolve="implementsBuiltinsInterfaces" />
-                  <node concept="37vLTw" id="3M8YG$9TqTP" role="37wK5m">
-                    <ref role="3cqZAo" node="24j7TNHlXsl" resolve="abstractConcept" />
+                <node concept="1rXfSq" id="3M8YG$9Rrgt" role="3uHU7w">
+                  <ref role="37wK5l" node="39$JcGGMkjk" resolve="linksToBuiltins" />
+                  <node concept="1rXfSq" id="3M8YG$9Sc9N" role="37wK5m">
+                    <ref role="37wK5l" node="3M8YG$9S5QR" resolve="filterAttributeContainment" />
+                    <node concept="2OqwBi" id="3M8YG$9Rrgy" role="37wK5m">
+                      <node concept="37vLTw" id="3M8YG$9Rrgz" role="2Oq$k0">
+                        <ref role="3cqZAo" node="24j7TNHlXsl" resolve="abstractConcept" />
+                      </node>
+                      <node concept="liA8E" id="3M8YG$9Rrg$" role="2OqNvi">
+                        <ref role="37wK5l" to="c17a:~SAbstractConcept.getContainmentLinks()" resolve="getContainmentLinks" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
-              <node concept="1rXfSq" id="3M8YG$9Rrgt" role="3uHU7w">
+              <node concept="1rXfSq" id="3M8YG$9RvGT" role="3uHU7w">
                 <ref role="37wK5l" node="39$JcGGMkjk" resolve="linksToBuiltins" />
-                <node concept="1rXfSq" id="3M8YG$9Sc9N" role="37wK5m">
-                  <ref role="37wK5l" node="3M8YG$9S5QR" resolve="filterAttributeContainment" />
-                  <node concept="2OqwBi" id="3M8YG$9Rrgy" role="37wK5m">
-                    <node concept="37vLTw" id="3M8YG$9Rrgz" role="2Oq$k0">
-                      <ref role="3cqZAo" node="24j7TNHlXsl" resolve="abstractConcept" />
-                    </node>
-                    <node concept="liA8E" id="3M8YG$9Rrg$" role="2OqNvi">
-                      <ref role="37wK5l" to="c17a:~SAbstractConcept.getContainmentLinks()" resolve="getContainmentLinks" />
-                    </node>
+                <node concept="2OqwBi" id="3M8YG$9RvGU" role="37wK5m">
+                  <node concept="37vLTw" id="3M8YG$9RvGV" role="2Oq$k0">
+                    <ref role="3cqZAo" node="24j7TNHlXsl" resolve="abstractConcept" />
+                  </node>
+                  <node concept="liA8E" id="3M8YG$9RvGW" role="2OqNvi">
+                    <ref role="37wK5l" to="c17a:~SAbstractConcept.getReferenceLinks()" resolve="getReferenceLinks" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="1rXfSq" id="3M8YG$9RvGT" role="3uHU7w">
-              <ref role="37wK5l" node="39$JcGGMkjk" resolve="linksToBuiltins" />
-              <node concept="2OqwBi" id="3M8YG$9RvGU" role="37wK5m">
-                <node concept="37vLTw" id="3M8YG$9RvGV" role="2Oq$k0">
-                  <ref role="3cqZAo" node="24j7TNHlXsl" resolve="abstractConcept" />
-                </node>
-                <node concept="liA8E" id="3M8YG$9RvGW" role="2OqNvi">
-                  <ref role="37wK5l" to="c17a:~SAbstractConcept.getReferenceLinks()" resolve="getReferenceLinks" />
-                </node>
+            <node concept="1rXfSq" id="5M8g5cSDm3f" role="3uHU7w">
+              <ref role="37wK5l" node="5M8g5cSCLEJ" resolve="annotatesBuiltins" />
+              <node concept="37vLTw" id="5M8g5cSDmLp" role="37wK5m">
+                <ref role="3cqZAo" node="24j7TNHlXsl" resolve="abstractConcept" />
               </node>
             </node>
           </node>
@@ -3351,6 +3405,146 @@
               <ref role="3uigEE" to="c17a:~SAbstractLink" resolve="SAbstractLink" />
             </node>
           </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5M8g5cSCJif" role="jymVt" />
+    <node concept="3clFb_" id="5M8g5cSCLEJ" role="jymVt">
+      <property role="TrG5h" value="annotatesBuiltins" />
+      <node concept="3clFbS" id="5M8g5cSCLEM" role="3clF47">
+        <node concept="3clFbJ" id="5M8g5cSCUbi" role="3cqZAp">
+          <node concept="3clFbS" id="5M8g5cSCUbk" role="3clFbx">
+            <node concept="3cpWs8" id="5M8g5cSD9i2" role="3cqZAp">
+              <node concept="3cpWsn" id="5M8g5cSD9i3" role="3cpWs9">
+                <property role="TrG5h" value="concept" />
+                <node concept="3uibUv" id="5M8g5cSD94M" role="1tU5fm">
+                  <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+                </node>
+                <node concept="10QFUN" id="5M8g5cSD9i4" role="33vP2m">
+                  <node concept="37vLTw" id="5M8g5cSD9i5" role="10QFUP">
+                    <ref role="3cqZAo" node="5M8g5cSCMxE" resolve="abstractConcept" />
+                  </node>
+                  <node concept="3uibUv" id="5M8g5cSD9i6" role="10QFUM">
+                    <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2xdQw9" id="5M8g5cSXADg" role="3cqZAp">
+              <node concept="3cpWs3" id="5M8g5cSXCZe" role="9lYJi">
+                <node concept="37vLTw" id="5M8g5cSXDT7" role="3uHU7w">
+                  <ref role="3cqZAo" node="5M8g5cSD9i3" resolve="concept" />
+                </node>
+                <node concept="Xl_RD" id="5M8g5cSXADi" role="3uHU7B">
+                  <property role="Xl_RC" value="annotations: " />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="5M8g5cSD7Kq" role="3cqZAp">
+              <node concept="3clFbS" id="5M8g5cSD7Ks" role="3clFbx">
+                <node concept="3cpWs6" id="5M8g5cSDccY" role="3cqZAp">
+                  <node concept="2OqwBi" id="5M8g5cSDe6w" role="3cqZAk">
+                    <node concept="2OqwBi" id="5M8g5cSDd1y" role="2Oq$k0">
+                      <node concept="37vLTw" id="5M8g5cSDd1z" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5M8g5cSCOQD" resolve="annotationFinder" />
+                      </node>
+                      <node concept="liA8E" id="5M8g5cSDd1$" role="2OqNvi">
+                        <ref role="37wK5l" node="18UigYQGjAO" resolve="extractAnnotated" />
+                        <node concept="10QFUN" id="5M8g5cSD2OH" role="37wK5m">
+                          <node concept="37vLTw" id="5M8g5cSD2OG" role="10QFUP">
+                            <ref role="3cqZAo" node="5M8g5cSCMxE" resolve="abstractConcept" />
+                          </node>
+                          <node concept="3uibUv" id="5M8g5cSD2OD" role="10QFUM">
+                            <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2HwmR7" id="5M8g5cSDg9e" role="2OqNvi">
+                      <node concept="1bVj0M" id="5M8g5cSDg9g" role="23t8la">
+                        <node concept="3clFbS" id="5M8g5cSDg9h" role="1bW5cS">
+                          <node concept="3cpWs8" id="5M8g5cSX2DF" role="3cqZAp">
+                            <node concept="3cpWsn" id="5M8g5cSX2DG" role="3cpWs9">
+                              <property role="TrG5h" value="inBuiltins" />
+                              <node concept="10P_77" id="5M8g5cSWUGP" role="1tU5fm" />
+                              <node concept="1rXfSq" id="5M8g5cSX2DH" role="33vP2m">
+                                <ref role="37wK5l" node="39$JcGGLJm2" resolve="isInBuiltins" />
+                                <node concept="37vLTw" id="5M8g5cSX2DI" role="37wK5m">
+                                  <ref role="3cqZAo" node="5M8g5cSDg9i" resolve="it" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2xdQw9" id="5M8g5cSX4sR" role="3cqZAp">
+                            <node concept="3cpWs3" id="5M8g5cSXbWG" role="9lYJi">
+                              <node concept="37vLTw" id="5M8g5cSXcQk" role="3uHU7w">
+                                <ref role="3cqZAo" node="5M8g5cSX2DG" resolve="inBuiltins" />
+                              </node>
+                              <node concept="3cpWs3" id="5M8g5cSX9MT" role="3uHU7B">
+                                <node concept="3cpWs3" id="5M8g5cSX86l" role="3uHU7B">
+                                  <node concept="Xl_RD" id="5M8g5cSX4sT" role="3uHU7B">
+                                    <property role="Xl_RC" value="inBuiltins: " />
+                                  </node>
+                                  <node concept="37vLTw" id="5M8g5cSX8YB" role="3uHU7w">
+                                    <ref role="3cqZAo" node="5M8g5cSDg9i" resolve="it" />
+                                  </node>
+                                </node>
+                                <node concept="Xl_RD" id="5M8g5cSXajg" role="3uHU7w">
+                                  <property role="Xl_RC" value=": " />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="5M8g5cSDgVR" role="3cqZAp">
+                            <node concept="37vLTw" id="5M8g5cSX2DJ" role="3clFbG">
+                              <ref role="3cqZAo" node="5M8g5cSX2DG" resolve="inBuiltins" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="5M8g5cSDg9i" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="5M8g5cSDg9j" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5M8g5cSCVNl" role="3clFbw">
+                <node concept="37vLTw" id="5M8g5cSCV05" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5M8g5cSCOQD" resolve="annotationFinder" />
+                </node>
+                <node concept="liA8E" id="5M8g5cSCWvD" role="2OqNvi">
+                  <ref role="37wK5l" node="18UigYQAG0z" resolve="isAnnotation" />
+                  <node concept="37vLTw" id="5M8g5cSD9i7" role="37wK5m">
+                    <ref role="3cqZAo" node="5M8g5cSD9i3" resolve="concept" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2ZW3vV" id="5M8g5cSD1hq" role="3clFbw">
+            <node concept="3uibUv" id="5M8g5cSD2bQ" role="2ZW6by">
+              <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+            </node>
+            <node concept="37vLTw" id="5M8g5cSD0sv" role="2ZW6bz">
+              <ref role="3cqZAo" node="5M8g5cSCMxE" resolve="abstractConcept" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5M8g5cSDjpm" role="3cqZAp">
+          <node concept="3clFbT" id="5M8g5cSDk6$" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="5M8g5cSCKJW" role="1B3o_S" />
+      <node concept="10P_77" id="5M8g5cSCL_s" role="3clF45" />
+      <node concept="37vLTG" id="5M8g5cSCMxE" role="3clF46">
+        <property role="TrG5h" value="abstractConcept" />
+        <node concept="3uibUv" id="5M8g5cSCMxD" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+        </node>
+        <node concept="2AHcQZ" id="5M8g5cSCNm6" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
     </node>
@@ -4550,6 +4744,15 @@
           <ref role="3uigEE" to="y7p:5JNiskhxHcX" resolve="ILionCoreConstants" />
         </node>
       </node>
+      <node concept="37vLTG" id="5M8g5cSDsg6" role="3clF46">
+        <property role="TrG5h" value="annotationFinder" />
+        <node concept="3uibUv" id="5M8g5cSDsg7" role="1tU5fm">
+          <ref role="3uigEE" node="18UigYQMpCK" resolve="AnnotationFinder" />
+        </node>
+        <node concept="2AHcQZ" id="5M8g5cSDsg8" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
       <node concept="37vLTG" id="3M8YG$atAD6" role="3clF46">
         <property role="TrG5h" value="languages" />
         <node concept="A3Dl8" id="3M8YG$atAD7" role="1tU5fm">
@@ -4581,6 +4784,9 @@
                 <ref role="37wK5l" node="24j7TNHl1J_" resolve="BuiltinsUsage" />
                 <node concept="37vLTw" id="3M8YG$atCdf" role="37wK5m">
                   <ref role="3cqZAo" node="3M8YG$atAD3" resolve="constants" />
+                </node>
+                <node concept="37vLTw" id="5M8g5cSDsEI" role="37wK5m">
+                  <ref role="3cqZAo" node="5M8g5cSDsg6" resolve="annotationFinder" />
                 </node>
               </node>
             </node>
@@ -4899,6 +5105,15 @@
           <ref role="3uigEE" to="y7p:5JNiskhxHcX" resolve="ILionCoreConstants" />
         </node>
       </node>
+      <node concept="37vLTG" id="5M8g5cSH8yX" role="3clF46">
+        <property role="TrG5h" value="annotationFinder" />
+        <node concept="3uibUv" id="5M8g5cSH8yY" role="1tU5fm">
+          <ref role="3uigEE" node="18UigYQMpCK" resolve="AnnotationFinder" />
+        </node>
+        <node concept="2AHcQZ" id="5M8g5cSH8yZ" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
       <node concept="37vLTG" id="3M8YG$a_Ie3" role="3clF46">
         <property role="TrG5h" value="languages" />
         <node concept="A3Dl8" id="3M8YG$a_Ie4" role="1tU5fm">
@@ -4917,6 +5132,9 @@
               </node>
               <node concept="37vLTw" id="3M8YG$a_Qgc" role="37wK5m">
                 <ref role="3cqZAo" node="3M8YG$a_Ie0" resolve="constants" />
+              </node>
+              <node concept="37vLTw" id="5M8g5cSH8FC" role="37wK5m">
+                <ref role="3cqZAo" node="5M8g5cSH8yX" resolve="annotationFinder" />
               </node>
               <node concept="37vLTw" id="3M8YG$a_Vda" role="37wK5m">
                 <ref role="3cqZAo" node="3M8YG$a_Ie3" resolve="languages" />
@@ -5010,6 +5228,15 @@
           <ref role="3uigEE" to="y7p:5JNiskhxHcX" resolve="ILionCoreConstants" />
         </node>
       </node>
+      <node concept="37vLTG" id="5M8g5cSDvnM" role="3clF46">
+        <property role="TrG5h" value="annotationFinder" />
+        <node concept="3uibUv" id="5M8g5cSDvnN" role="1tU5fm">
+          <ref role="3uigEE" node="18UigYQMpCK" resolve="AnnotationFinder" />
+        </node>
+        <node concept="2AHcQZ" id="5M8g5cSDvnO" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
       <node concept="37vLTG" id="3M8YG$atGOT" role="3clF46">
         <property role="TrG5h" value="languages" />
         <node concept="A3Dl8" id="3M8YG$atGOU" role="1tU5fm">
@@ -5025,6 +5252,9 @@
           <ref role="37wK5l" node="3M8YG$atACu" resolve="ALanguageDependsOnFinder" />
           <node concept="37vLTw" id="3M8YG$atGPf" role="37wK5m">
             <ref role="3cqZAo" node="3M8YG$atGOQ" resolve="constants" />
+          </node>
+          <node concept="37vLTw" id="5M8g5cSDvyj" role="37wK5m">
+            <ref role="3cqZAo" node="5M8g5cSDvnM" resolve="annotationFinder" />
           </node>
           <node concept="37vLTw" id="3M8YG$atGPg" role="37wK5m">
             <ref role="3cqZAo" node="3M8YG$atGOT" resolve="languages" />
@@ -5176,6 +5406,15 @@
           <ref role="3uigEE" to="y7p:5JNiskhxHcX" resolve="ILionCoreConstants" />
         </node>
       </node>
+      <node concept="37vLTG" id="5M8g5cSDuyq" role="3clF46">
+        <property role="TrG5h" value="annotationFinder" />
+        <node concept="3uibUv" id="5M8g5cSDuyr" role="1tU5fm">
+          <ref role="3uigEE" node="18UigYQMpCK" resolve="AnnotationFinder" />
+        </node>
+        <node concept="2AHcQZ" id="5M8g5cSDuys" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
       <node concept="37vLTG" id="3M8YG$atZlI" role="3clF46">
         <property role="TrG5h" value="languages" />
         <node concept="A3Dl8" id="3M8YG$atZlJ" role="1tU5fm">
@@ -5191,6 +5430,9 @@
           <ref role="37wK5l" node="3M8YG$atACu" resolve="ALanguageDependsOnFinder" />
           <node concept="37vLTw" id="3M8YG$atZm4" role="37wK5m">
             <ref role="3cqZAo" node="3M8YG$atZlF" resolve="constants" />
+          </node>
+          <node concept="37vLTw" id="5M8g5cSDuGu" role="37wK5m">
+            <ref role="3cqZAo" node="5M8g5cSDuyq" resolve="annotationFinder" />
           </node>
           <node concept="37vLTw" id="3M8YG$atZm5" role="37wK5m">
             <ref role="3cqZAo" node="3M8YG$atZlI" resolve="languages" />
@@ -5404,6 +5646,15 @@
           <ref role="3uigEE" to="y7p:5JNiskhxHcX" resolve="ILionCoreConstants" />
         </node>
       </node>
+      <node concept="37vLTG" id="5M8g5cSDwjc" role="3clF46">
+        <property role="TrG5h" value="annotationFinder" />
+        <node concept="3uibUv" id="5M8g5cSDwjd" role="1tU5fm">
+          <ref role="3uigEE" node="18UigYQMpCK" resolve="AnnotationFinder" />
+        </node>
+        <node concept="2AHcQZ" id="5M8g5cSDwje" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
       <node concept="37vLTG" id="3M8YG$aufzF" role="3clF46">
         <property role="TrG5h" value="languages" />
         <node concept="A3Dl8" id="3M8YG$aufzG" role="1tU5fm">
@@ -5419,6 +5670,9 @@
           <ref role="37wK5l" node="3M8YG$atACu" resolve="ALanguageDependsOnFinder" />
           <node concept="37vLTw" id="3M8YG$auf$1" role="37wK5m">
             <ref role="3cqZAo" node="3M8YG$aufzC" resolve="constants" />
+          </node>
+          <node concept="37vLTw" id="5M8g5cSDwrr" role="37wK5m">
+            <ref role="3cqZAo" node="5M8g5cSDwjc" resolve="annotationFinder" />
           </node>
           <node concept="37vLTw" id="3M8YG$auf$2" role="37wK5m">
             <ref role="3cqZAo" node="3M8YG$aufzF" resolve="languages" />
@@ -5564,6 +5818,15 @@
           <ref role="3uigEE" to="y7p:5JNiskhxHcX" resolve="ILionCoreConstants" />
         </node>
       </node>
+      <node concept="37vLTG" id="5M8g5cSDvMo" role="3clF46">
+        <property role="TrG5h" value="annotationFinder" />
+        <node concept="3uibUv" id="5M8g5cSDvMp" role="1tU5fm">
+          <ref role="3uigEE" node="18UigYQMpCK" resolve="AnnotationFinder" />
+        </node>
+        <node concept="2AHcQZ" id="5M8g5cSDvMq" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
       <node concept="37vLTG" id="3M8YG$aumwd" role="3clF46">
         <property role="TrG5h" value="languages" />
         <node concept="A3Dl8" id="3M8YG$aumwe" role="1tU5fm">
@@ -5579,6 +5842,9 @@
           <ref role="37wK5l" node="3M8YG$atACu" resolve="ALanguageDependsOnFinder" />
           <node concept="37vLTw" id="3M8YG$aumwz" role="37wK5m">
             <ref role="3cqZAo" node="3M8YG$aumwa" resolve="constants" />
+          </node>
+          <node concept="37vLTw" id="5M8g5cSDvYh" role="37wK5m">
+            <ref role="3cqZAo" node="5M8g5cSDvMo" resolve="annotationFinder" />
           </node>
           <node concept="37vLTw" id="3M8YG$aumw$" role="37wK5m">
             <ref role="3cqZAo" node="3M8YG$aumwd" resolve="languages" />
@@ -5767,6 +6033,14 @@
         <ref role="3uigEE" to="y7p:5JNiskhxHcX" resolve="ILionCoreConstants" />
       </node>
     </node>
+    <node concept="312cEg" id="5M8g5cSHanz" role="jymVt">
+      <property role="TrG5h" value="annotationFinder" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="5M8g5cSHan$" role="1B3o_S" />
+      <node concept="3uibUv" id="5M8g5cSHan_" role="1tU5fm">
+        <ref role="3uigEE" node="18UigYQMpCK" resolve="AnnotationFinder" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="3M8YG$avedw" role="jymVt" />
     <node concept="3Tm1VV" id="3M8YG$auzHK" role="1B3o_S" />
     <node concept="3uibUv" id="3M8YG$auAk_" role="1zkMxy">
@@ -5780,6 +6054,15 @@
         </node>
         <node concept="3uibUv" id="5JNiskhBUfe" role="1tU5fm">
           <ref role="3uigEE" to="y7p:5JNiskhxHcX" resolve="ILionCoreConstants" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5M8g5cSHa58" role="3clF46">
+        <property role="TrG5h" value="annotationFinder" />
+        <node concept="3uibUv" id="5M8g5cSHa59" role="1tU5fm">
+          <ref role="3uigEE" node="18UigYQMpCK" resolve="AnnotationFinder" />
+        </node>
+        <node concept="2AHcQZ" id="5M8g5cSHa5a" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
       <node concept="37vLTG" id="3M8YG$auzMh" role="3clF46">
@@ -5798,6 +6081,9 @@
           <node concept="37vLTw" id="3M8YG$auzMB" role="37wK5m">
             <ref role="3cqZAo" node="3M8YG$auzMe" resolve="constants" />
           </node>
+          <node concept="37vLTw" id="5M8g5cSHaj3" role="37wK5m">
+            <ref role="3cqZAo" node="5M8g5cSHa58" resolve="annotationFinder" />
+          </node>
           <node concept="37vLTw" id="3M8YG$auzMC" role="37wK5m">
             <ref role="3cqZAo" node="3M8YG$auzMh" resolve="languages" />
           </node>
@@ -5811,6 +6097,19 @@
               <node concept="Xjq3P" id="3M8YG$avi_$" role="2Oq$k0" />
               <node concept="2OwXpG" id="3M8YG$avj37" role="2OqNvi">
                 <ref role="2Oxat5" node="3M8YG$avgGl" resolve="constants" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cSHcCD" role="3cqZAp">
+          <node concept="37vLTI" id="5M8g5cSHdmg" role="3clFbG">
+            <node concept="37vLTw" id="5M8g5cSHdtY" role="37vLTx">
+              <ref role="3cqZAo" node="5M8g5cSHa58" resolve="annotationFinder" />
+            </node>
+            <node concept="2OqwBi" id="5M8g5cSHcPb" role="37vLTJ">
+              <node concept="Xjq3P" id="5M8g5cSHcCB" role="2Oq$k0" />
+              <node concept="2OwXpG" id="5M8g5cSHd9p" role="2OqNvi">
+                <ref role="2Oxat5" node="5M8g5cSHanz" resolve="annotationFinder" />
               </node>
             </node>
           </node>
@@ -5879,6 +6178,9 @@
                       <ref role="37wK5l" node="3M8YG$atZlE" resolve="DeclaredDependenciesDependsOnFinder" />
                       <node concept="37vLTw" id="3M8YG$avjpX" role="37wK5m">
                         <ref role="3cqZAo" node="3M8YG$avgGl" resolve="constants" />
+                      </node>
+                      <node concept="37vLTw" id="5M8g5cSHfI_" role="37wK5m">
+                        <ref role="3cqZAo" node="5M8g5cSHanz" resolve="annotationFinder" />
                       </node>
                       <node concept="37vLTw" id="3M8YG$avn2_" role="37wK5m">
                         <ref role="3cqZAo" node="3M8YG$atA3V" resolve="languages" />

--- a/solutions/io.lionweb.mps.json.test.support/models/io.lionweb.mps.json.test.support.mps
+++ b/solutions/io.lionweb.mps.json.test.support/models/io.lionweb.mps.json.test.support.mps
@@ -64,6 +64,9 @@
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -792,6 +795,11 @@
                     <node concept="2YIFZM" id="5hsSXrmDeQ3" role="37wK5m">
                       <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                       <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                    </node>
+                    <node concept="2ShNRf" id="7weWCFlyI7w" role="37wK5m">
+                      <node concept="HV5vD" id="7weWCFlyJjA" role="2ShVmc">
+                        <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -2403,6 +2411,11 @@
                   <node concept="2YIFZM" id="3FWZcLVUO03" role="37wK5m">
                     <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                     <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                  </node>
+                  <node concept="2ShNRf" id="7weWCFlz02_" role="37wK5m">
+                    <node concept="HV5vD" id="7weWCFlz02A" role="2ShVmc">
+                      <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                    </node>
                   </node>
                 </node>
               </node>

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.dependencies@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.dependencies@tests.mps
@@ -65,6 +65,9 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
@@ -544,6 +547,29 @@
         </node>
       </node>
     </node>
+    <node concept="1LZb2c" id="5M8g5cT6HVk" role="1SL9yI">
+      <property role="TrG5h" value="pluginStandaloneAnnotated" />
+      <node concept="3cqZAl" id="5M8g5cT6HVl" role="3clF45" />
+      <node concept="3clFbS" id="5M8g5cT6HVm" role="3clF47">
+        <node concept="3clFbF" id="5M8g5cT6HVn" role="3cqZAp">
+          <node concept="2OqwBi" id="5M8g5cT6HVo" role="3clFbG">
+            <node concept="2WthIp" id="5M8g5cT6HVp" role="2Oq$k0" />
+            <node concept="2XshWL" id="5M8g5cT6HVq" role="2OqNvi">
+              <ref role="2WH_rO" node="5M8g5cT6G2T" resolve="exportAnnotated" />
+              <node concept="pHN19" id="5M8g5cT6HVr" role="2XxRq1">
+                <node concept="2V$Bhx" id="5M8g5cT6HVs" role="2V$M_3">
+                  <property role="2V$B1T" value="ef7bf5ac-d06c-4342-b11d-e42104eb9343" />
+                  <property role="2V$B1Q" value="jetbrains.mps.lang.plugin.standalone" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="5M8g5cT6HVt" role="2XxRq1">
+                <property role="Xl_RC" value="TestDeps-PluginStandalone-annotated.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="1LZb2c" id="7dKo5gqksSc" role="1SL9yI">
       <property role="TrG5h" value="avoidMultipleConcepts" />
       <node concept="3cqZAl" id="7dKo5gqksSd" role="3clF45" />
@@ -604,6 +630,140 @@
         </node>
       </node>
       <node concept="3Tm6S6" id="5ocQ9W1x$W0" role="1B3o_S" />
+    </node>
+    <node concept="2XrIbr" id="5M8g5cT6G2T" role="1qtyYc">
+      <property role="TrG5h" value="exportAnnotated" />
+      <node concept="37vLTG" id="5M8g5cT6G2U" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="3uibUv" id="5M8g5cT6G2V" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5M8g5cT6G2W" role="3clF46">
+        <property role="TrG5h" value="fileName" />
+        <node concept="17QB3L" id="5M8g5cT6G2X" role="1tU5fm" />
+      </node>
+      <node concept="3cqZAl" id="5M8g5cT6G2Y" role="3clF45" />
+      <node concept="3clFbS" id="5M8g5cT6G2Z" role="3clF47">
+        <node concept="3cpWs8" id="5M8g5cT6Gcq" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cT6Gcn" role="3cpWs9">
+            <property role="TrG5h" value="languages" />
+            <node concept="A3Dl8" id="5M8g5cT6Gco" role="1tU5fm">
+              <node concept="3uibUv" id="5M8g5cT6Gcp" role="A3Ik2">
+                <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="5M8g5cT6G34" role="33vP2m">
+              <node concept="2HTt$P" id="5M8g5cT6G35" role="2ShVmc">
+                <node concept="3uibUv" id="5M8g5cT6G36" role="2HTBi0">
+                  <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+                </node>
+                <node concept="37vLTw" id="5M8g5cT6G37" role="2HTEbv">
+                  <ref role="3cqZAo" node="5M8g5cT6G2U" resolve="language" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5M8g5cT6GbR" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cT6GbS" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="5M8g5cT6GbT" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="5M8g5cT6GbU" role="33vP2m">
+              <node concept="1jGwE1" id="5M8g5cT6GbV" role="2Oq$k0" />
+              <node concept="liA8E" id="5M8g5cT6GbW" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5M8g5cT6GbX" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cT6GbY" role="3cpWs9">
+            <property role="TrG5h" value="converter" />
+            <node concept="3uibUv" id="5M8g5cT6GbZ" role="1tU5fm">
+              <ref role="3uigEE" to="6peh:24j7TNH1_mG" resolve="M2ToJson" />
+            </node>
+            <node concept="2ShNRf" id="5M8g5cT6Gc0" role="33vP2m">
+              <node concept="1pGfFk" id="5M8g5cT6Gc1" role="2ShVmc">
+                <ref role="37wK5l" to="6peh:24j7TNH1A2A" resolve="M2ToJson" />
+                <node concept="37vLTw" id="5M8g5cT6Gc2" role="37wK5m">
+                  <ref role="3cqZAo" node="5M8g5cT6GbS" resolve="repository" />
+                </node>
+                <node concept="37vLTw" id="5M8g5cT6Gcs" role="37wK5m">
+                  <ref role="3cqZAo" node="5M8g5cT6Gcn" resolve="languages" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cT6GY0" role="3cqZAp">
+          <node concept="2OqwBi" id="5M8g5cT6Hfr" role="3clFbG">
+            <node concept="37vLTw" id="5M8g5cT6GXY" role="2Oq$k0">
+              <ref role="3cqZAo" node="5M8g5cT6GbY" resolve="converter" />
+            </node>
+            <node concept="liA8E" id="5M8g5cT6H$Q" role="2OqNvi">
+              <ref role="37wK5l" to="6peh:5M8g5cT5Ngm" resolve="setExportDescriptionAnnotations" />
+              <node concept="3clFbT" id="5M8g5cT6HJn" role="37wK5m">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5M8g5cT6Gc4" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cT6Gc5" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="A3Dl8" id="5M8g5cT6Gc6" role="1tU5fm">
+              <node concept="3uibUv" id="5M8g5cT6Gc7" role="A3Ik2">
+                <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="5M8g5cT6Gc8" role="33vP2m">
+              <node concept="37vLTw" id="5M8g5cT6Gc9" role="2Oq$k0">
+                <ref role="3cqZAo" node="5M8g5cT6GbY" resolve="converter" />
+              </node>
+              <node concept="liA8E" id="5M8g5cT6Gca" role="2OqNvi">
+                <ref role="37wK5l" to="6peh:24j7TNH1Bia" resolve="convert" />
+                <node concept="Rm8GO" id="5M8g5cT6Gcb" role="37wK5m">
+                  <ref role="Rm8GQ" to="6peh:utjSYFI7F7" resolve="fineGrainedClosure" />
+                  <ref role="1Px2BO" to="6peh:24j7TNH1AVU" resolve="M2ToJson.Scope" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5M8g5cT6Gcc" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cT6Gcd" role="3cpWs9">
+            <property role="TrG5h" value="comparer" />
+            <node concept="3uibUv" id="5M8g5cT6Gce" role="1tU5fm">
+              <ref role="3uigEE" to="kte7:24j7TNH2adn" resolve="M2JsonComparer" />
+            </node>
+            <node concept="2ShNRf" id="5M8g5cT6Gcf" role="33vP2m">
+              <node concept="1pGfFk" id="5M8g5cT6Gcg" role="2ShVmc">
+                <ref role="37wK5l" to="kte7:24j7TNH2adB" resolve="M2JsonComparer" />
+                <node concept="37vLTw" id="5M8g5cT6Gch" role="37wK5m">
+                  <ref role="3cqZAo" node="5M8g5cT6G2W" resolve="fileName" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cT6Gci" role="3cqZAp">
+          <node concept="2OqwBi" id="5M8g5cT6Gcj" role="3clFbG">
+            <node concept="37vLTw" id="5M8g5cT6Gck" role="2Oq$k0">
+              <ref role="3cqZAo" node="5M8g5cT6Gcd" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="5M8g5cT6Gcl" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:5TNjoy24N5P" resolve="assertSortedEquals" />
+              <node concept="37vLTw" id="5M8g5cT6Gcm" role="37wK5m">
+                <ref role="3cqZAo" node="5M8g5cT6Gc5" resolve="result" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="5M8g5cT6G39" role="1B3o_S" />
     </node>
     <node concept="2XrIbr" id="4Yo3buYIfVq" role="1qtyYc">
       <property role="TrG5h" value="export" />

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2lioncore@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2lioncore@tests.mps
@@ -54,6 +54,9 @@
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -287,6 +290,11 @@
                           <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                           <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
                         </node>
+                        <node concept="2ShNRf" id="7weWCFlyI7w" role="37wK5m">
+                          <node concept="HV5vD" id="7weWCFlyJjA" role="2ShVmc">
+                            <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -349,6 +357,11 @@
                         <node concept="2YIFZM" id="5ocQ9W1xKKO" role="37wK5m">
                           <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                           <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                        </node>
+                        <node concept="2ShNRf" id="7weWCFlyWof" role="37wK5m">
+                          <node concept="HV5vD" id="7weWCFlyWog" role="2ShVmc">
+                            <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -523,6 +536,11 @@
                       <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
                       <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                     </node>
+                    <node concept="2ShNRf" id="7weWCFlyWVP" role="37wK5m">
+                      <node concept="HV5vD" id="7weWCFlyWVQ" role="2ShVmc">
+                        <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                      </node>
+                    </node>
                   </node>
                 </node>
                 <node concept="2ShNRf" id="1xqd6pt3WZ0" role="37wK5m">
@@ -692,6 +710,11 @@
                     <node concept="2YIFZM" id="6_BZUoIhBEz" role="37wK5m">
                       <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
                       <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
+                    </node>
+                    <node concept="2ShNRf" id="7weWCFlyXdF" role="37wK5m">
+                      <node concept="HV5vD" id="7weWCFlyXdG" role="2ShVmc">
+                        <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                      </node>
                     </node>
                   </node>
                 </node>

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2slanguage@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2slanguage@tests.mps
@@ -36,6 +36,9 @@
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -167,6 +170,11 @@
         <child id="1235573175711" name="elementType" index="2HTBi0" />
         <child id="1235573187520" name="singletonValue" index="2HTEbv" />
       </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
         <child id="1197683466920" name="keyType" index="3rvQeY" />
@@ -474,6 +482,117 @@
         </node>
       </node>
     </node>
+    <node concept="1LZb2c" id="7weWCFllF4f" role="1SL9yI">
+      <property role="TrG5h" value="MpsSpecific" />
+      <node concept="3cqZAl" id="7weWCFllF4g" role="3clF45" />
+      <node concept="3clFbS" id="7weWCFllF4h" role="3clF47">
+        <node concept="3cpWs8" id="7weWCFllHp6" role="3cqZAp">
+          <node concept="3cpWsn" id="7weWCFllHp7" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="7weWCFllHp8" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="7weWCFllHp9" role="33vP2m">
+              <node concept="1jGwE1" id="7weWCFllHpa" role="2Oq$k0" />
+              <node concept="liA8E" id="7weWCFllHpb" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7weWCFllHpc" role="3cqZAp">
+          <node concept="3cpWsn" id="7weWCFllHpd" role="3cpWs9">
+            <property role="TrG5h" value="converter" />
+            <node concept="3uibUv" id="7weWCFllHpe" role="1tU5fm">
+              <ref role="3uigEE" to="6peh:24j7TNH1_mG" resolve="M2ToJson" />
+            </node>
+            <node concept="2ShNRf" id="7weWCFllHpf" role="33vP2m">
+              <node concept="1pGfFk" id="7weWCFllHpg" role="2ShVmc">
+                <ref role="37wK5l" to="6peh:24j7TNH1A2A" resolve="M2ToJson" />
+                <node concept="37vLTw" id="7weWCFllHph" role="37wK5m">
+                  <ref role="3cqZAo" node="7weWCFllHp7" resolve="repository" />
+                </node>
+                <node concept="2ShNRf" id="7weWCFllI2x" role="37wK5m">
+                  <node concept="Tc6Ow" id="7weWCFllIoP" role="2ShVmc">
+                    <node concept="pHN19" id="7weWCFllF4m" role="HW$Y0">
+                      <node concept="2V$Bhx" id="7weWCFllF8g" role="2V$M_3">
+                        <property role="2V$B1T" value="e92f782f-6faf-41c2-bf76-2b1a350c0516" />
+                        <property role="2V$B1Q" value="io.lionweb.mps.specific" />
+                      </node>
+                    </node>
+                    <node concept="3uibUv" id="7weWCFllJOM" role="HW$YZ">
+                      <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7weWCFllHpm" role="3cqZAp">
+          <node concept="3cpWsn" id="7weWCFllHpn" role="3cpWs9">
+            <property role="TrG5h" value="languages" />
+            <node concept="A3Dl8" id="7weWCFllHpo" role="1tU5fm">
+              <node concept="3uibUv" id="7weWCFllHpp" role="A3Ik2">
+                <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7weWCFllHpq" role="33vP2m">
+              <node concept="37vLTw" id="7weWCFllHpr" role="2Oq$k0">
+                <ref role="3cqZAo" node="7weWCFllHpd" resolve="converter" />
+              </node>
+              <node concept="liA8E" id="7weWCFllHps" role="2OqNvi">
+                <ref role="37wK5l" to="6peh:24j7TNH1Bia" resolve="convert" />
+                <node concept="Rm8GO" id="7weWCFlm0Pe" role="37wK5m">
+                  <ref role="Rm8GQ" to="6peh:utjSYFI7F7" resolve="fineGrainedClosure" />
+                  <ref role="1Px2BO" to="6peh:24j7TNH1AVU" resolve="M2ToJson.Scope" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7weWCFllHpu" role="3cqZAp">
+          <node concept="2OqwBi" id="7weWCFllHpw" role="3tpDZA">
+            <node concept="37vLTw" id="7weWCFllHpx" role="2Oq$k0">
+              <ref role="3cqZAo" node="7weWCFllHpn" resolve="languages" />
+            </node>
+            <node concept="34oBXx" id="7weWCFllHpy" role="2OqNvi" />
+          </node>
+          <node concept="3cmrfG" id="7weWCFlm2UC" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7weWCFllHpz" role="3cqZAp">
+          <node concept="3cpWsn" id="7weWCFllHp$" role="3cpWs9">
+            <property role="TrG5h" value="comparer" />
+            <node concept="3uibUv" id="7weWCFllHp_" role="1tU5fm">
+              <ref role="3uigEE" to="kte7:24j7TNH2adn" resolve="M2JsonComparer" />
+            </node>
+            <node concept="2ShNRf" id="7weWCFllHpA" role="33vP2m">
+              <node concept="1pGfFk" id="7weWCFllHpB" role="2ShVmc">
+                <ref role="37wK5l" to="kte7:24j7TNH2adB" resolve="M2JsonComparer" />
+                <node concept="Xl_RD" id="7weWCFllJd4" role="37wK5m">
+                  <property role="Xl_RC" value="MpsSpecific-metamodel.json" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7weWCFllHpD" role="3cqZAp">
+          <node concept="2OqwBi" id="7weWCFllHpE" role="3clFbG">
+            <node concept="37vLTw" id="7weWCFllHpF" role="2Oq$k0">
+              <ref role="3cqZAo" node="7weWCFllHp$" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="7weWCFllHpG" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:5TNjoy24N5P" resolve="assertSortedEquals" />
+              <node concept="37vLTw" id="7weWCFllHpH" role="37wK5m">
+                <ref role="3cqZAo" node="7weWCFllHpn" resolve="languages" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1lH9Xt" id="5sACIIszQ7U">
     <property role="TrG5h" value="importJson2SLanguage" />
@@ -537,6 +656,11 @@
                         <node concept="2YIFZM" id="5hsSXrmDeQ3" role="37wK5m">
                           <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                           <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                        </node>
+                        <node concept="2ShNRf" id="7weWCFlyI7w" role="37wK5m">
+                          <node concept="HV5vD" id="7weWCFlyJjA" role="2ShVmc">
+                            <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                          </node>
                         </node>
                       </node>
                     </node>

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2slanguage@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2slanguage@tests.mps
@@ -10,7 +10,7 @@
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
   </languages>
   <imports>
-    <import index="imb3" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.language(io.lionweb.lioncore.java/)" />
+    <import index="imb3" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.language(io.lionweb.lionweb.java/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="6peh" ref="r:677983a1-6578-432d-8175-68c906e0375c(io.lionweb.mps.json)" />
@@ -120,6 +120,9 @@
         <child id="8276990574886367508" name="body" index="1zxBo7" />
         <child id="5351203823916750334" name="resource" index="3J1_TS" />
       </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
     </language>
     <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
@@ -159,6 +162,14 @@
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
@@ -170,11 +181,6 @@
         <child id="1235573175711" name="elementType" index="2HTBi0" />
         <child id="1235573187520" name="singletonValue" index="2HTEbv" />
       </concept>
-      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
-        <child id="1237721435808" name="initValue" index="HW$Y0" />
-        <child id="1237721435807" name="elementType" index="HW$YZ" />
-      </concept>
-      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
         <child id="1197683466920" name="keyType" index="3rvQeY" />
@@ -486,107 +492,70 @@
       <property role="TrG5h" value="MpsSpecific" />
       <node concept="3cqZAl" id="7weWCFllF4g" role="3clF45" />
       <node concept="3clFbS" id="7weWCFllF4h" role="3clF47">
-        <node concept="3cpWs8" id="7weWCFllHp6" role="3cqZAp">
-          <node concept="3cpWsn" id="7weWCFllHp7" role="3cpWs9">
-            <property role="TrG5h" value="repository" />
-            <node concept="3uibUv" id="7weWCFllHp8" role="1tU5fm">
-              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
-            </node>
-            <node concept="2OqwBi" id="7weWCFllHp9" role="33vP2m">
-              <node concept="1jGwE1" id="7weWCFllHpa" role="2Oq$k0" />
-              <node concept="liA8E" id="7weWCFllHpb" role="2OqNvi">
-                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="7weWCFllHpc" role="3cqZAp">
-          <node concept="3cpWsn" id="7weWCFllHpd" role="3cpWs9">
-            <property role="TrG5h" value="converter" />
-            <node concept="3uibUv" id="7weWCFllHpe" role="1tU5fm">
-              <ref role="3uigEE" to="6peh:24j7TNH1_mG" resolve="M2ToJson" />
-            </node>
-            <node concept="2ShNRf" id="7weWCFllHpf" role="33vP2m">
-              <node concept="1pGfFk" id="7weWCFllHpg" role="2ShVmc">
-                <ref role="37wK5l" to="6peh:24j7TNH1A2A" resolve="M2ToJson" />
-                <node concept="37vLTw" id="7weWCFllHph" role="37wK5m">
-                  <ref role="3cqZAo" node="7weWCFllHp7" resolve="repository" />
-                </node>
-                <node concept="2ShNRf" id="7weWCFllI2x" role="37wK5m">
-                  <node concept="Tc6Ow" id="7weWCFllIoP" role="2ShVmc">
-                    <node concept="pHN19" id="7weWCFllF4m" role="HW$Y0">
-                      <node concept="2V$Bhx" id="7weWCFllF8g" role="2V$M_3">
-                        <property role="2V$B1T" value="e92f782f-6faf-41c2-bf76-2b1a350c0516" />
-                        <property role="2V$B1Q" value="io.lionweb.mps.specific" />
-                      </node>
-                    </node>
-                    <node concept="3uibUv" id="7weWCFllJOM" role="HW$YZ">
-                      <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-                    </node>
-                  </node>
+        <node concept="3clFbF" id="5M8g5cT10qX" role="3cqZAp">
+          <node concept="2OqwBi" id="5M8g5cT10w9" role="3clFbG">
+            <node concept="2WthIp" id="5M8g5cT10qV" role="2Oq$k0" />
+            <node concept="2XshWL" id="5M8g5cT10Ak" role="2OqNvi">
+              <ref role="2WH_rO" node="5ocQ9W1x$VD" resolve="export" />
+              <node concept="pHN19" id="7weWCFllF4m" role="2XxRq1">
+                <node concept="2V$Bhx" id="7weWCFllF8g" role="2V$M_3">
+                  <property role="2V$B1T" value="e92f782f-6faf-41c2-bf76-2b1a350c0516" />
+                  <property role="2V$B1Q" value="io.lionweb.mps.specific" />
                 </node>
               </node>
+              <node concept="Xl_RD" id="7weWCFllJd4" role="2XxRq1">
+                <property role="Xl_RC" value="MpsSpecific-metamodel.json" />
+              </node>
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="7weWCFllHpm" role="3cqZAp">
-          <node concept="3cpWsn" id="7weWCFllHpn" role="3cpWs9">
-            <property role="TrG5h" value="languages" />
-            <node concept="A3Dl8" id="7weWCFllHpo" role="1tU5fm">
-              <node concept="3uibUv" id="7weWCFllHpp" role="A3Ik2">
-                <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
-              </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="5M8g5cSCpqW" role="1SL9yI">
+      <property role="TrG5h" value="TestLanguageAnnotation" />
+      <node concept="3cqZAl" id="5M8g5cSCpqX" role="3clF45" />
+      <node concept="3clFbS" id="5M8g5cSCpqY" role="3clF47">
+        <node concept="3SKdUt" id="5M8g5cT1f8G" role="3cqZAp">
+          <node concept="1PaTwC" id="5M8g5cT1f8H" role="1aUNEU">
+            <node concept="3oM_SD" id="5M8g5cT1f96" role="1PaTwD">
+              <property role="3oM_SC" value="TODO:" />
             </node>
-            <node concept="2OqwBi" id="7weWCFllHpq" role="33vP2m">
-              <node concept="37vLTw" id="7weWCFllHpr" role="2Oq$k0">
-                <ref role="3cqZAo" node="7weWCFllHpd" resolve="converter" />
-              </node>
-              <node concept="liA8E" id="7weWCFllHps" role="2OqNvi">
-                <ref role="37wK5l" to="6peh:24j7TNH1Bia" resolve="convert" />
-                <node concept="Rm8GO" id="7weWCFlm0Pe" role="37wK5m">
-                  <ref role="Rm8GQ" to="6peh:utjSYFI7F7" resolve="fineGrainedClosure" />
-                  <ref role="1Px2BO" to="6peh:24j7TNH1AVU" resolve="M2ToJson.Scope" />
+            <node concept="3oM_SD" id="5M8g5cT1f98" role="1PaTwD">
+              <property role="3oM_SC" value="does" />
+            </node>
+            <node concept="3oM_SD" id="5M8g5cT1f9b" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="5M8g5cT1f9f" role="1PaTwD">
+              <property role="3oM_SC" value="yet" />
+            </node>
+            <node concept="3oM_SD" id="5M8g5cT1f9k" role="1PaTwD">
+              <property role="3oM_SC" value="contain" />
+            </node>
+            <node concept="3oM_SD" id="5M8g5cT1f9q" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="5M8g5cT1f9M" role="1PaTwD">
+              <property role="3oM_SC" value="annotation" />
+            </node>
+            <node concept="3oM_SD" id="5M8g5cT1f9U" role="1PaTwD">
+              <property role="3oM_SC" value="instances" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cSCpqZ" role="3cqZAp">
+          <node concept="2OqwBi" id="5M8g5cSCpr0" role="3clFbG">
+            <node concept="2WthIp" id="5M8g5cSCpr1" role="2Oq$k0" />
+            <node concept="2XshWL" id="5M8g5cSCpr2" role="2OqNvi">
+              <ref role="2WH_rO" node="5ocQ9W1x$VD" resolve="export" />
+              <node concept="pHN19" id="5M8g5cSCpr3" role="2XxRq1">
+                <node concept="2V$Bhx" id="5M8g5cSCpEq" role="2V$M_3">
+                  <property role="2V$B1T" value="d8685aa4-94a0-46f9-a14e-818bb12c5c50" />
+                  <property role="2V$B1Q" value="io.lionweb.mps.converter.TestLanguageAnnotation" />
                 </node>
               </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3vlDli" id="7weWCFllHpu" role="3cqZAp">
-          <node concept="2OqwBi" id="7weWCFllHpw" role="3tpDZA">
-            <node concept="37vLTw" id="7weWCFllHpx" role="2Oq$k0">
-              <ref role="3cqZAo" node="7weWCFllHpn" resolve="languages" />
-            </node>
-            <node concept="34oBXx" id="7weWCFllHpy" role="2OqNvi" />
-          </node>
-          <node concept="3cmrfG" id="7weWCFlm2UC" role="3tpDZB">
-            <property role="3cmrfH" value="1" />
-          </node>
-        </node>
-        <node concept="3cpWs8" id="7weWCFllHpz" role="3cqZAp">
-          <node concept="3cpWsn" id="7weWCFllHp$" role="3cpWs9">
-            <property role="TrG5h" value="comparer" />
-            <node concept="3uibUv" id="7weWCFllHp_" role="1tU5fm">
-              <ref role="3uigEE" to="kte7:24j7TNH2adn" resolve="M2JsonComparer" />
-            </node>
-            <node concept="2ShNRf" id="7weWCFllHpA" role="33vP2m">
-              <node concept="1pGfFk" id="7weWCFllHpB" role="2ShVmc">
-                <ref role="37wK5l" to="kte7:24j7TNH2adB" resolve="M2JsonComparer" />
-                <node concept="Xl_RD" id="7weWCFllJd4" role="37wK5m">
-                  <property role="Xl_RC" value="MpsSpecific-metamodel.json" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7weWCFllHpD" role="3cqZAp">
-          <node concept="2OqwBi" id="7weWCFllHpE" role="3clFbG">
-            <node concept="37vLTw" id="7weWCFllHpF" role="2Oq$k0">
-              <ref role="3cqZAo" node="7weWCFllHp$" resolve="comparer" />
-            </node>
-            <node concept="liA8E" id="7weWCFllHpG" role="2OqNvi">
-              <ref role="37wK5l" to="kte7:5TNjoy24N5P" resolve="assertSortedEquals" />
-              <node concept="37vLTw" id="7weWCFllHpH" role="37wK5m">
-                <ref role="3cqZAo" node="7weWCFllHpn" resolve="languages" />
+              <node concept="Xl_RD" id="5M8g5cSCpr5" role="2XxRq1">
+                <property role="Xl_RC" value="TestLanguageAnnotation-metamodel.json" />
               </node>
             </node>
           </node>

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2slanguage@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2slanguage@tests.mps
@@ -88,6 +88,9 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -327,6 +330,148 @@
       </node>
       <node concept="3Tm6S6" id="5ocQ9W1x$W0" role="1B3o_S" />
     </node>
+    <node concept="2XrIbr" id="5M8g5cT6Owk" role="1qtyYc">
+      <property role="TrG5h" value="exportAnnotated" />
+      <node concept="37vLTG" id="5M8g5cT6Owl" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="3uibUv" id="5M8g5cT6Owm" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5M8g5cT6Own" role="3clF46">
+        <property role="TrG5h" value="fileName" />
+        <node concept="17QB3L" id="5M8g5cT6Owo" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="5M8g5cT6Owp" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+      </node>
+      <node concept="3clFbS" id="5M8g5cT6Owq" role="3clF47">
+        <node concept="3cpWs8" id="5M8g5cT6Owr" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cT6Ows" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="5M8g5cT6Owt" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="5M8g5cT6Owu" role="33vP2m">
+              <node concept="1jGwE1" id="5M8g5cT6Owv" role="2Oq$k0" />
+              <node concept="liA8E" id="5M8g5cT6Oww" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5M8g5cT6Owx" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cT6Owy" role="3cpWs9">
+            <property role="TrG5h" value="converter" />
+            <node concept="3uibUv" id="5M8g5cT6Owz" role="1tU5fm">
+              <ref role="3uigEE" to="6peh:24j7TNH1_mG" resolve="M2ToJson" />
+            </node>
+            <node concept="2ShNRf" id="5M8g5cT6Ow$" role="33vP2m">
+              <node concept="1pGfFk" id="5M8g5cT6Ow_" role="2ShVmc">
+                <ref role="37wK5l" to="6peh:24j7TNH1A2A" resolve="M2ToJson" />
+                <node concept="37vLTw" id="5M8g5cT6OwA" role="37wK5m">
+                  <ref role="3cqZAo" node="5M8g5cT6Ows" resolve="repository" />
+                </node>
+                <node concept="2ShNRf" id="5M8g5cT6OwB" role="37wK5m">
+                  <node concept="2HTt$P" id="5M8g5cT6OwC" role="2ShVmc">
+                    <node concept="3uibUv" id="5M8g5cT6OwD" role="2HTBi0">
+                      <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+                    </node>
+                    <node concept="37vLTw" id="5M8g5cT6OwE" role="2HTEbv">
+                      <ref role="3cqZAo" node="5M8g5cT6Owl" resolve="language" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cT6OVR" role="3cqZAp">
+          <node concept="2OqwBi" id="5M8g5cT6P9p" role="3clFbG">
+            <node concept="37vLTw" id="5M8g5cT6OVP" role="2Oq$k0">
+              <ref role="3cqZAo" node="5M8g5cT6Owy" resolve="converter" />
+            </node>
+            <node concept="liA8E" id="5M8g5cT6Pt9" role="2OqNvi">
+              <ref role="37wK5l" to="6peh:5M8g5cT5Ngm" resolve="setExportDescriptionAnnotations" />
+              <node concept="3clFbT" id="5M8g5cT6P_X" role="37wK5m">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5M8g5cT6OwF" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cT6OwG" role="3cpWs9">
+            <property role="TrG5h" value="languages" />
+            <node concept="A3Dl8" id="5M8g5cT6OwH" role="1tU5fm">
+              <node concept="3uibUv" id="5M8g5cT6OwI" role="A3Ik2">
+                <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="5M8g5cT6OwJ" role="33vP2m">
+              <node concept="37vLTw" id="5M8g5cT6OwK" role="2Oq$k0">
+                <ref role="3cqZAo" node="5M8g5cT6Owy" resolve="converter" />
+              </node>
+              <node concept="liA8E" id="5M8g5cT6OwL" role="2OqNvi">
+                <ref role="37wK5l" to="6peh:24j7TNH1Bia" resolve="convert" />
+                <node concept="Rm8GO" id="5M8g5cT6OwM" role="37wK5m">
+                  <ref role="1Px2BO" to="6peh:24j7TNH1AVU" resolve="M2ToJson.Scope" />
+                  <ref role="Rm8GQ" to="6peh:24j7TNH1AVV" resolve="listed" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="5M8g5cT6OwN" role="3cqZAp">
+          <node concept="3cmrfG" id="5M8g5cT6OwO" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+          <node concept="2OqwBi" id="5M8g5cT6OwP" role="3tpDZA">
+            <node concept="37vLTw" id="5M8g5cT6OwQ" role="2Oq$k0">
+              <ref role="3cqZAo" node="5M8g5cT6OwG" resolve="languages" />
+            </node>
+            <node concept="34oBXx" id="5M8g5cT6OwR" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5M8g5cT6OwS" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cT6OwT" role="3cpWs9">
+            <property role="TrG5h" value="comparer" />
+            <node concept="3uibUv" id="5M8g5cT6OwU" role="1tU5fm">
+              <ref role="3uigEE" to="kte7:24j7TNH2adn" resolve="M2JsonComparer" />
+            </node>
+            <node concept="2ShNRf" id="5M8g5cT6OwV" role="33vP2m">
+              <node concept="1pGfFk" id="5M8g5cT6OwW" role="2ShVmc">
+                <ref role="37wK5l" to="kte7:24j7TNH2adB" resolve="M2JsonComparer" />
+                <node concept="37vLTw" id="5M8g5cT6OwX" role="37wK5m">
+                  <ref role="3cqZAo" node="5M8g5cT6Own" resolve="fileName" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cT6OwY" role="3cqZAp">
+          <node concept="2OqwBi" id="5M8g5cT6OwZ" role="3clFbG">
+            <node concept="37vLTw" id="5M8g5cT6Ox0" role="2Oq$k0">
+              <ref role="3cqZAo" node="5M8g5cT6OwT" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="5M8g5cT6Ox1" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:5TNjoy24N5P" resolve="assertSortedEquals" />
+              <node concept="37vLTw" id="5M8g5cT6Ox2" role="37wK5m">
+                <ref role="3cqZAo" node="5M8g5cT6OwG" resolve="languages" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5M8g5cT6Ox3" role="3cqZAp">
+          <node concept="2OqwBi" id="5M8g5cT6Ox4" role="3cqZAk">
+            <node concept="37vLTw" id="5M8g5cT6Ox5" role="2Oq$k0">
+              <ref role="3cqZAo" node="5M8g5cT6OwG" resolve="languages" />
+            </node>
+            <node concept="1uHKPH" id="5M8g5cT6Ox6" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="5M8g5cT6Ox7" role="1B3o_S" />
+    </node>
     <node concept="1LZb2c" id="5ocQ9W1xDgb" role="1SL9yI">
       <property role="TrG5h" value="TestLang" />
       <node concept="3cqZAl" id="5ocQ9W1xDgc" role="3clF45" />
@@ -442,6 +587,29 @@
         </node>
       </node>
     </node>
+    <node concept="1LZb2c" id="5M8g5cT6PKd" role="1SL9yI">
+      <property role="TrG5h" value="TestAnnotationAnnotated" />
+      <node concept="3cqZAl" id="5M8g5cT6PKe" role="3clF45" />
+      <node concept="3clFbS" id="5M8g5cT6PKf" role="3clF47">
+        <node concept="3clFbF" id="5M8g5cT6PKg" role="3cqZAp">
+          <node concept="2OqwBi" id="5M8g5cT6PKh" role="3clFbG">
+            <node concept="2WthIp" id="5M8g5cT6PKi" role="2Oq$k0" />
+            <node concept="2XshWL" id="5M8g5cT6PKj" role="2OqNvi">
+              <ref role="2WH_rO" node="5M8g5cT6Owk" resolve="exportAnnotated" />
+              <node concept="pHN19" id="5M8g5cT6PKk" role="2XxRq1">
+                <node concept="2V$Bhx" id="5M8g5cT6PKl" role="2V$M_3">
+                  <property role="2V$B1T" value="afd6d8a2-5e3b-49d1-ab82-c9cb7dc063bb" />
+                  <property role="2V$B1Q" value="io.lionweb.mps.converter.TestAnnotation" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="5M8g5cT6PKm" role="2XxRq1">
+                <property role="Xl_RC" value="TestAnnotation-metamodel-annotated.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="1LZb2c" id="1xqd6ptRJwf" role="1SL9yI">
       <property role="TrG5h" value="MultiRefLang" />
       <node concept="3cqZAl" id="1xqd6ptRJwg" role="3clF45" />
@@ -488,6 +656,29 @@
         </node>
       </node>
     </node>
+    <node concept="1LZb2c" id="5M8g5cT6Q17" role="1SL9yI">
+      <property role="TrG5h" value="TestAbstractAnnotated" />
+      <node concept="3cqZAl" id="5M8g5cT6Q18" role="3clF45" />
+      <node concept="3clFbS" id="5M8g5cT6Q19" role="3clF47">
+        <node concept="3clFbF" id="5M8g5cT6Q1a" role="3cqZAp">
+          <node concept="2OqwBi" id="5M8g5cT6Q1b" role="3clFbG">
+            <node concept="2WthIp" id="5M8g5cT6Q1c" role="2Oq$k0" />
+            <node concept="2XshWL" id="5M8g5cT6Q1d" role="2OqNvi">
+              <ref role="2WH_rO" node="5M8g5cT6Owk" resolve="exportAnnotated" />
+              <node concept="pHN19" id="5M8g5cT6Q1e" role="2XxRq1">
+                <node concept="2V$Bhx" id="5M8g5cT6Q1f" role="2V$M_3">
+                  <property role="2V$B1T" value="3ecd737b-418b-4a70-a991-f6b83f0e3247" />
+                  <property role="2V$B1Q" value="io.lionweb.mps.converter.TestAbstract" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="5M8g5cT6Q1g" role="2XxRq1">
+                <property role="Xl_RC" value="TestAbstract-metamodel-annotated.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="1LZb2c" id="7weWCFllF4f" role="1SL9yI">
       <property role="TrG5h" value="MpsSpecific" />
       <node concept="3cqZAl" id="7weWCFllF4g" role="3clF45" />
@@ -505,6 +696,29 @@
               </node>
               <node concept="Xl_RD" id="7weWCFllJd4" role="2XxRq1">
                 <property role="Xl_RC" value="MpsSpecific-metamodel.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="5M8g5cT6QiO" role="1SL9yI">
+      <property role="TrG5h" value="MpsSpecificAnnotated" />
+      <node concept="3cqZAl" id="5M8g5cT6QiP" role="3clF45" />
+      <node concept="3clFbS" id="5M8g5cT6QiQ" role="3clF47">
+        <node concept="3clFbF" id="5M8g5cT6QiR" role="3cqZAp">
+          <node concept="2OqwBi" id="5M8g5cT6QiS" role="3clFbG">
+            <node concept="2WthIp" id="5M8g5cT6QiT" role="2Oq$k0" />
+            <node concept="2XshWL" id="5M8g5cT6QiU" role="2OqNvi">
+              <ref role="2WH_rO" node="5M8g5cT6Owk" resolve="exportAnnotated" />
+              <node concept="pHN19" id="5M8g5cT6QiV" role="2XxRq1">
+                <node concept="2V$Bhx" id="5M8g5cT6QiW" role="2V$M_3">
+                  <property role="2V$B1T" value="e92f782f-6faf-41c2-bf76-2b1a350c0516" />
+                  <property role="2V$B1Q" value="io.lionweb.mps.specific" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="5M8g5cT6QiX" role="2XxRq1">
+                <property role="Xl_RC" value="MpsSpecific-metamodel-annotated.json" />
               </node>
             </node>
           </node>

--- a/solutions/io.lionweb.mps.json.test/resources/MpsSpecific-metamodel-annotated.json
+++ b/solutions/io.lionweb.mps.json.test/resources/MpsSpecific-metamodel-annotated.json
@@ -8,6 +8,10 @@
     {
       "key": "LionCore-builtins",
       "version": "2023.1"
+    },
+    {
+      "key": "io-lionweb-mps-specific",
+      "version": "0"
     }
   ],
   "nodes": [
@@ -255,8 +259,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ShortDescription-ConceptDescription"
+      ],
       "parent": "io-lionweb-mps-specific"
+    },
+    {
+      "id": "ShortDescription-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "short description"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ShortDescription"
     },
     {
       "id": "ShortDescription-description",
@@ -381,8 +417,40 @@
           ]
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "VirtualPackage-ConceptDescription"
+      ],
       "parent": "io-lionweb-mps-specific"
+    },
+    {
+      "id": "VirtualPackage-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "virtual package"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "VirtualPackage"
     },
     {
       "id": "io-lionweb-mps-specific",

--- a/solutions/io.lionweb.mps.json.test/resources/MpsSpecific-metamodel.json
+++ b/solutions/io.lionweb.mps.json.test/resources/MpsSpecific-metamodel.json
@@ -1,0 +1,516 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-M3",
+      "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "io-lionweb-mps-specific",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "ConceptDescription",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "ConceptDescription"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ConceptDescription"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "ConceptDescription-conceptAlias",
+            "ConceptDescription-conceptShortDescription"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Classifier",
+              "reference": "-id-Classifier"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "io-lionweb-mps-specific"
+    },
+    {
+      "id": "ConceptDescription-conceptAlias",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "ConceptDescription-conceptAlias"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "conceptAlias"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "ConceptDescription"
+    },
+    {
+      "id": "ConceptDescription-conceptShortDescription",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "ConceptDescription-conceptShortDescription"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "conceptShortDescription"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "ConceptDescription"
+    },
+    {
+      "id": "ShortDescription",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "ShortDescription"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ShortDescription"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "ShortDescription-description"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [
+        "ShortDescription-ConceptDescription"
+      ],
+      "parent": "io-lionweb-mps-specific"
+    },
+    {
+      "id": "ShortDescription-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "short description"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ShortDescription"
+    },
+    {
+      "id": "ShortDescription-description",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "ShortDescription-description"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "description"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "ShortDescription"
+    },
+    {
+      "id": "VirtualPackage",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "VirtualPackage"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "VirtualPackage"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "INamed",
+              "reference": "LionCore-builtins-INamed"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        "VirtualPackage-ConceptDescription"
+      ],
+      "parent": "io-lionweb-mps-specific"
+    },
+    {
+      "id": "VirtualPackage-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "virtual package"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "VirtualPackage"
+    },
+    {
+      "id": "io-lionweb-mps-specific",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Language"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "io-lionweb-mps-specific"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-version"
+          },
+          "value": "0"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "io.lionweb.mps.specific"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-entities"
+          },
+          "children": [
+            "ConceptDescription",
+            "ShortDescription",
+            "VirtualPackage"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-dependsOn"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/TestAbstract-metamodel-annotated.json
+++ b/solutions/io.lionweb.mps.json.test/resources/TestAbstract-metamodel-annotated.json
@@ -8,6 +8,10 @@
     {
       "key": "LionCore-builtins",
       "version": "2023.1"
+    },
+    {
+      "key": "io-lionweb-mps-specific",
+      "version": "0"
     }
   ],
   "nodes": [
@@ -149,8 +153,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MDk-ConceptDescription"
+      ],
       "parent": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3"
+    },
+    {
+      "id": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MDk-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "ConcretePartition"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": "Short Desc ConcretePartition"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MDk"
     },
     {
       "id": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTE",
@@ -226,8 +262,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTE-ConceptDescription"
+      ],
       "parent": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3"
+    },
+    {
+      "id": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTE-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "AbstractConcept"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": "Short Desc AbstractConcept"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTE"
     },
     {
       "id": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTM",
@@ -303,8 +371,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTM-ConceptDescription"
+      ],
       "parent": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3"
+    },
+    {
+      "id": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTM-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "ConcreteConcept"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": "Short Desc ConcreteConcept"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTM"
     },
     {
       "id": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTQ",
@@ -372,8 +472,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTQ-ConceptDescription"
+      ],
       "parent": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3"
+    },
+    {
+      "id": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTQ-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "AbstractAnnotation"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": "Short Desc AbstractAnnotation"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTQ"
     },
     {
       "id": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTc",
@@ -441,8 +573,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTc-ConceptDescription"
+      ],
       "parent": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3"
+    },
+    {
+      "id": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTc-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "ConcreteAnnotation"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": "Short Desc ConcreteAnnotation"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTc"
     },
     {
       "id": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTk",
@@ -489,8 +653,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTk-ConceptDescription"
+      ],
       "parent": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3"
+    },
+    {
+      "id": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTk-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "AbstractInterface"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": "Short Desc AbstractInterface"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjM5MTk"
     },
     {
       "id": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjMzODY",
@@ -566,8 +762,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjMzODY-ConceptDescription"
+      ],
       "parent": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3"
+    },
+    {
+      "id": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjMzODY-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "AbstractPartition"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": "Short Desc AbstractPartition"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "M2VjZDczN2ItNDE4Yi00YTcwLWE5OTEtZjZiODNmMGUzMjQ3LzM1NDYwNTcyNTQyODAxNjMzODY"
     }
   ]
 }

--- a/solutions/io.lionweb.mps.json.test/resources/TestAnnotation-metamodel-annotated.json
+++ b/solutions/io.lionweb.mps.json.test/resources/TestAnnotation-metamodel-annotated.json
@@ -8,6 +8,10 @@
     {
       "key": "LionCore-builtins",
       "version": "2023.1"
+    },
+    {
+      "key": "io-lionweb-mps-specific",
+      "version": "0"
     }
   ],
   "nodes": [
@@ -147,8 +151,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzEzMTM0NDI1NzMxNzc4NDQ2MjI-ConceptDescription"
+      ],
       "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2Ji"
+    },
+    {
+      "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzEzMTM0NDI1NzMxNzc4NDQ2MjI-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "NodeAnnotation"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzEzMTM0NDI1NzMxNzc4NDQ2MjI"
     },
     {
       "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzE4OTg5MjE",
@@ -216,8 +252,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzE4OTg5MjE-ConceptDescription"
+      ],
       "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2Ji"
+    },
+    {
+      "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzE4OTg5MjE-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "DefaultAttributesAnnotation"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzE4OTg5MjE"
     },
     {
       "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA3OTc",
@@ -285,8 +353,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA3OTc-ConceptDescription"
+      ],
       "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2Ji"
+    },
+    {
+      "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA3OTc-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "INamedAnnotation"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA3OTc"
     },
     {
       "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA4MDI",
@@ -410,8 +510,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA4MDM-ConceptDescription"
+      ],
       "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2Ji"
+    },
+    {
+      "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA4MDM-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "MyConcept"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA4MDM"
     },
     {
       "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA4MDQ",
@@ -479,8 +611,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA4MDQ-ConceptDescription"
+      ],
       "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2Ji"
+    },
+    {
+      "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA4MDQ-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "ConceptAnnotation"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA4MDQ"
     },
     {
       "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA4MDk",
@@ -548,8 +712,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA4MDk-ConceptDescription"
+      ],
       "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2Ji"
+    },
+    {
+      "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA4MDk-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "IfaceAnnotation"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA4MDk"
     },
     {
       "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA4MTQ",
@@ -617,8 +813,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA4MTQ-ConceptDescription"
+      ],
       "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2Ji"
+    },
+    {
+      "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA4MTQ-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "AnnotationAnnotation"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzM0Njc0ODA2NzM0NzI3NDA4MTQ"
     },
     {
       "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc0NzQ5MTc",
@@ -691,8 +919,40 @@
           ]
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc0NzQ5MTc-ConceptDescription"
+      ],
       "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2Ji"
+    },
+    {
+      "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc0NzQ5MTc-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "ImplementsAnnotation"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc0NzQ5MTc"
     },
     {
       "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc0NzQ5NDc",
@@ -760,8 +1020,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc0NzQ5NDc-ConceptDescription"
+      ],
       "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2Ji"
+    },
+    {
+      "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc0NzQ5NDc-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "ExtendsAnnotation"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc0NzQ5NDc"
     },
     {
       "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc1NTg5ODk",
@@ -834,8 +1126,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc1NTg5ODk-ConceptDescription"
+      ],
       "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2Ji"
+    },
+    {
+      "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc1NTg5ODk-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "PropertiesAnnotation"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc1NTg5ODk"
     },
     {
       "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc1NTg5ODkvNzg3OTkxOTYzNjYwNzU1OTAxNw",
@@ -1116,8 +1440,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc2MzY0MTU-ConceptDescription"
+      ],
       "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2Ji"
+    },
+    {
+      "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc2MzY0MTU-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "ReferencesAnnotation"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc2MzY0MTU"
     },
     {
       "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc2MzY0MTUvNzg3OTkxOTYzNjYwNzY3MjQ0Mg",
@@ -1430,8 +1786,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc2MzYzNzM-ConceptDescription"
+      ],
       "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2Ji"
+    },
+    {
+      "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc2MzYzNzM-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "ChildrenAnnotation"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc2MzYzNzM"
     },
     {
       "id": "YWZkNmQ4YTItNWUzYi00OWQxLWFiODItYzljYjdkYzA2M2JiLzc4Nzk5MTk2MzY2MDc2MzYzNzMvNzg3OTkxOTYzNjYwNzYzNjQwMQ",

--- a/solutions/io.lionweb.mps.json.test/resources/TestDeps-PluginStandalone-annotated.json
+++ b/solutions/io.lionweb.mps.json.test/resources/TestDeps-PluginStandalone-annotated.json
@@ -8,6 +8,10 @@
     {
       "key": "LionCore-builtins",
       "version": "2023.1"
+    },
+    {
+      "key": "io-lionweb-mps-specific",
+      "version": "0"
     }
   ],
   "nodes": [
@@ -252,8 +256,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA2NzY2NzI1NTU-ConceptDescription"
+      ],
       "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIx"
+    },
+    {
+      "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA2NzY2NzI1NTU-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "before write"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA2NzY2NzI1NTU"
     },
     {
       "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA2NzY4Nzk1MjY",
@@ -329,8 +365,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA2NzY4Nzk1MjY-ConceptDescription"
+      ],
       "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIx"
+    },
+    {
+      "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA2NzY4Nzk1MjY-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "after read"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA2NzY4Nzk1MjY"
     },
     {
       "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA2ODQzODUxODM",
@@ -904,8 +972,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA2ODY4ODI1NTA-ConceptDescription"
+      ],
       "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIx"
+    },
+    {
+      "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA2ODY4ODI1NTA-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "reset"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA2ODY4ODI1NTA"
     },
     {
       "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA2ODY5NjkzNTY",
@@ -981,8 +1081,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA2ODY5NjkzNTY-ConceptDescription"
+      ],
       "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIx"
+    },
+    {
+      "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA2ODY5NjkzNTY-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "commit"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA2ODY5NjkzNTY"
     },
     {
       "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA3NjM1NTAwMDc",
@@ -1058,8 +1190,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA3NjM1NTAwMDc-ConceptDescription"
+      ],
       "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIx"
+    },
+    {
+      "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA3NjM1NTAwMDc-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "isModified"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTA3NjM1NTAwMDc"
     },
     {
       "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTAxNzkxMzQwNjM",
@@ -1149,8 +1313,40 @@
           ]
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTAxNzkxMzQwNjM-ConceptDescription"
+      ],
       "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIx"
+    },
+    {
+      "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTAxNzkxMzQwNjM-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "Preferences Component"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTAxNzkxMzQwNjM"
     },
     {
       "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTAxNzkxMzQwNjMvMTIxMDE3OTgyOTM5OA",
@@ -1578,8 +1774,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTM4ODg2NTM4OTY-ConceptDescription"
+      ],
       "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIx"
+    },
+    {
+      "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTM4ODg2NTM4OTY-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "init"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTM4ODg2NTM4OTY"
     },
     {
       "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTM4ODg2Nzc3MTE",
@@ -1655,8 +1883,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTM4ODg2Nzc3MTE-ConceptDescription"
+      ],
       "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIx"
+    },
+    {
+      "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTM4ODg2Nzc3MTE-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "dispose"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzEyMTM4ODg2Nzc3MTE"
     },
     {
       "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzI0OTg2MjA3MjA3NzA2NjQ1Njc",
@@ -2075,8 +2335,40 @@
           ]
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzY1NDcyMzc4NTA1Njc0NTgyNjg-ConceptDescription"
+      ],
       "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIx"
+    },
+    {
+      "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzY1NDcyMzc4NTA1Njc0NTgyNjg-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "Base Tool"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzY1NDcyMzc4NTA1Njc0NTgyNjg"
     },
     {
       "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIxLzY1NDcyMzc4NTA1Njc0NTgyNjgvMjQ5ODYyMDcyMDc3MDY2NDU3Mg",
@@ -4409,8 +4701,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzM0MTg5NTQ0MTA3MjYzNDQ0MjM-ConceptDescription"
+      ],
       "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQz"
+    },
+    {
+      "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzM0MTg5NTQ0MTA3MjYzNDQ0MjM-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "mpsPlatform"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": "access MPS platform"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzM0MTg5NTQ0MTA3MjYzNDQ0MjM"
     },
     {
       "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg0MA",
@@ -4495,8 +4819,40 @@
           ]
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg0MA-ConceptDescription"
+      ],
       "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQz"
+    },
+    {
+      "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg0MA-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "Application Plugin"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg0MA"
     },
     {
       "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg0MC80ODE5ODM3NzUxMzUxNzg4NDI",
@@ -4752,8 +5108,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg0Ng-ConceptDescription"
+      ],
       "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQz"
+    },
+    {
+      "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg0Ng-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "dispose"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg0Ng"
     },
     {
       "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg1MQ",
@@ -4829,8 +5217,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg1MQ-ConceptDescription"
+      ],
       "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQz"
+    },
+    {
+      "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg1MQ-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "init"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg1MQ"
     },
     {
       "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg1Ng",
@@ -4908,8 +5328,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg1Ng-ConceptDescription"
+      ],
       "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQz"
+    },
+    {
+      "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg1Ng-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "project plugin\u003c\u003e"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg1Ng"
     },
     {
       "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODg1Ni80ODE5ODM3NzUxMzUxNzg4NTg",
@@ -5045,8 +5497,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODgxOQ-ConceptDescription"
+      ],
       "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQz"
+    },
+    {
+      "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODgxOQ-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "dispose"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODgxOQ"
     },
     {
       "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODgyNQ",
@@ -5122,8 +5606,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODgyNQ-ConceptDescription"
+      ],
       "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQz"
+    },
+    {
+      "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODgyNQ-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "init"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODgyNQ"
     },
     {
       "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODgzMQ",
@@ -5201,8 +5717,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODgzMQ-ConceptDescription"
+      ],
       "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQz"
+    },
+    {
+      "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODgzMQ-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "application plugin\u003c\u003e"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODgzMQ"
     },
     {
       "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODgzMS80ODE5ODM3NzUxMzUxNzg4MzM",
@@ -5347,8 +5895,40 @@
           ]
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODgzNA-ConceptDescription"
+      ],
       "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQz"
+    },
+    {
+      "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODgzNA-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "Project Plugin"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODgzNA"
     },
     {
       "id": "ZWY3YmY1YWMtZDA2Yy00MzQyLWIxMWQtZTQyMTA0ZWI5MzQzLzQ4MTk4Mzc3NTEzNTE3ODgzNC80ODE5ODM3NzUxMzUxNzg4MzY",
@@ -6345,8 +6925,40 @@
           ]
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjg0MzE3OTAxODk-ConceptDescription"
+      ],
       "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2"
+    },
+    {
+      "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjg0MzE3OTAxODk-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": "a type"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjg0MzE3OTAxODk"
     },
     {
       "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjg0MzE3OTAxOTE",
@@ -6512,8 +7124,40 @@
           ]
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjg0OTg4ODYyOTI-ConceptDescription"
+      ],
       "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2"
+    },
+    {
+      "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjg0OTg4ODYyOTI-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": "parameter"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjg0OTg4ODYyOTI"
     },
     {
       "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjg1ODAxMjMxMzI",
@@ -7247,8 +7891,40 @@
           ]
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjg1ODAxMjMxNTc-ConceptDescription"
+      ],
       "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2"
+    },
+    {
+      "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjg1ODAxMjMxNTc-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "\u003cstatement\u003e"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjg1ODAxMjMxNTc"
     },
     {
       "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjg1ODAxMjMxNjU",
@@ -7339,8 +8015,40 @@
           ]
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjg1ODAxMjMxNjU-ConceptDescription"
+      ],
       "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2"
+    },
+    {
+      "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjg1ODAxMjMxNjU-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "method"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjg1ODAxMjMxNjU"
     },
     {
       "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjg1ODAxMjMxNjUvMTE3ODYwODY3MDA3Nw",
@@ -7492,8 +8200,40 @@
           ]
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjgzOTA0NjgyMDA-ConceptDescription"
+      ],
       "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2"
+    },
+    {
+      "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjgzOTA0NjgyMDA-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "field"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjgzOTA0NjgyMDA"
     },
     {
       "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNjgzOTA0NjgyMDAvMTI0MDI0OTUzNDYyNQ",
@@ -7701,8 +8441,40 @@
           ]
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNzA0NjIxNTQwMTU-ConceptDescription"
+      ],
       "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2"
+    },
+    {
+      "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNzA0NjIxNTQwMTU-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "static field"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": "static field declaration"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNzA0NjIxNTQwMTU"
     },
     {
       "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzEwNzA0NjIxNTQwMTUvNjQ2ODcxNjI3ODg5OTEyNTc4Ng",
@@ -8469,8 +9241,40 @@
           ]
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzExMDc1MzU5MDQ2NzA-ConceptDescription"
+      ],
       "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2"
+    },
+    {
+      "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzExMDc1MzU5MDQ2NzA-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": "reference to classifier"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzExMDc1MzU5MDQ2NzA"
     },
     {
       "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzExMDc1MzU5MDQ2NzAvMTEwNzUzNTkyNDEzOQ",
@@ -8681,8 +9485,40 @@
           ]
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzExMDc3OTY3MTM3OTY-ConceptDescription"
+      ],
       "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2"
+    },
+    {
+      "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzExMDc3OTY3MTM3OTY-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "interface"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": "Interface declaration"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzExMDc3OTY3MTM3OTY"
     },
     {
       "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzExMDc3OTY3MTM3OTYvMTEwNzc5NzEzODEzNQ",
@@ -9251,8 +10087,40 @@
           ]
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzExMzcwMjE5NDc3MjA-ConceptDescription"
+      ],
       "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2"
+    },
+    {
+      "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzExMzcwMjE5NDc3MjA-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": "embedded block of code"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzExMzcwMjE5NDc3MjA"
     },
     {
       "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzExMzcwMjE5NDc3MjAvMTEzNzAyMjUwNzg1MA",
@@ -9775,8 +10643,40 @@
           "targets": []
         }
       ],
-      "annotations": [],
+      "annotations": [
+        "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzExODgyMDYzMzE5MTY-ConceptDescription"
+      ],
       "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2"
+    },
+    {
+      "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzExODgyMDYzMzE5MTY-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "@interface"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": "Annotation declaration"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzExODgyMDYzMzE5MTY"
     },
     {
       "id": "ZjMwNjFhNTMtOTIyNi00Y2M1LWE0NDMtZjk1MmNlYWY1ODE2LzExODgyMDc4NDA0Mjc",

--- a/solutions/io.lionweb.mps.json.test/resources/TestLanguageAnnotation-metamodel-annotated.json
+++ b/solutions/io.lionweb.mps.json.test/resources/TestLanguageAnnotation-metamodel-annotated.json
@@ -12,7 +12,70 @@
   ],
   "nodes": [
     {
-      "id": "ConceptDescription",
+      "id": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Language"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUw"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-version"
+          },
+          "value": "0"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "io.lionweb.mps.converter.TestLanguageAnnotation"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-entities"
+          },
+          "children": [
+            "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAwODA",
+            "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxODc",
+            "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxOTI",
+            "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxOTc",
+            "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1ODI5NjM",
+            "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1ODI5NjQ"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-dependsOn"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": null
+    },
+    {
+      "id": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAwODA",
       "classifier": {
         "language": "LionCore-M3",
         "version": "2023.1",
@@ -25,7 +88,7 @@
             "version": "2023.1",
             "key": "IKeyed-key"
           },
-          "value": "ConceptDescription"
+          "value": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAwODA"
         },
         {
           "property": {
@@ -33,7 +96,7 @@
             "version": "2023.1",
             "key": "LionCore-builtins-INamed-name"
           },
-          "value": "ConceptDescription"
+          "value": "ClassifierAnnotation"
         }
       ],
       "containments": [
@@ -43,10 +106,7 @@
             "version": "2023.1",
             "key": "Classifier-features"
           },
-          "children": [
-            "ConceptDescription-conceptAlias",
-            "ConceptDescription-conceptShortDescription"
-          ]
+          "children": []
         }
       ],
       "references": [
@@ -81,114 +141,10 @@
         }
       ],
       "annotations": [],
-      "parent": "io-lionweb-mps-specific"
+      "parent": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUw"
     },
     {
-      "id": "ConceptDescription-conceptAlias",
-      "classifier": {
-        "language": "LionCore-M3",
-        "version": "2023.1",
-        "key": "Property"
-      },
-      "properties": [
-        {
-          "property": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Feature-optional"
-          },
-          "value": "true"
-        },
-        {
-          "property": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "IKeyed-key"
-          },
-          "value": "ConceptDescription-conceptAlias"
-        },
-        {
-          "property": {
-            "language": "LionCore-builtins",
-            "version": "2023.1",
-            "key": "LionCore-builtins-INamed-name"
-          },
-          "value": "conceptAlias"
-        }
-      ],
-      "containments": [],
-      "references": [
-        {
-          "reference": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Property-type"
-          },
-          "targets": [
-            {
-              "resolveInfo": "String",
-              "reference": "LionCore-builtins-String"
-            }
-          ]
-        }
-      ],
-      "annotations": [],
-      "parent": "ConceptDescription"
-    },
-    {
-      "id": "ConceptDescription-conceptShortDescription",
-      "classifier": {
-        "language": "LionCore-M3",
-        "version": "2023.1",
-        "key": "Property"
-      },
-      "properties": [
-        {
-          "property": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Feature-optional"
-          },
-          "value": "true"
-        },
-        {
-          "property": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "IKeyed-key"
-          },
-          "value": "ConceptDescription-conceptShortDescription"
-        },
-        {
-          "property": {
-            "language": "LionCore-builtins",
-            "version": "2023.1",
-            "key": "LionCore-builtins-INamed-name"
-          },
-          "value": "conceptShortDescription"
-        }
-      ],
-      "containments": [],
-      "references": [
-        {
-          "reference": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Property-type"
-          },
-          "targets": [
-            {
-              "resolveInfo": "String",
-              "reference": "LionCore-builtins-String"
-            }
-          ]
-        }
-      ],
-      "annotations": [],
-      "parent": "ConceptDescription"
-    },
-    {
-      "id": "ShortDescription",
+      "id": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxODc",
       "classifier": {
         "language": "LionCore-M3",
         "version": "2023.1",
@@ -201,7 +157,7 @@
             "version": "2023.1",
             "key": "IKeyed-key"
           },
-          "value": "ShortDescription"
+          "value": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxODc"
         },
         {
           "property": {
@@ -209,130 +165,7 @@
             "version": "2023.1",
             "key": "LionCore-builtins-INamed-name"
           },
-          "value": "ShortDescription"
-        }
-      ],
-      "containments": [
-        {
-          "containment": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Classifier-features"
-          },
-          "children": [
-            "ShortDescription-description"
-          ]
-        }
-      ],
-      "references": [
-        {
-          "reference": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Annotation-annotates"
-          },
-          "targets": [
-            {
-              "resolveInfo": "Node",
-              "reference": "LionCore-builtins-Node"
-            }
-          ]
-        },
-        {
-          "reference": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Annotation-extends"
-          },
-          "targets": []
-        },
-        {
-          "reference": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Annotation-implements"
-          },
-          "targets": []
-        }
-      ],
-      "annotations": [],
-      "parent": "io-lionweb-mps-specific"
-    },
-    {
-      "id": "ShortDescription-description",
-      "classifier": {
-        "language": "LionCore-M3",
-        "version": "2023.1",
-        "key": "Property"
-      },
-      "properties": [
-        {
-          "property": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Feature-optional"
-          },
-          "value": "true"
-        },
-        {
-          "property": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "IKeyed-key"
-          },
-          "value": "ShortDescription-description"
-        },
-        {
-          "property": {
-            "language": "LionCore-builtins",
-            "version": "2023.1",
-            "key": "LionCore-builtins-INamed-name"
-          },
-          "value": "description"
-        }
-      ],
-      "containments": [],
-      "references": [
-        {
-          "reference": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Property-type"
-          },
-          "targets": [
-            {
-              "resolveInfo": "String",
-              "reference": "LionCore-builtins-String"
-            }
-          ]
-        }
-      ],
-      "annotations": [],
-      "parent": "ShortDescription"
-    },
-    {
-      "id": "VirtualPackage",
-      "classifier": {
-        "language": "LionCore-M3",
-        "version": "2023.1",
-        "key": "Annotation"
-      },
-      "properties": [
-        {
-          "property": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "IKeyed-key"
-          },
-          "value": "VirtualPackage"
-        },
-        {
-          "property": {
-            "language": "LionCore-builtins",
-            "version": "2023.1",
-            "key": "LionCore-builtins-INamed-name"
-          },
-          "value": "VirtualPackage"
+          "value": "ConceptAnnotation"
         }
       ],
       "containments": [
@@ -354,8 +187,8 @@
           },
           "targets": [
             {
-              "resolveInfo": "Node",
-              "reference": "LionCore-builtins-Node"
+              "resolveInfo": "Concept",
+              "reference": "-id-Concept"
             }
           ]
         },
@@ -373,23 +206,18 @@
             "version": "2023.1",
             "key": "Annotation-implements"
           },
-          "targets": [
-            {
-              "resolveInfo": "INamed",
-              "reference": "LionCore-builtins-INamed"
-            }
-          ]
+          "targets": []
         }
       ],
       "annotations": [],
-      "parent": "io-lionweb-mps-specific"
+      "parent": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUw"
     },
     {
-      "id": "io-lionweb-mps-specific",
+      "id": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxOTI",
       "classifier": {
         "language": "LionCore-M3",
         "version": "2023.1",
-        "key": "Language"
+        "key": "Annotation"
       },
       "properties": [
         {
@@ -398,15 +226,7 @@
             "version": "2023.1",
             "key": "IKeyed-key"
           },
-          "value": "io-lionweb-mps-specific"
-        },
-        {
-          "property": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Language-version"
-          },
-          "value": "0"
+          "value": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxOTI"
         },
         {
           "property": {
@@ -414,7 +234,7 @@
             "version": "2023.1",
             "key": "LionCore-builtins-INamed-name"
           },
-          "value": "io.lionweb.mps.specific"
+          "value": "InterfaceAnnotation"
         }
       ],
       "containments": [
@@ -422,13 +242,9 @@
           "containment": {
             "language": "LionCore-M3",
             "version": "2023.1",
-            "key": "Language-entities"
+            "key": "Classifier-features"
           },
-          "children": [
-            "ConceptDescription",
-            "ShortDescription",
-            "VirtualPackage"
-          ]
+          "children": []
         }
       ],
       "references": [
@@ -436,13 +252,228 @@
           "reference": {
             "language": "LionCore-M3",
             "version": "2023.1",
-            "key": "Language-dependsOn"
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Interface",
+              "reference": "-id-Interface"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
           },
           "targets": []
         }
       ],
       "annotations": [],
-      "parent": null
+      "parent": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUw"
+    },
+    {
+      "id": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxOTc",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxOTc"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "AnnotationAnnotation"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Annotation",
+              "reference": "-id-Annotation"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUw"
+    },
+    {
+      "id": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1ODI5NjM",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1ODI5NjM"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "TrialConcept"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUw"
+    },
+    {
+      "id": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1ODI5NjQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1ODI5NjQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "TrialInterface"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUw"
     }
   ]
 }

--- a/solutions/io.lionweb.mps.json.test/resources/TestLanguageAnnotation-metamodel.json
+++ b/solutions/io.lionweb.mps.json.test/resources/TestLanguageAnnotation-metamodel.json
@@ -1,0 +1,479 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-M3",
+      "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Language"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUw"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-version"
+          },
+          "value": "0"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "io.lionweb.mps.converter.TestLanguageAnnotation"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-entities"
+          },
+          "children": [
+            "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAwODA",
+            "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxODc",
+            "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxOTI",
+            "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxOTc",
+            "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1ODI5NjM",
+            "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1ODI5NjQ"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-dependsOn"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": null
+    },
+    {
+      "id": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAwODA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAwODA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ClassifierAnnotation"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Classifier",
+              "reference": "-id-Classifier"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUw"
+    },
+    {
+      "id": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxODc",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxODc"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ConceptAnnotation"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Concept",
+              "reference": "-id-Concept"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUw"
+    },
+    {
+      "id": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxOTI",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxOTI"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "InterfaceAnnotation"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Interface",
+              "reference": "-id-Interface"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUw"
+    },
+    {
+      "id": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxOTc",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1NjAxOTc"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "AnnotationAnnotation"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Annotation",
+              "reference": "-id-Annotation"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUw"
+    },
+    {
+      "id": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1ODI5NjM",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1ODI5NjM"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "TrialConcept"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUw"
+    },
+    {
+      "id": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1ODI5NjQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUwLzY2Njc2NDk5NzQ0OTg1ODI5NjQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "TrialInterface"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "ZDg2ODVhYTQtOTRhMC00NmY5LWExNGUtODE4YmIxMmM1YzUw"
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.language.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.language.mps
@@ -867,6 +867,13 @@
       </node>
     </node>
     <node concept="2tJIrI" id="48csSBNRe$G" role="jymVt" />
+    <node concept="312cEg" id="5M8g5cT4Mfo" role="jymVt">
+      <property role="TrG5h" value="exportDescriptionAnnotations" />
+      <node concept="3Tm6S6" id="5M8g5cT4Em8" role="1B3o_S" />
+      <node concept="10P_77" id="5M8g5cT4LHd" role="1tU5fm" />
+      <node concept="3clFbT" id="5M8g5cT4Trm" role="33vP2m" />
+    </node>
+    <node concept="2tJIrI" id="5M8g5cT4z7z" role="jymVt" />
     <node concept="3clFbW" id="48csSBNRe$T" role="jymVt">
       <node concept="3cqZAl" id="48csSBNRe$U" role="3clF45" />
       <node concept="3Tm1VV" id="48csSBNRe$V" role="1B3o_S" />
@@ -5819,6 +5826,16 @@
     <node concept="3clFb_" id="34Q84zNrGZj" role="jymVt">
       <property role="TrG5h" value="addDescription" />
       <node concept="3clFbS" id="34Q84zNrGZm" role="3clF47">
+        <node concept="3clFbJ" id="5M8g5cT5eVp" role="3cqZAp">
+          <node concept="3clFbS" id="5M8g5cT5eVr" role="3clFbx">
+            <node concept="3cpWs6" id="5M8g5cT5wHP" role="3cqZAp" />
+          </node>
+          <node concept="3fqX7Q" id="5M8g5cT5jnj" role="3clFbw">
+            <node concept="37vLTw" id="5M8g5cT5pXa" role="3fr31v">
+              <ref role="3cqZAo" node="5M8g5cT4Mfo" resolve="exportDescriptionAnnotations" />
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="3IM5Sl$orpE" role="3cqZAp">
           <node concept="3cpWsn" id="3IM5Sl$orpF" role="3cpWs9">
             <property role="TrG5h" value="concept" />
@@ -6235,6 +6252,7 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="5M8g5cT52aM" role="jymVt" />
     <node concept="3Tm1VV" id="48csSBNRePS" role="1B3o_S" />
     <node concept="3UR2Jj" id="3Kqiw5yAhqw" role="lGtFl">
       <node concept="TZ5HA" id="3Kqiw5yAhqx" role="TZ5H$">
@@ -6278,6 +6296,45 @@
         <node concept="1dT_AC" id="3Kqiw5yAsfp" role="1dT_Ay">
           <property role="1dT_AB" value="The source of this converter are compiled languages inside MPS." />
         </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5M8g5cT4UjC" role="jymVt">
+      <property role="TrG5h" value="isExportDescriptionAnnotations" />
+      <node concept="10P_77" id="5M8g5cT4UjD" role="3clF45" />
+      <node concept="3Tm1VV" id="5M8g5cT4UjE" role="1B3o_S" />
+      <node concept="3clFbS" id="5M8g5cT4UjF" role="3clF47">
+        <node concept="3clFbF" id="5M8g5cT4UjG" role="3cqZAp">
+          <node concept="2OqwBi" id="5M8g5cT4Uj_" role="3clFbG">
+            <node concept="Xjq3P" id="5M8g5cT4UjA" role="2Oq$k0" />
+            <node concept="2OwXpG" id="5M8g5cT4UjB" role="2OqNvi">
+              <ref role="2Oxat5" node="5M8g5cT4Mfo" resolve="exportDescriptionAnnotations" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5M8g5cT4UjH" role="jymVt">
+      <property role="TrG5h" value="setExportDescriptionAnnotations" />
+      <node concept="3cqZAl" id="5M8g5cT4UjI" role="3clF45" />
+      <node concept="3Tm1VV" id="5M8g5cT4UjJ" role="1B3o_S" />
+      <node concept="3clFbS" id="5M8g5cT4UjK" role="3clF47">
+        <node concept="3clFbF" id="5M8g5cT4UjL" role="3cqZAp">
+          <node concept="37vLTI" id="5M8g5cT4UjM" role="3clFbG">
+            <node concept="37vLTw" id="5M8g5cT4UjN" role="37vLTx">
+              <ref role="3cqZAo" node="5M8g5cT4UjO" resolve="exportDescriptionAnnotations" />
+            </node>
+            <node concept="2OqwBi" id="5M8g5cT4Ujy" role="37vLTJ">
+              <node concept="Xjq3P" id="5M8g5cT4Ujz" role="2Oq$k0" />
+              <node concept="2OwXpG" id="5M8g5cT4Uj$" role="2OqNvi">
+                <ref role="2Oxat5" node="5M8g5cT4Mfo" resolve="exportDescriptionAnnotations" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5M8g5cT4UjO" role="3clF46">
+        <property role="TrG5h" value="exportDescriptionAnnotations" />
+        <node concept="10P_77" id="5M8g5cT4UjP" role="1tU5fm" />
       </node>
     </node>
   </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.language.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.language.mps
@@ -566,6 +566,9 @@
                       <node concept="37vLTw" id="3M8YG$aA7XW" role="37wK5m">
                         <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
                       </node>
+                      <node concept="37vLTw" id="5M8g5cSRWrf" role="37wK5m">
+                        <ref role="3cqZAo" node="18UigYQMTew" resolve="annotationFinder" />
+                      </node>
                       <node concept="37vLTw" id="utjSYGdDUY" role="37wK5m">
                         <ref role="3cqZAo" node="utjSYGdtbw" resolve="additionalLanguages" />
                       </node>
@@ -2177,6 +2180,9 @@
               </node>
               <node concept="37vLTw" id="3M8YG$aB6LR" role="37wK5m">
                 <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+              </node>
+              <node concept="37vLTw" id="5M8g5cSSfmj" role="37wK5m">
+                <ref role="3cqZAo" node="18UigYQMTew" resolve="annotationFinder" />
               </node>
               <node concept="2ShNRf" id="3M8YG$aB6LS" role="37wK5m">
                 <node concept="2HTt$P" id="3M8YG$aB6LT" role="2ShVmc">
@@ -9752,6 +9758,9 @@
               </node>
               <node concept="37vLTw" id="2GPsfcbeTn2" role="37wK5m">
                 <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+              </node>
+              <node concept="37vLTw" id="5M8g5cSRJoE" role="37wK5m">
+                <ref role="3cqZAo" node="18UigYQMTew" resolve="annotationFinder" />
               </node>
               <node concept="2ShNRf" id="2GPsfcbeTn3" role="37wK5m">
                 <node concept="2HTt$P" id="2GPsfcbeTn4" role="2ShVmc">

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.language.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.language.mps
@@ -45,6 +45,7 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
@@ -332,6 +333,7 @@
       </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1240151247486" name="jetbrains.mps.baseLanguage.collections.structure.ContainerIteratorType" flags="in" index="2YL$Hu" />
       <concept id="1240216724530" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashMapCreator" flags="nn" index="32Fmki" />
@@ -3885,6 +3887,69 @@
             </node>
             <node concept="3uibUv" id="6Pr6izIsR5H" role="1tU5fm">
               <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="7weWCFltqqx" role="3cqZAp">
+          <node concept="3clFbS" id="7weWCFltqqz" role="3clFbx">
+            <node concept="3cpWs8" id="7weWCFlurS5" role="3cqZAp">
+              <node concept="3cpWsn" id="7weWCFlurS6" role="3cpWs9">
+                <property role="TrG5h" value="index" />
+                <node concept="10Oyi0" id="7weWCFlup3C" role="1tU5fm" />
+                <node concept="2OqwBi" id="7weWCFlurS7" role="33vP2m">
+                  <node concept="2OqwBi" id="7weWCFlurS8" role="2Oq$k0">
+                    <node concept="37vLTw" id="7weWCFlurS9" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                    </node>
+                    <node concept="liA8E" id="7weWCFlurSa" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7weWCFlqTiX" resolve="listSLanguageInternalClassifiers" />
+                    </node>
+                  </node>
+                  <node concept="2WmjW8" id="7weWCFlurSb" role="2OqNvi">
+                    <node concept="37vLTw" id="7weWCFlurSc" role="25WWJ7">
+                      <ref role="3cqZAo" node="18UigYQQoXE" resolve="annotatedConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="7weWCFluCWT" role="3cqZAp">
+              <node concept="3clFbS" id="7weWCFluCWV" role="3clFbx">
+                <node concept="3clFbF" id="7weWCFlvezJ" role="3cqZAp">
+                  <node concept="37vLTI" id="7weWCFlvm7j" role="3clFbG">
+                    <node concept="1y4W85" id="7weWCFl$5Et" role="37vLTx">
+                      <node concept="37vLTw" id="7weWCFl$b4i" role="1y58nS">
+                        <ref role="3cqZAo" node="7weWCFlurS6" resolve="index" />
+                      </node>
+                      <node concept="2OqwBi" id="7weWCFlzRPO" role="1y566C">
+                        <node concept="37vLTw" id="7weWCFlzL4M" role="2Oq$k0">
+                          <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
+                        </node>
+                        <node concept="liA8E" id="7weWCFlzY_f" role="2OqNvi">
+                          <ref role="37wK5l" to="6peh:7weWCFlvJcc" resolve="listReplacementMpsSpecificClassifiers" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="7weWCFlvezG" role="37vLTJ">
+                      <ref role="3cqZAo" node="18UigYQOptS" resolve="annotated" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2d3UOw" id="7weWCFluRip" role="3clFbw">
+                <node concept="3cmrfG" id="7weWCFluY7$" role="3uHU7w">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="37vLTw" id="7weWCFluKdK" role="3uHU7B">
+                  <ref role="3cqZAo" node="7weWCFlurS6" resolve="index" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="7weWCFltBg1" role="3clFbw">
+            <node concept="10Nm6u" id="7weWCFltFi3" role="3uHU7w" />
+            <node concept="37vLTw" id="7weWCFltwSR" role="3uHU7B">
+              <ref role="3cqZAo" node="18UigYQQoXE" resolve="annotatedConcept" />
             </node>
           </node>
         </node>
@@ -8659,31 +8724,46 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="1Wc70l" id="4Yo3buZjBko" role="3clFbw">
-                    <node concept="3fqX7Q" id="4Yo3buZjOqH" role="3uHU7w">
-                      <node concept="1rXfSq" id="4Yo3buZk0_v" role="3fr31v">
-                        <ref role="37wK5l" node="4Yo3buYDGAr" resolve="isSmartReference" />
-                        <node concept="37vLTw" id="4Yo3buZkcnI" role="37wK5m">
-                          <ref role="3cqZAo" node="4Yo3buZb6Qj" resolve="e" />
+                  <node concept="1Wc70l" id="7weWCFl_nJ8" role="3clFbw">
+                    <node concept="3fqX7Q" id="7weWCFl_vXz" role="3uHU7w">
+                      <node concept="2OqwBi" id="7weWCFl_NMk" role="3fr31v">
+                        <node concept="37vLTw" id="7weWCFl_D3O" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                        </node>
+                        <node concept="liA8E" id="7weWCFlA0Kb" role="2OqNvi">
+                          <ref role="37wK5l" to="y7p:5JNiskiswUo" resolve="isMpsInternalConcept" />
+                          <node concept="37vLTw" id="7weWCFlAcuc" role="37wK5m">
+                            <ref role="3cqZAo" node="4Yo3buZb6Qj" resolve="e" />
+                          </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="1Wc70l" id="4Yo3buZkmTe" role="3uHU7B">
-                      <node concept="3y3z36" id="4Yo3buZkFbi" role="3uHU7B">
-                        <node concept="10Nm6u" id="4Yo3buZkQTO" role="3uHU7w" />
-                        <node concept="37vLTw" id="4Yo3buZkzl4" role="3uHU7B">
-                          <ref role="3cqZAo" node="4Yo3buZb6Qj" resolve="e" />
+                    <node concept="1Wc70l" id="4Yo3buZjBko" role="3uHU7B">
+                      <node concept="1Wc70l" id="4Yo3buZkmTe" role="3uHU7B">
+                        <node concept="3y3z36" id="4Yo3buZkFbi" role="3uHU7B">
+                          <node concept="10Nm6u" id="4Yo3buZkQTO" role="3uHU7w" />
+                          <node concept="37vLTw" id="4Yo3buZkzl4" role="3uHU7B">
+                            <ref role="3cqZAo" node="4Yo3buZb6Qj" resolve="e" />
+                          </node>
+                        </node>
+                        <node concept="3fqX7Q" id="4Yo3buZbmIa" role="3uHU7w">
+                          <node concept="2OqwBi" id="4Yo3buZbKrv" role="3fr31v">
+                            <node concept="37vLTw" id="4Yo3buZbzJu" role="2Oq$k0">
+                              <ref role="3cqZAo" node="48csSBNRezV" resolve="classifiers" />
+                            </node>
+                            <node concept="2Nt0df" id="4Yo3buZbYCw" role="2OqNvi">
+                              <node concept="37vLTw" id="4Yo3buZc9oQ" role="38cxEo">
+                                <ref role="3cqZAo" node="4Yo3buZb6Qj" resolve="e" />
+                              </node>
+                            </node>
+                          </node>
                         </node>
                       </node>
-                      <node concept="3fqX7Q" id="4Yo3buZbmIa" role="3uHU7w">
-                        <node concept="2OqwBi" id="4Yo3buZbKrv" role="3fr31v">
-                          <node concept="37vLTw" id="4Yo3buZbzJu" role="2Oq$k0">
-                            <ref role="3cqZAo" node="48csSBNRezV" resolve="classifiers" />
-                          </node>
-                          <node concept="2Nt0df" id="4Yo3buZbYCw" role="2OqNvi">
-                            <node concept="37vLTw" id="4Yo3buZc9oQ" role="38cxEo">
-                              <ref role="3cqZAo" node="4Yo3buZb6Qj" resolve="e" />
-                            </node>
+                      <node concept="3fqX7Q" id="4Yo3buZjOqH" role="3uHU7w">
+                        <node concept="1rXfSq" id="4Yo3buZk0_v" role="3fr31v">
+                          <ref role="37wK5l" node="4Yo3buYDGAr" resolve="isSmartReference" />
+                          <node concept="37vLTw" id="4Yo3buZkcnI" role="37wK5m">
+                            <ref role="3cqZAo" node="4Yo3buZb6Qj" resolve="e" />
                           </node>
                         </node>
                       </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
@@ -32,6 +32,7 @@
     <import index="apzt" ref="r:ea3bdd37-0680-4524-8252-d8093e3b6903(io.lionweb.mps.converter.util)" />
     <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
     <import index="tzx8" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.model.impl(io.lionweb.lionweb.java/)" />
+    <import index="cz4z" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.self(io.lionweb.lionweb.java/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -41,6 +42,7 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="5293379017992965193" name="jetbrains.mps.baseLanguage.structure.StubStatementList" flags="ig" index="2lzX1y" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
@@ -3654,6 +3656,11 @@
                       <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                       <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
                     </node>
+                    <node concept="2ShNRf" id="7weWCFlyUED" role="37wK5m">
+                      <node concept="HV5vD" id="7weWCFlyUEE" role="2ShVmc">
+                        <ref role="HV5vE" node="7weWCFlyxlE" resolve="LionCoreAdapter" />
+                      </node>
+                    </node>
                   </node>
                 </node>
                 <node concept="37vLTw" id="5wsogBcrRgJ" role="37wK5m">
@@ -3749,6 +3756,11 @@
                     <node concept="2YIFZM" id="5JNiskjhpJo" role="37wK5m">
                       <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                       <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                    </node>
+                    <node concept="2ShNRf" id="7weWCFlyURx" role="37wK5m">
+                      <node concept="HV5vD" id="7weWCFlyURy" role="2ShVmc">
+                        <ref role="HV5vE" node="7weWCFlyxlE" resolve="LionCoreAdapter" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -4623,6 +4635,11 @@
                   <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
                   <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                 </node>
+                <node concept="2ShNRf" id="7weWCFlyI7w" role="37wK5m">
+                  <node concept="HV5vD" id="7weWCFlyJjA" role="2ShVmc">
+                    <ref role="HV5vE" node="7weWCFlyxlE" resolve="LionCoreAdapter" />
+                  </node>
+                </node>
               </node>
             </node>
             <node concept="37vLTw" id="5TNjoy1Ae_g" role="37vLTJ">
@@ -4925,6 +4942,50 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="7weWCFlvJ3J" role="jymVt" />
+    <node concept="3clFb_" id="7weWCFlwidJ" role="jymVt">
+      <property role="TrG5h" value="getAnnotationConcept" />
+      <node concept="3clFbS" id="7weWCFlwidM" role="3clF47" />
+      <node concept="3Tm1VV" id="7weWCFlwidN" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlwi9Z" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlwin$" role="jymVt">
+      <property role="TrG5h" value="getClassifierConcept" />
+      <node concept="3clFbS" id="7weWCFlwin_" role="3clF47" />
+      <node concept="3Tm1VV" id="7weWCFlwinA" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlwinB" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlwj$H" role="jymVt">
+      <property role="TrG5h" value="getConceptConcept" />
+      <node concept="3clFbS" id="7weWCFlwj$I" role="3clF47" />
+      <node concept="3Tm1VV" id="7weWCFlwj$J" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlwj$K" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlwk05" role="jymVt">
+      <property role="TrG5h" value="getInterfaceConcept" />
+      <node concept="3clFbS" id="7weWCFlwk06" role="3clF47" />
+      <node concept="3Tm1VV" id="7weWCFlwk07" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlwk08" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7weWCFlwedG" role="jymVt" />
+    <node concept="3clFb_" id="7weWCFlvJcc" role="jymVt">
+      <property role="TrG5h" value="listReplacementMpsSpecificClassifiers" />
+      <node concept="3clFbS" id="7weWCFlvJcf" role="3clF47" />
+      <node concept="3Tm1VV" id="7weWCFlvJcg" role="1B3o_S" />
+      <node concept="_YKpA" id="7weWCFlvJ8_" role="3clF45">
+        <node concept="3uibUv" id="7weWCFlvJc9" role="_ZDj9">
+          <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="312cEu" id="5JNiskj4S1d">
     <property role="3GE5qa" value="jsonConstants" />
@@ -4935,6 +4996,14 @@
     </node>
     <node concept="3uibUv" id="5JNiskj4S_T" role="EKbjA">
       <ref role="3uigEE" node="5JNiskj4R_R" resolve="IJsonConstants" />
+    </node>
+    <node concept="312cEg" id="7weWCFlwCp6" role="jymVt">
+      <property role="TrG5h" value="m3" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="7weWCFlwNpW" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlwCp9" role="1tU5fm">
+        <ref role="3uigEE" node="7weWCFlywjb" resolve="ILionCoreAdapter" />
+      </node>
     </node>
     <node concept="3clFbW" id="5JNiskj4SJa" role="jymVt">
       <node concept="37vLTG" id="5JNiskj4SJb" role="3clF46">
@@ -4955,7 +5024,81 @@
             <ref role="3cqZAo" node="5JNiskj4SJb" resolve="builtins" />
           </node>
         </node>
+        <node concept="3clFbF" id="7weWCFlwCpa" role="3cqZAp">
+          <node concept="37vLTI" id="7weWCFlwCpc" role="3clFbG">
+            <node concept="2OqwBi" id="7weWCFlwEBF" role="37vLTJ">
+              <node concept="Xjq3P" id="7weWCFlwFFX" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7weWCFlwEBI" role="2OqNvi">
+                <ref role="2Oxat5" node="7weWCFlwCp6" resolve="m3" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7weWCFlwCpg" role="37vLTx">
+              <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbH" id="5JNiskj6ryJ" role="3cqZAp" />
+        <node concept="3clFbF" id="7weWCFlxjeu" role="3cqZAp">
+          <node concept="37vLTI" id="7weWCFlxkxc" role="3clFbG">
+            <node concept="2OqwBi" id="7weWCFlxmzL" role="37vLTx">
+              <node concept="37vLTw" id="7weWCFlxmke" role="2Oq$k0">
+                <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
+              </node>
+              <node concept="liA8E" id="7weWCFlyC9C" role="2OqNvi">
+                <ref role="37wK5l" node="7weWCFlye1e" resolve="getAnnotation" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7weWCFlxjes" role="37vLTJ">
+              <ref role="3cqZAo" node="7weWCFlwRoH" resolve="ANNOTATION_CONCEPT" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7weWCFlxpN1" role="3cqZAp">
+          <node concept="37vLTI" id="7weWCFlxr6p" role="3clFbG">
+            <node concept="2OqwBi" id="7weWCFlxsjJ" role="37vLTx">
+              <node concept="37vLTw" id="7weWCFlxs3F" role="2Oq$k0">
+                <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
+              </node>
+              <node concept="liA8E" id="7weWCFlyCYt" role="2OqNvi">
+                <ref role="37wK5l" node="7weWCFlyegi" resolve="getClassifier" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7weWCFlxpMZ" role="37vLTJ">
+              <ref role="3cqZAo" node="7weWCFlwYLn" resolve="CLASSIFIER_CONCEPT" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7weWCFlxvC8" role="3cqZAp">
+          <node concept="37vLTI" id="7weWCFlxxae" role="3clFbG">
+            <node concept="2OqwBi" id="7weWCFlxyXS" role="37vLTx">
+              <node concept="37vLTw" id="7weWCFlxyHj" role="2Oq$k0">
+                <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
+              </node>
+              <node concept="liA8E" id="7weWCFlyDSA" role="2OqNvi">
+                <ref role="37wK5l" node="7weWCFlye2B" resolve="getConcept" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7weWCFlxvC6" role="37vLTJ">
+              <ref role="3cqZAo" node="7weWCFlx57a" resolve="CONCEPT_CONCEPT" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7weWCFlxAgR" role="3cqZAp">
+          <node concept="37vLTI" id="7weWCFlxB_t" role="3clFbG">
+            <node concept="2OqwBi" id="7weWCFlxDsZ" role="37vLTx">
+              <node concept="37vLTw" id="7weWCFlxDbT" role="2Oq$k0">
+                <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
+              </node>
+              <node concept="liA8E" id="7weWCFlyEZu" role="2OqNvi">
+                <ref role="37wK5l" node="7weWCFlye49" resolve="getInterface" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7weWCFlxAgP" role="37vLTJ">
+              <ref role="3cqZAo" node="7weWCFlxbqI" resolve="INTERFACE_CONCEPT" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7weWCFlxi6m" role="3cqZAp" />
         <node concept="3clFbF" id="5JNiskj6AAg" role="3cqZAp">
           <node concept="37vLTI" id="5JNiskj6B66" role="3clFbG">
             <node concept="2ShNRf" id="5JNiskj6BrP" role="37vLTx">
@@ -5204,6 +5347,15 @@
               </node>
             </node>
           </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7weWCFlwAZa" role="3clF46">
+        <property role="TrG5h" value="m3" />
+        <node concept="3uibUv" id="7weWCFlwC9l" role="1tU5fm">
+          <ref role="3uigEE" node="7weWCFlywjb" resolve="ILionCoreAdapter" />
+        </node>
+        <node concept="2AHcQZ" id="7weWCFlwCka" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
     </node>
@@ -5802,6 +5954,562 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="34Q84zNSFdB" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7weWCFlwstm" role="jymVt" />
+    <node concept="312cEg" id="7weWCFlwRoH" role="jymVt">
+      <property role="TrG5h" value="ANNOTATION_CONCEPT" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="7weWCFlwRoI" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlwRoJ" role="1tU5fm">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlwuJI" role="jymVt">
+      <property role="TrG5h" value="getAnnotationConcept" />
+      <node concept="3Tm1VV" id="7weWCFlwuJK" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlwuJL" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3clFbS" id="7weWCFlwuJN" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlxHfg" role="3cqZAp">
+          <node concept="37vLTw" id="7weWCFlxHfd" role="3clFbG">
+            <ref role="3cqZAo" node="7weWCFlwRoH" resolve="ANNOTATION_CONCEPT" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlwuJO" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7weWCFlwYLn" role="jymVt">
+      <property role="TrG5h" value="CLASSIFIER_CONCEPT" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="7weWCFlwYLo" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlwYLp" role="1tU5fm">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlwuJR" role="jymVt">
+      <property role="TrG5h" value="getClassifierConcept" />
+      <node concept="3Tm1VV" id="7weWCFlwuJT" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlwuJU" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3clFbS" id="7weWCFlwuJW" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlxL18" role="3cqZAp">
+          <node concept="37vLTw" id="7weWCFlxL15" role="3clFbG">
+            <ref role="3cqZAo" node="7weWCFlwYLn" resolve="CLASSIFIER_CONCEPT" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlwuJX" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7weWCFlx57a" role="jymVt">
+      <property role="TrG5h" value="CONCEPT_CONCEPT" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="7weWCFlx57b" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlx57c" role="1tU5fm">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlwuK0" role="jymVt">
+      <property role="TrG5h" value="getConceptConcept" />
+      <node concept="3Tm1VV" id="7weWCFlwuK2" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlwuK3" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3clFbS" id="7weWCFlwuK5" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlxUg4" role="3cqZAp">
+          <node concept="37vLTw" id="7weWCFlxUg1" role="3clFbG">
+            <ref role="3cqZAo" node="7weWCFlx57a" resolve="CONCEPT_CONCEPT" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlwuK6" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7weWCFlxbqI" role="jymVt">
+      <property role="TrG5h" value="INTERFACE_CONCEPT" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="7weWCFlxbqJ" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlxbqK" role="1tU5fm">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlwuK9" role="jymVt">
+      <property role="TrG5h" value="getInterfaceConcept" />
+      <node concept="3Tm1VV" id="7weWCFlwuKb" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlwuKc" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3clFbS" id="7weWCFlwuKe" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlxY0V" role="3cqZAp">
+          <node concept="37vLTw" id="7weWCFlxY0S" role="3clFbG">
+            <ref role="3cqZAo" node="7weWCFlxbqI" resolve="INTERFACE_CONCEPT" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlwuKf" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7weWCFlvQOd" role="jymVt" />
+    <node concept="3clFb_" id="7weWCFlvMhM" role="jymVt">
+      <property role="TrG5h" value="listReplacementMpsSpecificClassifiers" />
+      <node concept="3Tm1VV" id="7weWCFlvMhO" role="1B3o_S" />
+      <node concept="_YKpA" id="7weWCFlvMhP" role="3clF45">
+        <node concept="3uibUv" id="7weWCFlvMhQ" role="_ZDj9">
+          <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7weWCFlvMhS" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlvSqS" role="3cqZAp">
+          <node concept="2ShNRf" id="7weWCFlvSqQ" role="3clFbG">
+            <node concept="Tc6Ow" id="7weWCFlvUWA" role="2ShVmc">
+              <node concept="3uibUv" id="7weWCFlvYZn" role="HW$YZ">
+                <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
+              </node>
+              <node concept="1rXfSq" id="7weWCFlw6kx" role="HW$Y0">
+                <ref role="37wK5l" node="5TNjoy1vujq" resolve="getNode" />
+              </node>
+              <node concept="1rXfSq" id="7weWCFlwa3U" role="HW$Y0">
+                <ref role="37wK5l" node="7weWCFlwuJI" resolve="getAnnotationConcept" />
+              </node>
+              <node concept="1rXfSq" id="7weWCFlwqSd" role="HW$Y0">
+                <ref role="37wK5l" node="7weWCFlwuJR" resolve="getClassifierConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlvMhT" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+  </node>
+  <node concept="3HP615" id="7weWCFlyclH">
+    <property role="3GE5qa" value="lionCoreAdapter" />
+    <property role="TrG5h" value="ILionCoreAdapter_2023_1" />
+    <node concept="3clFb_" id="7weWCFlye1e" role="jymVt">
+      <property role="TrG5h" value="getAnnotation" />
+      <node concept="2lzX1y" id="7weWCFlye1h" role="3clF47" />
+      <node concept="3uibUv" id="7weWCFlye1i" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlye1k" role="1B3o_S" />
+    </node>
+    <node concept="3clFb_" id="7weWCFlye2B" role="jymVt">
+      <property role="TrG5h" value="getConcept" />
+      <node concept="2lzX1y" id="7weWCFlye2E" role="3clF47" />
+      <node concept="3uibUv" id="7weWCFlye2F" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlye2H" role="1B3o_S" />
+    </node>
+    <node concept="3clFb_" id="7weWCFlye49" role="jymVt">
+      <property role="TrG5h" value="getInterface" />
+      <node concept="2lzX1y" id="7weWCFlye4c" role="3clF47" />
+      <node concept="3uibUv" id="7weWCFlye4d" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlye4f" role="1B3o_S" />
+    </node>
+    <node concept="3clFb_" id="7weWCFlye5O" role="jymVt">
+      <property role="TrG5h" value="getContainment" />
+      <node concept="2lzX1y" id="7weWCFlye5R" role="3clF47" />
+      <node concept="3uibUv" id="7weWCFlye5S" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlye5U" role="1B3o_S" />
+    </node>
+    <node concept="3clFb_" id="7weWCFlye7C" role="jymVt">
+      <property role="TrG5h" value="getDataType" />
+      <node concept="2lzX1y" id="7weWCFlye7F" role="3clF47" />
+      <node concept="3uibUv" id="7weWCFlye7G" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlye7I" role="1B3o_S" />
+    </node>
+    <node concept="3clFb_" id="7weWCFlye9_" role="jymVt">
+      <property role="TrG5h" value="getEnumeration" />
+      <node concept="2lzX1y" id="7weWCFlye9C" role="3clF47" />
+      <node concept="3uibUv" id="7weWCFlye9D" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlye9F" role="1B3o_S" />
+    </node>
+    <node concept="3clFb_" id="7weWCFlyebF" role="jymVt">
+      <property role="TrG5h" value="getEnumerationLiteral" />
+      <node concept="2lzX1y" id="7weWCFlyebI" role="3clF47" />
+      <node concept="3uibUv" id="7weWCFlyebJ" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyebL" role="1B3o_S" />
+    </node>
+    <node concept="3clFb_" id="7weWCFlyedU" role="jymVt">
+      <property role="TrG5h" value="getFeature" />
+      <node concept="2lzX1y" id="7weWCFlyedX" role="3clF47" />
+      <node concept="3uibUv" id="7weWCFlyedY" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyee0" role="1B3o_S" />
+    </node>
+    <node concept="3clFb_" id="7weWCFlyegi" role="jymVt">
+      <property role="TrG5h" value="getClassifier" />
+      <node concept="2lzX1y" id="7weWCFlyegl" role="3clF47" />
+      <node concept="3uibUv" id="7weWCFlyegm" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyego" role="1B3o_S" />
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeiN" role="jymVt">
+      <property role="TrG5h" value="getLink" />
+      <node concept="2lzX1y" id="7weWCFlyeiQ" role="3clF47" />
+      <node concept="3uibUv" id="7weWCFlyeiR" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeiT" role="1B3o_S" />
+    </node>
+    <node concept="3clFb_" id="7weWCFlyelt" role="jymVt">
+      <property role="TrG5h" value="getLanguage" />
+      <node concept="2lzX1y" id="7weWCFlyelw" role="3clF47" />
+      <node concept="3uibUv" id="7weWCFlyelx" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyelz" role="1B3o_S" />
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeog" role="jymVt">
+      <property role="TrG5h" value="getLanguageEntity" />
+      <node concept="2lzX1y" id="7weWCFlyeoj" role="3clF47" />
+      <node concept="3uibUv" id="7weWCFlyeok" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeom" role="1B3o_S" />
+    </node>
+    <node concept="3clFb_" id="7weWCFlyerc" role="jymVt">
+      <property role="TrG5h" value="getPrimitiveType" />
+      <node concept="2lzX1y" id="7weWCFlyerf" role="3clF47" />
+      <node concept="3uibUv" id="7weWCFlyerg" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeri" role="1B3o_S" />
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeuh" role="jymVt">
+      <property role="TrG5h" value="getProperty" />
+      <node concept="2lzX1y" id="7weWCFlyeuk" role="3clF47" />
+      <node concept="3uibUv" id="7weWCFlyeul" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeun" role="1B3o_S" />
+    </node>
+    <node concept="3clFb_" id="7weWCFlyexv" role="jymVt">
+      <property role="TrG5h" value="getReference" />
+      <node concept="2lzX1y" id="7weWCFlyexy" role="3clF47" />
+      <node concept="3uibUv" id="7weWCFlyexz" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyex_" role="1B3o_S" />
+    </node>
+    <node concept="3Tm1VV" id="7weWCFlyclI" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="7weWCFlyxlE">
+    <property role="3GE5qa" value="lionCoreAdapter" />
+    <property role="TrG5h" value="LionCoreAdapter" />
+    <node concept="3Tm1VV" id="7weWCFlyxlF" role="1B3o_S" />
+    <node concept="3uibUv" id="7weWCFlyxmq" role="1zkMxy">
+      <ref role="3uigEE" node="7weWCFlyeHs" resolve="LionCoreAdapter_2023_1" />
+    </node>
+    <node concept="3uibUv" id="7weWCFlyxmW" role="EKbjA">
+      <ref role="3uigEE" node="7weWCFlywjb" resolve="ILionCoreAdapter" />
+    </node>
+  </node>
+  <node concept="3HP615" id="7weWCFlywjb">
+    <property role="3GE5qa" value="lionCoreAdapter" />
+    <property role="TrG5h" value="ILionCoreAdapter" />
+    <node concept="3Tm1VV" id="7weWCFlywjc" role="1B3o_S" />
+    <node concept="3uibUv" id="7weWCFlywjL" role="3HQHJm">
+      <ref role="3uigEE" node="7weWCFlyclH" resolve="ILionCoreAdapter_2023_1" />
+    </node>
+  </node>
+  <node concept="312cEu" id="7weWCFlyeHs">
+    <property role="3GE5qa" value="lionCoreAdapter" />
+    <property role="TrG5h" value="LionCoreAdapter_2023_1" />
+    <node concept="3Tm1VV" id="7weWCFlyeHt" role="1B3o_S" />
+    <node concept="3uibUv" id="7weWCFlyeIO" role="EKbjA">
+      <ref role="3uigEE" node="7weWCFlyclH" resolve="ILionCoreAdapter_2023_1" />
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeJe" role="jymVt">
+      <property role="TrG5h" value="getAnnotation" />
+      <node concept="3uibUv" id="7weWCFlyeJg" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeJh" role="1B3o_S" />
+      <node concept="3clFbS" id="7weWCFlyeJi" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlyfmu" role="3cqZAp">
+          <node concept="2YIFZM" id="7weWCFlyfBh" role="3clFbG">
+            <ref role="37wK5l" to="cz4z:~LionCore.getAnnotation()" resolve="getAnnotation" />
+            <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlyeJj" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeJm" role="jymVt">
+      <property role="TrG5h" value="getConcept" />
+      <node concept="3uibUv" id="7weWCFlyeJo" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeJp" role="1B3o_S" />
+      <node concept="3clFbS" id="7weWCFlyeJq" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlyfS6" role="3cqZAp">
+          <node concept="2YIFZM" id="7weWCFlygqo" role="3clFbG">
+            <ref role="37wK5l" to="cz4z:~LionCore.getConcept()" resolve="getConcept" />
+            <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlyeJr" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeJu" role="jymVt">
+      <property role="TrG5h" value="getInterface" />
+      <node concept="3uibUv" id="7weWCFlyeJw" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeJx" role="1B3o_S" />
+      <node concept="3clFbS" id="7weWCFlyeJy" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlygFp" role="3cqZAp">
+          <node concept="2YIFZM" id="7weWCFlyhHx" role="3clFbG">
+            <ref role="37wK5l" to="cz4z:~LionCore.getInterface()" resolve="getInterface" />
+            <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlyeJz" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeJA" role="jymVt">
+      <property role="TrG5h" value="getContainment" />
+      <node concept="3uibUv" id="7weWCFlyeJC" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeJD" role="1B3o_S" />
+      <node concept="3clFbS" id="7weWCFlyeJE" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlyiwX" role="3cqZAp">
+          <node concept="2YIFZM" id="7weWCFlyj3N" role="3clFbG">
+            <ref role="37wK5l" to="cz4z:~LionCore.getContainment()" resolve="getContainment" />
+            <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlyeJF" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeJI" role="jymVt">
+      <property role="TrG5h" value="getDataType" />
+      <node concept="3uibUv" id="7weWCFlyeJK" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeJL" role="1B3o_S" />
+      <node concept="3clFbS" id="7weWCFlyeJM" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlyjAl" role="3cqZAp">
+          <node concept="2YIFZM" id="7weWCFlyk9t" role="3clFbG">
+            <ref role="37wK5l" to="cz4z:~LionCore.getDataType()" resolve="getDataType" />
+            <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlyeJN" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeJQ" role="jymVt">
+      <property role="TrG5h" value="getEnumeration" />
+      <node concept="3uibUv" id="7weWCFlyeJS" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeJT" role="1B3o_S" />
+      <node concept="3clFbS" id="7weWCFlyeJU" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlykGh" role="3cqZAp">
+          <node concept="2YIFZM" id="7weWCFlylfF" role="3clFbG">
+            <ref role="37wK5l" to="cz4z:~LionCore.getEnumeration()" resolve="getEnumeration" />
+            <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlyeJV" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeJY" role="jymVt">
+      <property role="TrG5h" value="getEnumerationLiteral" />
+      <node concept="3uibUv" id="7weWCFlyeK0" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeK1" role="1B3o_S" />
+      <node concept="3clFbS" id="7weWCFlyeK2" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlylML" role="3cqZAp">
+          <node concept="2YIFZM" id="7weWCFlymmt" role="3clFbG">
+            <ref role="37wK5l" to="cz4z:~LionCore.getEnumerationLiteral()" resolve="getEnumerationLiteral" />
+            <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlyeK3" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeK6" role="jymVt">
+      <property role="TrG5h" value="getFeature" />
+      <node concept="3uibUv" id="7weWCFlyeK8" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeK9" role="1B3o_S" />
+      <node concept="3clFbS" id="7weWCFlyeKa" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlymTP" role="3cqZAp">
+          <node concept="2YIFZM" id="7weWCFlyntN" role="3clFbG">
+            <ref role="37wK5l" to="cz4z:~LionCore.getFeature()" resolve="getFeature" />
+            <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlyeKb" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeKe" role="jymVt">
+      <property role="TrG5h" value="getClassifier" />
+      <node concept="3uibUv" id="7weWCFlyeKg" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeKh" role="1B3o_S" />
+      <node concept="3clFbS" id="7weWCFlyeKi" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlyo1t" role="3cqZAp">
+          <node concept="2YIFZM" id="7weWCFlyo_H" role="3clFbG">
+            <ref role="37wK5l" to="cz4z:~LionCore.getClassifier()" resolve="getClassifier" />
+            <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlyeKj" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeKm" role="jymVt">
+      <property role="TrG5h" value="getLink" />
+      <node concept="3uibUv" id="7weWCFlyeKo" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeKp" role="1B3o_S" />
+      <node concept="3clFbS" id="7weWCFlyeKq" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlyp9D" role="3cqZAp">
+          <node concept="2YIFZM" id="7weWCFlypIb" role="3clFbG">
+            <ref role="37wK5l" to="cz4z:~LionCore.getLink()" resolve="getLink" />
+            <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlyeKr" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeKu" role="jymVt">
+      <property role="TrG5h" value="getLanguage" />
+      <node concept="3uibUv" id="7weWCFlyeKw" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeKx" role="1B3o_S" />
+      <node concept="3clFbS" id="7weWCFlyeKy" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlyqip" role="3cqZAp">
+          <node concept="2YIFZM" id="7weWCFlyq$X" role="3clFbG">
+            <ref role="37wK5l" to="cz4z:~LionCore.getLanguage()" resolve="getLanguage" />
+            <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlyeKz" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeKA" role="jymVt">
+      <property role="TrG5h" value="getLanguageEntity" />
+      <node concept="3uibUv" id="7weWCFlyeKC" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeKD" role="1B3o_S" />
+      <node concept="3clFbS" id="7weWCFlyeKE" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlyr9t" role="3cqZAp">
+          <node concept="2YIFZM" id="7weWCFlyrGf" role="3clFbG">
+            <ref role="37wK5l" to="cz4z:~LionCore.getLanguageEntity()" resolve="getLanguageEntity" />
+            <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlyeKF" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeKI" role="jymVt">
+      <property role="TrG5h" value="getPrimitiveType" />
+      <node concept="3uibUv" id="7weWCFlyeKK" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeKL" role="1B3o_S" />
+      <node concept="3clFbS" id="7weWCFlyeKM" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlysh1" role="3cqZAp">
+          <node concept="2YIFZM" id="7weWCFlysQp" role="3clFbG">
+            <ref role="37wK5l" to="cz4z:~LionCore.getPrimitiveType()" resolve="getPrimitiveType" />
+            <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlyeKN" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeKQ" role="jymVt">
+      <property role="TrG5h" value="getProperty" />
+      <node concept="3uibUv" id="7weWCFlyeKS" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeKT" role="1B3o_S" />
+      <node concept="3clFbS" id="7weWCFlyeKU" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlytrt" role="3cqZAp">
+          <node concept="2YIFZM" id="7weWCFlyu17" role="3clFbG">
+            <ref role="37wK5l" to="cz4z:~LionCore.getProperty()" resolve="getProperty" />
+            <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlyeKV" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlyeKY" role="jymVt">
+      <property role="TrG5h" value="getReference" />
+      <node concept="3uibUv" id="7weWCFlyeL0" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="3Tm1VV" id="7weWCFlyeL1" role="1B3o_S" />
+      <node concept="3clFbS" id="7weWCFlyeL2" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlyuAt" role="3cqZAp">
+          <node concept="2YIFZM" id="7weWCFlyuT_" role="3clFbG">
+            <ref role="37wK5l" to="cz4z:~LionCore.getReference()" resolve="getReference" />
+            <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlyeL3" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
@@ -253,6 +253,9 @@
       <concept id="8465538089690331492" name="jetbrains.mps.baseLanguage.javadoc.structure.DeprecatedBlockDocTag" flags="ng" index="TZ5HI">
         <child id="2667874559098216723" name="text" index="3HnX3l" />
       </concept>
+      <concept id="2217234381367190443" name="jetbrains.mps.baseLanguage.javadoc.structure.SeeBlockDocTag" flags="ng" index="VUp57">
+        <child id="2217234381367190458" name="reference" index="VUp5m" />
+      </concept>
       <concept id="2217234381367530212" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocReference" flags="ng" index="VXe08">
         <reference id="2217234381367530213" name="classifier" index="VXe09" />
       </concept>
@@ -4674,6 +4677,18 @@
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskj4Oxw" role="1B3o_S" />
+      <node concept="P$JXv" id="5M8g5cS_YzB" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_YA_" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_YAA" role="1dT_Ay">
+            <property role="1dT_AB" value="All LionCore builtin primitive types as JSON DataType." />
+          </node>
+        </node>
+        <node concept="VUp57" id="5M8g5cS_YEV" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cS_YMV" role="VUp5m">
+            <ref role="VXe0S" to="y7p:5JNiski3k19" resolve="listLcPrimitiveTypes" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="5JNiskj4Oxy" role="jymVt" />
     <node concept="3clFb_" id="5JNiskj4Oxz" role="jymVt">
@@ -4685,6 +4700,18 @@
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskj4OxH" role="1B3o_S" />
+      <node concept="P$JXv" id="5M8g5cS_YN8" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cSA8Ky" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cSA8Kz" role="1dT_Ay">
+            <property role="1dT_AB" value="All LionCore builtin classifiers as JSON Classifier." />
+          </node>
+        </node>
+        <node concept="VUp57" id="5M8g5cSA8M1" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cSA8Nv" role="VUp5m">
+            <ref role="VXe0S" to="y7p:5JNiski3jZs" resolve="listLcClassifiers" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="5JNiskj4OxJ" role="jymVt" />
     <node concept="3clFb_" id="4Yo3buYJP_4" role="jymVt">
@@ -4693,6 +4720,24 @@
       <node concept="3Tm1VV" id="4Yo3buYJP_8" role="1B3o_S" />
       <node concept="3uibUv" id="4Yo3buYJPz9" role="3clF45">
         <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cSA8QE" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cSA8QF" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cSA8QG" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cSA9EQ" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cSA9F4" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cSA9F6" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cSA9Fl" role="92FcQ">
+                <ref role="VXe09" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cSA9EP" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="4Yo3buYJPxh" role="jymVt" />
@@ -4703,6 +4748,13 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskj4OxM" role="1B3o_S" />
       <node concept="3clFbS" id="5JNiskj4OxN" role="3clF47" />
+      <node concept="P$JXv" id="5M8g5cSA9HN" role="lGtFl">
+        <node concept="VUp57" id="5M8g5cSA9KL" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cSA9NB" role="VUp5m">
+            <ref role="VXe0S" to="y7p:5JNiski3jVi" resolve="lcStringType" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskj4OxT" role="jymVt">
       <property role="TrG5h" value="getInteger" />
@@ -4711,6 +4763,13 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskj4OxV" role="1B3o_S" />
       <node concept="3clFbS" id="5JNiskj4OxW" role="3clF47" />
+      <node concept="P$JXv" id="5M8g5cSA9NO" role="lGtFl">
+        <node concept="VUp57" id="5M8g5cSA9Pp" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cSA9TF" role="VUp5m">
+            <ref role="VXe0S" to="y7p:5JNiski3jVW" resolve="lcIntegerType" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskj4Oy2" role="jymVt">
       <property role="TrG5h" value="getBoolean" />
@@ -4719,6 +4778,13 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskj4Oy4" role="1B3o_S" />
       <node concept="3clFbS" id="5JNiskj4Oy5" role="3clF47" />
+      <node concept="P$JXv" id="5M8g5cSA9TS" role="lGtFl">
+        <node concept="VUp57" id="5M8g5cSA9Vt" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cSA9ZJ" role="VUp5m">
+            <ref role="VXe0S" to="y7p:5JNiski3jVB" resolve="lcBooleanType" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskj4Oyb" role="jymVt">
       <property role="TrG5h" value="getJSON" />
@@ -4727,6 +4793,13 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskj4Oyd" role="1B3o_S" />
       <node concept="3clFbS" id="5JNiskj4Oye" role="3clF47" />
+      <node concept="P$JXv" id="5M8g5cSA9ZW" role="lGtFl">
+        <node concept="VUp57" id="5M8g5cSAa1x" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cSAa5N" role="VUp5m">
+            <ref role="VXe0S" to="y7p:5JNiski3jWh" resolve="lcJsonType" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskj4Oyk" role="jymVt">
       <property role="TrG5h" value="getINamed" />
@@ -4735,6 +4808,13 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskj4Oym" role="1B3o_S" />
       <node concept="3clFbS" id="5JNiskj4Oyn" role="3clF47" />
+      <node concept="P$JXv" id="5M8g5cSAa60" role="lGtFl">
+        <node concept="VUp57" id="5M8g5cSAa7_" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cSAabR" role="VUp5m">
+            <ref role="VXe0S" to="y7p:5JNiski3jXc" resolve="lcINamedInterface" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskj4Oyt" role="jymVt">
       <property role="TrG5h" value="getNode" />
@@ -4743,6 +4823,13 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskj4Oyv" role="1B3o_S" />
       <node concept="3clFbS" id="5JNiskj4Oyw" role="3clF47" />
+      <node concept="P$JXv" id="5M8g5cSAac4" role="lGtFl">
+        <node concept="VUp57" id="5M8g5cSAagw" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cSAajm" role="VUp5m">
+            <ref role="VXe0S" to="y7p:5JNiski3jWA" resolve="lcNodeConcept" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="5JNiskj4Oxi" role="jymVt" />
     <node concept="3Tm1VV" id="5JNiskj4NAK" role="1B3o_S" />
@@ -4762,6 +4849,24 @@
       <node concept="3uibUv" id="5JNiskj6wRz" role="3clF45">
         <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS_oz4" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_shD" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_shE" role="1dT_Ay">
+            <property role="1dT_AB" value="io.lionweb.mps.specific as JSON " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS_som" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS_so$" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS_soA" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS_t4J" role="92FcQ">
+                <ref role="VXe09" to="imb3:~Language" resolve="Language" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_sol" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="5JNiskj6wPP" role="jymVt" />
     <node concept="3clFb_" id="5JNiskj67eE" role="jymVt">
@@ -4771,6 +4876,29 @@
       <node concept="3uibUv" id="5JNiskj67dJ" role="3clF45">
         <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS_sln" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_uJN" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_uJO" role="1dT_Ay">
+            <property role="1dT_AB" value="io.lionweb.mps.specific.lang.MPS-specific annotations.VirtualPackage as JSON " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS_uMF" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS_uMT" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS_uMV" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS_uNa" role="92FcQ">
+                <ref role="VXe09" to="imb3:~Annotation" resolve="Annotation" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_uME" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="VUp57" id="5M8g5cS_uQi" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cS_uTj" role="VUp5m">
+            <ref role="VXe0S" to="y7p:5JNiskipPo2" resolve="lcVirtualPackageAnnotation" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskj67nR" role="jymVt">
       <property role="TrG5h" value="getVirtualPackage_Name" />
@@ -4778,6 +4906,29 @@
       <node concept="3Tm1VV" id="5JNiskj67nV" role="1B3o_S" />
       <node concept="3uibUv" id="5JNiskj67my" role="3clF45">
         <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS_uWr" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_uWs" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_xnS" role="1dT_Ay">
+            <property role="1dT_AB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.INamed.name as JSON " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS_xnT" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS_xnU" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS_xnV" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS_xnW" role="92FcQ">
+                <ref role="VXe09" to="imb3:~Annotation" resolve="Annotation" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_uWt" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="VUp57" id="5M8g5cS_zkL" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cS_zqw" role="VUp5m">
+            <ref role="VXe0S" to="y7p:5JNiskir74n" resolve="lcVirtualPackage_NameProperty" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskj67qn" role="jymVt" />
@@ -4788,6 +4939,29 @@
       <node concept="3uibUv" id="5JNiskj67hP" role="3clF45">
         <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS_xqw" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_zqN" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_zqO" role="1dT_Ay">
+            <property role="1dT_AB" value="io.lionweb.mps.specific.lang.MPS-specific annotations.ShortDescription as JSON " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS_zqP" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS_zqQ" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS_zqR" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS_zqS" role="92FcQ">
+                <ref role="VXe09" to="imb3:~Annotation" resolve="Annotation" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_zqT" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="VUp57" id="5M8g5cS_zzF" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cS_zDq" role="VUp5m">
+            <ref role="VXe0S" to="y7p:5JNiskipPPY" resolve="lcShortDescriptionAnnotation" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskj67rQ" role="jymVt">
       <property role="TrG5h" value="getShortDescription_Description" />
@@ -4795,6 +4969,29 @@
       <node concept="3Tm1VV" id="5JNiskj67rS" role="1B3o_S" />
       <node concept="3uibUv" id="5JNiskj67rT" role="3clF45">
         <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS_zDL" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_zGJ" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_zGK" role="1dT_Ay">
+            <property role="1dT_AB" value="io.lionweb.mps.specific.lang.MPS-specific annotations.ShortDescription.description as JSON " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS_zGL" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS_zGM" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS_zGN" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS_zGO" role="92FcQ">
+                <ref role="VXe09" to="imb3:~Property" resolve="Property" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_zGP" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="VUp57" id="5M8g5cS_zPJ" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cS_zYj" role="VUp5m">
+            <ref role="VXe0S" to="y7p:5JNiskir8mM" resolve="lcShortDescription_DescriptionProperty" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskj67cR" role="jymVt" />
@@ -4871,6 +5068,18 @@
           <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
         </node>
       </node>
+      <node concept="P$JXv" id="5M8g5cS_zYE" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_zYF" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_zYG" role="1dT_Ay">
+            <property role="1dT_AB" value="All M1 JSON annotations that are converted from MPS node properties." />
+          </node>
+        </node>
+        <node concept="VUp57" id="5M8g5cS_$ak" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cS_$fY" role="VUp5m">
+            <ref role="VXe0S" to="y7p:5JNiskjpaH9" resolve="listSpecificAnnotationProperties" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskjpjYQ" role="jymVt">
       <property role="TrG5h" value="listSpecificAnnotationMembers" />
@@ -4879,6 +5088,18 @@
       <node concept="_YKpA" id="5JNiskjpjW$" role="3clF45">
         <node concept="3uibUv" id="5JNiskjpjYN" role="_ZDj9">
           <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="5M8g5cS_$4u" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_$4v" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_$4w" role="1dT_Ay">
+            <property role="1dT_AB" value="All M1 JSON annotation properties that are converted from MPS node properties." />
+          </node>
+        </node>
+        <node concept="VUp57" id="5M8g5cS_A9h" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cS_A9i" role="VUp5m">
+            <ref role="VXe0S" to="y7p:5JNiskjpaH9" resolve="listSpecificAnnotationProperties" />
+          </node>
         </node>
       </node>
     </node>
@@ -4892,6 +5113,35 @@
         </node>
         <node concept="3uibUv" id="5JNiskjt_sj" role="3rvSg0">
           <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="5M8g5cS_AkF" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_AkG" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_AkH" role="1dT_Ay">
+            <property role="1dT_AB" value="Map from " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS_Bsf" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS_Bsl" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS_Bsn" role="2XjZqd" />
+              <node concept="VXe0Z" id="5M8g5cS_BsA" role="92FcQ">
+                <ref role="VXe0S" node="5JNiskjpjPN" resolve="listSpecificAnnotations" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_Bse" role="1dT_Ay">
+            <property role="1dT_AB" value=" to " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS_Bts" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS_BtJ" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS_BtL" role="2XjZqd" />
+              <node concept="VXe0Z" id="5M8g5cS_Bu0" role="92FcQ">
+                <ref role="VXe0S" node="5JNiskjpjYQ" resolve="listSpecificAnnotationMembers" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_Btr" role="1dT_Ay">
+            <property role="1dT_AB" value="." />
+          </node>
         </node>
       </node>
     </node>
@@ -4914,6 +5164,18 @@
       <node concept="3uibUv" id="34Q84zNB8rv" role="3clF45">
         <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS_BxF" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_BxG" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_BxH" role="1dT_Ay">
+            <property role="1dT_AB" value="All M2 JSON annotations that are converted from MPS concept properties." />
+          </node>
+        </node>
+        <node concept="VUp57" id="5M8g5cS_BBx" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cS_BK0" role="VUp5m">
+            <ref role="VXe0S" to="y7p:34Q84zNtsh8" resolve="listConceptDescriptionProperties" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="34Q84zNToVR" role="jymVt">
       <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptAlias" />
@@ -4922,6 +5184,32 @@
       <node concept="3uibUv" id="34Q84zNToVU" role="3clF45">
         <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS_BKf" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_BKg" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_BT5" role="1dT_Ay">
+            <property role="1dT_AB" value="io.lionweb.mps.specific.lang.MPS-specific annotations.ConceptDescription.conceptAlias as JSON " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS_BT6" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS_BT7" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS_BT8" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS_BT9" role="92FcQ">
+                <ref role="VXe09" to="imb3:~Property" resolve="Property" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_BTa" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_BKh" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="VUp57" id="5M8g5cS_DGt" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cS_DMd" role="VUp5m">
+            <ref role="VXe0S" to="y7p:34Q84zNQVqH" resolve="mpsConceptAliasProperty" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="34Q84zNTp5n" role="jymVt">
       <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptShortDescription" />
@@ -4929,6 +5217,32 @@
       <node concept="3Tm1VV" id="34Q84zNTp5p" role="1B3o_S" />
       <node concept="3uibUv" id="34Q84zNTp5q" role="3clF45">
         <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS_DMs" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_DPq" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_DPr" role="1dT_Ay">
+            <property role="1dT_AB" value="io.lionweb.mps.specific.lang.MPS-specific annotations.ConceptDescription.conceptShortDescription as JSON " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS_DPs" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS_DPt" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS_DPu" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS_DPv" role="92FcQ">
+                <ref role="VXe09" to="imb3:~Property" resolve="Property" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_DPw" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_DPx" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="VUp57" id="5M8g5cS_E5h" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cS_Eb1" role="VUp5m">
+            <ref role="VXe0S" to="y7p:34Q84zNQWR0" resolve="mpsConceptShortDescriptionProperty" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNToUC" role="jymVt" />
@@ -4941,6 +5255,18 @@
           <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
         </node>
       </node>
+      <node concept="P$JXv" id="5M8g5cS_Ebo" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_Eh8" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_Eh9" role="1dT_Ay">
+            <property role="1dT_AB" value="All M2 JSON annotation properties that are converted from MPS concept properties." />
+          </node>
+        </node>
+        <node concept="VUp57" id="5M8g5cS_EpG" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cS_Evm" role="VUp5m">
+            <ref role="VXe0S" to="y7p:34Q84zNtsh8" resolve="listConceptDescriptionProperties" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="7weWCFlvJ3J" role="jymVt" />
     <node concept="3clFb_" id="7weWCFlwidJ" role="jymVt">
@@ -4950,6 +5276,24 @@
       <node concept="3uibUv" id="7weWCFlwi9Z" role="3clF45">
         <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS_EvH" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_EvI" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_EvJ" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS_H9O" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS_Ha2" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS_Ha4" role="2XjZqd" />
+              <node concept="VXe0Z" id="5M8g5cS_Irm" role="92FcQ">
+                <ref role="VXe0S" to="cz4z:~LionCore.getAnnotation()" resolve="getAnnotation" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_H9N" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="7weWCFlwin$" role="jymVt">
       <property role="TrG5h" value="getClassifierConcept" />
@@ -4957,6 +5301,24 @@
       <node concept="3Tm1VV" id="7weWCFlwinA" role="1B3o_S" />
       <node concept="3uibUv" id="7weWCFlwinB" role="3clF45">
         <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS_IBF" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_IED" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_IEE" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS_IEF" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS_IEG" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS_IEH" role="2XjZqd" />
+              <node concept="VXe0Z" id="5M8g5cS_IEI" role="92FcQ">
+                <ref role="VXe0S" to="cz4z:~LionCore.getClassifier()" resolve="getClassifier" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_IEJ" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="7weWCFlwj$H" role="jymVt">
@@ -4966,6 +5328,24 @@
       <node concept="3uibUv" id="7weWCFlwj$K" role="3clF45">
         <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS_INA" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_IQ$" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_IQ_" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS_IQA" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS_IQB" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS_IQC" role="2XjZqd" />
+              <node concept="VXe0Z" id="5M8g5cS_IQD" role="92FcQ">
+                <ref role="VXe0S" to="cz4z:~LionCore.getConcept()" resolve="getConcept" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_IQE" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="7weWCFlwk05" role="jymVt">
       <property role="TrG5h" value="getInterfaceConcept" />
@@ -4973,6 +5353,24 @@
       <node concept="3Tm1VV" id="7weWCFlwk07" role="1B3o_S" />
       <node concept="3uibUv" id="7weWCFlwk08" role="3clF45">
         <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS_IZt" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_J2r" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_J2s" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS_J2t" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS_J2u" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS_J2v" role="2XjZqd" />
+              <node concept="VXe0Z" id="5M8g5cS_J2w" role="92FcQ">
+                <ref role="VXe0S" to="cz4z:~LionCore.getInterface()" resolve="getInterface" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_J2x" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7weWCFlwedG" role="jymVt" />
@@ -4983,6 +5381,18 @@
       <node concept="_YKpA" id="7weWCFlvJ8_" role="3clF45">
         <node concept="3uibUv" id="7weWCFlvJc9" role="_ZDj9">
           <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="5M8g5cS_Jrc" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_Jrd" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_Jre" role="1dT_Ay">
+            <property role="1dT_AB" value="All JSON classifiers that need special treatment" />
+          </node>
+        </node>
+        <node concept="VUp57" id="5M8g5cS_Vv6" role="3nqlJM">
+          <node concept="VXe0Z" id="5M8g5cS_Y2B" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7weWCFlqTiX" resolve="listSLanguageInternalClassifiers" />
+          </node>
         </node>
       </node>
     </node>
@@ -6083,6 +6493,12 @@
               <node concept="1rXfSq" id="7weWCFlwqSd" role="HW$Y0">
                 <ref role="37wK5l" node="7weWCFlwuJR" resolve="getClassifierConcept" />
               </node>
+              <node concept="1rXfSq" id="5M8g5cSALiW" role="HW$Y0">
+                <ref role="37wK5l" node="7weWCFlwuK0" resolve="getConceptConcept" />
+              </node>
+              <node concept="1rXfSq" id="5M8g5cSAPIi" role="HW$Y0">
+                <ref role="37wK5l" node="7weWCFlwuK9" resolve="getInterfaceConcept" />
+              </node>
             </node>
           </node>
         </node>
@@ -6216,6 +6632,24 @@
       <node concept="3Tm1VV" id="7weWCFlyex_" role="1B3o_S" />
     </node>
     <node concept="3Tm1VV" id="7weWCFlyclI" role="1B3o_S" />
+    <node concept="3UR2Jj" id="5M8g5cSAaxx" role="lGtFl">
+      <node concept="TZ5HA" id="5M8g5cSAaxy" role="TZ5H$">
+        <node concept="1dT_AC" id="5M8g5cSAaxz" role="1dT_Ay">
+          <property role="1dT_AB" value="Non-static access to " />
+        </node>
+        <node concept="1dT_AA" id="5M8g5cSAazU" role="1dT_Ay">
+          <node concept="92FcH" id="5M8g5cSAa$0" role="qph3F">
+            <node concept="TZ5HA" id="5M8g5cSAa$2" role="2XjZqd" />
+            <node concept="VXe08" id="5M8g5cSAaVw" role="92FcQ">
+              <ref role="VXe09" to="cz4z:~LionCore" resolve="LionCore" />
+            </node>
+          </node>
+        </node>
+        <node concept="1dT_AC" id="5M8g5cSAazT" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="312cEu" id="7weWCFlyxlE">
     <property role="3GE5qa" value="lionCoreAdapter" />

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
@@ -3256,6 +3256,25 @@
       </node>
       <node concept="10Nm6u" id="24j7TNH1Ch5" role="33vP2m" />
     </node>
+    <node concept="2tJIrI" id="5M8g5cT5CKB" role="jymVt" />
+    <node concept="312cEg" id="5M8g5cT5Ge$" role="jymVt">
+      <property role="TrG5h" value="exportDescriptionAnnotations" />
+      <node concept="3Tm6S6" id="5M8g5cT5Dkw" role="1B3o_S" />
+      <node concept="3uibUv" id="5M8g5cT5D_C" role="1tU5fm">
+        <ref role="3uigEE" to="wyt6:~Boolean" resolve="Boolean" />
+      </node>
+      <node concept="10Nm6u" id="5M8g5cT5MJx" role="33vP2m" />
+      <node concept="2AHcQZ" id="5M8g5cT5MJU" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="z59LJ" id="5M8g5cT5MLq" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cT5MLr" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cT5MLs" role="1dT_Ay">
+            <property role="1dT_AB" value="If true, export concept description and/or alias as annotation." />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="5TNjoy1AP3l" role="jymVt" />
     <node concept="3clFbW" id="24j7TNH1A2A" role="jymVt">
       <node concept="37vLTG" id="5TNjoy1AdX$" role="3clF46">
@@ -3456,6 +3475,30 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="5M8g5cT5O7W" role="3cqZAp" />
+        <node concept="3clFbJ" id="5M8g5cT5OVv" role="3cqZAp">
+          <node concept="3clFbS" id="5M8g5cT5OVx" role="3clFbx">
+            <node concept="3clFbF" id="5M8g5cT5QmL" role="3cqZAp">
+              <node concept="2OqwBi" id="5M8g5cT5QSs" role="3clFbG">
+                <node concept="37vLTw" id="5M8g5cT5QmJ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5TNjoy1A$wU" resolve="converter" />
+                </node>
+                <node concept="liA8E" id="5M8g5cT5Rga" role="2OqNvi">
+                  <ref role="37wK5l" to="5els:5M8g5cT4UjH" resolve="setExportDescriptionAnnotations" />
+                  <node concept="37vLTw" id="5M8g5cT5Ryx" role="37wK5m">
+                    <ref role="3cqZAo" node="5M8g5cT5Ge$" resolve="exportDescriptionAnnotations" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="5M8g5cT5P$C" role="3clFbw">
+            <node concept="10Nm6u" id="5M8g5cT5POR" role="3uHU7w" />
+            <node concept="37vLTw" id="5M8g5cT5PcM" role="3uHU7B">
+              <ref role="3cqZAo" node="5M8g5cT5Ge$" resolve="exportDescriptionAnnotations" />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbH" id="24j7TNH1ObR" role="3cqZAp" />
         <node concept="3clFbF" id="24j7TNH1Opg" role="3cqZAp">
           <node concept="15s5l7" id="5TNjoy1CFhH" role="lGtFl">
@@ -3531,6 +3574,30 @@
         <node concept="1dT_AC" id="5TNjoy1PdSB" role="1dT_Ay">
           <property role="1dT_AB" value="Facade to export MPS languages (M2) to JSON." />
         </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5M8g5cT5Ngm" role="jymVt">
+      <property role="TrG5h" value="setExportDescriptionAnnotations" />
+      <node concept="3cqZAl" id="5M8g5cT5Ngn" role="3clF45" />
+      <node concept="3Tm1VV" id="5M8g5cT5Ngo" role="1B3o_S" />
+      <node concept="3clFbS" id="5M8g5cT5Ngp" role="3clF47">
+        <node concept="3clFbF" id="5M8g5cT5Ngq" role="3cqZAp">
+          <node concept="37vLTI" id="5M8g5cT5Ngr" role="3clFbG">
+            <node concept="37vLTw" id="5M8g5cT5Ngs" role="37vLTx">
+              <ref role="3cqZAo" node="5M8g5cT5Ngt" resolve="exportDescriptionAnnotations" />
+            </node>
+            <node concept="2OqwBi" id="5M8g5cT5Ngj" role="37vLTJ">
+              <node concept="Xjq3P" id="5M8g5cT5Ngk" role="2Oq$k0" />
+              <node concept="2OwXpG" id="5M8g5cT5Ngl" role="2OqNvi">
+                <ref role="2Oxat5" node="5M8g5cT5Ge$" resolve="exportDescriptionAnnotations" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5M8g5cT5Ngt" role="3clF46">
+        <property role="TrG5h" value="exportDescriptionAnnotations" />
+        <node concept="10P_77" id="5M8g5cT5NQj" role="1tU5fm" />
       </node>
     </node>
   </node>

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -33,6 +33,7 @@
     <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" />
     <import index="pjrh" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter(MPS.Core/)" />
+    <import index="ze1i" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.runtime(MPS.Core/)" />
     <import index="4xw4" ref="r:23ccdcd2-ac4f-4247-aad5-4d197fcb7e18(io.lionweb.mps.specific.lang)" implicit="true" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
   </imports>
@@ -969,25 +970,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="34Q84zNQEPO" role="3cqZAp" />
-        <node concept="3clFbF" id="34Q84zNRqnP" role="3cqZAp">
-          <node concept="37vLTI" id="34Q84zNRrsU" role="3clFbG">
-            <node concept="37vLTw" id="34Q84zNRqnN" role="37vLTJ">
-              <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
-            </node>
-            <node concept="2OqwBi" id="34Q84zNRv_k" role="37vLTx">
-              <node concept="2tJFMh" id="34Q84zNRv_l" role="2Oq$k0">
-                <node concept="ZC_QK" id="34Q84zNRv_m" role="2tJFKM">
-                  <ref role="2aWVGs" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                </node>
-              </node>
-              <node concept="Vyspw" id="34Q84zNRv_n" role="2OqNvi">
-                <node concept="37vLTw" id="34Q84zNRv_o" role="Vysub">
-                  <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3clFbF" id="34Q84zNOhCM" role="3cqZAp">
           <node concept="37vLTI" id="34Q84zNOiG9" role="3clFbG">
             <node concept="2OqwBi" id="34Q84zNOmSj" role="37vLTx">
@@ -1010,7 +992,63 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="34Q84zNRJer" role="3cqZAp" />
+        <node concept="3clFbF" id="34Q84zNRqnP" role="3cqZAp">
+          <node concept="37vLTI" id="34Q84zNRrsU" role="3clFbG">
+            <node concept="37vLTw" id="34Q84zNRqnN" role="37vLTJ">
+              <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
+            </node>
+            <node concept="2OqwBi" id="34Q84zNRv_k" role="37vLTx">
+              <node concept="2tJFMh" id="34Q84zNRv_l" role="2Oq$k0">
+                <node concept="ZC_QK" id="34Q84zNRv_m" role="2tJFKM">
+                  <ref role="2aWVGs" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="34Q84zNRv_n" role="2OqNvi">
+                <node concept="37vLTw" id="34Q84zNRv_o" role="Vysub">
+                  <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7weWCFlnuRC" role="3cqZAp">
+          <node concept="37vLTI" id="7weWCFlnwgk" role="3clFbG">
+            <node concept="2YIFZM" id="7weWCFlnY$f" role="37vLTx">
+              <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+              <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
+              <node concept="37vLTw" id="7weWCFlnY$g" role="37wK5m">
+                <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+              </node>
+              <node concept="37vLTw" id="7weWCFlo0Q3" role="37wK5m">
+                <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+              </node>
+              <node concept="2YIFZM" id="7weWCFlo4mC" role="37wK5m">
+                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                <node concept="2OqwBi" id="7weWCFlo6pf" role="37wK5m">
+                  <node concept="37vLTw" id="7weWCFlo5rf" role="2Oq$k0">
+                    <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
+                  </node>
+                  <node concept="3TrcHB" id="7weWCFlo898" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7weWCFlobCi" role="37wK5m">
+                <node concept="37vLTw" id="7weWCFloahn" role="2Oq$k0">
+                  <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
+                </node>
+                <node concept="3TrcHB" id="7weWCFlod5n" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="7weWCFlnuRA" role="37vLTJ">
+              <ref role="3cqZAo" node="7weWCFlnksG" resolve="SLANG_ABSTRACT_CONCEPT_CONCEPT" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7weWCFloe7n" role="3cqZAp" />
         <node concept="3clFbF" id="34Q84zNOpJK" role="3cqZAp">
           <node concept="37vLTI" id="34Q84zNOpJL" role="3clFbG">
             <node concept="2OqwBi" id="34Q84zNOpJM" role="37vLTx">
@@ -1723,6 +1761,31 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="312cEg" id="7weWCFlnksG" role="jymVt">
+      <property role="TrG5h" value="SLANG_ABSTRACT_CONCEPT_CONCEPT" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="7weWCFlnhL_" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlnjU3" role="1tU5fm">
+        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlnoxb" role="jymVt">
+      <property role="TrG5h" value="slangAbstractConceptConcept" />
+      <node concept="3Tm1VV" id="7weWCFlnoxd" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlnoxe" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+      <node concept="3clFbS" id="7weWCFlnoxg" role="3clF47">
+        <node concept="3clFbF" id="7weWCFlntkN" role="3cqZAp">
+          <node concept="37vLTw" id="7weWCFlntkK" role="3clFbG">
+            <ref role="3cqZAo" node="7weWCFlnksG" resolve="SLANG_ABSTRACT_CONCEPT_CONCEPT" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFlnoxh" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="34Q84zNS0hq" role="jymVt" />
     <node concept="312cEg" id="34Q84zNNvW1" role="jymVt">
       <property role="TrG5h" value="MPS_CONCEPT_ALIAS_PROPERTY" />
@@ -1991,6 +2054,70 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="34Q84zNNqg0" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7weWCFlmZps" role="jymVt" />
+    <node concept="2tJIrI" id="7weWCFln0QZ" role="jymVt" />
+    <node concept="3clFb_" id="7weWCFln2o1" role="jymVt">
+      <property role="TrG5h" value="listMpsInternalClassifiers" />
+      <node concept="3Tm1VV" id="7weWCFlqObT" role="1B3o_S" />
+      <node concept="2I9FWS" id="7weWCFln2oa" role="3clF45">
+        <ref role="2I9WkF" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+      </node>
+      <node concept="3clFbS" id="7weWCFln2of" role="3clF47">
+        <node concept="3clFbF" id="7weWCFln2oi" role="3cqZAp">
+          <node concept="2ShNRf" id="7weWCFln6BC" role="3clFbG">
+            <node concept="Tc6Ow" id="7weWCFln6BD" role="2ShVmc">
+              <node concept="1rXfSq" id="7weWCFln6BE" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhqgVl" resolve="mpsNodeConcept" />
+              </node>
+              <node concept="1rXfSq" id="7weWCFln6BF" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhqsXL" resolve="mpsAnnotationConcept" />
+              </node>
+              <node concept="1rXfSq" id="7weWCFlnd9$" role="HW$Y0">
+                <ref role="37wK5l" node="34Q84zNR2iW" resolve="mpsAbstractConceptDeclarationConcept" />
+              </node>
+              <node concept="3Tqbb2" id="7weWCFln6BG" role="HW$YZ">
+                <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFln2og" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFln2oj" role="jymVt">
+      <property role="TrG5h" value="listSLanguageInternalClassifiers" />
+      <node concept="3Tm1VV" id="7weWCFlqMLz" role="1B3o_S" />
+      <node concept="_YKpA" id="7weWCFln2os" role="3clF45">
+        <node concept="3uibUv" id="7weWCFln2ot" role="_ZDj9">
+          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7weWCFln2oB" role="3clF47">
+        <node concept="3clFbF" id="7weWCFln2oE" role="3cqZAp">
+          <node concept="2ShNRf" id="7weWCFlnaja" role="3clFbG">
+            <node concept="Tc6Ow" id="7weWCFlnajb" role="2ShVmc">
+              <node concept="1rXfSq" id="7weWCFlnajc" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhqgVh" resolve="slangNodeConcept" />
+              </node>
+              <node concept="1rXfSq" id="7weWCFlnajd" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhqsXH" resolve="slangAnnotationConcept" />
+              </node>
+              <node concept="1rXfSq" id="7weWCFlogCi" role="HW$Y0">
+                <ref role="37wK5l" node="7weWCFlnoxb" resolve="slangAbstractConceptConcept" />
+              </node>
+              <node concept="3uibUv" id="7weWCFlnaje" role="HW$YZ">
+                <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7weWCFln2oC" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -6795,6 +6922,14 @@
         <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
       </node>
     </node>
+    <node concept="3clFb_" id="7weWCFlnm$K" role="jymVt">
+      <property role="TrG5h" value="slangAbstractConceptConcept" />
+      <node concept="3clFbS" id="7weWCFlnm$N" role="3clF47" />
+      <node concept="3Tm1VV" id="7weWCFlnm$O" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlnmfS" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="34Q84zNQU1i" role="jymVt" />
     <node concept="3clFb_" id="34Q84zNQVqH" role="jymVt">
       <property role="TrG5h" value="mpsConceptAliasProperty" />
@@ -10010,7 +10145,7 @@
           </node>
         </node>
       </node>
-      <node concept="3Tmbuc" id="5JNiskixdim" role="1B3o_S" />
+      <node concept="3Tm1VV" id="7weWCFlq$R_" role="1B3o_S" />
       <node concept="2I9FWS" id="5JNiskhYXhY" role="3clF45">
         <ref role="2I9WkF" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
       </node>
@@ -10044,7 +10179,7 @@
           </node>
         </node>
       </node>
-      <node concept="3Tmbuc" id="5JNiskixg$3" role="1B3o_S" />
+      <node concept="3Tm1VV" id="7weWCFlqxOZ" role="1B3o_S" />
       <node concept="_YKpA" id="5JNiskhYXic" role="3clF45">
         <node concept="3uibUv" id="5JNiskhYXid" role="_ZDj9">
           <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
@@ -11458,6 +11593,57 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3k2c" role="jymVt" />
+    <node concept="3clFb_" id="7weWCFlqTiI" role="jymVt">
+      <property role="TrG5h" value="listMpsInternalClassifiers" />
+      <node concept="3clFbS" id="7weWCFlqTiJ" role="3clF47" />
+      <node concept="3Tm1VV" id="7weWCFlqTiQ" role="1B3o_S" />
+      <node concept="2I9FWS" id="7weWCFlqTiR" role="3clF45">
+        <ref role="2I9WkF" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+      </node>
+      <node concept="P$JXv" id="7weWCFlqTiS" role="lGtFl">
+        <node concept="TZ5HA" id="7weWCFlqTiT" role="TZ5H$">
+          <node concept="1dT_AC" id="7weWCFlqTiU" role="1dT_Ay">
+            <property role="1dT_AB" value="All MPS concepts that need special treatment in LionWeb as MPS Concept." />
+          </node>
+        </node>
+        <node concept="x79VA" id="7weWCFlqTiV" role="3nqlJM">
+          <property role="x79VB" value="All MPS concepts that need special treatment in LionWeb." />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7weWCFlqUnk" role="jymVt" />
+    <node concept="3clFb_" id="7weWCFlqTiX" role="jymVt">
+      <property role="TrG5h" value="listSLanguageInternalClassifiers" />
+      <node concept="3clFbS" id="7weWCFlqTiY" role="3clF47" />
+      <node concept="3Tm1VV" id="7weWCFlqTj5" role="1B3o_S" />
+      <node concept="_YKpA" id="7weWCFlqTj6" role="3clF45">
+        <node concept="3uibUv" id="7weWCFlqTj7" role="_ZDj9">
+          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="7weWCFlqTj8" role="lGtFl">
+        <node concept="TZ5HA" id="7weWCFlqTj9" role="TZ5H$">
+          <node concept="1dT_AC" id="7weWCFlqTja" role="1dT_Ay">
+            <property role="1dT_AB" value="All MPS concepts that need special treatment in LionWeb as MPS " />
+          </node>
+          <node concept="1dT_AA" id="7weWCFlqTjb" role="1dT_Ay">
+            <node concept="92FcH" id="7weWCFlqTjc" role="qph3F">
+              <node concept="TZ5HA" id="7weWCFlqTjd" role="2XjZqd" />
+              <node concept="VXe08" id="7weWCFlqTje" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="7weWCFlqTjf" role="1dT_Ay">
+            <property role="1dT_AB" value="." />
+          </node>
+        </node>
+        <node concept="x79VA" id="7weWCFlqTjg" role="3nqlJM">
+          <property role="x79VB" value="All MPS concepts that need special treatment in LionWeb." />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7weWCFlqSXi" role="jymVt" />
     <node concept="3clFb_" id="5JNiski3k2d" role="jymVt">
       <property role="TrG5h" value="isMpsInternalFeature" />
       <node concept="3clFbS" id="5JNiski3k2e" role="3clF47" />

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -401,6 +401,7 @@
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="4611582986551314327" name="jetbrains.mps.baseLanguage.collections.structure.OfTypeOperation" flags="nn" index="UnYns">
         <child id="4611582986551314344" name="requestedType" index="UnYnz" />
       </concept>
@@ -883,56 +884,48 @@
             </node>
           </node>
         </node>
-        <node concept="1X3_iC" id="34Q84zNQCeD" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="34Q84zNQalU" role="8Wnug">
-            <node concept="37vLTI" id="34Q84zNQalV" role="3clFbG">
-              <node concept="37vLTw" id="34Q84zNQalW" role="37vLTJ">
-                <ref role="3cqZAo" node="34Q84zNPOE1" resolve="KEY_STRUCTURE_LANGUAGE" />
-              </node>
-              <node concept="Xl_RD" id="34Q84zNQalX" role="37vLTx">
-                <property role="Xl_RC" value="TODO" />
+        <node concept="3clFbF" id="34Q84zNQalU" role="3cqZAp">
+          <node concept="37vLTI" id="34Q84zNQalV" role="3clFbG">
+            <node concept="37vLTw" id="34Q84zNQalW" role="37vLTJ">
+              <ref role="3cqZAo" node="34Q84zNPOE1" resolve="KEY_STRUCTURE_LANGUAGE" />
+            </node>
+            <node concept="2YIFZM" id="5M8g5cT0H0_" role="37vLTx">
+              <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
+              <node concept="37vLTw" id="5M8g5cT0H0A" role="37wK5m">
+                <ref role="3cqZAo" node="5JNiskiqAL0" resolve="LC_SHORT_DESCRIPTION_ANNOTATION" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="1X3_iC" id="34Q84zNQCeE" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="34Q84zNQalY" role="8Wnug">
-            <node concept="37vLTI" id="34Q84zNQalZ" role="3clFbG">
-              <node concept="37vLTw" id="34Q84zNQam0" role="37vLTJ">
-                <ref role="3cqZAo" node="34Q84zNPQ8E" resolve="ID_STRUCTURE_LANGUAGE" />
+        <node concept="3clFbF" id="34Q84zNQalY" role="3cqZAp">
+          <node concept="37vLTI" id="34Q84zNQalZ" role="3clFbG">
+            <node concept="37vLTw" id="34Q84zNQam0" role="37vLTJ">
+              <ref role="3cqZAo" node="34Q84zNPQ8E" resolve="ID_STRUCTURE_LANGUAGE" />
+            </node>
+            <node concept="2OqwBi" id="34Q84zNQam1" role="37vLTx">
+              <node concept="37vLTw" id="34Q84zNQam2" role="2Oq$k0">
+                <ref role="3cqZAo" node="34Q84zNPNje" resolve="SLANG_STRUCTURE_LANGUAGE" />
               </node>
-              <node concept="2OqwBi" id="34Q84zNQam1" role="37vLTx">
-                <node concept="37vLTw" id="34Q84zNQam2" role="2Oq$k0">
+              <node concept="liA8E" id="34Q84zNQam3" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="34Q84zNQam4" role="3cqZAp">
+          <node concept="37vLTI" id="34Q84zNQam5" role="3clFbG">
+            <node concept="37vLTw" id="34Q84zNQam6" role="37vLTJ">
+              <ref role="3cqZAo" node="34Q84zNPRvz" resolve="VERSION_STRUCTURE_LANGUAGE" />
+            </node>
+            <node concept="2YIFZM" id="34Q84zNQam7" role="37vLTx">
+              <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
+              <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
+              <node concept="2YIFZM" id="34Q84zNQam8" role="37wK5m">
+                <ref role="1Pybhc" node="6jTTMHD72IS" resolve="MpsLanguageUtil" />
+                <ref role="37wK5l" node="6jTTMHD72KX" resolve="getLanguageVersion" />
+                <node concept="37vLTw" id="34Q84zNQam9" role="37wK5m">
                   <ref role="3cqZAo" node="34Q84zNPNje" resolve="SLANG_STRUCTURE_LANGUAGE" />
-                </node>
-                <node concept="liA8E" id="34Q84zNQam3" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="34Q84zNQCeF" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="34Q84zNQam4" role="8Wnug">
-            <node concept="37vLTI" id="34Q84zNQam5" role="3clFbG">
-              <node concept="37vLTw" id="34Q84zNQam6" role="37vLTJ">
-                <ref role="3cqZAo" node="34Q84zNPRvz" resolve="VERSION_STRUCTURE_LANGUAGE" />
-              </node>
-              <node concept="2YIFZM" id="34Q84zNQam7" role="37vLTx">
-                <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
-                <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
-                <node concept="2YIFZM" id="34Q84zNQam8" role="37wK5m">
-                  <ref role="1Pybhc" node="6jTTMHD72IS" resolve="MpsLanguageUtil" />
-                  <ref role="37wK5l" node="6jTTMHD72KX" resolve="getLanguageVersion" />
-                  <node concept="37vLTw" id="34Q84zNQam9" role="37wK5m">
-                    <ref role="3cqZAo" node="34Q84zNPNje" resolve="SLANG_STRUCTURE_LANGUAGE" />
-                  </node>
                 </node>
               </node>
             </node>
@@ -1761,91 +1754,67 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="1X3_iC" id="34Q84zNQD95" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="34Q84zNPOE1" role="8Wnug">
-        <property role="TrG5h" value="KEY_STRUCTURE_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="34Q84zNPOE2" role="1B3o_S" />
-        <node concept="17QB3L" id="34Q84zNPOE3" role="1tU5fm" />
-      </node>
+    <node concept="312cEg" id="34Q84zNPOE1" role="jymVt">
+      <property role="TrG5h" value="KEY_STRUCTURE_LANGUAGE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="34Q84zNPOE2" role="1B3o_S" />
+      <node concept="17QB3L" id="34Q84zNPOE3" role="1tU5fm" />
     </node>
-    <node concept="1X3_iC" id="34Q84zNQD96" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="3clFb_" id="34Q84zNPHSm" role="8Wnug">
-        <property role="TrG5h" value="keyStructureLanguage" />
-        <node concept="3Tm1VV" id="34Q84zNPHSo" role="1B3o_S" />
-        <node concept="17QB3L" id="34Q84zNPHSp" role="3clF45" />
-        <node concept="3clFbS" id="34Q84zNPHSu" role="3clF47">
-          <node concept="3clFbF" id="34Q84zNQ16D" role="3cqZAp">
-            <node concept="37vLTw" id="34Q84zNQ16A" role="3clFbG">
-              <ref role="3cqZAo" node="34Q84zNPOE1" resolve="KEY_STRUCTURE_LANGUAGE" />
-            </node>
+    <node concept="3clFb_" id="34Q84zNPHSm" role="jymVt">
+      <property role="TrG5h" value="keyStructureLanguage" />
+      <node concept="3Tm1VV" id="34Q84zNPHSo" role="1B3o_S" />
+      <node concept="17QB3L" id="34Q84zNPHSp" role="3clF45" />
+      <node concept="3clFbS" id="34Q84zNPHSu" role="3clF47">
+        <node concept="3clFbF" id="34Q84zNQ16D" role="3cqZAp">
+          <node concept="37vLTw" id="34Q84zNQ16A" role="3clFbG">
+            <ref role="3cqZAo" node="34Q84zNPOE1" resolve="KEY_STRUCTURE_LANGUAGE" />
           </node>
         </node>
-        <node concept="2AHcQZ" id="34Q84zNPHSv" role="2AJF6D">
-          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-        </node>
+      </node>
+      <node concept="2AHcQZ" id="34Q84zNPHSv" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="1X3_iC" id="34Q84zNQD97" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="34Q84zNPQ8E" role="8Wnug">
-        <property role="TrG5h" value="ID_STRUCTURE_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="34Q84zNPQ8F" role="1B3o_S" />
-        <node concept="17QB3L" id="34Q84zNPQ8G" role="1tU5fm" />
-      </node>
+    <node concept="312cEg" id="34Q84zNPQ8E" role="jymVt">
+      <property role="TrG5h" value="ID_STRUCTURE_LANGUAGE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="34Q84zNPQ8F" role="1B3o_S" />
+      <node concept="17QB3L" id="34Q84zNPQ8G" role="1tU5fm" />
     </node>
-    <node concept="1X3_iC" id="34Q84zNQD98" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="3clFb_" id="34Q84zNPHSy" role="8Wnug">
-        <property role="TrG5h" value="idStructureLanguage" />
-        <node concept="3Tm1VV" id="34Q84zNPHS$" role="1B3o_S" />
-        <node concept="17QB3L" id="34Q84zNPHS_" role="3clF45" />
-        <node concept="3clFbS" id="34Q84zNPHSE" role="3clF47">
-          <node concept="3clFbF" id="34Q84zNPYL3" role="3cqZAp">
-            <node concept="37vLTw" id="34Q84zNPYL0" role="3clFbG">
-              <ref role="3cqZAo" node="34Q84zNPQ8E" resolve="ID_STRUCTURE_LANGUAGE" />
-            </node>
+    <node concept="3clFb_" id="34Q84zNPHSy" role="jymVt">
+      <property role="TrG5h" value="idStructureLanguage" />
+      <node concept="3Tm1VV" id="34Q84zNPHS$" role="1B3o_S" />
+      <node concept="17QB3L" id="34Q84zNPHS_" role="3clF45" />
+      <node concept="3clFbS" id="34Q84zNPHSE" role="3clF47">
+        <node concept="3clFbF" id="34Q84zNPYL3" role="3cqZAp">
+          <node concept="37vLTw" id="34Q84zNPYL0" role="3clFbG">
+            <ref role="3cqZAo" node="34Q84zNPQ8E" resolve="ID_STRUCTURE_LANGUAGE" />
           </node>
         </node>
-        <node concept="2AHcQZ" id="34Q84zNPHSF" role="2AJF6D">
-          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-        </node>
+      </node>
+      <node concept="2AHcQZ" id="34Q84zNPHSF" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="1X3_iC" id="34Q84zNQD99" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="34Q84zNPRvz" role="8Wnug">
-        <property role="TrG5h" value="VERSION_STRUCTURE_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="34Q84zNPRv$" role="1B3o_S" />
-        <node concept="17QB3L" id="34Q84zNPRv_" role="1tU5fm" />
-      </node>
+    <node concept="312cEg" id="34Q84zNPRvz" role="jymVt">
+      <property role="TrG5h" value="VERSION_STRUCTURE_LANGUAGE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="34Q84zNPRv$" role="1B3o_S" />
+      <node concept="17QB3L" id="34Q84zNPRv_" role="1tU5fm" />
     </node>
-    <node concept="1X3_iC" id="34Q84zNQD9a" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="3clFb_" id="34Q84zNPHSI" role="8Wnug">
-        <property role="TrG5h" value="versionStructureLanguage" />
-        <node concept="3Tm1VV" id="34Q84zNPHSK" role="1B3o_S" />
-        <node concept="17QB3L" id="34Q84zNPHSL" role="3clF45" />
-        <node concept="3clFbS" id="34Q84zNPHSQ" role="3clF47">
-          <node concept="3clFbF" id="34Q84zNPWtZ" role="3cqZAp">
-            <node concept="37vLTw" id="34Q84zNPWtW" role="3clFbG">
-              <ref role="3cqZAo" node="34Q84zNPRvz" resolve="VERSION_STRUCTURE_LANGUAGE" />
-            </node>
+    <node concept="3clFb_" id="34Q84zNPHSI" role="jymVt">
+      <property role="TrG5h" value="versionStructureLanguage" />
+      <node concept="3Tm1VV" id="34Q84zNPHSK" role="1B3o_S" />
+      <node concept="17QB3L" id="34Q84zNPHSL" role="3clF45" />
+      <node concept="3clFbS" id="34Q84zNPHSQ" role="3clF47">
+        <node concept="3clFbF" id="34Q84zNPWtZ" role="3cqZAp">
+          <node concept="37vLTw" id="34Q84zNPWtW" role="3clFbG">
+            <ref role="3cqZAo" node="34Q84zNPRvz" resolve="VERSION_STRUCTURE_LANGUAGE" />
           </node>
         </node>
-        <node concept="2AHcQZ" id="34Q84zNPHSR" role="2AJF6D">
-          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-        </node>
+      </node>
+      <node concept="2AHcQZ" id="34Q84zNPHSR" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNNuO4" role="jymVt" />
@@ -2274,6 +2243,171 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7weWCFlmZps" role="jymVt" />
+    <node concept="2tJIrI" id="5M8g5cSYLiu" role="jymVt" />
+    <node concept="3clFb_" id="5M8g5cSYOn5" role="jymVt">
+      <property role="TrG5h" value="listSLanguages" />
+      <node concept="3Tm1VV" id="5M8g5cSYOnd" role="1B3o_S" />
+      <node concept="_YKpA" id="5M8g5cSYOne" role="3clF45">
+        <node concept="3uibUv" id="5M8g5cSYOnf" role="_ZDj9">
+          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5M8g5cSYOng" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3clFbS" id="5M8g5cSYOnh" role="3clF47">
+        <node concept="3cpWs8" id="5M8g5cSZ6es" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cSZ6et" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="_YKpA" id="5M8g5cSZ5fF" role="1tU5fm">
+              <node concept="3uibUv" id="5M8g5cSZ5fI" role="_ZDj9">
+                <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+              </node>
+            </node>
+            <node concept="3nyPlj" id="5M8g5cSZ6eu" role="33vP2m">
+              <ref role="37wK5l" node="5JNiskhYXbv" resolve="listSLanguages" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cSZbB_" role="3cqZAp">
+          <node concept="2OqwBi" id="5M8g5cSZd5f" role="3clFbG">
+            <node concept="37vLTw" id="5M8g5cSZbBz" role="2Oq$k0">
+              <ref role="3cqZAo" node="5M8g5cSZ6et" resolve="result" />
+            </node>
+            <node concept="TSZUe" id="5M8g5cSZeXn" role="2OqNvi">
+              <node concept="1rXfSq" id="5M8g5cSZgO3" role="25WWJ7">
+                <ref role="37wK5l" node="34Q84zNPHS5" resolve="slangStructureLanguage" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cSZmhS" role="3cqZAp">
+          <node concept="37vLTw" id="5M8g5cSZmhQ" role="3clFbG">
+            <ref role="3cqZAo" node="5M8g5cSZ6et" resolve="result" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5M8g5cSYOnk" role="jymVt">
+      <property role="TrG5h" value="listKeyLanguages" />
+      <node concept="3Tm1VV" id="5M8g5cSYOns" role="1B3o_S" />
+      <node concept="_YKpA" id="5M8g5cSYOnt" role="3clF45">
+        <node concept="17QB3L" id="5M8g5cSYOnu" role="_ZDj9" />
+      </node>
+      <node concept="2AHcQZ" id="5M8g5cSYOnv" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3clFbS" id="5M8g5cSYOnw" role="3clF47">
+        <node concept="3cpWs8" id="5M8g5cSZocc" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cSZocd" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="_YKpA" id="5M8g5cSZn5g" role="1tU5fm">
+              <node concept="17QB3L" id="5M8g5cSZn5j" role="_ZDj9" />
+            </node>
+            <node concept="3nyPlj" id="5M8g5cSZoce" role="33vP2m">
+              <ref role="37wK5l" node="5JNiskhYXbN" resolve="listKeyLanguages" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cSZtpf" role="3cqZAp">
+          <node concept="2OqwBi" id="5M8g5cSZuPs" role="3clFbG">
+            <node concept="37vLTw" id="5M8g5cSZtpd" role="2Oq$k0">
+              <ref role="3cqZAo" node="5M8g5cSZocd" resolve="result" />
+            </node>
+            <node concept="TSZUe" id="5M8g5cSZxvh" role="2OqNvi">
+              <node concept="1rXfSq" id="5M8g5cSZLMr" role="25WWJ7">
+                <ref role="37wK5l" node="34Q84zNPHSm" resolve="keyStructureLanguage" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cSYOny" role="3cqZAp">
+          <node concept="37vLTw" id="5M8g5cSZocf" role="3clFbG">
+            <ref role="3cqZAo" node="5M8g5cSZocd" resolve="result" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5M8g5cSYOnz" role="jymVt">
+      <property role="TrG5h" value="listSLanguageLanguageIds" />
+      <node concept="3Tm1VV" id="5M8g5cSYOnF" role="1B3o_S" />
+      <node concept="_YKpA" id="5M8g5cSYOnG" role="3clF45">
+        <node concept="17QB3L" id="5M8g5cSYOnH" role="_ZDj9" />
+      </node>
+      <node concept="2AHcQZ" id="5M8g5cSYOnI" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3clFbS" id="5M8g5cSYOnJ" role="3clF47">
+        <node concept="3cpWs8" id="5M8g5cSZNIA" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cSZNIB" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="_YKpA" id="5M8g5cSZMBI" role="1tU5fm">
+              <node concept="17QB3L" id="5M8g5cSZMBL" role="_ZDj9" />
+            </node>
+            <node concept="3nyPlj" id="5M8g5cSZNIC" role="33vP2m">
+              <ref role="37wK5l" node="5JNiskhYXc2" resolve="listSLanguageLanguageIds" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cSZVO7" role="3cqZAp">
+          <node concept="2OqwBi" id="5M8g5cSZXjo" role="3clFbG">
+            <node concept="37vLTw" id="5M8g5cSZVO5" role="2Oq$k0">
+              <ref role="3cqZAo" node="5M8g5cSZNIB" resolve="result" />
+            </node>
+            <node concept="TSZUe" id="5M8g5cSZZZt" role="2OqNvi">
+              <node concept="1rXfSq" id="5M8g5cT01Z9" role="25WWJ7">
+                <ref role="37wK5l" node="34Q84zNPHSy" resolve="idStructureLanguage" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cSYOnL" role="3cqZAp">
+          <node concept="37vLTw" id="5M8g5cSZNID" role="3clFbG">
+            <ref role="3cqZAo" node="5M8g5cSZNIB" resolve="result" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5M8g5cSYOnM" role="jymVt">
+      <property role="TrG5h" value="listVersionLanguages" />
+      <node concept="3Tm1VV" id="5M8g5cSYOnU" role="1B3o_S" />
+      <node concept="_YKpA" id="5M8g5cSYOnV" role="3clF45">
+        <node concept="17QB3L" id="5M8g5cSYOnW" role="_ZDj9" />
+      </node>
+      <node concept="2AHcQZ" id="5M8g5cSYOnX" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3clFbS" id="5M8g5cSYOnY" role="3clF47">
+        <node concept="3cpWs8" id="5M8g5cT03YY" role="3cqZAp">
+          <node concept="3cpWsn" id="5M8g5cT03YZ" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="_YKpA" id="5M8g5cT02T8" role="1tU5fm">
+              <node concept="17QB3L" id="5M8g5cT02Tb" role="_ZDj9" />
+            </node>
+            <node concept="3nyPlj" id="5M8g5cT03Z0" role="33vP2m">
+              <ref role="37wK5l" node="5JNiskhYXcm" resolve="listVersionLanguages" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cT0cAd" role="3cqZAp">
+          <node concept="2OqwBi" id="5M8g5cT0e8$" role="3clFbG">
+            <node concept="37vLTw" id="5M8g5cT0cAb" role="2Oq$k0">
+              <ref role="3cqZAo" node="5M8g5cT03YZ" resolve="result" />
+            </node>
+            <node concept="TSZUe" id="5M8g5cT0gQx" role="2OqNvi">
+              <node concept="1rXfSq" id="5M8g5cT0iOW" role="25WWJ7">
+                <ref role="37wK5l" node="34Q84zNPHSI" resolve="versionStructureLanguage" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cSYOo0" role="3cqZAp">
+          <node concept="37vLTw" id="5M8g5cT03Z1" role="3clFbG">
+            <ref role="3cqZAo" node="5M8g5cT03YZ" resolve="result" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="7weWCFln0QZ" role="jymVt" />
     <node concept="3clFb_" id="7weWCFln2o1" role="jymVt">
       <property role="TrG5h" value="listMpsInternalClassifiers" />
@@ -7156,53 +7290,41 @@
         </node>
       </node>
     </node>
-    <node concept="1X3_iC" id="34Q84zNQzHr" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="3clFb_" id="34Q84zNODJP" role="8Wnug">
-        <property role="TrG5h" value="keyStructureLanguage" />
-        <node concept="3clFbS" id="34Q84zNODJQ" role="3clF47" />
-        <node concept="3Tm1VV" id="34Q84zNODJR" role="1B3o_S" />
-        <node concept="17QB3L" id="34Q84zNODJS" role="3clF45" />
-        <node concept="P$JXv" id="34Q84zNODJT" role="lGtFl">
-          <node concept="TZ5HA" id="34Q84zNODJU" role="TZ5H$">
-            <node concept="1dT_AC" id="34Q84zNODJV" role="1dT_Ay">
-              <property role="1dT_AB" value="jetbrains.mps.lang.structure as key: " />
-            </node>
+    <node concept="3clFb_" id="34Q84zNODJP" role="jymVt">
+      <property role="TrG5h" value="keyStructureLanguage" />
+      <node concept="3clFbS" id="34Q84zNODJQ" role="3clF47" />
+      <node concept="3Tm1VV" id="34Q84zNODJR" role="1B3o_S" />
+      <node concept="17QB3L" id="34Q84zNODJS" role="3clF45" />
+      <node concept="P$JXv" id="34Q84zNODJT" role="lGtFl">
+        <node concept="TZ5HA" id="34Q84zNODJU" role="TZ5H$">
+          <node concept="1dT_AC" id="34Q84zNODJV" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.structure as key: " />
           </node>
         </node>
       </node>
     </node>
-    <node concept="1X3_iC" id="34Q84zNQzHs" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="3clFb_" id="34Q84zNODJW" role="8Wnug">
-        <property role="TrG5h" value="idStructureLanguage" />
-        <node concept="3clFbS" id="34Q84zNODJX" role="3clF47" />
-        <node concept="3Tm1VV" id="34Q84zNODJY" role="1B3o_S" />
-        <node concept="17QB3L" id="34Q84zNODJZ" role="3clF45" />
-        <node concept="P$JXv" id="34Q84zNODK0" role="lGtFl">
-          <node concept="TZ5HA" id="34Q84zNODK1" role="TZ5H$">
-            <node concept="1dT_AC" id="34Q84zNODK2" role="1dT_Ay">
-              <property role="1dT_AB" value="jetbrains.mps.lang.structure as id" />
-            </node>
+    <node concept="3clFb_" id="34Q84zNODJW" role="jymVt">
+      <property role="TrG5h" value="idStructureLanguage" />
+      <node concept="3clFbS" id="34Q84zNODJX" role="3clF47" />
+      <node concept="3Tm1VV" id="34Q84zNODJY" role="1B3o_S" />
+      <node concept="17QB3L" id="34Q84zNODJZ" role="3clF45" />
+      <node concept="P$JXv" id="34Q84zNODK0" role="lGtFl">
+        <node concept="TZ5HA" id="34Q84zNODK1" role="TZ5H$">
+          <node concept="1dT_AC" id="34Q84zNODK2" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.structure as id" />
           </node>
         </node>
       </node>
     </node>
-    <node concept="1X3_iC" id="34Q84zNQzHt" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="3clFb_" id="34Q84zNODK3" role="8Wnug">
-        <property role="TrG5h" value="versionStructureLanguage" />
-        <node concept="3clFbS" id="34Q84zNODK4" role="3clF47" />
-        <node concept="3Tm1VV" id="34Q84zNODK5" role="1B3o_S" />
-        <node concept="17QB3L" id="34Q84zNODK6" role="3clF45" />
-        <node concept="P$JXv" id="34Q84zNODK7" role="lGtFl">
-          <node concept="TZ5HA" id="34Q84zNODK8" role="TZ5H$">
-            <node concept="1dT_AC" id="34Q84zNODK9" role="1dT_Ay">
-              <property role="1dT_AB" value="version of jetbrains.mps.lang.structure" />
-            </node>
+    <node concept="3clFb_" id="34Q84zNODK3" role="jymVt">
+      <property role="TrG5h" value="versionStructureLanguage" />
+      <node concept="3clFbS" id="34Q84zNODK4" role="3clF47" />
+      <node concept="3Tm1VV" id="34Q84zNODK5" role="1B3o_S" />
+      <node concept="17QB3L" id="34Q84zNODK6" role="3clF45" />
+      <node concept="P$JXv" id="34Q84zNODK7" role="lGtFl">
+        <node concept="TZ5HA" id="34Q84zNODK8" role="TZ5H$">
+          <node concept="1dT_AC" id="34Q84zNODK9" role="1dT_Ay">
+            <property role="1dT_AB" value="version of jetbrains.mps.lang.structure" />
           </node>
         </node>
       </node>

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -33,7 +33,6 @@
     <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" />
     <import index="pjrh" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter(MPS.Core/)" />
-    <import index="ze1i" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.runtime(MPS.Core/)" />
     <import index="4xw4" ref="r:23ccdcd2-ac4f-4247-aad5-4d197fcb7e18(io.lionweb.mps.specific.lang)" implicit="true" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
   </imports>

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -1049,6 +1049,120 @@
           </node>
         </node>
         <node concept="3clFbH" id="7weWCFloe7n" role="3cqZAp" />
+        <node concept="3clFbF" id="5M8g5cSBlZU" role="3cqZAp">
+          <node concept="37vLTI" id="5M8g5cSBlZV" role="3clFbG">
+            <node concept="37vLTw" id="5M8g5cSBlZW" role="37vLTJ">
+              <ref role="3cqZAo" node="5M8g5cSB02I" resolve="MPS_CONCEPT_DECLARATION_CONCEPT" />
+            </node>
+            <node concept="2OqwBi" id="5M8g5cSBlZX" role="37vLTx">
+              <node concept="2tJFMh" id="5M8g5cSBlZY" role="2Oq$k0">
+                <node concept="ZC_QK" id="5M8g5cSBlZZ" role="2tJFKM">
+                  <ref role="2aWVGs" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="5M8g5cSBm00" role="2OqNvi">
+                <node concept="37vLTw" id="5M8g5cSBm01" role="Vysub">
+                  <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cSBlZH" role="3cqZAp">
+          <node concept="37vLTI" id="5M8g5cSBlZI" role="3clFbG">
+            <node concept="2YIFZM" id="5M8g5cSBlZJ" role="37vLTx">
+              <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+              <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
+              <node concept="37vLTw" id="5M8g5cSBlZK" role="37wK5m">
+                <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+              </node>
+              <node concept="37vLTw" id="5M8g5cSBlZL" role="37wK5m">
+                <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+              </node>
+              <node concept="2YIFZM" id="5M8g5cSBlZM" role="37wK5m">
+                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                <node concept="2OqwBi" id="5M8g5cSBlZN" role="37wK5m">
+                  <node concept="37vLTw" id="5M8g5cSBlZO" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5M8g5cSB02I" resolve="MPS_CONCEPT_DECLARATION_CONCEPT" />
+                  </node>
+                  <node concept="3TrcHB" id="5M8g5cSBlZP" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5M8g5cSBlZQ" role="37wK5m">
+                <node concept="37vLTw" id="5M8g5cSBlZR" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5M8g5cSB02I" resolve="MPS_CONCEPT_DECLARATION_CONCEPT" />
+                </node>
+                <node concept="3TrcHB" id="5M8g5cSBlZS" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="5M8g5cSBlZT" role="37vLTJ">
+              <ref role="3cqZAo" node="5M8g5cSB02$" resolve="SLANG_CONCEPT_CONCEPT" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5M8g5cSBlZG" role="3cqZAp" />
+        <node concept="3clFbF" id="5M8g5cSBug_" role="3cqZAp">
+          <node concept="37vLTI" id="5M8g5cSBugA" role="3clFbG">
+            <node concept="37vLTw" id="5M8g5cSBugB" role="37vLTJ">
+              <ref role="3cqZAo" node="5M8g5cSAY3o" resolve="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
+            </node>
+            <node concept="2OqwBi" id="5M8g5cSBugC" role="37vLTx">
+              <node concept="2tJFMh" id="5M8g5cSBugD" role="2Oq$k0">
+                <node concept="ZC_QK" id="5M8g5cSBugE" role="2tJFKM">
+                  <ref role="2aWVGs" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="5M8g5cSBugF" role="2OqNvi">
+                <node concept="37vLTw" id="5M8g5cSBugG" role="Vysub">
+                  <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5M8g5cSBugo" role="3cqZAp">
+          <node concept="37vLTI" id="5M8g5cSBugp" role="3clFbG">
+            <node concept="2YIFZM" id="5M8g5cSBugq" role="37vLTx">
+              <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+              <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
+              <node concept="37vLTw" id="5M8g5cSBugr" role="37wK5m">
+                <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+              </node>
+              <node concept="37vLTw" id="5M8g5cSBugs" role="37wK5m">
+                <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+              </node>
+              <node concept="2YIFZM" id="5M8g5cSBugt" role="37wK5m">
+                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                <node concept="2OqwBi" id="5M8g5cSBugu" role="37wK5m">
+                  <node concept="37vLTw" id="5M8g5cSBugv" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5M8g5cSAY3o" resolve="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
+                  </node>
+                  <node concept="3TrcHB" id="5M8g5cSBugw" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5M8g5cSBugx" role="37wK5m">
+                <node concept="37vLTw" id="5M8g5cSBugy" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5M8g5cSAY3o" resolve="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
+                </node>
+                <node concept="3TrcHB" id="5M8g5cSBugz" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="5M8g5cSBug$" role="37vLTJ">
+              <ref role="3cqZAo" node="5M8g5cSAY3e" resolve="SLANG_INTERFACE_CONCEPT_CONCEPT" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5M8g5cSBugn" role="3cqZAp" />
         <node concept="3clFbF" id="34Q84zNOpJK" role="3cqZAp">
           <node concept="37vLTI" id="34Q84zNOpJL" role="3clFbG">
             <node concept="2OqwBi" id="34Q84zNOpJM" role="37vLTx">
@@ -1787,6 +1901,108 @@
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNS0hq" role="jymVt" />
+    <node concept="312cEg" id="5M8g5cSB02I" role="jymVt">
+      <property role="TrG5h" value="MPS_CONCEPT_DECLARATION_CONCEPT" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="5M8g5cSB02J" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5M8g5cSB02K" role="1tU5fm">
+        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5M8g5cSB02B" role="jymVt">
+      <property role="TrG5h" value="mpsConceptDeclarationConcept" />
+      <node concept="3Tm1VV" id="5M8g5cSB02C" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5M8g5cSB02D" role="3clF45">
+        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+      </node>
+      <node concept="3clFbS" id="5M8g5cSB02E" role="3clF47">
+        <node concept="3clFbF" id="5M8g5cSB02F" role="3cqZAp">
+          <node concept="37vLTw" id="5M8g5cSB02G" role="3clFbG">
+            <ref role="3cqZAo" node="5M8g5cSB02I" resolve="MPS_CONCEPT_DECLARATION_CONCEPT" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5M8g5cSB02H" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="312cEg" id="5M8g5cSB02$" role="jymVt">
+      <property role="TrG5h" value="SLANG_CONCEPT_CONCEPT" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="5M8g5cSB02_" role="1B3o_S" />
+      <node concept="3uibUv" id="5M8g5cSB02A" role="1tU5fm">
+        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5M8g5cSB02t" role="jymVt">
+      <property role="TrG5h" value="slangConceptConcept" />
+      <node concept="3Tm1VV" id="5M8g5cSB02u" role="1B3o_S" />
+      <node concept="3uibUv" id="5M8g5cSB02v" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+      <node concept="3clFbS" id="5M8g5cSB02w" role="3clF47">
+        <node concept="3clFbF" id="5M8g5cSB02x" role="3cqZAp">
+          <node concept="37vLTw" id="5M8g5cSB02y" role="3clFbG">
+            <ref role="3cqZAo" node="5M8g5cSB02$" resolve="SLANG_CONCEPT_CONCEPT" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5M8g5cSB02z" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5M8g5cSB02s" role="jymVt" />
+    <node concept="312cEg" id="5M8g5cSAY3o" role="jymVt">
+      <property role="TrG5h" value="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="5M8g5cSAY3p" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5M8g5cSAY3q" role="1tU5fm">
+        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5M8g5cSAY3h" role="jymVt">
+      <property role="TrG5h" value="mpsInterfaceConceptDeclarationConcept" />
+      <node concept="3Tm1VV" id="5M8g5cSAY3i" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5M8g5cSAY3j" role="3clF45">
+        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+      </node>
+      <node concept="3clFbS" id="5M8g5cSAY3k" role="3clF47">
+        <node concept="3clFbF" id="5M8g5cSAY3l" role="3cqZAp">
+          <node concept="37vLTw" id="5M8g5cSAY3m" role="3clFbG">
+            <ref role="3cqZAo" node="5M8g5cSAY3o" resolve="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5M8g5cSAY3n" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="312cEg" id="5M8g5cSAY3e" role="jymVt">
+      <property role="TrG5h" value="SLANG_INTERFACE_CONCEPT_CONCEPT" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="5M8g5cSAY3f" role="1B3o_S" />
+      <node concept="3uibUv" id="5M8g5cSAY3g" role="1tU5fm">
+        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5M8g5cSAY37" role="jymVt">
+      <property role="TrG5h" value="slangInterfaceConceptConcept" />
+      <node concept="3Tm1VV" id="5M8g5cSAY38" role="1B3o_S" />
+      <node concept="3uibUv" id="5M8g5cSAY39" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+      <node concept="3clFbS" id="5M8g5cSAY3a" role="3clF47">
+        <node concept="3clFbF" id="5M8g5cSAY3b" role="3cqZAp">
+          <node concept="37vLTw" id="5M8g5cSAY3c" role="3clFbG">
+            <ref role="3cqZAo" node="5M8g5cSAY3e" resolve="SLANG_INTERFACE_CONCEPT_CONCEPT" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5M8g5cSAY3d" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5M8g5cSAY36" role="jymVt" />
     <node concept="312cEg" id="34Q84zNNvW1" role="jymVt">
       <property role="TrG5h" value="MPS_CONCEPT_ALIAS_PROPERTY" />
       <property role="3TUv4t" value="true" />
@@ -2078,6 +2294,12 @@
               <node concept="1rXfSq" id="7weWCFlnd9$" role="HW$Y0">
                 <ref role="37wK5l" node="34Q84zNR2iW" resolve="mpsAbstractConceptDeclarationConcept" />
               </node>
+              <node concept="1rXfSq" id="5M8g5cSBLmK" role="HW$Y0">
+                <ref role="37wK5l" node="5M8g5cSB02B" resolve="mpsConceptDeclarationConcept" />
+              </node>
+              <node concept="1rXfSq" id="5M8g5cSBOLL" role="HW$Y0">
+                <ref role="37wK5l" node="5M8g5cSAY3h" resolve="mpsInterfaceConceptDeclarationConcept" />
+              </node>
               <node concept="3Tqbb2" id="7weWCFln6BG" role="HW$YZ">
                 <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
               </node>
@@ -2109,6 +2331,12 @@
               </node>
               <node concept="1rXfSq" id="7weWCFlogCi" role="HW$Y0">
                 <ref role="37wK5l" node="7weWCFlnoxb" resolve="slangAbstractConceptConcept" />
+              </node>
+              <node concept="1rXfSq" id="5M8g5cSBEjb" role="HW$Y0">
+                <ref role="37wK5l" node="5M8g5cSB02t" resolve="slangConceptConcept" />
+              </node>
+              <node concept="1rXfSq" id="5M8g5cSBHN5" role="HW$Y0">
+                <ref role="37wK5l" node="5M8g5cSAY37" resolve="slangInterfaceConceptConcept" />
               </node>
               <node concept="3uibUv" id="7weWCFlnaje" role="HW$YZ">
                 <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
@@ -6582,6 +6810,11 @@
       <node concept="3Tqbb2" id="5JNiskipPo5" role="3clF45">
         <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$2Gt" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$2Gw" role="3nqlJM">
+          <property role="x79VB" value="io.lionweb.mps.specific.lang.MPS-specific annotations.VirtualPackage" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskipPo6" role="jymVt">
       <property role="TrG5h" value="mpsVirtualPackageProperty" />
@@ -6590,6 +6823,11 @@
       <node concept="3Tqbb2" id="5JNiskipPo9" role="3clF45">
         <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$3uH" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$3uK" role="3nqlJM">
+          <property role="x79VB" value="jetbrains.mps.lang.core.structure.BaseConcept.virtualPackage" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskipPoa" role="jymVt">
       <property role="TrG5h" value="slangVirtualPackageProperty" />
@@ -6597,6 +6835,24 @@
       <node concept="3Tm1VV" id="5JNiskipPoc" role="1B3o_S" />
       <node concept="3uibUv" id="5JNiskipPod" role="3clF45">
         <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS$4BM" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS$api" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS$apj" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.BaseConcept.virtualPackage as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS$c0j" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS$cxA" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS$cxC" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS$d30" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SProperty" resolve="SProperty" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS$c0i" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskipPoe" role="jymVt">
@@ -6629,6 +6885,11 @@
       <node concept="3Tqbb2" id="5JNiskir74q" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$e5U" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$e5X" role="3nqlJM">
+          <property role="x79VB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.INamed.name" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskireGB" role="jymVt">
       <property role="TrG5h" value="keyVirtualPackage_NameProperty" />
@@ -6649,6 +6910,11 @@
       <node concept="3Tqbb2" id="5JNiskipPQ1" role="3clF45">
         <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$jFb" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$jFe" role="3nqlJM">
+          <property role="x79VB" value="io.lionweb.mps.specific.lang.MPS-specific annotations.ShortDescription" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskipPPU" role="jymVt">
       <property role="TrG5h" value="mpsShortDescriptionProperty" />
@@ -6657,6 +6923,11 @@
       <node concept="3Tqbb2" id="5JNiskipPPX" role="3clF45">
         <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$kJ5" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$kJ8" role="3nqlJM">
+          <property role="x79VB" value="jetbrains.mps.lang.core.structure.BaseConcept.shortDescription" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskipPPQ" role="jymVt">
       <property role="TrG5h" value="slangShortDescriptionProperty" />
@@ -6664,6 +6935,24 @@
       <node concept="3Tm1VV" id="5JNiskipPPS" role="1B3o_S" />
       <node concept="3uibUv" id="5JNiskipPPT" role="3clF45">
         <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS$lNt" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS$lNu" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS$lNv" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.BaseConcept.shortDescription as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS$lRC" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS$lRQ" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS$lRS" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS$lS7" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SProperty" resolve="SProperty" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS$lRB" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskipPPM" role="jymVt">
@@ -6695,6 +6984,11 @@
       <node concept="3Tm1VV" id="5JNiskir8mO" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiskir8mP" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS$lWo" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$lWr" role="3nqlJM">
+          <property role="x79VB" value="io.lionweb.mps.specific.lang.MPS-specific annotations.ShortDescription.description" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskirgAw" role="jymVt">
@@ -6921,6 +7215,13 @@
       <node concept="3Tqbb2" id="34Q84zNQRl3" role="3clF45">
         <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
       </node>
+      <node concept="P$JXv" id="5M8g5cSzLqs" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cSzLqt" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cSzLqu" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="7weWCFlnm$K" role="jymVt">
       <property role="TrG5h" value="slangAbstractConceptConcept" />
@@ -6929,14 +7230,123 @@
       <node concept="3uibUv" id="7weWCFlnmfS" role="3clF45">
         <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
       </node>
+      <node concept="P$JXv" id="5M8g5cSzNOu" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cSzNOv" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cSzNOw" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cSzNZQ" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cSzO04" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cSzO06" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cSzOzc" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SConcept" resolve="SConcept" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cSzNZP" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNQU1i" role="jymVt" />
+    <node concept="3clFb_" id="5M8g5cSAUka" role="jymVt">
+      <property role="TrG5h" value="mpsConceptDeclarationConcept" />
+      <node concept="3clFbS" id="5M8g5cSAUkb" role="3clF47" />
+      <node concept="3Tm1VV" id="5M8g5cSAUkc" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5M8g5cSAUkd" role="3clF45">
+        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cSAUke" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cSAUkf" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cSAUkg" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.ConceptDeclaration" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5M8g5cSAUjY" role="jymVt">
+      <property role="TrG5h" value="slangConceptConcept" />
+      <node concept="3clFbS" id="5M8g5cSAUjZ" role="3clF47" />
+      <node concept="3Tm1VV" id="5M8g5cSAUk0" role="1B3o_S" />
+      <node concept="3uibUv" id="5M8g5cSAUk1" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cSAUk2" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cSAUk3" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cSAUk4" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.ConceptDeclaration as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cSAUk5" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cSAUk6" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cSAUk7" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cSAUk8" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SConcept" resolve="SConcept" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cSAUk9" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5M8g5cSAUjX" role="jymVt" />
+    <node concept="3clFb_" id="5M8g5cSAU2C" role="jymVt">
+      <property role="TrG5h" value="mpsInterfaceConceptDeclarationConcept" />
+      <node concept="3clFbS" id="5M8g5cSAU2D" role="3clF47" />
+      <node concept="3Tm1VV" id="5M8g5cSAU2E" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5M8g5cSAU2F" role="3clF45">
+        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cSAU2G" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cSAU2H" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cSAU2I" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.InterfaceConceptDeclaration" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5M8g5cSAU2s" role="jymVt">
+      <property role="TrG5h" value="slangInterfaceConceptConcept" />
+      <node concept="3clFbS" id="5M8g5cSAU2t" role="3clF47" />
+      <node concept="3Tm1VV" id="5M8g5cSAU2u" role="1B3o_S" />
+      <node concept="3uibUv" id="5M8g5cSAU2v" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cSAU2w" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cSAU2x" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cSAU2y" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.InterfaceConceptDeclaration as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cSAU2z" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cSAU2$" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cSAU2_" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cSAU2A" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SConcept" resolve="SConcept" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cSAU2B" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5M8g5cSAU2r" role="jymVt" />
     <node concept="3clFb_" id="34Q84zNQVqH" role="jymVt">
       <property role="TrG5h" value="mpsConceptAliasProperty" />
       <node concept="3clFbS" id="34Q84zNQVqK" role="3clF47" />
       <node concept="3Tm1VV" id="34Q84zNQVqL" role="1B3o_S" />
       <node concept="3Tqbb2" id="34Q84zNQUak" role="3clF45">
         <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cSzOBt" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cSzOBu" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cSzOBv" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration.conceptAlias" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNQWR0" role="jymVt">
@@ -6945,6 +7355,13 @@
       <node concept="3Tm1VV" id="34Q84zNQWR2" role="1B3o_S" />
       <node concept="3Tqbb2" id="34Q84zNQWR3" role="3clF45">
         <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cSzONm" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cSzONn" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cSzONo" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration.conceptShortDescription" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNQO5q" role="jymVt" />
@@ -6957,6 +7374,24 @@
           <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
         </node>
       </node>
+      <node concept="P$JXv" id="5M8g5cS_6EV" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_6EW" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_6EX" role="1dT_Ay">
+            <property role="1dT_AB" value="All MPS node properties that are converted into LionWeb M1 annotations as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS_bYL" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS_bYZ" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS_bZ1" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS_bZg" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SProperty" resolve="SProperty" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_bYK" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="34Q84zNtsh8" role="jymVt">
       <property role="TrG5h" value="listConceptDescriptionProperties" />
@@ -6965,6 +7400,24 @@
       <node concept="_YKpA" id="34Q84zNtshb" role="3clF45">
         <node concept="3uibUv" id="34Q84zNtshc" role="_ZDj9">
           <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="5M8g5cS_c3x" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_c3y" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_c3z" role="1dT_Ay">
+            <property role="1dT_AB" value="All MPS concept properties that are converted into LionWeb M2 annotations as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS_m9d" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS_mFy" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS_mF$" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS_ndY" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SProperty" resolve="SProperty" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_m9c" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
         </node>
       </node>
     </node>
@@ -10489,6 +10942,11 @@
       <node concept="3Tqbb2" id="5JNiski3jVl" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$pgd" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$pgg" role="3nqlJM">
+          <property role="x79VB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.String" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVm" role="jymVt">
       <property role="TrG5h" value="mpsStringType" />
@@ -10497,6 +10955,11 @@
       <node concept="3Tqbb2" id="5JNiski3jVp" role="3clF45">
         <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$pDp" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$pDs" role="3nqlJM">
+          <property role="x79VB" value="jetbrains.mps.lang.core.structure.string" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVq" role="jymVt">
       <property role="TrG5h" value="slangStringType" />
@@ -10504,6 +10967,24 @@
       <node concept="3Tm1VV" id="5JNiski3jVs" role="1B3o_S" />
       <node concept="3uibUv" id="5JNiski3jVt" role="3clF45">
         <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS$s9Z" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS$sa0" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS$sa1" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.string as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS$smz" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS$smL" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS$smN" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS$sn2" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SDataType" resolve="SDataType" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS$smy" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVu" role="jymVt">
@@ -10536,6 +11017,11 @@
       <node concept="3Tqbb2" id="5JNiski3jVE" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$szI" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$szL" role="3nqlJM">
+          <property role="x79VB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.Boolean" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVF" role="jymVt">
       <property role="TrG5h" value="mpsBooleanType" />
@@ -10544,6 +11030,11 @@
       <node concept="3Tqbb2" id="5JNiski3jVI" role="3clF45">
         <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$sWU" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$sWX" role="3nqlJM">
+          <property role="x79VB" value="jetbrains.mps.lang.core.structure.boolean" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVJ" role="jymVt">
       <property role="TrG5h" value="slangBooleanType" />
@@ -10551,6 +11042,24 @@
       <node concept="3Tm1VV" id="5JNiski3jVL" role="1B3o_S" />
       <node concept="3uibUv" id="5JNiski3jVM" role="3clF45">
         <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS$tlY" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS$tyx" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS$tyy" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.boolean as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS$tyz" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS$ty$" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS$ty_" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS$tyA" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SDataType" resolve="SDataType" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS$tyB" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVN" role="jymVt">
@@ -10583,6 +11092,11 @@
       <node concept="3Tqbb2" id="5JNiski3jVZ" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$u7Z" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$u82" role="3nqlJM">
+          <property role="x79VB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.Integer" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jW0" role="jymVt">
       <property role="TrG5h" value="mpsIntegerType" />
@@ -10591,6 +11105,11 @@
       <node concept="3Tqbb2" id="5JNiski3jW3" role="3clF45">
         <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$uUn" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$uUq" role="3nqlJM">
+          <property role="x79VB" value="jetbrains.mps.lang.core.structure.integer" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jW4" role="jymVt">
       <property role="TrG5h" value="slangIntegerType" />
@@ -10598,6 +11117,24 @@
       <node concept="3Tm1VV" id="5JNiski3jW6" role="1B3o_S" />
       <node concept="3uibUv" id="5JNiski3jW7" role="3clF45">
         <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS$vjz" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS$vw6" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS$vw7" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.integer as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS$vw8" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS$vw9" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS$vwa" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS$vwb" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SDataType" resolve="SDataType" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS$vwc" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jW8" role="jymVt">
@@ -10630,6 +11167,11 @@
       <node concept="3Tqbb2" id="5JNiski3jWk" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$uxb" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$uxe" role="3nqlJM">
+          <property role="x79VB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.JSON" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jWl" role="jymVt">
       <property role="TrG5h" value="mpsJsonType" />
@@ -10638,6 +11180,11 @@
       <node concept="3Tqbb2" id="5JNiski3jWo" role="3clF45">
         <ref role="ehGHo" to="tpce:fKAz7CR" resolve="ConstrainedDataTypeDeclaration" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$w5$" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$w5B" role="3nqlJM">
+          <property role="x79VB" value="io.lionweb.mps.m3.structure.JSON" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jWp" role="jymVt">
       <property role="TrG5h" value="slangJsonType" />
@@ -10645,6 +11192,22 @@
       <node concept="3Tm1VV" id="5JNiski3jWr" role="1B3o_S" />
       <node concept="3uibUv" id="5JNiski3jWs" role="3clF45">
         <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS$yBI" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS$yBJ" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS$yOh" role="1dT_Ay">
+            <property role="1dT_AB" value="io.lionweb.mps.m3.structure.JSON as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS$yOi" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS$yOj" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS$yOk" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS$yOl" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SDataType" resolve="SDataType" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS$yBK" role="1dT_Ay" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jWt" role="jymVt">
@@ -10677,6 +11240,11 @@
       <node concept="3Tqbb2" id="5JNiski3jWD" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjklrv" resolve="Concept" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$z0X" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$z10" role="3nqlJM">
+          <property role="x79VB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.Node" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jWE" role="jymVt">
       <property role="TrG5h" value="mpsNodeConcept" />
@@ -10685,6 +11253,11 @@
       <node concept="3Tqbb2" id="5JNiski3jWH" role="3clF45">
         <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$_z_" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$_zC" role="3nqlJM">
+          <property role="x79VB" value="jetbrains.mps.lang.core.structure.BaseConcept" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jWI" role="jymVt">
       <property role="TrG5h" value="slangNodeConcept" />
@@ -10692,6 +11265,25 @@
       <node concept="3Tm1VV" id="5JNiski3jWK" role="1B3o_S" />
       <node concept="3uibUv" id="5JNiski3jWL" role="3clF45">
         <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS$C7a" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS$Cw4" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS$Cw5" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.BaseConcept as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS$Cw6" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS$Cw7" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS$Cw8" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS$Cw9" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SConcept" resolve="SConcept" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS$Cwa" role="1dT_Ay" />
+        </node>
+        <node concept="TZ5HA" id="5M8g5cS$C7b" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS$C7c" role="1dT_Ay" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jWM" role="jymVt">
@@ -10724,6 +11316,11 @@
       <node concept="3Tqbb2" id="5JNiski3jWY" role="3clF45">
         <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$CGP" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$CGS" role="3nqlJM">
+          <property role="x79VB" value="jetbrains.mps.lang.core.structure.NodeAttribute" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jWZ" role="jymVt">
       <property role="TrG5h" value="slangAnnotationConcept" />
@@ -10731,6 +11328,25 @@
       <node concept="3Tm1VV" id="5JNiski3jX1" role="1B3o_S" />
       <node concept="3uibUv" id="5JNiski3jX2" role="3clF45">
         <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS$Fjt" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS$FGn" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS$FGo" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.NodeAttribute as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS$FGp" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS$FGq" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS$FGr" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS$FGs" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SConcept" resolve="SConcept" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS$FGt" role="1dT_Ay" />
+        </node>
+        <node concept="TZ5HA" id="5M8g5cS$Fju" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS$Fjv" role="1dT_Ay" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jX3" role="jymVt">
@@ -10751,6 +11367,24 @@
       <node concept="3uibUv" id="5JNiski3jXa" role="3clF45">
         <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$Jgo" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS$Jgp" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS$Jgq" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.BaseConcept.smodelAttribute as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS$M_w" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS$M_I" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS$M_K" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS$M_Z" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS$M_v" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskitFWC" role="jymVt">
       <property role="TrG5h" value="mpsAnnotationContainment" />
@@ -10758,6 +11392,11 @@
       <node concept="3Tm1VV" id="5JNiskitFWE" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiskitGo_" role="3clF45">
         <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS$MAz" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$MAA" role="3nqlJM">
+          <property role="x79VB" value="jetbrains.mps.lang.core.structure.BaseConcept.smodelAttribute" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiydnL" role="jymVt">
@@ -10779,6 +11418,11 @@
       <node concept="3Tqbb2" id="5JNiski3jXf" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjklHQ" resolve="Interface" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$QyV" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$QyY" role="3nqlJM">
+          <property role="x79VB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.INamed" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jXg" role="jymVt">
       <property role="TrG5h" value="mpsINamedInterface" />
@@ -10787,6 +11431,11 @@
       <node concept="3Tqbb2" id="5JNiski3jXj" role="3clF45">
         <ref role="ehGHo" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$TEV" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$TEY" role="3nqlJM">
+          <property role="x79VB" value="jetbrains.mps.lang.core.structure.INamedConcept" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jXk" role="jymVt">
       <property role="TrG5h" value="slangINamedInterface" />
@@ -10794,6 +11443,22 @@
       <node concept="3Tm1VV" id="5JNiski3jXm" role="1B3o_S" />
       <node concept="3uibUv" id="5JNiski3jXn" role="3clF45">
         <ref role="3uigEE" to="c17a:~SInterfaceConcept" resolve="SInterfaceConcept" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS$Wir" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS$Wis" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS$WFl" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.INamedConcept as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS$WFm" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS$WFn" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS$WFo" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS$WFp" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SInterfaceConcept" resolve="SInterfaceConcept" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS$Wit" role="1dT_Ay" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jXo" role="jymVt">
@@ -10826,6 +11491,11 @@
       <node concept="3Tqbb2" id="5JNiski3jX$" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS$WG9" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS$WGc" role="3nqlJM">
+          <property role="x79VB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.INamed.name" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jX_" role="jymVt">
       <property role="TrG5h" value="mpsNameProperty" />
@@ -10834,6 +11504,11 @@
       <node concept="3Tqbb2" id="5JNiski3jXC" role="3clF45">
         <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
       </node>
+      <node concept="P$JXv" id="5M8g5cS_0yH" role="lGtFl">
+        <node concept="x79VA" id="5M8g5cS_0yK" role="3nqlJM">
+          <property role="x79VB" value="jetbrains.mps.lang.core.structure.INamedConcept.name" />
+        </node>
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jXD" role="jymVt">
       <property role="TrG5h" value="slangNameProperty" />
@@ -10841,6 +11516,22 @@
       <node concept="3Tm1VV" id="5JNiski3jXF" role="1B3o_S" />
       <node concept="3uibUv" id="5JNiski3jXG" role="3clF45">
         <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+      </node>
+      <node concept="P$JXv" id="5M8g5cS_4Q8" role="lGtFl">
+        <node concept="TZ5HA" id="5M8g5cS_4Q9" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS_52F" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.INamedConcept.name as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS_52G" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS_52H" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS_52I" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS_52J" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SProperty" resolve="SProperty" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS_4Qa" role="1dT_Ay" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jXH" role="jymVt">

--- a/solutions/io.lionweb.mps.server.plugin/models/io.lionweb.mps.server.plugin.plugin.mps
+++ b/solutions/io.lionweb.mps.server.plugin/models/io.lionweb.mps.server.plugin.plugin.mps
@@ -1370,6 +1370,11 @@
                       <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                       <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
                     </node>
+                    <node concept="2ShNRf" id="7weWCFlyI7w" role="37wK5m">
+                      <node concept="HV5vD" id="7weWCFlyJjA" role="2ShVmc">
+                        <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>

--- a/solutions/io.lionweb.mps.server.test/models/io.lionweb.mps.server.test.language@tests.mps
+++ b/solutions/io.lionweb.mps.server.test/models/io.lionweb.mps.server.test.language@tests.mps
@@ -29,6 +29,9 @@
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -325,6 +328,11 @@
                     <node concept="2YIFZM" id="5hsSXrmDtPC" role="37wK5m">
                       <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                       <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                    </node>
+                    <node concept="2ShNRf" id="7weWCFlze2c" role="37wK5m">
+                      <node concept="HV5vD" id="7weWCFlze2d" role="2ShVmc">
+                        <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -811,6 +819,11 @@
                           <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                           <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
                         </node>
+                        <node concept="2ShNRf" id="7weWCFlzbut" role="37wK5m">
+                          <node concept="HV5vD" id="7weWCFlzbuu" role="2ShVmc">
+                            <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                     <node concept="liA8E" id="5TNjoy1x3nU" role="2OqNvi">
@@ -1109,6 +1122,11 @@
                     <node concept="2YIFZM" id="5hsSXrmDeQ3" role="37wK5m">
                       <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                       <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                    </node>
+                    <node concept="2ShNRf" id="7weWCFlyI7w" role="37wK5m">
+                      <node concept="HV5vD" id="7weWCFlyJjA" role="2ShVmc">
+                        <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                      </node>
                     </node>
                   </node>
                 </node>


### PR DESCRIPTION
Meta-annotations used to point at e.g. `AbstractConceptDeclaration` instead of `Classifier`