### PR TITLE
Refactored how representations of the same thing in different metamodels are stapled together

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -861,6 +861,7 @@
           <module ref="9d6d7230-3178-4b3f-a837-7c0180c86207(io.lionweb.lionweb.java)" kind="cl" />
           <module ref="4d96f781-5fa4-4d94-817a-c51f74fdf43f(io.lionweb.mps.converter)" kind="cl" />
           <module ref="39d4fcb0-6a78-41ac-8e8f-01bb784b65fc(io.lionweb.mps.json)" kind="cl" />
+          <module ref="7350a1d7-537e-4f0d-9965-e91c82522d7d(io.lionweb.mps.m3.runtime)" kind="cl" />
         </dependencies>
         <uses>
           <language id="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" />
@@ -3923,7 +3924,7 @@
     </copy>
   </target>
   
-  <target name="java.compile.io.lionweb.mps.client.connector" depends="java.compile.io.lionweb.mps.converter, java.compile.io.lionweb.mps.json, fetchDependencies">
+  <target name="java.compile.io.lionweb.mps.client.connector" depends="java.compile.io.lionweb.mps.converter, java.compile.io.lionweb.mps.json, java.compile.io.lionweb.mps.m3.runtime, fetchDependencies">
     <mkdir dir="${lionweb-mps.home}/solutions/io.lionweb.mps.client.connector/source_gen" />
     <mkdir dir="${build.tmp}/java/out/io.lionweb.mps.client.connector" />
     <javac destdir="${build.tmp}/java/out/io.lionweb.mps.client.connector" fork="false" encoding="utf8" includeantruntime="false" debug="true">
@@ -3957,6 +3958,7 @@
         <fileset file="${artifacts.mps}/lib/mps-textgen.jar" />
         <pathelement path="${build.tmp}/java/out/io.lionweb.mps.converter" />
         <pathelement path="${build.tmp}/java/out/io.lionweb.mps.json" />
+        <pathelement path="${build.tmp}/java/out/io.lionweb.mps.m3.runtime" />
         <fileset file="${lionweb-mps.home}/solutions/io.lionweb.lionweb.java/libs/gson.jar" />
         <fileset file="${lionweb-mps.home}/solutions/io.lionweb.lionweb.java/libs/lionweb-java-2023.1-core.jar" />
         <fileset dir="${artifacts.IDEA}/lib" includes="*.jar" />

--- a/build.xml
+++ b/build.xml
@@ -158,6 +158,7 @@
           <module ref="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" kind="rt" />
           <module ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" kind="cl" />
           <module ref="01cf0d82-8d29-4fc4-be96-28abaf4ad33d(io.lionweb.mps.m3)" kind="cl" />
+          <module ref="e92f782f-6faf-41c2-bf76-2b1a350c0516(io.lionweb.mps.specific)" kind="cl" />
           <module ref="411e5b27-8a76-482e-8af8-1704262b4468(io.lionweb.mps.structure.attribute)" kind="cl" />
           <module ref="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" kind="cl" />
           <module ref="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" kind="cl" />
@@ -3380,7 +3381,7 @@
     </copy>
   </target>
   
-  <target name="java.compile.io.lionweb.mps.m3.runtime" depends="java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.structure.attribute, fetchDependencies">
+  <target name="java.compile.io.lionweb.mps.m3.runtime" depends="java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.specific, java.compile.io.lionweb.mps.structure.attribute, fetchDependencies">
     <mkdir dir="${lionweb-mps.home}/solutions/io.lionweb.mps.m3.runtime/source_gen" />
     <mkdir dir="${build.tmp}/java/out/io.lionweb.mps.m3.runtime" />
     <javac destdir="${build.tmp}/java/out/io.lionweb.mps.m3.runtime" fork="false" encoding="utf8" includeantruntime="false" debug="true">
@@ -3417,6 +3418,7 @@
         <fileset file="${artifacts.mps}/lib/mps-project-check.jar" />
         <fileset file="${artifacts.mps}/lib/mps-textgen.jar" />
         <pathelement path="${build.tmp}/java/out/io.lionweb.mps.m3" />
+        <pathelement path="${build.tmp}/java/out/io.lionweb.mps.specific" />
         <pathelement path="${build.tmp}/java/out/io.lionweb.mps.structure.attribute" />
         <fileset file="${artifacts.IDEA}/lib/annotations.jar" />
         <fileset dir="${artifacts.IDEA}/lib" includes="*.jar" />

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog for LionWeb-MPS
 
-## Next
+## Up to 0.2.7-2023.1
 * Optionally export computed property values of instances to LionWeb JSON.
 
 * For concepts with alias and/or short description, optinally export annotation with that information.  

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.editor.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.editor.mps
@@ -254,7 +254,7 @@
           </node>
           <node concept="2iRfu4" id="5M8g5cT5W15" role="2iSdaV" />
           <node concept="3F0A7n" id="5M8g5cT5W16" role="3EZMnx">
-            <ref role="1NtTu8" to="d0tf:utjSYFId7H" resolve="scope" />
+            <ref role="1NtTu8" to="d0tf:5M8g5cT5W10" resolve="exportDescriptionAnnotations" />
           </node>
         </node>
       </node>

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.intentions.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.intentions.mps
@@ -638,6 +638,31 @@
                 </node>
               </node>
             </node>
+            <node concept="3cpWs8" id="7OJcYqxWMq3" role="3cqZAp">
+              <node concept="3cpWsn" id="7OJcYqxWMq4" role="3cpWs9">
+                <property role="TrG5h" value="jsonConstants" />
+                <node concept="3uibUv" id="7OJcYqxWL$q" role="1tU5fm">
+                  <ref role="3uigEE" to="6peh:5JNiskj4S1d" resolve="JsonConstants" />
+                </node>
+                <node concept="2ShNRf" id="7OJcYqxWMq5" role="33vP2m">
+                  <node concept="1pGfFk" id="7OJcYqxWMq6" role="2ShVmc">
+                    <ref role="37wK5l" to="6peh:5JNiskj4SJa" resolve="JsonConstants" />
+                    <node concept="2YIFZM" id="7OJcYqxWMq7" role="37wK5m">
+                      <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
+                      <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                    </node>
+                    <node concept="2ShNRf" id="7OJcYqxWMq8" role="37wK5m">
+                      <node concept="HV5vD" id="7OJcYqxWMq9" role="2ShVmc">
+                        <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="7OJcYqxWMqa" role="37wK5m">
+                      <ref role="3cqZAo" node="5M3rB6C9CRl" resolve="constants" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
             <node concept="3cpWs8" id="z1IqfFSPZD" role="3cqZAp">
               <node concept="3cpWsn" id="z1IqfFSPZE" role="3cpWs9">
                 <property role="TrG5h" value="deserializer" />
@@ -650,19 +675,8 @@
                     <node concept="37vLTw" id="z1IqfFSPZH" role="37wK5m">
                       <ref role="3cqZAo" node="z1IqfFSMnI" resolve="inputStream" />
                     </node>
-                    <node concept="2ShNRf" id="5hsSXrmD6rv" role="37wK5m">
-                      <node concept="1pGfFk" id="5hsSXrmDcUm" role="2ShVmc">
-                        <ref role="37wK5l" to="6peh:5JNiskj4SJa" resolve="JsonConstants" />
-                        <node concept="2YIFZM" id="5hsSXrmDeQ3" role="37wK5m">
-                          <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
-                          <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
-                        </node>
-                        <node concept="2ShNRf" id="7weWCFlyStI" role="37wK5m">
-                          <node concept="HV5vD" id="7weWCFlyStJ" role="2ShVmc">
-                            <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
-                          </node>
-                        </node>
-                      </node>
+                    <node concept="37vLTw" id="7OJcYqxWMqb" role="37wK5m">
+                      <ref role="3cqZAo" node="7OJcYqxWMq4" resolve="jsonConstants" />
                     </node>
                   </node>
                 </node>
@@ -713,19 +727,8 @@
                     <node concept="37vLTw" id="5M3rB6C9CRp" role="37wK5m">
                       <ref role="3cqZAo" node="5M3rB6C9CRl" resolve="constants" />
                     </node>
-                    <node concept="2ShNRf" id="5TNjoy1zul3" role="37wK5m">
-                      <node concept="1pGfFk" id="5TNjoy1zul4" role="2ShVmc">
-                        <ref role="37wK5l" to="6peh:5JNiskj4SJa" resolve="JsonConstants" />
-                        <node concept="2YIFZM" id="5TNjoy1zul5" role="37wK5m">
-                          <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
-                          <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
-                        </node>
-                        <node concept="2ShNRf" id="7weWCFlySHz" role="37wK5m">
-                          <node concept="HV5vD" id="7weWCFlySH$" role="2ShVmc">
-                            <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
-                          </node>
-                        </node>
-                      </node>
+                    <node concept="37vLTw" id="7OJcYqxWMqc" role="37wK5m">
+                      <ref role="3cqZAo" node="7OJcYqxWMq4" resolve="jsonConstants" />
                     </node>
                     <node concept="37vLTw" id="5M3rB6C9D6$" role="37wK5m">
                       <ref role="3cqZAo" node="5M3rB6C9D6x" resolve="mapper" />
@@ -1215,6 +1218,9 @@
                           <node concept="HV5vD" id="7weWCFlyJjA" role="2ShVmc">
                             <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
                           </node>
+                        </node>
+                        <node concept="37vLTw" id="7OJcYqxWK07" role="37wK5m">
+                          <ref role="3cqZAo" node="5M3rB6C9AIf" resolve="constants" />
                         </node>
                       </node>
                     </node>
@@ -1756,6 +1762,20 @@
               </node>
             </node>
             <node concept="3clFbH" id="1apSfP9EUNT" role="3cqZAp" />
+            <node concept="3cpWs8" id="5M3rB6BZyeO" role="3cqZAp">
+              <node concept="3cpWsn" id="5M3rB6BZyeP" role="3cpWs9">
+                <property role="TrG5h" value="repository" />
+                <node concept="3uibUv" id="5M3rB6BZxFZ" role="1tU5fm">
+                  <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+                </node>
+                <node concept="2OqwBi" id="5M3rB6BZyeQ" role="33vP2m">
+                  <node concept="1XNTG" id="5M3rB6BZyeR" role="2Oq$k0" />
+                  <node concept="liA8E" id="5M3rB6BZyeS" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
             <node concept="3cpWs8" id="1apSfP9EUNU" role="3cqZAp">
               <node concept="3cpWsn" id="1apSfP9EUNV" role="3cpWs9">
                 <property role="TrG5h" value="deserializer" />
@@ -1778,6 +1798,14 @@
                         <node concept="2ShNRf" id="7weWCFlyTup" role="37wK5m">
                           <node concept="HV5vD" id="7weWCFlyTuq" role="2ShVmc">
                             <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                          </node>
+                        </node>
+                        <node concept="2ShNRf" id="7OJcYqxWOun" role="37wK5m">
+                          <node concept="1pGfFk" id="7OJcYqxWOP9" role="2ShVmc">
+                            <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                            <node concept="37vLTw" id="7OJcYqxWQOm" role="37wK5m">
+                              <ref role="3cqZAo" node="5M3rB6BZyeP" resolve="repository" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -1805,20 +1833,6 @@
               </node>
             </node>
             <node concept="3clFbH" id="1apSfP9EUO7" role="3cqZAp" />
-            <node concept="3cpWs8" id="5M3rB6BZyeO" role="3cqZAp">
-              <node concept="3cpWsn" id="5M3rB6BZyeP" role="3cpWs9">
-                <property role="TrG5h" value="repository" />
-                <node concept="3uibUv" id="5M3rB6BZxFZ" role="1tU5fm">
-                  <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
-                </node>
-                <node concept="2OqwBi" id="5M3rB6BZyeQ" role="33vP2m">
-                  <node concept="1XNTG" id="5M3rB6BZyeR" role="2Oq$k0" />
-                  <node concept="liA8E" id="5M3rB6BZyeS" role="2OqNvi">
-                    <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="3clFbH" id="18UigYOS2av" role="3cqZAp" />
             <node concept="3cpWs8" id="1apSfP9EUOg" role="3cqZAp">
               <node concept="3cpWsn" id="1apSfP9EUOh" role="3cpWs9">

--- a/languages/io.lionweb.mps.m3/models/io.lionweb.mps.m3.core.mps
+++ b/languages/io.lionweb.mps.m3/models/io.lionweb.mps.m3.core.mps
@@ -100,6 +100,30 @@
         <ref role="2Rx9Fl" to="2pzz:2ju2syjnJk2" resolve="Boolean" />
       </node>
     </node>
+    <node concept="2RzPWn" id="7OJcYqxxt15" role="2RzR6B">
+      <property role="2RzON1" value="Annotation" />
+      <property role="TrG5h" value="Annotation" />
+      <ref role="2RzPfO" node="5sACIIs$PgR" resolve="Classifier" />
+      <node concept="2RzOpR" id="7OJcYqxxtbn" role="2RzPPN">
+        <property role="2RzON1" value="Annotation-annotates" />
+        <property role="TrG5h" value="annotates" />
+        <ref role="2RzQvY" to="2pzz:39$JcGFBN1$" resolve="Node" />
+      </node>
+      <node concept="2RzOpR" id="7OJcYqxxtbf" role="2RzPPN">
+        <property role="2RzON1" value="Annotation-extends" />
+        <property role="TrG5h" value="extends" />
+        <property role="2RzO1C" value="true" />
+        <property role="2RzOhW" value="false" />
+        <ref role="2RzQvY" node="7OJcYqxxt15" resolve="Annotation" />
+      </node>
+      <node concept="2RzOpR" id="7OJcYqxxtbg" role="2RzPPN">
+        <property role="2RzON1" value="Annotation-implements" />
+        <property role="TrG5h" value="implements" />
+        <property role="2RzO1C" value="true" />
+        <property role="2RzOhW" value="true" />
+        <ref role="2RzQvY" node="5sACIIs$PgY" resolve="Interface" />
+      </node>
+    </node>
     <node concept="2RzPWn" id="5sACIIs$Phb" role="2RzR6B">
       <property role="2RzP46" value="false" />
       <property role="2RzON1" value="Containment" />

--- a/solutions/io.lionweb.mps.build/models/io.lionweb.mps.build.mps
+++ b/solutions/io.lionweb.mps.build/models/io.lionweb.mps.build.mps
@@ -1373,6 +1373,11 @@
             <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
           </node>
         </node>
+        <node concept="1SiIV0" id="alE3w2kcVm" role="3bR37C">
+          <node concept="3bR9La" id="alE3w2kcVn" role="1SiIV1">
+            <ref role="3bR37D" node="6jI_U5e9kIC" resolve="io.lionweb.mps.m3.runtime" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="7jdzMamjpqS" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/solutions/io.lionweb.mps.build/models/io.lionweb.mps.build.mps
+++ b/solutions/io.lionweb.mps.build/models/io.lionweb.mps.build.mps
@@ -566,6 +566,11 @@
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
+        <node concept="1SiIV0" id="alE3w2j2_7" role="3bR37C">
+          <node concept="3bR9La" id="alE3w2j2_8" role="1SiIV1">
+            <ref role="3bR37D" node="RuBGkv2iXR" resolve="io.lionweb.mps.specific" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="6fYiNFaW8NT" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/solutions/io.lionweb.mps.client.connector/io.lionweb.mps.client.connector.msd
+++ b/solutions/io.lionweb.mps.client.connector/io.lionweb.mps.client.connector.msd
@@ -19,6 +19,7 @@
     <dependency reexport="false">4d96f781-5fa4-4d94-817a-c51f74fdf43f(io.lionweb.mps.converter)</dependency>
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
+    <dependency reexport="false">7350a1d7-537e-4f0d-9965-e91c82522d7d(io.lionweb.mps.m3.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
@@ -36,6 +37,7 @@
     <module reference="9c93572b-546d-4da4-b227-ffb1ad05618d(io.lionweb.mps.client.connector)" version="0" />
     <module reference="4d96f781-5fa4-4d94-817a-c51f74fdf43f(io.lionweb.mps.converter)" version="0" />
     <module reference="39d4fcb0-6a78-41ac-8e8f-01bb784b65fc(io.lionweb.mps.json)" version="0" />
+    <module reference="7350a1d7-537e-4f0d-9965-e91c82522d7d(io.lionweb.mps.m3.runtime)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/solutions/io.lionweb.mps.client.connector/models/io.lionweb.mps.client.connector.impl.mps
+++ b/solutions/io.lionweb.mps.client.connector/models/io.lionweb.mps.client.connector.impl.mps
@@ -23,6 +23,7 @@
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="imb3" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.language(io.lionweb.lionweb.java/)" />
     <import index="cz4z" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.self(io.lionweb.lionweb.java/)" />
+    <import index="y7p" ref="r:3303ef0b-a58e-4f50-b3cb-bd3d7aaf3653(io.lionweb.mps.m3.runtime)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">

--- a/solutions/io.lionweb.mps.client.connector/models/io.lionweb.mps.client.connector.impl.mps
+++ b/solutions/io.lionweb.mps.client.connector/models/io.lionweb.mps.client.connector.impl.mps
@@ -1490,6 +1490,7 @@
                             <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
                           </node>
                         </node>
+                        <node concept="10Nm6u" id="7OJcYqxWHRS" role="37wK5m" />
                       </node>
                     </node>
                   </node>

--- a/solutions/io.lionweb.mps.converter.test/models/io.lionweb.mps.converter.test.attributefinder@tests.mps
+++ b/solutions/io.lionweb.mps.converter.test/models/io.lionweb.mps.converter.test.attributefinder@tests.mps
@@ -302,14 +302,27 @@
             </node>
           </node>
         </node>
-        <node concept="3vlDli" id="4oHUzWXGmRb" role="3cqZAp">
-          <node concept="pHN19" id="4oHUzWXGmRc" role="3tpDZB">
-            <node concept="2V$Bhx" id="4oHUzWXGqsm" role="2V$M_3">
-              <property role="2V$B1T" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
-              <property role="2V$B1Q" value="jetbrains.mps.lang.core" />
+        <node concept="3SKdUt" id="7OJcYq_usoN" role="3cqZAp">
+          <node concept="1PaTwC" id="7OJcYq_usoO" role="1aUNEU">
+            <node concept="3oM_SD" id="7OJcYq_usoP" role="1PaTwD">
+              <property role="3oM_SC" value="AttributeFinder" />
+            </node>
+            <node concept="3oM_SD" id="7OJcYq_usoQ" role="1PaTwD">
+              <property role="3oM_SC" value="should" />
+            </node>
+            <node concept="3oM_SD" id="7OJcYq_usoR" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="7OJcYq_usoS" role="1PaTwD">
+              <property role="3oM_SC" value="translate" />
+            </node>
+            <node concept="3oM_SD" id="7OJcYq_usoT" role="1PaTwD">
+              <property role="3oM_SC" value="keys" />
             </node>
           </node>
-          <node concept="37vLTw" id="4oHUzWXGmRe" role="3tpDZA">
+        </node>
+        <node concept="3ykFI1" id="7OJcYq_usoU" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYq_usoV" role="3ykU8v">
             <ref role="3cqZAo" node="4oHUzWXGmR3" resolve="lang" />
           </node>
         </node>
@@ -610,12 +623,28 @@
             </node>
           </node>
         </node>
-        <node concept="3vlDli" id="4oHUzWXGB_E" role="3cqZAp">
-          <node concept="37vLTw" id="4oHUzWXGB_F" role="3tpDZA">
-            <ref role="3cqZAo" node="4oHUzWXGB_x" resolve="key" />
+        <node concept="3SKdUt" id="7OJcYq_usuj" role="3cqZAp">
+          <node concept="1PaTwC" id="7OJcYq_usuk" role="1aUNEU">
+            <node concept="3oM_SD" id="7OJcYq_usul" role="1PaTwD">
+              <property role="3oM_SC" value="AttributeFinder" />
+            </node>
+            <node concept="3oM_SD" id="7OJcYq_usum" role="1PaTwD">
+              <property role="3oM_SC" value="should" />
+            </node>
+            <node concept="3oM_SD" id="7OJcYq_usun" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="7OJcYq_usuo" role="1PaTwD">
+              <property role="3oM_SC" value="translate" />
+            </node>
+            <node concept="3oM_SD" id="7OJcYq_usup" role="1PaTwD">
+              <property role="3oM_SC" value="keys" />
+            </node>
           </node>
-          <node concept="Xl_RD" id="4oHUzWXGB_G" role="3tpDZB">
-            <property role="Xl_RC" value="LionCore-builtins" />
+        </node>
+        <node concept="3ykFI1" id="7OJcYq_usuq" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYq_usur" role="3ykU8v">
+            <ref role="3cqZAo" node="4oHUzWXGB_x" resolve="key" />
           </node>
         </node>
       </node>
@@ -840,12 +869,28 @@
             </node>
           </node>
         </node>
-        <node concept="3vlDli" id="4oHUzWXGFrK" role="3cqZAp">
-          <node concept="37vLTw" id="4oHUzWXGFrL" role="3tpDZA">
-            <ref role="3cqZAo" node="4oHUzWXGFrB" resolve="key" />
+        <node concept="3SKdUt" id="7OJcYq_us1o" role="3cqZAp">
+          <node concept="1PaTwC" id="7OJcYq_us1p" role="1aUNEU">
+            <node concept="3oM_SD" id="7OJcYq_us1Q" role="1PaTwD">
+              <property role="3oM_SC" value="AttributeFinder" />
+            </node>
+            <node concept="3oM_SD" id="7OJcYq_us1U" role="1PaTwD">
+              <property role="3oM_SC" value="should" />
+            </node>
+            <node concept="3oM_SD" id="7OJcYq_us1Z" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="7OJcYq_uscT" role="1PaTwD">
+              <property role="3oM_SC" value="translate" />
+            </node>
+            <node concept="3oM_SD" id="7OJcYq_usd6" role="1PaTwD">
+              <property role="3oM_SC" value="keys" />
+            </node>
           </node>
-          <node concept="Xl_RD" id="4oHUzWXGFrM" role="3tpDZB">
-            <property role="Xl_RC" value="LionCore-builtins" />
+        </node>
+        <node concept="3ykFI1" id="7OJcYq_usgK" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYq_usic" role="3ykU8v">
+            <ref role="3cqZAo" node="4oHUzWXGFrB" resolve="key" />
           </node>
         </node>
       </node>

--- a/solutions/io.lionweb.mps.converter.test/models/io.lionweb.mps.converter.test.idmapper@tests.mps
+++ b/solutions/io.lionweb.mps.converter.test/models/io.lionweb.mps.converter.test.idmapper@tests.mps
@@ -1010,7 +1010,7 @@
       </node>
     </node>
     <node concept="1LZb2c" id="SgalDIJnKT" role="1SL9yI">
-      <property role="TrG5h" value="builtins" />
+      <property role="TrG5h" value="langCore" />
       <node concept="3cqZAl" id="SgalDIJnKU" role="3clF45" />
       <node concept="3clFbS" id="SgalDIJnKV" role="3clF47">
         <node concept="3cpWs8" id="SgalDIJzrS" role="3cqZAp">
@@ -1018,7 +1018,7 @@
             <property role="TrG5h" value="expected" />
             <node concept="17QB3L" id="SgalDIJzrU" role="1tU5fm" />
             <node concept="Xl_RD" id="SgalDIK0Eh" role="33vP2m">
-              <property role="Xl_RC" value="LionCore-builtins" />
+              <property role="Xl_RC" value="Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj" />
             </node>
           </node>
         </node>
@@ -2407,7 +2407,7 @@
       </node>
     </node>
     <node concept="1LZb2c" id="SgalDIKsJF" role="1SL9yI">
-      <property role="TrG5h" value="builtins" />
+      <property role="TrG5h" value="langCore" />
       <node concept="3cqZAl" id="SgalDIKsJG" role="3clF45" />
       <node concept="3clFbS" id="SgalDIKsJH" role="3clF47">
         <node concept="3cpWs8" id="SgalDIKsJI" role="3cqZAp">
@@ -2415,7 +2415,7 @@
             <property role="TrG5h" value="expected" />
             <node concept="17QB3L" id="SgalDIKsJK" role="1tU5fm" />
             <node concept="Xl_RD" id="SgalDIKsJL" role="33vP2m">
-              <property role="Xl_RC" value="LionCore-builtins" />
+              <property role="Xl_RC" value="Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj" />
             </node>
           </node>
         </node>

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.mps
@@ -720,9 +720,9 @@
       <node concept="3clFbS" id="5M3rB6A9AkY" role="3clF47">
         <node concept="3cpWs8" id="7OJcYqz9qrf" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqz9qrg" role="3cpWs9">
-            <property role="TrG5h" value="mapping" />
+            <property role="TrG5h" value="staple" />
             <node concept="3uibUv" id="7OJcYqz9pnH" role="1tU5fm">
-              <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+              <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageStaple" />
             </node>
             <node concept="2OqwBi" id="7OJcYqz9qrh" role="33vP2m">
               <node concept="2OqwBi" id="7OJcYqz9qri" role="2Oq$k0">
@@ -769,7 +769,7 @@
                 <node concept="17QB3L" id="2mPmTXszo10" role="1tU5fm" />
                 <node concept="2OqwBi" id="7OJcYqz9AyQ" role="33vP2m">
                   <node concept="37vLTw" id="7OJcYqz9_Ch" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7OJcYqz9qrg" resolve="mapping" />
+                    <ref role="3cqZAo" node="7OJcYqz9qrg" resolve="staple" />
                   </node>
                   <node concept="liA8E" id="7OJcYqz9CtQ" role="2OqNvi">
                     <ref role="37wK5l" to="y7p:7OJcYqvKqd6" resolve="getMpsId" />
@@ -786,7 +786,7 @@
           <node concept="3y3z36" id="7OJcYqz9y1J" role="3clFbw">
             <node concept="10Nm6u" id="7OJcYqz9zUs" role="3uHU7w" />
             <node concept="37vLTw" id="7OJcYqz9w9f" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYqz9qrg" resolve="mapping" />
+              <ref role="3cqZAo" node="7OJcYqz9qrg" resolve="staple" />
             </node>
           </node>
         </node>
@@ -825,9 +825,9 @@
       <node concept="3clFbS" id="5M3rB6A9Ale" role="3clF47">
         <node concept="3cpWs8" id="7OJcYqz9WJb" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqz9WJc" role="3cpWs9">
-            <property role="TrG5h" value="mapping" />
+            <property role="TrG5h" value="staple" />
             <node concept="3uibUv" id="7OJcYqz9VGk" role="1tU5fm">
-              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierStaple" />
             </node>
             <node concept="2OqwBi" id="7OJcYqz9WJd" role="33vP2m">
               <node concept="2OqwBi" id="7OJcYqz9WJe" role="2Oq$k0">
@@ -835,7 +835,7 @@
                   <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
                 </node>
                 <node concept="liA8E" id="7OJcYqz9WJg" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listClassifiers" />
+                  <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listLcClassifiers" />
                 </node>
               </node>
               <node concept="1z4cxt" id="7OJcYqz9WJh" role="2OqNvi">
@@ -874,7 +874,7 @@
                 <node concept="17QB3L" id="2mPmTXsztcN" role="1tU5fm" />
                 <node concept="2OqwBi" id="7OJcYqza7i$" role="33vP2m">
                   <node concept="37vLTw" id="7OJcYqza5wx" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7OJcYqz9WJc" resolve="mapping" />
+                    <ref role="3cqZAo" node="7OJcYqz9WJc" resolve="staple" />
                   </node>
                   <node concept="liA8E" id="7OJcYqza9bj" role="2OqNvi">
                     <ref role="37wK5l" to="y7p:7OJcYqvKiQm" resolve="getMpsId" />
@@ -891,7 +891,7 @@
           <node concept="3y3z36" id="7OJcYqza2Pl" role="3clFbw">
             <node concept="10Nm6u" id="7OJcYqza3$J" role="3uHU7w" />
             <node concept="37vLTw" id="7OJcYqza1Y1" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYqz9WJc" resolve="mapping" />
+              <ref role="3cqZAo" node="7OJcYqz9WJc" resolve="staple" />
             </node>
           </node>
         </node>
@@ -930,9 +930,9 @@
       <node concept="3clFbS" id="5M3rB6A9Alu" role="3clF47">
         <node concept="3cpWs8" id="7OJcYqzaaOV" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqzaaOW" role="3cpWs9">
-            <property role="TrG5h" value="mapping" />
+            <property role="TrG5h" value="staple" />
             <node concept="3uibUv" id="7OJcYqzaaOX" role="1tU5fm">
-              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierStaple" />
             </node>
             <node concept="2OqwBi" id="7OJcYqzaaOY" role="33vP2m">
               <node concept="2OqwBi" id="7OJcYqzaaOZ" role="2Oq$k0">
@@ -940,7 +940,7 @@
                   <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
                 </node>
                 <node concept="liA8E" id="7OJcYqzaaP1" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listClassifiers" />
+                  <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listLcClassifiers" />
                 </node>
               </node>
               <node concept="1z4cxt" id="7OJcYqzaaP2" role="2OqNvi">
@@ -979,7 +979,7 @@
                 <node concept="17QB3L" id="2mPmTXszxoi" role="1tU5fm" />
                 <node concept="2OqwBi" id="7OJcYqzaowk" role="33vP2m">
                   <node concept="37vLTw" id="7OJcYqzanBo" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7OJcYqzaaOW" resolve="mapping" />
+                    <ref role="3cqZAo" node="7OJcYqzaaOW" resolve="staple" />
                   </node>
                   <node concept="liA8E" id="7OJcYqzaqq7" role="2OqNvi">
                     <ref role="37wK5l" to="y7p:7OJcYqvKiQm" resolve="getMpsId" />
@@ -996,7 +996,7 @@
           <node concept="3y3z36" id="7OJcYqzajU_" role="3clFbw">
             <node concept="10Nm6u" id="7OJcYqzalEy" role="3uHU7w" />
             <node concept="37vLTw" id="7OJcYqzagcD" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYqzaaOW" resolve="mapping" />
+              <ref role="3cqZAo" node="7OJcYqzaaOW" resolve="staple" />
             </node>
           </node>
         </node>
@@ -1035,9 +1035,9 @@
       <node concept="3clFbS" id="5M3rB6A9AlI" role="3clF47">
         <node concept="3cpWs8" id="7OJcYqzavX4" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqzavX5" role="3cpWs9">
-            <property role="TrG5h" value="mapping" />
+            <property role="TrG5h" value="staple" />
             <node concept="3uibUv" id="7OJcYqzavX6" role="1tU5fm">
-              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierStaple" />
             </node>
             <node concept="2OqwBi" id="7OJcYqzavX7" role="33vP2m">
               <node concept="2OqwBi" id="7OJcYqzavX8" role="2Oq$k0">
@@ -1045,7 +1045,7 @@
                   <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
                 </node>
                 <node concept="liA8E" id="7OJcYqzavXa" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listClassifiers" />
+                  <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listLcClassifiers" />
                 </node>
               </node>
               <node concept="1z4cxt" id="7OJcYqzavXb" role="2OqNvi">
@@ -1084,7 +1084,7 @@
                 <node concept="17QB3L" id="2mPmTXsz_QM" role="1tU5fm" />
                 <node concept="2OqwBi" id="7OJcYqzaH8c" role="33vP2m">
                   <node concept="37vLTw" id="7OJcYqzaF7a" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7OJcYqzavX5" resolve="mapping" />
+                    <ref role="3cqZAo" node="7OJcYqzavX5" resolve="staple" />
                   </node>
                   <node concept="liA8E" id="7OJcYqzaIQc" role="2OqNvi">
                     <ref role="37wK5l" to="y7p:7OJcYqvKiQm" resolve="getMpsId" />
@@ -1101,7 +1101,7 @@
           <node concept="3y3z36" id="7OJcYqza_D6" role="3clFbw">
             <node concept="10Nm6u" id="7OJcYqzaBq7" role="3uHU7w" />
             <node concept="37vLTw" id="7OJcYqzazCB" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYqzavX5" resolve="mapping" />
+              <ref role="3cqZAo" node="7OJcYqzavX5" resolve="staple" />
             </node>
           </node>
         </node>
@@ -1173,9 +1173,9 @@
       <node concept="3clFbS" id="5M3rB6A9AlY" role="3clF47">
         <node concept="3cpWs8" id="7OJcYqzb6AP" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqzb6AQ" role="3cpWs9">
-            <property role="TrG5h" value="mapping" />
+            <property role="TrG5h" value="staple" />
             <node concept="3uibUv" id="7OJcYqzb5qe" role="1tU5fm">
-              <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyKeyMapping" />
+              <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
             </node>
             <node concept="2OqwBi" id="7OJcYqzb6AR" role="33vP2m">
               <node concept="2OqwBi" id="7OJcYqzb6AS" role="2Oq$k0">
@@ -1183,7 +1183,7 @@
                   <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
                 </node>
                 <node concept="liA8E" id="7OJcYqzb6AU" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:7OJcYqwZxOH" resolve="listLcProperty" />
+                  <ref role="37wK5l" to="y7p:7OJcYqwZxOH" resolve="listLcProperties" />
                 </node>
               </node>
               <node concept="1z4cxt" id="7OJcYqzb6AV" role="2OqNvi">
@@ -1222,7 +1222,7 @@
                 <node concept="17QB3L" id="2mPmTXszfrK" role="1tU5fm" />
                 <node concept="2OqwBi" id="7OJcYqzbiUn" role="33vP2m">
                   <node concept="37vLTw" id="7OJcYqzbhMJ" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7OJcYqzb6AQ" resolve="mapping" />
+                    <ref role="3cqZAo" node="7OJcYqzb6AQ" resolve="staple" />
                   </node>
                   <node concept="liA8E" id="7OJcYqzblhF" role="2OqNvi">
                     <ref role="37wK5l" to="y7p:7OJcYqvKqd6" resolve="getMpsId" />
@@ -1239,7 +1239,7 @@
           <node concept="3y3z36" id="7OJcYqzbeAQ" role="3clFbw">
             <node concept="10Nm6u" id="7OJcYqzbg0z" role="3uHU7w" />
             <node concept="37vLTw" id="7OJcYqzbchA" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYqzb6AQ" resolve="mapping" />
+              <ref role="3cqZAo" node="7OJcYqzb6AQ" resolve="staple" />
             </node>
           </node>
         </node>
@@ -1377,9 +1377,9 @@
       <node concept="3clFbS" id="5M3rB6A9AmY" role="3clF47">
         <node concept="3cpWs8" id="7OJcYqzbFJQ" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqzbFJR" role="3cpWs9">
-            <property role="TrG5h" value="mapping" />
+            <property role="TrG5h" value="staple" />
             <node concept="3uibUv" id="7OJcYqzbE_b" role="1tU5fm">
-              <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+              <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
             </node>
             <node concept="2OqwBi" id="7OJcYqzbFJS" role="33vP2m">
               <node concept="2OqwBi" id="7OJcYqzbFJT" role="2Oq$k0">
@@ -1387,7 +1387,7 @@
                   <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
                 </node>
                 <node concept="liA8E" id="7OJcYqzbFJV" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
                 </node>
               </node>
               <node concept="1z4cxt" id="7OJcYqzbFJW" role="2OqNvi">
@@ -1426,7 +1426,7 @@
                 <node concept="17QB3L" id="2mPmTXszEvB" role="1tU5fm" />
                 <node concept="2OqwBi" id="7OJcYqzbTXi" role="33vP2m">
                   <node concept="37vLTw" id="7OJcYqzbSZZ" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7OJcYqzbFJR" resolve="mapping" />
+                    <ref role="3cqZAo" node="7OJcYqzbFJR" resolve="staple" />
                   </node>
                   <node concept="liA8E" id="7OJcYqzbVN7" role="2OqNvi">
                     <ref role="37wK5l" to="y7p:7OJcYqvKiQm" resolve="getMpsId" />
@@ -1443,7 +1443,7 @@
           <node concept="3y3z36" id="7OJcYqzbQpU" role="3clFbw">
             <node concept="10Nm6u" id="7OJcYqzbRcG" role="3uHU7w" />
             <node concept="37vLTw" id="7OJcYqzbOkG" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYqzbFJR" resolve="mapping" />
+              <ref role="3cqZAo" node="7OJcYqzbFJR" resolve="staple" />
             </node>
           </node>
         </node>
@@ -1482,9 +1482,9 @@
       <node concept="3clFbS" id="5M3rB6A9Ane" role="3clF47">
         <node concept="3cpWs8" id="7OJcYqzbXGj" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqzbXGk" role="3cpWs9">
-            <property role="TrG5h" value="mapping" />
+            <property role="TrG5h" value="staple" />
             <node concept="3uibUv" id="7OJcYqzbXGl" role="1tU5fm">
-              <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+              <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
             </node>
             <node concept="2OqwBi" id="7OJcYqzbXGm" role="33vP2m">
               <node concept="2OqwBi" id="7OJcYqzbXGn" role="2Oq$k0">
@@ -1492,7 +1492,7 @@
                   <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
                 </node>
                 <node concept="liA8E" id="7OJcYqzbXGp" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
                 </node>
               </node>
               <node concept="1z4cxt" id="7OJcYqzbXGq" role="2OqNvi">
@@ -1531,7 +1531,7 @@
                 <node concept="17QB3L" id="2mPmTXszJue" role="1tU5fm" />
                 <node concept="2OqwBi" id="7OJcYqzc87M" role="33vP2m">
                   <node concept="37vLTw" id="7OJcYqzc7fu" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7OJcYqzbXGk" resolve="mapping" />
+                    <ref role="3cqZAo" node="7OJcYqzbXGk" resolve="staple" />
                   </node>
                   <node concept="liA8E" id="7OJcYqzca1u" role="2OqNvi">
                     <ref role="37wK5l" to="y7p:7OJcYqvKiQm" resolve="getMpsId" />
@@ -1548,7 +1548,7 @@
           <node concept="3y3z36" id="7OJcYqzc3AU" role="3clFbw">
             <node concept="10Nm6u" id="7OJcYqzc5rb" role="3uHU7w" />
             <node concept="37vLTw" id="7OJcYqzc1$g" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYqzbXGk" resolve="mapping" />
+              <ref role="3cqZAo" node="7OJcYqzbXGk" resolve="staple" />
             </node>
           </node>
         </node>

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.mps
@@ -22,7 +22,6 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
-      <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
@@ -61,7 +60,6 @@
         <child id="1164991057263" name="throwable" index="YScLw" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
-      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <property id="1075300953594" name="abstractClass" index="1sVAO0" />
@@ -87,6 +85,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -109,9 +108,6 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
-      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
-        <property id="1068580320021" name="value" index="3cmrfH" />
-      </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
@@ -222,21 +218,14 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
-      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
-        <child id="540871147943773366" name="argument" index="25WWJ7" />
-      </concept>
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
       <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
-      <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
       <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
-      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
-        <child id="1225711182005" name="list" index="1y566C" />
-        <child id="1225711191269" name="index" index="1y58nS" />
-      </concept>
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="31378964227347002" name="jetbrains.mps.baseLanguage.collections.structure.SelectNotNullOperation" flags="ng" index="1KnU$U" />
     </language>
@@ -729,22 +718,44 @@
         <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
       <node concept="3clFbS" id="5M3rB6A9AkY" role="3clF47">
-        <node concept="3cpWs8" id="2mPmTXszo0N" role="3cqZAp">
-          <node concept="3cpWsn" id="2mPmTXszo0O" role="3cpWs9">
-            <property role="TrG5h" value="index" />
-            <node concept="10Oyi0" id="2mPmTXszo0P" role="1tU5fm" />
-            <node concept="2OqwBi" id="2mPmTXszo0Q" role="33vP2m">
-              <node concept="2OqwBi" id="2mPmTXszo0R" role="2Oq$k0">
-                <node concept="37vLTw" id="2mPmTXszo0S" role="2Oq$k0">
+        <node concept="3cpWs8" id="7OJcYqz9qrf" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqz9qrg" role="3cpWs9">
+            <property role="TrG5h" value="mapping" />
+            <node concept="3uibUv" id="7OJcYqz9pnH" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqz9qrh" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqz9qri" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYqz9qrj" role="2Oq$k0">
                   <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
                 </node>
-                <node concept="liA8E" id="2mPmTXszo0T" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jYO" resolve="listKeyLanguages" />
+                <node concept="liA8E" id="7OJcYqz9qrk" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqwXhGH" resolve="listLcLanguages" />
                 </node>
               </node>
-              <node concept="2WmjW8" id="2mPmTXszo0U" role="2OqNvi">
-                <node concept="37vLTw" id="2mPmTXszo0V" role="25WWJ7">
-                  <ref role="3cqZAo" node="5M3rB6A9AkQ" resolve="key" />
+              <node concept="1z4cxt" id="7OJcYqz9qrl" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYqz9qrm" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYqz9qrn" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYqz9qro" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYqz9qrp" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYqz9qrq" role="3uHU7w">
+                          <ref role="3cqZAo" node="5M3rB6A9AkQ" resolve="key" />
+                        </node>
+                        <node concept="2OqwBi" id="7OJcYqz9qrr" role="3uHU7B">
+                          <node concept="37vLTw" id="7OJcYqz9qrs" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqz9qru" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqz9qrt" role="2OqNvi">
+                            <ref role="37wK5l" to="y7p:7OJcYqvKqdu" resolve="getLcKey" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYqz9qru" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYqz9qrv" role="1tU5fm" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -756,17 +767,12 @@
               <node concept="3cpWsn" id="2mPmTXszo0Z" role="3cpWs9">
                 <property role="TrG5h" value="result" />
                 <node concept="17QB3L" id="2mPmTXszo10" role="1tU5fm" />
-                <node concept="1y4W85" id="2mPmTXszo11" role="33vP2m">
-                  <node concept="37vLTw" id="2mPmTXszo12" role="1y58nS">
-                    <ref role="3cqZAo" node="2mPmTXszo0O" resolve="index" />
+                <node concept="2OqwBi" id="7OJcYqz9AyQ" role="33vP2m">
+                  <node concept="37vLTw" id="7OJcYqz9_Ch" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqz9qrg" resolve="mapping" />
                   </node>
-                  <node concept="2OqwBi" id="2mPmTXszo13" role="1y566C">
-                    <node concept="37vLTw" id="2mPmTXszo14" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
-                    </node>
-                    <node concept="liA8E" id="2mPmTXszo15" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3jYX" resolve="listSLanguageLanguageIds" />
-                    </node>
+                  <node concept="liA8E" id="7OJcYqz9CtQ" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKqd6" resolve="getMpsId" />
                   </node>
                 </node>
               </node>
@@ -777,12 +783,10 @@
               </node>
             </node>
           </node>
-          <node concept="2d3UOw" id="2mPmTXszo18" role="3clFbw">
-            <node concept="3cmrfG" id="2mPmTXszo19" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="37vLTw" id="2mPmTXszo1a" role="3uHU7B">
-              <ref role="3cqZAo" node="2mPmTXszo0O" resolve="index" />
+          <node concept="3y3z36" id="7OJcYqz9y1J" role="3clFbw">
+            <node concept="10Nm6u" id="7OJcYqz9zUs" role="3uHU7w" />
+            <node concept="37vLTw" id="7OJcYqz9w9f" role="3uHU7B">
+              <ref role="3cqZAo" node="7OJcYqz9qrg" resolve="mapping" />
             </node>
           </node>
         </node>
@@ -819,22 +823,44 @@
         <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
       <node concept="3clFbS" id="5M3rB6A9Ale" role="3clF47">
-        <node concept="3cpWs8" id="2mPmTXsztcA" role="3cqZAp">
-          <node concept="3cpWsn" id="2mPmTXsztcB" role="3cpWs9">
-            <property role="TrG5h" value="index" />
-            <node concept="10Oyi0" id="2mPmTXsztcC" role="1tU5fm" />
-            <node concept="2OqwBi" id="2mPmTXsztcD" role="33vP2m">
-              <node concept="2OqwBi" id="2mPmTXsztcE" role="2Oq$k0">
-                <node concept="37vLTw" id="2mPmTXsztcF" role="2Oq$k0">
+        <node concept="3cpWs8" id="7OJcYqz9WJb" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqz9WJc" role="3cpWs9">
+            <property role="TrG5h" value="mapping" />
+            <node concept="3uibUv" id="7OJcYqz9VGk" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqz9WJd" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqz9WJe" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYqz9WJf" role="2Oq$k0">
                   <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
                 </node>
-                <node concept="liA8E" id="2mPmTXsztcG" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jZU" resolve="listKeyClassifiers" />
+                <node concept="liA8E" id="7OJcYqz9WJg" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listClassifiers" />
                 </node>
               </node>
-              <node concept="2WmjW8" id="2mPmTXsztcH" role="2OqNvi">
-                <node concept="37vLTw" id="2mPmTXsztcI" role="25WWJ7">
-                  <ref role="3cqZAo" node="5M3rB6A9Al8" resolve="key" />
+              <node concept="1z4cxt" id="7OJcYqz9WJh" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYqz9WJi" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYqz9WJj" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYqz9WJk" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYqz9WJl" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYqz9WJm" role="3uHU7w">
+                          <ref role="3cqZAo" node="5M3rB6A9Al8" resolve="key" />
+                        </node>
+                        <node concept="2OqwBi" id="7OJcYqz9WJn" role="3uHU7B">
+                          <node concept="37vLTw" id="7OJcYqz9WJo" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqz9WJq" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqz9WJp" role="2OqNvi">
+                            <ref role="37wK5l" to="y7p:7OJcYqvKjL5" resolve="getLcKey" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYqz9WJq" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYqz9WJr" role="1tU5fm" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -846,17 +872,12 @@
               <node concept="3cpWsn" id="2mPmTXsztcM" role="3cpWs9">
                 <property role="TrG5h" value="result" />
                 <node concept="17QB3L" id="2mPmTXsztcN" role="1tU5fm" />
-                <node concept="1y4W85" id="2mPmTXsztcO" role="33vP2m">
-                  <node concept="37vLTw" id="2mPmTXsztcP" role="1y58nS">
-                    <ref role="3cqZAo" node="2mPmTXsztcB" resolve="index" />
+                <node concept="2OqwBi" id="7OJcYqza7i$" role="33vP2m">
+                  <node concept="37vLTw" id="7OJcYqza5wx" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqz9WJc" resolve="mapping" />
                   </node>
-                  <node concept="2OqwBi" id="2mPmTXsztcQ" role="1y566C">
-                    <node concept="37vLTw" id="2mPmTXsztcR" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
-                    </node>
-                    <node concept="liA8E" id="2mPmTXsztcS" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3k03" resolve="listSClassifierIds" />
-                    </node>
+                  <node concept="liA8E" id="7OJcYqza9bj" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKiQm" resolve="getMpsId" />
                   </node>
                 </node>
               </node>
@@ -867,12 +888,10 @@
               </node>
             </node>
           </node>
-          <node concept="2d3UOw" id="2mPmTXsztcV" role="3clFbw">
-            <node concept="3cmrfG" id="2mPmTXsztcW" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="37vLTw" id="2mPmTXsztcX" role="3uHU7B">
-              <ref role="3cqZAo" node="2mPmTXsztcB" resolve="index" />
+          <node concept="3y3z36" id="7OJcYqza2Pl" role="3clFbw">
+            <node concept="10Nm6u" id="7OJcYqza3$J" role="3uHU7w" />
+            <node concept="37vLTw" id="7OJcYqza1Y1" role="3uHU7B">
+              <ref role="3cqZAo" node="7OJcYqz9WJc" resolve="mapping" />
             </node>
           </node>
         </node>
@@ -909,22 +928,44 @@
         <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
       <node concept="3clFbS" id="5M3rB6A9Alu" role="3clF47">
-        <node concept="3cpWs8" id="2mPmTXszxo5" role="3cqZAp">
-          <node concept="3cpWsn" id="2mPmTXszxo6" role="3cpWs9">
-            <property role="TrG5h" value="index" />
-            <node concept="10Oyi0" id="2mPmTXszxo7" role="1tU5fm" />
-            <node concept="2OqwBi" id="2mPmTXszxo8" role="33vP2m">
-              <node concept="2OqwBi" id="2mPmTXszxo9" role="2Oq$k0">
-                <node concept="37vLTw" id="2mPmTXszxoa" role="2Oq$k0">
+        <node concept="3cpWs8" id="7OJcYqzaaOV" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqzaaOW" role="3cpWs9">
+            <property role="TrG5h" value="mapping" />
+            <node concept="3uibUv" id="7OJcYqzaaOX" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqzaaOY" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqzaaOZ" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYqzaaP0" role="2Oq$k0">
                   <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
                 </node>
-                <node concept="liA8E" id="2mPmTXszxob" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jZU" resolve="listKeyClassifiers" />
+                <node concept="liA8E" id="7OJcYqzaaP1" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listClassifiers" />
                 </node>
               </node>
-              <node concept="2WmjW8" id="2mPmTXszxoc" role="2OqNvi">
-                <node concept="37vLTw" id="2mPmTXszxod" role="25WWJ7">
-                  <ref role="3cqZAo" node="5M3rB6A9Alm" resolve="key" />
+              <node concept="1z4cxt" id="7OJcYqzaaP2" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYqzaaP3" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYqzaaP4" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYqzaaP5" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYqzaaP6" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYqzaaP7" role="3uHU7w">
+                          <ref role="3cqZAo" node="5M3rB6A9Alm" resolve="key" />
+                        </node>
+                        <node concept="2OqwBi" id="7OJcYqzaaP8" role="3uHU7B">
+                          <node concept="37vLTw" id="7OJcYqzaaP9" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqzaaPb" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqzaaPa" role="2OqNvi">
+                            <ref role="37wK5l" to="y7p:7OJcYqvKjL5" resolve="getLcKey" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYqzaaPb" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYqzaaPc" role="1tU5fm" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -936,17 +977,12 @@
               <node concept="3cpWsn" id="2mPmTXszxoh" role="3cpWs9">
                 <property role="TrG5h" value="result" />
                 <node concept="17QB3L" id="2mPmTXszxoi" role="1tU5fm" />
-                <node concept="1y4W85" id="2mPmTXszxoj" role="33vP2m">
-                  <node concept="37vLTw" id="2mPmTXszxok" role="1y58nS">
-                    <ref role="3cqZAo" node="2mPmTXszxo6" resolve="index" />
+                <node concept="2OqwBi" id="7OJcYqzaowk" role="33vP2m">
+                  <node concept="37vLTw" id="7OJcYqzanBo" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqzaaOW" resolve="mapping" />
                   </node>
-                  <node concept="2OqwBi" id="2mPmTXszxol" role="1y566C">
-                    <node concept="37vLTw" id="2mPmTXszxom" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
-                    </node>
-                    <node concept="liA8E" id="2mPmTXszxon" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3k03" resolve="listSClassifierIds" />
-                    </node>
+                  <node concept="liA8E" id="7OJcYqzaqq7" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKiQm" resolve="getMpsId" />
                   </node>
                 </node>
               </node>
@@ -957,12 +993,10 @@
               </node>
             </node>
           </node>
-          <node concept="2d3UOw" id="2mPmTXszxoq" role="3clFbw">
-            <node concept="3cmrfG" id="2mPmTXszxor" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="37vLTw" id="2mPmTXszxos" role="3uHU7B">
-              <ref role="3cqZAo" node="2mPmTXszxo6" resolve="index" />
+          <node concept="3y3z36" id="7OJcYqzajU_" role="3clFbw">
+            <node concept="10Nm6u" id="7OJcYqzalEy" role="3uHU7w" />
+            <node concept="37vLTw" id="7OJcYqzagcD" role="3uHU7B">
+              <ref role="3cqZAo" node="7OJcYqzaaOW" resolve="mapping" />
             </node>
           </node>
         </node>
@@ -999,22 +1033,44 @@
         <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
       <node concept="3clFbS" id="5M3rB6A9AlI" role="3clF47">
-        <node concept="3cpWs8" id="2mPmTXsz_Q_" role="3cqZAp">
-          <node concept="3cpWsn" id="2mPmTXsz_QA" role="3cpWs9">
-            <property role="TrG5h" value="index" />
-            <node concept="10Oyi0" id="2mPmTXsz_QB" role="1tU5fm" />
-            <node concept="2OqwBi" id="2mPmTXsz_QC" role="33vP2m">
-              <node concept="2OqwBi" id="2mPmTXsz_QD" role="2Oq$k0">
-                <node concept="37vLTw" id="2mPmTXsz_QE" role="2Oq$k0">
+        <node concept="3cpWs8" id="7OJcYqzavX4" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqzavX5" role="3cpWs9">
+            <property role="TrG5h" value="mapping" />
+            <node concept="3uibUv" id="7OJcYqzavX6" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqzavX7" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqzavX8" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYqzavX9" role="2Oq$k0">
                   <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
                 </node>
-                <node concept="liA8E" id="2mPmTXsz_QF" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jZU" resolve="listKeyClassifiers" />
+                <node concept="liA8E" id="7OJcYqzavXa" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listClassifiers" />
                 </node>
               </node>
-              <node concept="2WmjW8" id="2mPmTXsz_QG" role="2OqNvi">
-                <node concept="37vLTw" id="2mPmTXsz_QH" role="25WWJ7">
-                  <ref role="3cqZAo" node="5M3rB6A9AlA" resolve="key" />
+              <node concept="1z4cxt" id="7OJcYqzavXb" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYqzavXc" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYqzavXd" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYqzavXe" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYqzavXf" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYqzavXg" role="3uHU7w">
+                          <ref role="3cqZAo" node="5M3rB6A9AlA" resolve="key" />
+                        </node>
+                        <node concept="2OqwBi" id="7OJcYqzavXh" role="3uHU7B">
+                          <node concept="37vLTw" id="7OJcYqzavXi" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqzavXk" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqzavXj" role="2OqNvi">
+                            <ref role="37wK5l" to="y7p:7OJcYqvKjL5" resolve="getLcKey" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYqzavXk" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYqzavXl" role="1tU5fm" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -1026,17 +1082,12 @@
               <node concept="3cpWsn" id="2mPmTXsz_QL" role="3cpWs9">
                 <property role="TrG5h" value="result" />
                 <node concept="17QB3L" id="2mPmTXsz_QM" role="1tU5fm" />
-                <node concept="1y4W85" id="2mPmTXsz_QN" role="33vP2m">
-                  <node concept="37vLTw" id="2mPmTXsz_QO" role="1y58nS">
-                    <ref role="3cqZAo" node="2mPmTXsz_QA" resolve="index" />
+                <node concept="2OqwBi" id="7OJcYqzaH8c" role="33vP2m">
+                  <node concept="37vLTw" id="7OJcYqzaF7a" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqzavX5" resolve="mapping" />
                   </node>
-                  <node concept="2OqwBi" id="2mPmTXsz_QP" role="1y566C">
-                    <node concept="37vLTw" id="2mPmTXsz_QQ" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
-                    </node>
-                    <node concept="liA8E" id="2mPmTXsz_QR" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3k03" resolve="listSClassifierIds" />
-                    </node>
+                  <node concept="liA8E" id="7OJcYqzaIQc" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKiQm" resolve="getMpsId" />
                   </node>
                 </node>
               </node>
@@ -1047,12 +1098,10 @@
               </node>
             </node>
           </node>
-          <node concept="2d3UOw" id="2mPmTXsz_QU" role="3clFbw">
-            <node concept="3cmrfG" id="2mPmTXsz_QV" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="37vLTw" id="2mPmTXsz_QW" role="3uHU7B">
-              <ref role="3cqZAo" node="2mPmTXsz_QA" resolve="index" />
+          <node concept="3y3z36" id="7OJcYqza_D6" role="3clFbw">
+            <node concept="10Nm6u" id="7OJcYqzaBq7" role="3uHU7w" />
+            <node concept="37vLTw" id="7OJcYqzazCB" role="3uHU7B">
+              <ref role="3cqZAo" node="7OJcYqzavX5" resolve="mapping" />
             </node>
           </node>
         </node>
@@ -1122,22 +1171,44 @@
         <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
       <node concept="3clFbS" id="5M3rB6A9AlY" role="3clF47">
-        <node concept="3cpWs8" id="2mPmTXswJ$5" role="3cqZAp">
-          <node concept="3cpWsn" id="2mPmTXswJ$6" role="3cpWs9">
-            <property role="TrG5h" value="index" />
-            <node concept="10Oyi0" id="2mPmTXswIYi" role="1tU5fm" />
-            <node concept="2OqwBi" id="2mPmTXswJ$7" role="33vP2m">
-              <node concept="2OqwBi" id="2mPmTXswJ$8" role="2Oq$k0">
-                <node concept="37vLTw" id="2mPmTXswJ$9" role="2Oq$k0">
+        <node concept="3cpWs8" id="7OJcYqzb6AP" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqzb6AQ" role="3cpWs9">
+            <property role="TrG5h" value="mapping" />
+            <node concept="3uibUv" id="7OJcYqzb5qe" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyKeyMapping" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqzb6AR" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqzb6AS" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYqzb6AT" role="2Oq$k0">
                   <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
                 </node>
-                <node concept="liA8E" id="2mPmTXswJ$a" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3k0L" resolve="listKeyProperties" />
+                <node concept="liA8E" id="7OJcYqzb6AU" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqwZxOH" resolve="listLcProperty" />
                 </node>
               </node>
-              <node concept="2WmjW8" id="2mPmTXswJ$b" role="2OqNvi">
-                <node concept="37vLTw" id="2mPmTXswJ$c" role="25WWJ7">
-                  <ref role="3cqZAo" node="5M3rB6A9AlQ" resolve="key" />
+              <node concept="1z4cxt" id="7OJcYqzb6AV" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYqzb6AW" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYqzb6AX" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYqzb6AY" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYqzb6AZ" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYqzb6B0" role="3uHU7w">
+                          <ref role="3cqZAo" node="5M3rB6A9AlQ" resolve="key" />
+                        </node>
+                        <node concept="2OqwBi" id="7OJcYqzb6B1" role="3uHU7B">
+                          <node concept="37vLTw" id="7OJcYqzb6B2" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqzb6B4" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqzb6B3" role="2OqNvi">
+                            <ref role="37wK5l" to="y7p:7OJcYqvKqdu" resolve="getLcKey" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYqzb6B4" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYqzb6B5" role="1tU5fm" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -1149,17 +1220,12 @@
               <node concept="3cpWsn" id="2mPmTXszg8k" role="3cpWs9">
                 <property role="TrG5h" value="result" />
                 <node concept="17QB3L" id="2mPmTXszfrK" role="1tU5fm" />
-                <node concept="1y4W85" id="2mPmTXszg8l" role="33vP2m">
-                  <node concept="37vLTw" id="2mPmTXszg8m" role="1y58nS">
-                    <ref role="3cqZAo" node="2mPmTXswJ$6" resolve="index" />
+                <node concept="2OqwBi" id="7OJcYqzbiUn" role="33vP2m">
+                  <node concept="37vLTw" id="7OJcYqzbhMJ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqzb6AQ" resolve="mapping" />
                   </node>
-                  <node concept="2OqwBi" id="2mPmTXszg8n" role="1y566C">
-                    <node concept="37vLTw" id="2mPmTXszg8o" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
-                    </node>
-                    <node concept="liA8E" id="2mPmTXszg8p" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3k0U" resolve="listSPropertyIds" />
-                    </node>
+                  <node concept="liA8E" id="7OJcYqzblhF" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKqd6" resolve="getMpsId" />
                   </node>
                 </node>
               </node>
@@ -1170,12 +1236,10 @@
               </node>
             </node>
           </node>
-          <node concept="2d3UOw" id="2mPmTXswMtB" role="3clFbw">
-            <node concept="3cmrfG" id="2mPmTXswNyF" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="37vLTw" id="2mPmTXswJ$d" role="3uHU7B">
-              <ref role="3cqZAo" node="2mPmTXswJ$6" resolve="index" />
+          <node concept="3y3z36" id="7OJcYqzbeAQ" role="3clFbw">
+            <node concept="10Nm6u" id="7OJcYqzbg0z" role="3uHU7w" />
+            <node concept="37vLTw" id="7OJcYqzbchA" role="3uHU7B">
+              <ref role="3cqZAo" node="7OJcYqzb6AQ" resolve="mapping" />
             </node>
           </node>
         </node>
@@ -1311,22 +1375,44 @@
         <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
       <node concept="3clFbS" id="5M3rB6A9AmY" role="3clF47">
-        <node concept="3cpWs8" id="2mPmTXszEvq" role="3cqZAp">
-          <node concept="3cpWsn" id="2mPmTXszEvr" role="3cpWs9">
-            <property role="TrG5h" value="index" />
-            <node concept="10Oyi0" id="2mPmTXszEvs" role="1tU5fm" />
-            <node concept="2OqwBi" id="2mPmTXszEvt" role="33vP2m">
-              <node concept="2OqwBi" id="2mPmTXszEvu" role="2Oq$k0">
-                <node concept="37vLTw" id="2mPmTXszEvv" role="2Oq$k0">
+        <node concept="3cpWs8" id="7OJcYqzbFJQ" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqzbFJR" role="3cpWs9">
+            <property role="TrG5h" value="mapping" />
+            <node concept="3uibUv" id="7OJcYqzbE_b" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqzbFJS" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqzbFJT" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYqzbFJU" role="2Oq$k0">
                   <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
                 </node>
-                <node concept="liA8E" id="2mPmTXszEvw" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3k1B" resolve="listKeyPrimitiveTypes" />
+                <node concept="liA8E" id="7OJcYqzbFJV" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
                 </node>
               </node>
-              <node concept="2WmjW8" id="2mPmTXszEvx" role="2OqNvi">
-                <node concept="37vLTw" id="2mPmTXszEvy" role="25WWJ7">
-                  <ref role="3cqZAo" node="5M3rB6A9AmQ" resolve="key" />
+              <node concept="1z4cxt" id="7OJcYqzbFJW" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYqzbFJX" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYqzbFJY" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYqzbFJZ" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYqzbFK0" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYqzbFK1" role="3uHU7w">
+                          <ref role="3cqZAo" node="5M3rB6A9AmQ" resolve="key" />
+                        </node>
+                        <node concept="2OqwBi" id="7OJcYqzbFK2" role="3uHU7B">
+                          <node concept="37vLTw" id="7OJcYqzbFK3" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqzbFK5" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqzbFK4" role="2OqNvi">
+                            <ref role="37wK5l" to="y7p:7OJcYqvKjL5" resolve="getLcKey" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYqzbFK5" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYqzbFK6" role="1tU5fm" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -1338,17 +1424,12 @@
               <node concept="3cpWsn" id="2mPmTXszEvA" role="3cpWs9">
                 <property role="TrG5h" value="result" />
                 <node concept="17QB3L" id="2mPmTXszEvB" role="1tU5fm" />
-                <node concept="1y4W85" id="2mPmTXszEvC" role="33vP2m">
-                  <node concept="37vLTw" id="2mPmTXszEvD" role="1y58nS">
-                    <ref role="3cqZAo" node="2mPmTXszEvr" resolve="index" />
+                <node concept="2OqwBi" id="7OJcYqzbTXi" role="33vP2m">
+                  <node concept="37vLTw" id="7OJcYqzbSZZ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqzbFJR" resolve="mapping" />
                   </node>
-                  <node concept="2OqwBi" id="2mPmTXszEvE" role="1y566C">
-                    <node concept="37vLTw" id="2mPmTXszEvF" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
-                    </node>
-                    <node concept="liA8E" id="2mPmTXszEvG" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3k1K" resolve="listSPrimitiveTypeIds" />
-                    </node>
+                  <node concept="liA8E" id="7OJcYqzbVN7" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKiQm" resolve="getMpsId" />
                   </node>
                 </node>
               </node>
@@ -1359,12 +1440,10 @@
               </node>
             </node>
           </node>
-          <node concept="2d3UOw" id="2mPmTXszEvJ" role="3clFbw">
-            <node concept="3cmrfG" id="2mPmTXszEvK" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="37vLTw" id="2mPmTXszEvL" role="3uHU7B">
-              <ref role="3cqZAo" node="2mPmTXszEvr" resolve="index" />
+          <node concept="3y3z36" id="7OJcYqzbQpU" role="3clFbw">
+            <node concept="10Nm6u" id="7OJcYqzbRcG" role="3uHU7w" />
+            <node concept="37vLTw" id="7OJcYqzbOkG" role="3uHU7B">
+              <ref role="3cqZAo" node="7OJcYqzbFJR" resolve="mapping" />
             </node>
           </node>
         </node>
@@ -1401,22 +1480,44 @@
         <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
       <node concept="3clFbS" id="5M3rB6A9Ane" role="3clF47">
-        <node concept="3cpWs8" id="2mPmTXszJu1" role="3cqZAp">
-          <node concept="3cpWsn" id="2mPmTXszJu2" role="3cpWs9">
-            <property role="TrG5h" value="index" />
-            <node concept="10Oyi0" id="2mPmTXszJu3" role="1tU5fm" />
-            <node concept="2OqwBi" id="2mPmTXszJu4" role="33vP2m">
-              <node concept="2OqwBi" id="2mPmTXszJu5" role="2Oq$k0">
-                <node concept="37vLTw" id="2mPmTXszJu6" role="2Oq$k0">
+        <node concept="3cpWs8" id="7OJcYqzbXGj" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqzbXGk" role="3cpWs9">
+            <property role="TrG5h" value="mapping" />
+            <node concept="3uibUv" id="7OJcYqzbXGl" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqzbXGm" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqzbXGn" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYqzbXGo" role="2Oq$k0">
                   <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
                 </node>
-                <node concept="liA8E" id="2mPmTXszJu7" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3k1B" resolve="listKeyPrimitiveTypes" />
+                <node concept="liA8E" id="7OJcYqzbXGp" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
                 </node>
               </node>
-              <node concept="2WmjW8" id="2mPmTXszJu8" role="2OqNvi">
-                <node concept="37vLTw" id="2mPmTXszJu9" role="25WWJ7">
-                  <ref role="3cqZAo" node="5M3rB6A9An6" resolve="key" />
+              <node concept="1z4cxt" id="7OJcYqzbXGq" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYqzbXGr" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYqzbXGs" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYqzbXGt" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYqzbXGu" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYqzbXGv" role="3uHU7w">
+                          <ref role="3cqZAo" node="5M3rB6A9An6" resolve="key" />
+                        </node>
+                        <node concept="2OqwBi" id="7OJcYqzbXGw" role="3uHU7B">
+                          <node concept="37vLTw" id="7OJcYqzbXGx" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqzbXGz" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqzbXGy" role="2OqNvi">
+                            <ref role="37wK5l" to="y7p:7OJcYqvKjL5" resolve="getLcKey" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYqzbXGz" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYqzbXG$" role="1tU5fm" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -1428,17 +1529,12 @@
               <node concept="3cpWsn" id="2mPmTXszJud" role="3cpWs9">
                 <property role="TrG5h" value="result" />
                 <node concept="17QB3L" id="2mPmTXszJue" role="1tU5fm" />
-                <node concept="1y4W85" id="2mPmTXszJuf" role="33vP2m">
-                  <node concept="37vLTw" id="2mPmTXszJug" role="1y58nS">
-                    <ref role="3cqZAo" node="2mPmTXszJu2" resolve="index" />
+                <node concept="2OqwBi" id="7OJcYqzc87M" role="33vP2m">
+                  <node concept="37vLTw" id="7OJcYqzc7fu" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqzbXGk" resolve="mapping" />
                   </node>
-                  <node concept="2OqwBi" id="2mPmTXszJuh" role="1y566C">
-                    <node concept="37vLTw" id="2mPmTXszJui" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
-                    </node>
-                    <node concept="liA8E" id="2mPmTXszJuj" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3k1K" resolve="listSPrimitiveTypeIds" />
-                    </node>
+                  <node concept="liA8E" id="7OJcYqzca1u" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKiQm" resolve="getMpsId" />
                   </node>
                 </node>
               </node>
@@ -1449,12 +1545,10 @@
               </node>
             </node>
           </node>
-          <node concept="2d3UOw" id="2mPmTXszJum" role="3clFbw">
-            <node concept="3cmrfG" id="2mPmTXszJun" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="37vLTw" id="2mPmTXszJuo" role="3uHU7B">
-              <ref role="3cqZAo" node="2mPmTXszJu2" resolve="index" />
+          <node concept="3y3z36" id="7OJcYqzc3AU" role="3clFbw">
+            <node concept="10Nm6u" id="7OJcYqzc5rb" role="3uHU7w" />
+            <node concept="37vLTw" id="7OJcYqzc1$g" role="3uHU7B">
+              <ref role="3cqZAo" node="7OJcYqzbXGk" resolve="mapping" />
             </node>
           </node>
         </node>

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.slanguage.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.slanguage.mps
@@ -21,7 +21,6 @@
     <import index="wb4m" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter.structure.link(MPS.Core/)" />
     <import index="rzjr" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter.structure.ref(MPS.Core/)" />
     <import index="xx25" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter.structure.types(MPS.Core/)" />
-    <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="apzt" ref="r:ea3bdd37-0680-4524-8252-d8093e3b6903(io.lionweb.mps.converter.util)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.slanguage.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.slanguage.mps
@@ -37,7 +37,7 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
-      <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
@@ -79,7 +79,6 @@
         <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
-      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
@@ -100,6 +99,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -124,9 +124,6 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
-      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
-        <property id="1068580320021" name="value" index="3cmrfH" />
-      </concept>
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -184,6 +181,12 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
     </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
       <concept id="2546654756694997551" name="jetbrains.mps.baseLanguage.javadoc.structure.LinkInlineDocTag" flags="ng" index="92FcH">
         <child id="2546654756694997556" name="reference" index="92FcQ" />
@@ -214,9 +217,6 @@
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
-      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
-        <reference id="1138056395725" name="property" index="3TsBF5" />
-      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -239,14 +239,11 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
-      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
-        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
-      <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
-      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
-        <child id="1225711182005" name="list" index="1y566C" />
-        <child id="1225711191269" name="index" index="1y58nS" />
-      </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
     </language>
   </registry>
   <node concept="312cEu" id="6VkSF6aHm0Q">
@@ -1334,22 +1331,44 @@
                   <node concept="10Nm6u" id="6VkSF6cbKGq" role="33vP2m" />
                 </node>
               </node>
-              <node concept="3cpWs8" id="39$JcGGxid5" role="3cqZAp">
-                <node concept="3cpWsn" id="39$JcGGxid6" role="3cpWs9">
-                  <property role="TrG5h" value="index" />
-                  <node concept="10Oyi0" id="39$JcGGxhAZ" role="1tU5fm" />
-                  <node concept="2OqwBi" id="39$JcGGxid7" role="33vP2m">
-                    <node concept="2OqwBi" id="39$JcGGxid8" role="2Oq$k0">
-                      <node concept="37vLTw" id="39$JcGGxid9" role="2Oq$k0">
+              <node concept="3cpWs8" id="7OJcYqzwWUK" role="3cqZAp">
+                <node concept="3cpWsn" id="7OJcYqzwWUL" role="3cpWs9">
+                  <property role="TrG5h" value="mapping" />
+                  <node concept="3uibUv" id="7OJcYqzwWGb" role="1tU5fm">
+                    <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqzwWUM" role="33vP2m">
+                    <node concept="2OqwBi" id="7OJcYqzwWUN" role="2Oq$k0">
+                      <node concept="37vLTw" id="7OJcYqzwWUO" role="2Oq$k0">
                         <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
                       </node>
-                      <node concept="liA8E" id="39$JcGGxida" role="2OqNvi">
-                        <ref role="37wK5l" to="y7p:5JNiski3k1p" resolve="listSLanguagePrimitiveTypes" />
+                      <node concept="liA8E" id="7OJcYqzwWUP" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
                       </node>
                     </node>
-                    <node concept="2WmjW8" id="39$JcGGxidb" role="2OqNvi">
-                      <node concept="37vLTw" id="39$JcGGxidc" role="25WWJ7">
-                        <ref role="3cqZAo" node="6VkSF6aHmma" resolve="primitive" />
+                    <node concept="1z4cxt" id="7OJcYqzwWUQ" role="2OqNvi">
+                      <node concept="1bVj0M" id="7OJcYqzwWUR" role="23t8la">
+                        <node concept="3clFbS" id="7OJcYqzwWUS" role="1bW5cS">
+                          <node concept="3clFbF" id="7OJcYqzwWUT" role="3cqZAp">
+                            <node concept="17R0WA" id="7OJcYqzwWUU" role="3clFbG">
+                              <node concept="37vLTw" id="7OJcYqzwWUV" role="3uHU7w">
+                                <ref role="3cqZAo" node="6VkSF6aHmma" resolve="primitive" />
+                              </node>
+                              <node concept="2OqwBi" id="7OJcYqzwWUW" role="3uHU7B">
+                                <node concept="37vLTw" id="7OJcYqzwWUX" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7OJcYqzwWUZ" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="7OJcYqzwWUY" role="2OqNvi">
+                                  <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="7OJcYqzwWUZ" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="7OJcYqzwWV0" role="1tU5fm" />
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -1359,22 +1378,12 @@
                 <node concept="3clFbS" id="39$JcGGxla0" role="3clFbx">
                   <node concept="3clFbF" id="6VkSF6cbz1W" role="3cqZAp">
                     <node concept="37vLTI" id="6VkSF6cbz1Y" role="3clFbG">
-                      <node concept="2OqwBi" id="6VkSF6cbjIS" role="37vLTx">
-                        <node concept="1y4W85" id="39$JcGGxwYP" role="2Oq$k0">
-                          <node concept="37vLTw" id="39$JcGGxxUX" role="1y58nS">
-                            <ref role="3cqZAo" node="39$JcGGxid6" resolve="index" />
-                          </node>
-                          <node concept="2OqwBi" id="6VkSF6cbjIT" role="1y566C">
-                            <node concept="37vLTw" id="6VkSF6cbjIU" role="2Oq$k0">
-                              <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
-                            </node>
-                            <node concept="liA8E" id="39$JcGGxv2F" role="2OqNvi">
-                              <ref role="37wK5l" to="y7p:5JNiski3k1h" resolve="listMpsPrimitiveTypes" />
-                            </node>
-                          </node>
+                      <node concept="2OqwBi" id="7OJcYqzx3um" role="37vLTx">
+                        <node concept="37vLTw" id="7OJcYqzx2GS" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7OJcYqzwWUL" resolve="mapping" />
                         </node>
-                        <node concept="3TrcHB" id="6VkSF6cbjIW" role="2OqNvi">
-                          <ref role="3TsBF5" to="tpce:6Kv_6E714g3" resolve="datatypeId" />
+                        <node concept="liA8E" id="7OJcYqzx4gV" role="2OqNvi">
+                          <ref role="37wK5l" to="y7p:7OJcYqvKiQm" resolve="getMpsId" />
                         </node>
                       </node>
                       <node concept="37vLTw" id="6VkSF6cbz22" role="37vLTJ">
@@ -1383,12 +1392,10 @@
                     </node>
                   </node>
                 </node>
-                <node concept="2d3UOw" id="39$JcGGxptg" role="3clFbw">
-                  <node concept="3cmrfG" id="39$JcGGxqjx" role="3uHU7w">
-                    <property role="3cmrfH" value="0" />
-                  </node>
-                  <node concept="37vLTw" id="39$JcGGxm7y" role="3uHU7B">
-                    <ref role="3cqZAo" node="39$JcGGxid6" resolve="index" />
+                <node concept="3y3z36" id="7OJcYqzwZWN" role="3clFbw">
+                  <node concept="10Nm6u" id="7OJcYqzx134" role="3uHU7w" />
+                  <node concept="37vLTw" id="7OJcYqzwZpP" role="3uHU7B">
+                    <ref role="3cqZAo" node="7OJcYqzwWUL" resolve="mapping" />
                   </node>
                 </node>
               </node>
@@ -1445,12 +1452,17 @@
                           <node concept="2OqwBi" id="6VkSF6ccCbl" role="33vP2m">
                             <node concept="2OqwBi" id="6VkSF6ccCbm" role="2Oq$k0">
                               <node concept="2JrnkZ" id="6VkSF6ccCbn" role="2Oq$k0">
-                                <node concept="2OqwBi" id="6VkSF6ccCbo" role="2JrQYb">
-                                  <node concept="37vLTw" id="6VkSF6ccCbp" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+                                <node concept="2OqwBi" id="7OJcYqyZQZ4" role="2JrQYb">
+                                  <node concept="2OqwBi" id="6VkSF6ccCbo" role="2Oq$k0">
+                                    <node concept="37vLTw" id="6VkSF6ccCbp" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+                                    </node>
+                                    <node concept="liA8E" id="5JNiskhHyzm" role="2OqNvi">
+                                      <ref role="37wK5l" to="y7p:7OJcYqwQm1S" resolve="getNode" />
+                                    </node>
                                   </node>
-                                  <node concept="liA8E" id="5JNiskhHyzm" role="2OqNvi">
-                                    <ref role="37wK5l" to="y7p:5JNiski3jWE" resolve="mpsNodeConcept" />
+                                  <node concept="liA8E" id="7OJcYqyZTr6" role="2OqNvi">
+                                    <ref role="37wK5l" to="y7p:7OJcYqvKqcS" resolve="getMps" />
                                   </node>
                                 </node>
                               </node>

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.slanguage.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.slanguage.mps
@@ -1324,13 +1324,6 @@
               </node>
             </node>
             <node concept="3clFbS" id="48csSBOgvyf" role="3eOfB_">
-              <node concept="3cpWs8" id="6VkSF6cbjIQ" role="3cqZAp">
-                <node concept="3cpWsn" id="6VkSF6cbjIR" role="3cpWs9">
-                  <property role="TrG5h" value="primitiveId" />
-                  <node concept="17QB3L" id="6VkSF6cbiSz" role="1tU5fm" />
-                  <node concept="10Nm6u" id="6VkSF6cbKGq" role="33vP2m" />
-                </node>
-              </node>
               <node concept="3cpWs8" id="7OJcYqzwWUK" role="3cqZAp">
                 <node concept="3cpWsn" id="7OJcYqzwWUL" role="3cpWs9">
                   <property role="TrG5h" value="staple" />
@@ -1376,40 +1369,11 @@
               </node>
               <node concept="3clFbJ" id="39$JcGGxl9Y" role="3cqZAp">
                 <node concept="3clFbS" id="39$JcGGxla0" role="3clFbx">
-                  <node concept="3clFbF" id="6VkSF6cbz1W" role="3cqZAp">
-                    <node concept="37vLTI" id="6VkSF6cbz1Y" role="3clFbG">
-                      <node concept="2OqwBi" id="7OJcYqzx3um" role="37vLTx">
-                        <node concept="37vLTw" id="7OJcYqzx2GS" role="2Oq$k0">
-                          <ref role="3cqZAo" node="7OJcYqzwWUL" resolve="staple" />
-                        </node>
-                        <node concept="liA8E" id="7OJcYqzx4gV" role="2OqNvi">
-                          <ref role="37wK5l" to="y7p:7OJcYqvKiQm" resolve="getMpsId" />
-                        </node>
-                      </node>
-                      <node concept="37vLTw" id="6VkSF6cbz22" role="37vLTJ">
-                        <ref role="3cqZAo" node="6VkSF6cbjIR" resolve="primitiveId" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3y3z36" id="7OJcYqzwZWN" role="3clFbw">
-                  <node concept="10Nm6u" id="7OJcYqzx134" role="3uHU7w" />
-                  <node concept="37vLTw" id="7OJcYqzwZpP" role="3uHU7B">
-                    <ref role="3cqZAo" node="7OJcYqzwWUL" resolve="staple" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbH" id="6VkSF6cbLsS" role="3cqZAp" />
-              <node concept="3clFbJ" id="6VkSF6cbN4F" role="3cqZAp">
-                <node concept="3clFbS" id="6VkSF6cbN4H" role="3clFbx">
                   <node concept="3J1_TO" id="6VkSF6cbpRY" role="3cqZAp">
                     <node concept="3uVAMA" id="6VkSF6cbtsm" role="1zxBo5">
                       <node concept="XOnhg" id="6VkSF6cbtsn" role="1zc67B">
                         <property role="TrG5h" value="e" />
                         <node concept="nSUau" id="6VkSF6cbtso" role="1tU5fm">
-                          <node concept="3uibUv" id="3M8YG$dobWe" role="nSUat">
-                            <ref role="3uigEE" to="wyt6:~NumberFormatException" resolve="NumberFormatException" />
-                          </node>
                           <node concept="3uibUv" id="6VkSF6cbucT" role="nSUat">
                             <ref role="3uigEE" to="apzt:3zvxfLhsQ3L" resolve="IdDeserializationException" />
                           </node>
@@ -1430,11 +1394,12 @@
                         <node concept="3cpWsn" id="6VkSF6cbwyy" role="3cpWs9">
                           <property role="TrG5h" value="id" />
                           <node concept="3cpWsb" id="6VkSF6cbvYQ" role="1tU5fm" />
-                          <node concept="2YIFZM" id="6VkSF6cbwyz" role="33vP2m">
-                            <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                            <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                            <node concept="37vLTw" id="6VkSF6cbwy$" role="37wK5m">
-                              <ref role="3cqZAo" node="6VkSF6cbjIR" resolve="primitiveId" />
+                          <node concept="2OqwBi" id="7OJcYq_mBCY" role="33vP2m">
+                            <node concept="37vLTw" id="7OJcYq_mAVt" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7OJcYqzwWUL" resolve="staple" />
+                            </node>
+                            <node concept="liA8E" id="7OJcYq_mCwn" role="2OqNvi">
+                              <ref role="37wK5l" to="y7p:7OJcYq_mkbH" resolve="getMpsPropId" />
                             </node>
                           </node>
                         </node>
@@ -1521,10 +1486,10 @@
                     </node>
                   </node>
                 </node>
-                <node concept="3y3z36" id="6VkSF6cbP2o" role="3clFbw">
-                  <node concept="10Nm6u" id="6VkSF6cbPI7" role="3uHU7w" />
-                  <node concept="37vLTw" id="6VkSF6cbNTs" role="3uHU7B">
-                    <ref role="3cqZAo" node="6VkSF6cbjIR" resolve="primitiveId" />
+                <node concept="3y3z36" id="7OJcYqzwZWN" role="3clFbw">
+                  <node concept="10Nm6u" id="7OJcYqzx134" role="3uHU7w" />
+                  <node concept="37vLTw" id="7OJcYqzwZpP" role="3uHU7B">
+                    <ref role="3cqZAo" node="7OJcYqzwWUL" resolve="staple" />
                   </node>
                 </node>
               </node>

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.slanguage.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.slanguage.mps
@@ -1333,9 +1333,9 @@
               </node>
               <node concept="3cpWs8" id="7OJcYqzwWUK" role="3cqZAp">
                 <node concept="3cpWsn" id="7OJcYqzwWUL" role="3cpWs9">
-                  <property role="TrG5h" value="mapping" />
+                  <property role="TrG5h" value="staple" />
                   <node concept="3uibUv" id="7OJcYqzwWGb" role="1tU5fm">
-                    <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+                    <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
                   </node>
                   <node concept="2OqwBi" id="7OJcYqzwWUM" role="33vP2m">
                     <node concept="2OqwBi" id="7OJcYqzwWUN" role="2Oq$k0">
@@ -1343,7 +1343,7 @@
                         <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
                       </node>
                       <node concept="liA8E" id="7OJcYqzwWUP" role="2OqNvi">
-                        <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+                        <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
                       </node>
                     </node>
                     <node concept="1z4cxt" id="7OJcYqzwWUQ" role="2OqNvi">
@@ -1380,7 +1380,7 @@
                     <node concept="37vLTI" id="6VkSF6cbz1Y" role="3clFbG">
                       <node concept="2OqwBi" id="7OJcYqzx3um" role="37vLTx">
                         <node concept="37vLTw" id="7OJcYqzx2GS" role="2Oq$k0">
-                          <ref role="3cqZAo" node="7OJcYqzwWUL" resolve="mapping" />
+                          <ref role="3cqZAo" node="7OJcYqzwWUL" resolve="staple" />
                         </node>
                         <node concept="liA8E" id="7OJcYqzx4gV" role="2OqNvi">
                           <ref role="37wK5l" to="y7p:7OJcYqvKiQm" resolve="getMpsId" />
@@ -1395,7 +1395,7 @@
                 <node concept="3y3z36" id="7OJcYqzwZWN" role="3clFbw">
                   <node concept="10Nm6u" id="7OJcYqzx134" role="3uHU7w" />
                   <node concept="37vLTw" id="7OJcYqzwZpP" role="3uHU7B">
-                    <ref role="3cqZAo" node="7OJcYqzwWUL" resolve="mapping" />
+                    <ref role="3cqZAo" node="7OJcYqzwWUL" resolve="staple" />
                   </node>
                 </node>
               </node>

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.language2lioncore.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.language2lioncore.mps
@@ -751,7 +751,7 @@
               <ref role="3cqZAo" node="4oHUzWXgi04" resolve="constants" />
             </node>
             <node concept="liA8E" id="7OJcYqxFX1P" role="2OqNvi">
-              <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+              <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
             </node>
           </node>
         </node>
@@ -764,7 +764,7 @@
               <ref role="3cqZAo" node="4oHUzWXgi04" resolve="constants" />
             </node>
             <node concept="liA8E" id="7OJcYqxIWiT" role="2OqNvi">
-              <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listClassifiers" />
+              <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listLcClassifiers" />
             </node>
           </node>
           <node concept="3clFbS" id="7OJcYqxIyOx" role="2LFqv$">
@@ -4615,9 +4615,9 @@
       <node concept="3clFbS" id="48csSBNReP$" role="3clF47">
         <node concept="3cpWs8" id="7OJcYqxPdGt" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqxPdGu" role="3cpWs9">
-            <property role="TrG5h" value="first" />
+            <property role="TrG5h" value="staple" />
             <node concept="3uibUv" id="7OJcYqxPc9F" role="1tU5fm">
-              <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+              <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
             </node>
             <node concept="2OqwBi" id="7OJcYqxPdGv" role="33vP2m">
               <node concept="2OqwBi" id="7OJcYqxPdGw" role="2Oq$k0">
@@ -4625,7 +4625,7 @@
                   <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
                 </node>
                 <node concept="liA8E" id="7OJcYqxPdGy" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
                 </node>
               </node>
               <node concept="1z4cxt" id="7OJcYqxPdGz" role="2OqNvi">
@@ -4662,7 +4662,7 @@
               <node concept="2OqwBi" id="7OJcYqxQpUB" role="3cqZAk">
                 <node concept="2OqwBi" id="7OJcYqxQ7yi" role="2Oq$k0">
                   <node concept="37vLTw" id="7OJcYqxQ1gW" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7OJcYqxPdGu" resolve="first" />
+                    <ref role="3cqZAo" node="7OJcYqxPdGu" resolve="staple" />
                   </node>
                   <node concept="liA8E" id="7OJcYqxQedL" role="2OqNvi">
                     <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
@@ -4675,7 +4675,7 @@
           <node concept="3y3z36" id="7OJcYqxPGp_" role="3clFbw">
             <node concept="10Nm6u" id="7OJcYqxPL7a" role="3uHU7w" />
             <node concept="37vLTw" id="7OJcYqxPAis" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYqxPdGu" resolve="first" />
+              <ref role="3cqZAo" node="7OJcYqxPdGu" resolve="staple" />
             </node>
           </node>
         </node>

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.language2lioncore.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.language2lioncore.mps
@@ -36,13 +36,9 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
-      <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
-      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
-        <child id="1076505808688" name="condition" index="2$JKZa" />
-      </concept>
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
@@ -81,7 +77,6 @@
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
-      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
@@ -288,12 +283,6 @@
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
-      <concept id="1237467461002" name="jetbrains.mps.baseLanguage.collections.structure.GetIteratorOperation" flags="nn" index="uNJiE" />
-      <concept id="1237467705688" name="jetbrains.mps.baseLanguage.collections.structure.IteratorType" flags="in" index="uOF1S">
-        <child id="1237467730343" name="elementType" index="uOL27" />
-      </concept>
-      <concept id="1237470895604" name="jetbrains.mps.baseLanguage.collections.structure.HasNextOperation" flags="nn" index="v0PNk" />
-      <concept id="1237471031357" name="jetbrains.mps.baseLanguage.collections.structure.GetNextOperation" flags="nn" index="v1n4t" />
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -318,8 +307,6 @@
       </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
-      <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
-      <concept id="1240151247486" name="jetbrains.mps.baseLanguage.collections.structure.ContainerIteratorType" flags="in" index="2YL$Hu" />
       <concept id="1240216724530" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashMapCreator" flags="nn" index="32Fmki" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
@@ -331,10 +318,7 @@
         <child id="1197687035757" name="valueType" index="3rHtpV" />
       </concept>
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
-      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
-        <child id="1225711182005" name="list" index="1y566C" />
-        <child id="1225711191269" name="index" index="1y58nS" />
-      </concept>
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1240824834947" name="jetbrains.mps.baseLanguage.collections.structure.ValueAccessOperation" flags="nn" index="3AV6Ez" />
       <concept id="1240825616499" name="jetbrains.mps.baseLanguage.collections.structure.KeyAccessOperation" flags="nn" index="3AY5_j" />
@@ -721,68 +705,40 @@
         </node>
       </node>
       <node concept="3clFbS" id="4oHUzWXghYP" role="3clF47">
-        <node concept="3cpWs8" id="4oHUzWXghYQ" role="3cqZAp">
-          <node concept="3cpWsn" id="4oHUzWXghYR" role="3cpWs9">
-            <property role="TrG5h" value="sDataTypeIter" />
-            <node concept="2YL$Hu" id="4oHUzWXghYS" role="1tU5fm">
-              <node concept="3uibUv" id="4oHUzWXghYT" role="uOL27">
-                <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="4oHUzWXghYU" role="33vP2m">
-              <node concept="2OqwBi" id="4oHUzWXghYV" role="2Oq$k0">
-                <node concept="37vLTw" id="4oHUzWXgi08" role="2Oq$k0">
-                  <ref role="3cqZAo" node="4oHUzWXgi04" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="4oHUzWXghYX" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3k1p" resolve="listSLanguagePrimitiveTypes" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="4oHUzWXghYY" role="2OqNvi" />
-            </node>
+        <node concept="2Gpval" id="7OJcYqxGAz3" role="3cqZAp">
+          <node concept="2GrKxI" id="7OJcYqxGAz5" role="2Gsz3X">
+            <property role="TrG5h" value="primitiveType" />
           </node>
-        </node>
-        <node concept="3cpWs8" id="4oHUzWXghYZ" role="3cqZAp">
-          <node concept="3cpWsn" id="4oHUzWXghZ0" role="3cpWs9">
-            <property role="TrG5h" value="lcDataTypeIter" />
-            <node concept="uOF1S" id="4oHUzWXghZ1" role="1tU5fm">
-              <node concept="3Tqbb2" id="4oHUzWXghZ2" role="uOL27">
-                <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="4oHUzWXghZ3" role="33vP2m">
-              <node concept="2OqwBi" id="4oHUzWXghZ4" role="2Oq$k0">
-                <node concept="37vLTw" id="4oHUzWXgi09" role="2Oq$k0">
-                  <ref role="3cqZAo" node="4oHUzWXgi04" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="4oHUzWXghZ6" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3k19" resolve="listLcPrimitiveTypes" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="4oHUzWXghZ7" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="2$JKZl" id="4oHUzWXghZ8" role="3cqZAp">
-          <node concept="3clFbS" id="4oHUzWXghZ9" role="2LFqv$">
-            <node concept="3clFbF" id="4oHUzWXghZa" role="3cqZAp">
-              <node concept="37vLTI" id="4oHUzWXghZb" role="3clFbG">
-                <node concept="2OqwBi" id="4oHUzWXghZc" role="37vLTx">
-                  <node concept="37vLTw" id="4oHUzWXghZd" role="2Oq$k0">
-                    <ref role="3cqZAo" node="4oHUzWXghZ0" resolve="lcDataTypeIter" />
+          <node concept="3clFbS" id="7OJcYqxGAz9" role="2LFqv$">
+            <node concept="3clFbF" id="7OJcYqxH4fu" role="3cqZAp">
+              <node concept="37vLTI" id="7OJcYqxHKEI" role="3clFbG">
+                <node concept="2OqwBi" id="7OJcYqxI3bv" role="37vLTx">
+                  <node concept="2GrUjf" id="7OJcYqxHRsp" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="7OJcYqxGAz5" resolve="primitiveType" />
                   </node>
-                  <node concept="v1n4t" id="4oHUzWXghZe" role="2OqNvi" />
+                  <node concept="liA8E" id="7OJcYqxIfqS" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
+                  </node>
                 </node>
-                <node concept="3EllGN" id="4oHUzWXghZf" role="37vLTJ">
-                  <node concept="2OqwBi" id="4oHUzWXghZg" role="3ElVtu">
-                    <node concept="37vLTw" id="4oHUzWXghZh" role="2Oq$k0">
-                      <ref role="3cqZAo" node="4oHUzWXghYR" resolve="sDataTypeIter" />
+                <node concept="3EllGN" id="7OJcYqxHmzx" role="37vLTJ">
+                  <node concept="1eOMI4" id="7OJcYqy2XQM" role="3ElVtu">
+                    <node concept="10QFUN" id="7OJcYqy2XQL" role="1eOMHV">
+                      <node concept="2OqwBi" id="7OJcYqy2XQI" role="10QFUP">
+                        <node concept="2GrUjf" id="7OJcYqy2XQJ" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="7OJcYqxGAz5" resolve="primitiveType" />
+                        </node>
+                        <node concept="liA8E" id="7OJcYqy2XQK" role="2OqNvi">
+                          <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
+                        </node>
+                      </node>
+                      <node concept="3uibUv" id="7OJcYqy34dC" role="10QFUM">
+                        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+                      </node>
                     </node>
-                    <node concept="v1n4t" id="4oHUzWXghZi" role="2OqNvi" />
                   </node>
-                  <node concept="2OqwBi" id="4oHUzWXghZj" role="3ElQJh">
-                    <node concept="Xjq3P" id="4oHUzWXghZk" role="2Oq$k0" />
-                    <node concept="2OwXpG" id="4oHUzWXghZl" role="2OqNvi">
+                  <node concept="2OqwBi" id="7OJcYqxH93r" role="3ElQJh">
+                    <node concept="Xjq3P" id="7OJcYqxH4ft" role="2Oq$k0" />
+                    <node concept="2OwXpG" id="7OJcYqxHfVT" role="2OqNvi">
                       <ref role="2Oxat5" node="48csSBNRe$5" resolve="dataTypes" />
                     </node>
                   </node>
@@ -790,102 +746,62 @@
               </node>
             </node>
           </node>
-          <node concept="1Wc70l" id="4oHUzWXghZm" role="2$JKZa">
-            <node concept="2OqwBi" id="4oHUzWXghZn" role="3uHU7w">
-              <node concept="37vLTw" id="4oHUzWXghZo" role="2Oq$k0">
-                <ref role="3cqZAo" node="4oHUzWXghZ0" resolve="lcDataTypeIter" />
-              </node>
-              <node concept="v0PNk" id="4oHUzWXghZp" role="2OqNvi" />
+          <node concept="2OqwBi" id="7OJcYqxFRo7" role="2GsD0m">
+            <node concept="37vLTw" id="7OJcYqxFMva" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oHUzWXgi04" resolve="constants" />
             </node>
-            <node concept="2OqwBi" id="4oHUzWXghZq" role="3uHU7B">
-              <node concept="37vLTw" id="4oHUzWXghZr" role="2Oq$k0">
-                <ref role="3cqZAo" node="4oHUzWXghYR" resolve="sDataTypeIter" />
-              </node>
-              <node concept="v0PNk" id="4oHUzWXghZs" role="2OqNvi" />
+            <node concept="liA8E" id="7OJcYqxFX1P" role="2OqNvi">
+              <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="4oHUzWXghZt" role="3cqZAp">
-          <node concept="3cpWsn" id="4oHUzWXghZu" role="3cpWs9">
-            <property role="TrG5h" value="sClassifierIter" />
-            <node concept="2YL$Hu" id="4oHUzWXghZv" role="1tU5fm">
-              <node concept="3uibUv" id="4oHUzWXghZw" role="uOL27">
-                <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-              </node>
+        <node concept="2Gpval" id="7OJcYqxIyOr" role="3cqZAp">
+          <node concept="2GrKxI" id="7OJcYqxIyOt" role="2Gsz3X">
+            <property role="TrG5h" value="classifier" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqxIQb8" role="2GsD0m">
+            <node concept="37vLTw" id="7OJcYqxIJIn" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oHUzWXgi04" resolve="constants" />
             </node>
-            <node concept="2OqwBi" id="4oHUzWXghZx" role="33vP2m">
-              <node concept="2OqwBi" id="4oHUzWXghZy" role="2Oq$k0">
-                <node concept="37vLTw" id="4oHUzWXgi06" role="2Oq$k0">
-                  <ref role="3cqZAo" node="4oHUzWXgi04" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="4oHUzWXghZ$" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jZG" resolve="listSLanguageClassifiers" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="4oHUzWXghZ_" role="2OqNvi" />
+            <node concept="liA8E" id="7OJcYqxIWiT" role="2OqNvi">
+              <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listClassifiers" />
             </node>
           </node>
-        </node>
-        <node concept="3cpWs8" id="4oHUzWXghZA" role="3cqZAp">
-          <node concept="3cpWsn" id="4oHUzWXghZB" role="3cpWs9">
-            <property role="TrG5h" value="lcClassifierIter" />
-            <node concept="uOF1S" id="4oHUzWXghZC" role="1tU5fm">
-              <node concept="3Tqbb2" id="4oHUzWXghZD" role="uOL27">
-                <ref role="ehGHo" to="h3y3:2ju2syjkl4i" resolve="Classifier" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="4oHUzWXghZE" role="33vP2m">
-              <node concept="2OqwBi" id="4oHUzWXghZF" role="2Oq$k0">
-                <node concept="37vLTw" id="4oHUzWXgi07" role="2Oq$k0">
-                  <ref role="3cqZAo" node="4oHUzWXgi04" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="4oHUzWXghZH" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jZs" resolve="listLcClassifiers" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="4oHUzWXghZI" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="2$JKZl" id="4oHUzWXghZJ" role="3cqZAp">
-          <node concept="3clFbS" id="4oHUzWXghZK" role="2LFqv$">
-            <node concept="3clFbF" id="4oHUzWXghZL" role="3cqZAp">
-              <node concept="37vLTI" id="4oHUzWXghZM" role="3clFbG">
-                <node concept="2OqwBi" id="4oHUzWXghZN" role="37vLTx">
-                  <node concept="37vLTw" id="4oHUzWXghZO" role="2Oq$k0">
-                    <ref role="3cqZAo" node="4oHUzWXghZB" resolve="lcClassifierIter" />
+          <node concept="3clFbS" id="7OJcYqxIyOx" role="2LFqv$">
+            <node concept="3clFbF" id="7OJcYqxJ8MH" role="3cqZAp">
+              <node concept="37vLTI" id="7OJcYqxJLHu" role="3clFbG">
+                <node concept="2OqwBi" id="7OJcYqxJYPW" role="37vLTx">
+                  <node concept="2GrUjf" id="7OJcYqxJSqR" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="7OJcYqxIyOt" resolve="classifier" />
                   </node>
-                  <node concept="v1n4t" id="4oHUzWXghZP" role="2OqNvi" />
+                  <node concept="liA8E" id="7OJcYqxK4bz" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
+                  </node>
                 </node>
-                <node concept="3EllGN" id="4oHUzWXghZQ" role="37vLTJ">
-                  <node concept="2OqwBi" id="4oHUzWXghZR" role="3ElVtu">
-                    <node concept="37vLTw" id="4oHUzWXghZS" role="2Oq$k0">
-                      <ref role="3cqZAo" node="4oHUzWXghZu" resolve="sClassifierIter" />
+                <node concept="3EllGN" id="7OJcYqxJqAz" role="37vLTJ">
+                  <node concept="1eOMI4" id="7OJcYqy3nvo" role="3ElVtu">
+                    <node concept="10QFUN" id="7OJcYqy3nvn" role="1eOMHV">
+                      <node concept="2OqwBi" id="7OJcYqy3nvk" role="10QFUP">
+                        <node concept="2GrUjf" id="7OJcYqy3nvl" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="7OJcYqxIyOt" resolve="classifier" />
+                        </node>
+                        <node concept="liA8E" id="7OJcYqy3nvm" role="2OqNvi">
+                          <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
+                        </node>
+                      </node>
+                      <node concept="3uibUv" id="7OJcYqy3tKr" role="10QFUM">
+                        <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                      </node>
                     </node>
-                    <node concept="v1n4t" id="4oHUzWXghZT" role="2OqNvi" />
                   </node>
-                  <node concept="2OqwBi" id="4oHUzWXghZU" role="3ElQJh">
-                    <node concept="Xjq3P" id="4oHUzWXghZV" role="2Oq$k0" />
-                    <node concept="2OwXpG" id="4oHUzWXghZW" role="2OqNvi">
+                  <node concept="2OqwBi" id="7OJcYqxJdQl" role="3ElQJh">
+                    <node concept="Xjq3P" id="7OJcYqxJ8MG" role="2Oq$k0" />
+                    <node concept="2OwXpG" id="7OJcYqxJkBP" role="2OqNvi">
                       <ref role="2Oxat5" node="48csSBNRezV" resolve="classifiers" />
                     </node>
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="1Wc70l" id="4oHUzWXghZX" role="2$JKZa">
-            <node concept="2OqwBi" id="4oHUzWXghZY" role="3uHU7w">
-              <node concept="37vLTw" id="4oHUzWXghZZ" role="2Oq$k0">
-                <ref role="3cqZAo" node="4oHUzWXghZB" resolve="lcClassifierIter" />
-              </node>
-              <node concept="v0PNk" id="4oHUzWXgi00" role="2OqNvi" />
-            </node>
-            <node concept="2OqwBi" id="4oHUzWXgi01" role="3uHU7B">
-              <node concept="37vLTw" id="4oHUzWXgi02" role="2Oq$k0">
-                <ref role="3cqZAo" node="4oHUzWXghZu" resolve="sClassifierIter" />
-              </node>
-              <node concept="v0PNk" id="4oHUzWXgi03" role="2OqNvi" />
             </node>
           </node>
         </node>
@@ -1298,12 +1214,17 @@
                   <ref role="3cqZAo" node="48csSBPbjAB" resolve="mpsDataTypes" />
                 </node>
                 <node concept="TSZUe" id="48csSBPbG1x" role="2OqNvi">
-                  <node concept="2OqwBi" id="39$JcGGX5WS" role="25WWJ7">
-                    <node concept="37vLTw" id="39$JcGGX1$Z" role="2Oq$k0">
-                      <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+                  <node concept="2OqwBi" id="7OJcYqxMG6F" role="25WWJ7">
+                    <node concept="2OqwBi" id="39$JcGGX5WS" role="2Oq$k0">
+                      <node concept="37vLTw" id="39$JcGGX1$Z" role="2Oq$k0">
+                        <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYqxM_Jv" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:7OJcYqwQm1t" resolve="getBoolean" />
+                      </node>
                     </node>
-                    <node concept="liA8E" id="5JNiskhHKmz" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3jVJ" resolve="slangBooleanType" />
+                    <node concept="liA8E" id="7OJcYqxMMFG" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
                     </node>
                   </node>
                 </node>
@@ -1315,12 +1236,17 @@
                   <ref role="3cqZAo" node="48csSBPbjAB" resolve="mpsDataTypes" />
                 </node>
                 <node concept="TSZUe" id="48csSBPbQ9B" role="2OqNvi">
-                  <node concept="2OqwBi" id="39$JcGGXdRm" role="25WWJ7">
-                    <node concept="37vLTw" id="39$JcGGXdRn" role="2Oq$k0">
-                      <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+                  <node concept="2OqwBi" id="7OJcYqxNpn5" role="25WWJ7">
+                    <node concept="2OqwBi" id="39$JcGGXdRm" role="2Oq$k0">
+                      <node concept="37vLTw" id="39$JcGGXdRn" role="2Oq$k0">
+                        <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYqxNk2y" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:7OJcYqwQm1A" resolve="getInteger" />
+                      </node>
                     </node>
-                    <node concept="liA8E" id="5JNiskhIajz" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3jW4" resolve="slangIntegerType" />
+                    <node concept="liA8E" id="7OJcYqxNvmX" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
                     </node>
                   </node>
                 </node>
@@ -1332,12 +1258,17 @@
                   <ref role="3cqZAo" node="48csSBPbjAB" resolve="mpsDataTypes" />
                 </node>
                 <node concept="TSZUe" id="48csSBPbQa4" role="2OqNvi">
-                  <node concept="2OqwBi" id="39$JcGGXkk3" role="25WWJ7">
-                    <node concept="37vLTw" id="39$JcGGXkk4" role="2Oq$k0">
-                      <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+                  <node concept="2OqwBi" id="7OJcYqxN3tO" role="25WWJ7">
+                    <node concept="2OqwBi" id="39$JcGGXkk3" role="2Oq$k0">
+                      <node concept="37vLTw" id="39$JcGGXkk4" role="2Oq$k0">
+                        <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYqxMYza" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:7OJcYqwQm1k" resolve="getString" />
+                      </node>
                     </node>
-                    <node concept="liA8E" id="5JNiskhHWv_" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3jVq" resolve="slangStringType" />
+                    <node concept="liA8E" id="7OJcYqxN96D" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
                     </node>
                   </node>
                 </node>
@@ -1357,12 +1288,17 @@
                 </node>
               </node>
             </node>
-            <node concept="2OqwBi" id="SgalDIMogw" role="3uHU7w">
-              <node concept="37vLTw" id="SgalDIMkgT" role="2Oq$k0">
-                <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+            <node concept="2OqwBi" id="7OJcYqxKuuB" role="3uHU7w">
+              <node concept="2OqwBi" id="SgalDIMogw" role="2Oq$k0">
+                <node concept="37vLTw" id="SgalDIMkgT" role="2Oq$k0">
+                  <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+                </node>
+                <node concept="liA8E" id="7OJcYqxKnVx" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqxK_pb" resolve="getCoreLanguage" />
+                </node>
               </node>
-              <node concept="liA8E" id="5JNiskhIkg0" role="2OqNvi">
-                <ref role="37wK5l" to="y7p:5JNiski3jYb" resolve="slangCoreLanguageId" />
+              <node concept="liA8E" id="7OJcYqxMpwL" role="2OqNvi">
+                <ref role="37wK5l" to="y7p:7OJcYqw7aei" resolve="getSlangId" />
               </node>
             </node>
           </node>
@@ -3098,12 +3034,17 @@
                 <node concept="37vLTw" id="3M8YG$cf0JY" role="3uHU7B">
                   <ref role="3cqZAo" node="3M8YG$cf0JT" resolve="superConcept" />
                 </node>
-                <node concept="2OqwBi" id="6Pr6izINgzO" role="3uHU7w">
-                  <node concept="37vLTw" id="6Pr6izINgzP" role="2Oq$k0">
-                    <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+                <node concept="2OqwBi" id="7OJcYqxNEDU" role="3uHU7w">
+                  <node concept="2OqwBi" id="6Pr6izINgzO" role="2Oq$k0">
+                    <node concept="37vLTw" id="6Pr6izINgzP" role="2Oq$k0">
+                      <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+                    </node>
+                    <node concept="liA8E" id="5JNiskhIHp2" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqwQm21" resolve="getAnnotation" />
+                    </node>
                   </node>
-                  <node concept="liA8E" id="5JNiskhIHp2" role="2OqNvi">
-                    <ref role="37wK5l" to="y7p:5JNiski3jWZ" resolve="slangAnnotationConcept" />
+                  <node concept="liA8E" id="7OJcYqxNLtp" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
                   </node>
                 </node>
               </node>
@@ -3188,12 +3129,17 @@
           <node concept="3clFbS" id="6Pr6izIMRYx" role="3clFbx">
             <node concept="3clFbF" id="6Pr6izIOV6J" role="3cqZAp">
               <node concept="37vLTI" id="6Pr6izIP1te" role="3clFbG">
-                <node concept="2OqwBi" id="6Pr6izIPg9j" role="37vLTx">
-                  <node concept="37vLTw" id="6Pr6izIP8Ls" role="2Oq$k0">
-                    <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+                <node concept="2OqwBi" id="7OJcYqxO14e" role="37vLTx">
+                  <node concept="2OqwBi" id="6Pr6izIPg9j" role="2Oq$k0">
+                    <node concept="37vLTw" id="6Pr6izIP8Ls" role="2Oq$k0">
+                      <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqxNVNG" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqwQm1S" resolve="getNode" />
+                    </node>
                   </node>
-                  <node concept="liA8E" id="5JNiskhIvPx" role="2OqNvi">
-                    <ref role="37wK5l" to="y7p:5JNiski3jWI" resolve="slangNodeConcept" />
+                  <node concept="liA8E" id="7OJcYqxO5lD" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
                   </node>
                 </node>
                 <node concept="37vLTw" id="6Pr6izIOV6H" role="37vLTJ">
@@ -3967,12 +3913,17 @@
                 <node concept="3Tqbb2" id="2fx6VTT$tRB" role="1tU5fm">
                   <ref role="ehGHo" to="h3y3:2ju2syjko0M" resolve="DataType" />
                 </node>
-                <node concept="2OqwBi" id="2fx6VTT$tRj" role="33vP2m">
-                  <node concept="37vLTw" id="2fx6VTT$tRk" role="2Oq$k0">
-                    <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+                <node concept="2OqwBi" id="7OJcYqxF8hh" role="33vP2m">
+                  <node concept="2OqwBi" id="2fx6VTT$tRj" role="2Oq$k0">
+                    <node concept="37vLTw" id="2fx6VTT$tRk" role="2Oq$k0">
+                      <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
+                    </node>
+                    <node concept="liA8E" id="5JNiskhIUWn" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqwQm1k" resolve="getString" />
+                    </node>
                   </node>
-                  <node concept="liA8E" id="5JNiskhIUWn" role="2OqNvi">
-                    <ref role="37wK5l" to="y7p:5JNiski3jVi" resolve="lcStringType" />
+                  <node concept="liA8E" id="7OJcYqxFeAJ" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwP92e" resolve="getLc" />
                   </node>
                 </node>
               </node>
@@ -4662,54 +4613,69 @@
     <node concept="3clFb_" id="48csSBNRePz" role="jymVt">
       <property role="TrG5h" value="createPrimitiveType" />
       <node concept="3clFbS" id="48csSBNReP$" role="3clF47">
-        <node concept="3cpWs8" id="39$JcGFGbP6" role="3cqZAp">
-          <node concept="3cpWsn" id="39$JcGFGbP7" role="3cpWs9">
-            <property role="TrG5h" value="index" />
-            <node concept="10Oyi0" id="39$JcGFG9$f" role="1tU5fm" />
-            <node concept="2OqwBi" id="39$JcGFGbP8" role="33vP2m">
-              <node concept="2OqwBi" id="39$JcGFGbP9" role="2Oq$k0">
-                <node concept="37vLTw" id="39$JcGFGbPa" role="2Oq$k0">
+        <node concept="3cpWs8" id="7OJcYqxPdGt" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqxPdGu" role="3cpWs9">
+            <property role="TrG5h" value="first" />
+            <node concept="3uibUv" id="7OJcYqxPc9F" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqxPdGv" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqxPdGw" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYqxPdGx" role="2Oq$k0">
                   <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
                 </node>
-                <node concept="liA8E" id="39$JcGFGbPb" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3k1p" resolve="listSLanguagePrimitiveTypes" />
+                <node concept="liA8E" id="7OJcYqxPdGy" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
                 </node>
               </node>
-              <node concept="2WmjW8" id="39$JcGFGbPc" role="2OqNvi">
-                <node concept="37vLTw" id="39$JcGFGbPd" role="25WWJ7">
-                  <ref role="3cqZAo" node="48csSBNRePQ" resolve="mps" />
+              <node concept="1z4cxt" id="7OJcYqxPdGz" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYqxPdG$" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYqxPdG_" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYqxPdGA" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYqxPdGB" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYqxPdGC" role="3uHU7w">
+                          <ref role="3cqZAo" node="48csSBNRePQ" resolve="mps" />
+                        </node>
+                        <node concept="2OqwBi" id="7OJcYqxPdGD" role="3uHU7B">
+                          <node concept="37vLTw" id="7OJcYqxPdGE" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqxPdGG" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqxPdGF" role="2OqNvi">
+                            <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYqxPdGG" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYqxPdGH" role="1tU5fm" />
+                  </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbJ" id="39$JcGFGmje" role="3cqZAp">
-          <node concept="3clFbS" id="39$JcGFGmjg" role="3clFbx">
-            <node concept="3cpWs6" id="39$JcGFG_dt" role="3cqZAp">
-              <node concept="2OqwBi" id="39$JcGFO25W" role="3cqZAk">
-                <node concept="1y4W85" id="39$JcGFGXht" role="2Oq$k0">
-                  <node concept="37vLTw" id="39$JcGFH0NK" role="1y58nS">
-                    <ref role="3cqZAo" node="39$JcGFGbP7" resolve="index" />
+        <node concept="3clFbJ" id="7OJcYqxPwa_" role="3cqZAp">
+          <node concept="3clFbS" id="7OJcYqxPwaB" role="3clFbx">
+            <node concept="3cpWs6" id="7OJcYqxPR5$" role="3cqZAp">
+              <node concept="2OqwBi" id="7OJcYqxQpUB" role="3cqZAk">
+                <node concept="2OqwBi" id="7OJcYqxQ7yi" role="2Oq$k0">
+                  <node concept="37vLTw" id="7OJcYqxQ1gW" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxPdGu" resolve="first" />
                   </node>
-                  <node concept="2OqwBi" id="39$JcGFGG1f" role="1y566C">
-                    <node concept="37vLTw" id="39$JcGFGCLC" role="2Oq$k0">
-                      <ref role="3cqZAo" node="48csSBNRezH" resolve="constants" />
-                    </node>
-                    <node concept="liA8E" id="39$JcGFGJHW" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3k19" resolve="listLcPrimitiveTypes" />
-                    </node>
+                  <node concept="liA8E" id="7OJcYqxQedL" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
                   </node>
                 </node>
-                <node concept="1$rogu" id="39$JcGFO68V" role="2OqNvi" />
+                <node concept="1$rogu" id="7OJcYqxQwqY" role="2OqNvi" />
               </node>
             </node>
           </node>
-          <node concept="2d3UOw" id="39$JcGFGu6F" role="3clFbw">
-            <node concept="3cmrfG" id="39$JcGFGx_m" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="37vLTw" id="39$JcGFGpOg" role="3uHU7B">
-              <ref role="3cqZAo" node="39$JcGFGbP7" resolve="index" />
+          <node concept="3y3z36" id="7OJcYqxPGp_" role="3clFbw">
+            <node concept="10Nm6u" id="7OJcYqxPL7a" role="3uHU7w" />
+            <node concept="37vLTw" id="7OJcYqxPAis" role="3uHU7B">
+              <ref role="3cqZAo" node="7OJcYqxPdGu" resolve="first" />
             </node>
           </node>
         </node>

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.lioncore2mps.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.lioncore2mps.mps
@@ -71,16 +71,12 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
-      <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
-      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
-        <child id="1076505808688" name="condition" index="2$JKZa" />
-      </concept>
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
@@ -505,12 +501,6 @@
       <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
         <child id="1226511765987" name="elementType" index="2hN53Y" />
       </concept>
-      <concept id="1237467461002" name="jetbrains.mps.baseLanguage.collections.structure.GetIteratorOperation" flags="nn" index="uNJiE" />
-      <concept id="1237467705688" name="jetbrains.mps.baseLanguage.collections.structure.IteratorType" flags="in" index="uOF1S">
-        <child id="1237467730343" name="elementType" index="uOL27" />
-      </concept>
-      <concept id="1237470895604" name="jetbrains.mps.baseLanguage.collections.structure.HasNextOperation" flags="nn" index="v0PNk" />
-      <concept id="1237471031357" name="jetbrains.mps.baseLanguage.collections.structure.GetNextOperation" flags="nn" index="v1n4t" />
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -560,10 +550,6 @@
       </concept>
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="7125221305512719026" name="jetbrains.mps.baseLanguage.collections.structure.CollectionType" flags="in" index="3vKaQO" />
-      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
-        <child id="1225711182005" name="list" index="1y566C" />
-        <child id="1225711191269" name="index" index="1y58nS" />
-      </concept>
       <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
@@ -4117,22 +4103,44 @@
         </node>
       </node>
       <node concept="3clFbS" id="DUXtH0z8cQ" role="3clF47">
-        <node concept="3cpWs8" id="39$JcGFJrM8" role="3cqZAp">
-          <node concept="3cpWsn" id="39$JcGFJrM9" role="3cpWs9">
-            <property role="TrG5h" value="index" />
-            <node concept="10Oyi0" id="39$JcGFJq92" role="1tU5fm" />
-            <node concept="2OqwBi" id="39$JcGFJrMa" role="33vP2m">
-              <node concept="2OqwBi" id="39$JcGFJrMb" role="2Oq$k0">
-                <node concept="37vLTw" id="39$JcGFJrMc" role="2Oq$k0">
+        <node concept="3cpWs8" id="7OJcYqztYaA" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqztYaB" role="3cpWs9">
+            <property role="TrG5h" value="mapping" />
+            <node concept="3uibUv" id="7OJcYqztVkW" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqztYaC" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqztYaD" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYqztYaE" role="2Oq$k0">
                   <ref role="3cqZAo" node="3ePT3MaOLS3" resolve="constants" />
                 </node>
-                <node concept="liA8E" id="39$JcGFJrMd" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3k19" resolve="listLcPrimitiveTypes" />
+                <node concept="liA8E" id="7OJcYqztYaF" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
                 </node>
               </node>
-              <node concept="2WmjW8" id="39$JcGFJrMe" role="2OqNvi">
-                <node concept="37vLTw" id="39$JcGFJrMf" role="25WWJ7">
-                  <ref role="3cqZAo" node="DUXtH0z8d4" resolve="primitiveType" />
+              <node concept="1z4cxt" id="7OJcYqztYaG" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYqztYaH" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYqztYaI" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYqztYaJ" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYqztYaK" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYqztYaL" role="3uHU7w">
+                          <ref role="3cqZAo" node="DUXtH0z8d4" resolve="primitiveType" />
+                        </node>
+                        <node concept="2OqwBi" id="7OJcYqztYaM" role="3uHU7B">
+                          <node concept="37vLTw" id="7OJcYqztYaN" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqztYaP" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqztYaO" role="2OqNvi">
+                            <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYqztYaP" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYqztYaQ" role="1tU5fm" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -4142,29 +4150,22 @@
           <node concept="3clFbS" id="39$JcGFJYui" role="3clFbx">
             <node concept="3cpWs6" id="39$JcGFKRbW" role="3cqZAp">
               <node concept="2OqwBi" id="39$JcGFNnqE" role="3cqZAk">
-                <node concept="1y4W85" id="39$JcGFMuvM" role="2Oq$k0">
-                  <node concept="37vLTw" id="39$JcGFMIO4" role="1y58nS">
-                    <ref role="3cqZAo" node="39$JcGFJrM9" resolve="index" />
+                <node concept="2OqwBi" id="7OJcYqzw8Dh" role="2Oq$k0">
+                  <node concept="37vLTw" id="7OJcYqzvS7u" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqztYaB" resolve="mapping" />
                   </node>
-                  <node concept="2OqwBi" id="39$JcGFLqjS" role="1y566C">
-                    <node concept="37vLTw" id="39$JcGFLavO" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3ePT3MaOLS3" resolve="constants" />
-                    </node>
-                    <node concept="liA8E" id="39$JcGFLEbS" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3k1h" resolve="listMpsPrimitiveTypes" />
-                    </node>
+                  <node concept="liA8E" id="7OJcYqzwp2B" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKihR" resolve="getMps" />
                   </node>
                 </node>
                 <node concept="1$rogu" id="39$JcGFN$5J" role="2OqNvi" />
               </node>
             </node>
           </node>
-          <node concept="2d3UOw" id="39$JcGFKwqw" role="3clFbw">
-            <node concept="3cmrfG" id="39$JcGFKGdH" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="37vLTw" id="39$JcGFKhmx" role="3uHU7B">
-              <ref role="3cqZAo" node="39$JcGFJrM9" resolve="index" />
+          <node concept="3y3z36" id="7OJcYqzv9fk" role="3clFbw">
+            <node concept="10Nm6u" id="7OJcYqzvsAT" role="3uHU7w" />
+            <node concept="37vLTw" id="7OJcYqzuBTU" role="3uHU7B">
+              <ref role="3cqZAo" node="7OJcYqztYaB" resolve="mapping" />
             </node>
           </node>
         </node>
@@ -4574,12 +4575,17 @@
             <node concept="37vLTw" id="6fYiNFaszEq" role="37wK5m">
               <ref role="3cqZAo" node="1x6uvBPnP7Z" resolve="structure" />
             </node>
-            <node concept="2OqwBi" id="4WflrVaEycu" role="37wK5m">
-              <node concept="37vLTw" id="4WflrVaEug9" role="2Oq$k0">
-                <ref role="3cqZAo" node="3ePT3MaOLS3" resolve="constants" />
+            <node concept="2OqwBi" id="7OJcYqz8fe0" role="37wK5m">
+              <node concept="2OqwBi" id="4WflrVaEycu" role="2Oq$k0">
+                <node concept="37vLTw" id="4WflrVaEug9" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3ePT3MaOLS3" resolve="constants" />
+                </node>
+                <node concept="liA8E" id="5JNiskhJW9v" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqwQm2_" resolve="getAttributeLanguage" />
+                </node>
               </node>
-              <node concept="liA8E" id="5JNiskhJW9v" role="2OqNvi">
-                <ref role="37wK5l" to="y7p:5JNiski3jYw" resolve="slangAttributeLanguage" />
+              <node concept="liA8E" id="7OJcYqz8hXz" role="2OqNvi">
+                <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
               </node>
             </node>
           </node>
@@ -6596,50 +6602,19 @@
         </node>
       </node>
       <node concept="3clFbS" id="5M3rB6B$JGc" role="3clF47">
-        <node concept="3cpWs8" id="5M3rB6B$JGd" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6B$JGe" role="3cpWs9">
-            <property role="TrG5h" value="lcDataTypeIter" />
-            <node concept="uOF1S" id="5M3rB6B$JGf" role="1tU5fm">
-              <node concept="3Tqbb2" id="5M3rB6B$JGg" role="uOL27">
-                <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-              </node>
+        <node concept="2Gpval" id="7OJcYqzgp3N" role="3cqZAp">
+          <node concept="2GrKxI" id="7OJcYqzgp3P" role="2Gsz3X">
+            <property role="TrG5h" value="dataType" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqzgv2T" role="2GsD0m">
+            <node concept="37vLTw" id="7OJcYqzgtha" role="2Oq$k0">
+              <ref role="3cqZAo" node="5M3rB6B$JHn" resolve="constants" />
             </node>
-            <node concept="2OqwBi" id="5M3rB6B$JGh" role="33vP2m">
-              <node concept="2OqwBi" id="5M3rB6B$JGi" role="2Oq$k0">
-                <node concept="37vLTw" id="5M3rB6B$JHs" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5M3rB6B$JHn" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="5M3rB6B$JGk" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3k19" resolve="listLcPrimitiveTypes" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6B$JGl" role="2OqNvi" />
+            <node concept="liA8E" id="7OJcYqzgvRK" role="2OqNvi">
+              <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
             </node>
           </node>
-        </node>
-        <node concept="3cpWs8" id="5M3rB6B$JGm" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6B$JGn" role="3cpWs9">
-            <property role="TrG5h" value="mpsDataTypeIter" />
-            <node concept="uOF1S" id="5M3rB6B$JGo" role="1tU5fm">
-              <node concept="3Tqbb2" id="5M3rB6B$JGp" role="uOL27">
-                <ref role="ehGHo" to="tpce:fKAxPRU" resolve="DataTypeDeclaration" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5M3rB6B$JGq" role="33vP2m">
-              <node concept="2OqwBi" id="5M3rB6B$JGr" role="2Oq$k0">
-                <node concept="37vLTw" id="5M3rB6B$JHr" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5M3rB6B$JHn" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="5M3rB6B$JGt" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3k1h" resolve="listMpsPrimitiveTypes" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6B$JGu" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="2$JKZl" id="5M3rB6B$JGv" role="3cqZAp">
-          <node concept="3clFbS" id="5M3rB6B$JGw" role="2LFqv$">
+          <node concept="3clFbS" id="7OJcYqzgp3T" role="2LFqv$">
             <node concept="3clFbF" id="5M3rB6B$JGx" role="3cqZAp">
               <node concept="2OqwBi" id="5M3rB6B$JGy" role="3clFbG">
                 <node concept="37vLTw" id="5M3rB6B$JGz" role="2Oq$k0">
@@ -6647,81 +6622,40 @@
                 </node>
                 <node concept="liA8E" id="5M3rB6B$JG$" role="2OqNvi">
                   <ref role="37wK5l" node="3diEf07vIBh" resolve="registerDataType" />
-                  <node concept="2OqwBi" id="5M3rB6B$JG_" role="37wK5m">
-                    <node concept="37vLTw" id="5M3rB6B$JGA" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M3rB6B$JGe" resolve="lcDataTypeIter" />
+                  <node concept="2OqwBi" id="7OJcYqzg$of" role="37wK5m">
+                    <node concept="2GrUjf" id="7OJcYqzgyyn" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="7OJcYqzgp3P" resolve="dataType" />
                     </node>
-                    <node concept="v1n4t" id="5M3rB6B$JGB" role="2OqNvi" />
-                  </node>
-                  <node concept="2OqwBi" id="5M3rB6B$JGC" role="37wK5m">
-                    <node concept="37vLTw" id="5M3rB6B$JGD" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M3rB6B$JGn" resolve="mpsDataTypeIter" />
+                    <node concept="liA8E" id="7OJcYqzgA9u" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
                     </node>
-                    <node concept="v1n4t" id="5M3rB6B$JGE" role="2OqNvi" />
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqzgEFS" role="37wK5m">
+                    <node concept="2GrUjf" id="7OJcYqzgD17" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="7OJcYqzgp3P" resolve="dataType" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqzgMeB" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKihR" resolve="getMps" />
+                    </node>
                   </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="1Wc70l" id="5M3rB6B$JGF" role="2$JKZa">
-            <node concept="2OqwBi" id="5M3rB6B$JGG" role="3uHU7w">
-              <node concept="37vLTw" id="5M3rB6B$JGH" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6B$JGn" resolve="mpsDataTypeIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6B$JGI" role="2OqNvi" />
+        </node>
+        <node concept="2Gpval" id="7OJcYqzgORw" role="3cqZAp">
+          <node concept="2GrKxI" id="7OJcYqzgORy" role="2Gsz3X">
+            <property role="TrG5h" value="classifier" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqzgRGj" role="2GsD0m">
+            <node concept="37vLTw" id="7OJcYqzgQAp" role="2Oq$k0">
+              <ref role="3cqZAo" node="5M3rB6B$JHn" resolve="constants" />
             </node>
-            <node concept="2OqwBi" id="5M3rB6B$JGJ" role="3uHU7B">
-              <node concept="37vLTw" id="5M3rB6B$JGK" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6B$JGe" resolve="lcDataTypeIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6B$JGL" role="2OqNvi" />
+            <node concept="liA8E" id="7OJcYqzgTsi" role="2OqNvi">
+              <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listClassifiers" />
             </node>
           </node>
-        </node>
-        <node concept="3cpWs8" id="5M3rB6B$JGM" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6B$JGN" role="3cpWs9">
-            <property role="TrG5h" value="lcClassifierIter" />
-            <node concept="uOF1S" id="5M3rB6B$JGO" role="1tU5fm">
-              <node concept="3Tqbb2" id="5M3rB6B$JGP" role="uOL27">
-                <ref role="ehGHo" to="h3y3:2ju2syjkl4i" resolve="Classifier" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5M3rB6B$JGQ" role="33vP2m">
-              <node concept="2OqwBi" id="5M3rB6B$JGR" role="2Oq$k0">
-                <node concept="37vLTw" id="5M3rB6B$JHp" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5M3rB6B$JHn" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="5M3rB6B$JGT" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jZs" resolve="listLcClassifiers" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6B$JGU" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="5M3rB6B$JGV" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6B$JGW" role="3cpWs9">
-            <property role="TrG5h" value="mpsClassifierIter" />
-            <node concept="uOF1S" id="5M3rB6B$JGX" role="1tU5fm">
-              <node concept="3Tqbb2" id="5M3rB6B$JGY" role="uOL27">
-                <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5M3rB6B$JGZ" role="33vP2m">
-              <node concept="2OqwBi" id="5M3rB6B$JH0" role="2Oq$k0">
-                <node concept="37vLTw" id="5M3rB6B$JHq" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5M3rB6B$JHn" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="5M3rB6B$JH2" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jZ$" resolve="listMpsClassifiers" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6B$JH3" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="2$JKZl" id="5M3rB6B$JH4" role="3cqZAp">
-          <node concept="3clFbS" id="5M3rB6B$JH5" role="2LFqv$">
+          <node concept="3clFbS" id="7OJcYqzgORA" role="2LFqv$">
             <node concept="3clFbF" id="5M3rB6B$JH6" role="3cqZAp">
               <node concept="2OqwBi" id="5M3rB6B$JH7" role="3clFbG">
                 <node concept="37vLTw" id="5M3rB6B$JH8" role="2Oq$k0">
@@ -6729,34 +6663,24 @@
                 </node>
                 <node concept="liA8E" id="5M3rB6B$JH9" role="2OqNvi">
                   <ref role="37wK5l" node="3diEf07vIbR" resolve="registerClassifier" />
-                  <node concept="2OqwBi" id="5M3rB6B$JHa" role="37wK5m">
-                    <node concept="37vLTw" id="5M3rB6B$JHb" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M3rB6B$JGN" resolve="lcClassifierIter" />
+                  <node concept="2OqwBi" id="7OJcYqzgYDi" role="37wK5m">
+                    <node concept="2GrUjf" id="7OJcYqzgXQE" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="7OJcYqzgORy" resolve="classifier" />
                     </node>
-                    <node concept="v1n4t" id="5M3rB6B$JHc" role="2OqNvi" />
+                    <node concept="liA8E" id="7OJcYqzh02M" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
+                    </node>
                   </node>
-                  <node concept="2OqwBi" id="5M3rB6B$JHd" role="37wK5m">
-                    <node concept="37vLTw" id="5M3rB6B$JHe" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M3rB6B$JGW" resolve="mpsClassifierIter" />
+                  <node concept="2OqwBi" id="7OJcYqzh3Un" role="37wK5m">
+                    <node concept="2GrUjf" id="7OJcYqzh2r$" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="7OJcYqzgORy" resolve="classifier" />
                     </node>
-                    <node concept="v1n4t" id="5M3rB6B$JHf" role="2OqNvi" />
+                    <node concept="liA8E" id="7OJcYqzh5$W" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKihR" resolve="getMps" />
+                    </node>
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="1Wc70l" id="5M3rB6B$JHg" role="2$JKZa">
-            <node concept="2OqwBi" id="5M3rB6B$JHh" role="3uHU7w">
-              <node concept="37vLTw" id="5M3rB6B$JHi" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6B$JGN" resolve="lcClassifierIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6B$JHj" role="2OqNvi" />
-            </node>
-            <node concept="2OqwBi" id="5M3rB6B$JHk" role="3uHU7B">
-              <node concept="37vLTw" id="5M3rB6B$JHl" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6B$JGW" resolve="mpsClassifierIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6B$JHm" role="2OqNvi" />
             </node>
           </node>
         </node>
@@ -12405,12 +12329,34 @@
                 <ref role="3cqZAo" node="59Df55kEtFv" resolve="dataTypeDeclarations" />
               </node>
               <node concept="66VNe" id="39$JcGGGBWN" role="2OqNvi">
-                <node concept="2OqwBi" id="39$JcGGH3Iq" role="576Qk">
-                  <node concept="37vLTw" id="39$JcGGGQy5" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3ePT3MaOLS3" resolve="constants" />
+                <node concept="2OqwBi" id="7OJcYqzxLVp" role="576Qk">
+                  <node concept="2OqwBi" id="39$JcGGH3Iq" role="2Oq$k0">
+                    <node concept="37vLTw" id="39$JcGGGQy5" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3ePT3MaOLS3" resolve="constants" />
+                    </node>
+                    <node concept="liA8E" id="39$JcGGHkhW" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+                    </node>
                   </node>
-                  <node concept="liA8E" id="39$JcGGHkhW" role="2OqNvi">
-                    <ref role="37wK5l" to="y7p:5JNiski3k1h" resolve="listMpsPrimitiveTypes" />
+                  <node concept="3$u5V9" id="7OJcYqzy1gm" role="2OqNvi">
+                    <node concept="1bVj0M" id="7OJcYqzy1go" role="23t8la">
+                      <node concept="3clFbS" id="7OJcYqzy1gp" role="1bW5cS">
+                        <node concept="3clFbF" id="7OJcYqzygtX" role="3cqZAp">
+                          <node concept="2OqwBi" id="7OJcYqzymiq" role="3clFbG">
+                            <node concept="37vLTw" id="7OJcYqzygtW" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7OJcYqzy1gq" resolve="it" />
+                            </node>
+                            <node concept="liA8E" id="7OJcYqzy_fL" role="2OqNvi">
+                              <ref role="37wK5l" to="y7p:7OJcYqvKihR" resolve="getMps" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="7OJcYqzy1gq" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7OJcYqzy1gr" role="1tU5fm" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -12764,12 +12710,39 @@
                   </node>
                 </node>
                 <node concept="66VNe" id="39$JcGGI__S" role="2OqNvi">
-                  <node concept="2OqwBi" id="39$JcGGJ2qB" role="576Qk">
-                    <node concept="37vLTw" id="39$JcGGIOIW" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3ePT3MaOLS3" resolve="constants" />
+                  <node concept="2OqwBi" id="7OJcYqzyU_x" role="576Qk">
+                    <node concept="2OqwBi" id="39$JcGGJ2qB" role="2Oq$k0">
+                      <node concept="37vLTw" id="39$JcGGIOIW" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3ePT3MaOLS3" resolve="constants" />
+                      </node>
+                      <node concept="liA8E" id="39$JcGGJeTb" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+                      </node>
                     </node>
-                    <node concept="liA8E" id="39$JcGGJeTb" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3k1p" resolve="listSLanguagePrimitiveTypes" />
+                    <node concept="3$u5V9" id="7OJcYqzz9Li" role="2OqNvi">
+                      <node concept="1bVj0M" id="7OJcYqzz9Lk" role="23t8la">
+                        <node concept="3clFbS" id="7OJcYqzz9Ll" role="1bW5cS">
+                          <node concept="3clFbF" id="7OJcYqzzoFs" role="3cqZAp">
+                            <node concept="10QFUN" id="7OJcYq$bsHV" role="3clFbG">
+                              <node concept="2OqwBi" id="7OJcYq$bsHS" role="10QFUP">
+                                <node concept="37vLTw" id="7OJcYq$bsHT" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7OJcYqzz9Lm" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="7OJcYq$bsHU" role="2OqNvi">
+                                  <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
+                                </node>
+                              </node>
+                              <node concept="3uibUv" id="7OJcYq$bSpt" role="10QFUM">
+                                <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="7OJcYqzz9Lm" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="7OJcYqzz9Ln" role="1tU5fm" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.lioncore2mps.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.lioncore2mps.mps
@@ -4105,9 +4105,9 @@
       <node concept="3clFbS" id="DUXtH0z8cQ" role="3clF47">
         <node concept="3cpWs8" id="7OJcYqztYaA" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqztYaB" role="3cpWs9">
-            <property role="TrG5h" value="mapping" />
+            <property role="TrG5h" value="staple" />
             <node concept="3uibUv" id="7OJcYqztVkW" role="1tU5fm">
-              <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+              <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
             </node>
             <node concept="2OqwBi" id="7OJcYqztYaC" role="33vP2m">
               <node concept="2OqwBi" id="7OJcYqztYaD" role="2Oq$k0">
@@ -4115,7 +4115,7 @@
                   <ref role="3cqZAo" node="3ePT3MaOLS3" resolve="constants" />
                 </node>
                 <node concept="liA8E" id="7OJcYqztYaF" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
                 </node>
               </node>
               <node concept="1z4cxt" id="7OJcYqztYaG" role="2OqNvi">
@@ -4152,7 +4152,7 @@
               <node concept="2OqwBi" id="39$JcGFNnqE" role="3cqZAk">
                 <node concept="2OqwBi" id="7OJcYqzw8Dh" role="2Oq$k0">
                   <node concept="37vLTw" id="7OJcYqzvS7u" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7OJcYqztYaB" resolve="mapping" />
+                    <ref role="3cqZAo" node="7OJcYqztYaB" resolve="staple" />
                   </node>
                   <node concept="liA8E" id="7OJcYqzwp2B" role="2OqNvi">
                     <ref role="37wK5l" to="y7p:7OJcYqvKihR" resolve="getMps" />
@@ -4165,7 +4165,7 @@
           <node concept="3y3z36" id="7OJcYqzv9fk" role="3clFbw">
             <node concept="10Nm6u" id="7OJcYqzvsAT" role="3uHU7w" />
             <node concept="37vLTw" id="7OJcYqzuBTU" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYqztYaB" resolve="mapping" />
+              <ref role="3cqZAo" node="7OJcYqztYaB" resolve="staple" />
             </node>
           </node>
         </node>
@@ -6611,7 +6611,7 @@
               <ref role="3cqZAo" node="5M3rB6B$JHn" resolve="constants" />
             </node>
             <node concept="liA8E" id="7OJcYqzgvRK" role="2OqNvi">
-              <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+              <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
             </node>
           </node>
           <node concept="3clFbS" id="7OJcYqzgp3T" role="2LFqv$">
@@ -6652,7 +6652,7 @@
               <ref role="3cqZAo" node="5M3rB6B$JHn" resolve="constants" />
             </node>
             <node concept="liA8E" id="7OJcYqzgTsi" role="2OqNvi">
-              <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listClassifiers" />
+              <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listLcClassifiers" />
             </node>
           </node>
           <node concept="3clFbS" id="7OJcYqzgORA" role="2LFqv$">
@@ -12335,7 +12335,7 @@
                       <ref role="3cqZAo" node="3ePT3MaOLS3" resolve="constants" />
                     </node>
                     <node concept="liA8E" id="39$JcGGHkhW" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+                      <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
                     </node>
                   </node>
                   <node concept="3$u5V9" id="7OJcYqzy1gm" role="2OqNvi">
@@ -12716,7 +12716,7 @@
                         <ref role="3cqZAo" node="3ePT3MaOLS3" resolve="constants" />
                       </node>
                       <node concept="liA8E" id="39$JcGGJeTb" role="2OqNvi">
-                        <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+                        <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
                       </node>
                     </node>
                     <node concept="3$u5V9" id="7OJcYqzz9Li" role="2OqNvi">

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.mps2lioncore.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.mps2lioncore.mps
@@ -43,13 +43,9 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
-      <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
-      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
-        <child id="1076505808688" name="condition" index="2$JKZa" />
-      </concept>
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
@@ -87,7 +83,6 @@
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
-      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
@@ -101,6 +96,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -317,12 +313,6 @@
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
-      <concept id="1237467461002" name="jetbrains.mps.baseLanguage.collections.structure.GetIteratorOperation" flags="nn" index="uNJiE" />
-      <concept id="1237467705688" name="jetbrains.mps.baseLanguage.collections.structure.IteratorType" flags="in" index="uOF1S">
-        <child id="1237467730343" name="elementType" index="uOL27" />
-      </concept>
-      <concept id="1237470895604" name="jetbrains.mps.baseLanguage.collections.structure.HasNextOperation" flags="nn" index="v0PNk" />
-      <concept id="1237471031357" name="jetbrains.mps.baseLanguage.collections.structure.GetNextOperation" flags="nn" index="v1n4t" />
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -344,7 +334,6 @@
       </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
-      <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
       <concept id="1240216724530" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashMapCreator" flags="nn" index="32Fmki" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
@@ -356,11 +345,9 @@
         <child id="1197687035757" name="valueType" index="3rHtpV" />
       </concept>
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
-      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
-        <child id="1225711182005" name="list" index="1y566C" />
-        <child id="1225711191269" name="index" index="1y58nS" />
-      </concept>
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1240824834947" name="jetbrains.mps.baseLanguage.collections.structure.ValueAccessOperation" flags="nn" index="3AV6Ez" />
       <concept id="1240825616499" name="jetbrains.mps.baseLanguage.collections.structure.KeyAccessOperation" flags="nn" index="3AY5_j" />
       <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
@@ -785,64 +772,37 @@
       <node concept="3Tm6S6" id="5M3rB6B_htO" role="1B3o_S" />
       <node concept="3cqZAl" id="5M3rB6B_htP" role="3clF45" />
       <node concept="3clFbS" id="5M3rB6B_hsr" role="3clF47">
-        <node concept="3cpWs8" id="5M3rB6B_hss" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6B_hst" role="3cpWs9">
-            <property role="TrG5h" value="mpsDataTypeIter" />
-            <node concept="uOF1S" id="5M3rB6B_hsu" role="1tU5fm">
-              <node concept="3Tqbb2" id="5M3rB6B_hsv" role="uOL27">
-                <ref role="ehGHo" to="tpce:fKAxPRU" resolve="DataTypeDeclaration" />
-              </node>
+        <node concept="2Gpval" id="7OJcYqz0YHV" role="3cqZAp">
+          <node concept="2GrKxI" id="7OJcYqz0YHX" role="2Gsz3X">
+            <property role="TrG5h" value="dataType" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqz1iTz" role="2GsD0m">
+            <node concept="37vLTw" id="7OJcYqz1eNM" role="2Oq$k0">
+              <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
             </node>
-            <node concept="2OqwBi" id="5M3rB6B_hsw" role="33vP2m">
-              <node concept="2OqwBi" id="5M3rB6B_hsx" role="2Oq$k0">
-                <node concept="37vLTw" id="5M3rB6B_htI" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="5M3rB6B_hsz" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3k1h" resolve="listMpsPrimitiveTypes" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6B_hs$" role="2OqNvi" />
+            <node concept="liA8E" id="7OJcYqz1pGl" role="2OqNvi">
+              <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
             </node>
           </node>
-        </node>
-        <node concept="3cpWs8" id="5M3rB6B_hs_" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6B_hsA" role="3cpWs9">
-            <property role="TrG5h" value="lcDataTypeIter" />
-            <node concept="uOF1S" id="5M3rB6B_hsB" role="1tU5fm">
-              <node concept="3Tqbb2" id="5M3rB6B_hsC" role="uOL27">
-                <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5M3rB6B_hsD" role="33vP2m">
-              <node concept="2OqwBi" id="5M3rB6B_hsE" role="2Oq$k0">
-                <node concept="37vLTw" id="5M3rB6B_htH" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="5M3rB6B_hsG" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3k19" resolve="listLcPrimitiveTypes" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6B_hsH" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="2$JKZl" id="5M3rB6B_hsI" role="3cqZAp">
-          <node concept="3clFbS" id="5M3rB6B_hsJ" role="2LFqv$">
+          <node concept="3clFbS" id="7OJcYqz0YI1" role="2LFqv$">
             <node concept="3clFbF" id="5M3rB6B_hsK" role="3cqZAp">
               <node concept="37vLTI" id="5M3rB6B_hsL" role="3clFbG">
-                <node concept="2OqwBi" id="5M3rB6B_hsM" role="37vLTx">
-                  <node concept="37vLTw" id="5M3rB6B_hsN" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5M3rB6B_hsA" resolve="lcDataTypeIter" />
+                <node concept="2OqwBi" id="7OJcYqz2dqz" role="37vLTx">
+                  <node concept="2GrUjf" id="7OJcYqz29kL" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="7OJcYqz0YHX" resolve="dataType" />
                   </node>
-                  <node concept="v1n4t" id="5M3rB6B_hsO" role="2OqNvi" />
+                  <node concept="liA8E" id="7OJcYqz2pSR" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
+                  </node>
                 </node>
                 <node concept="3EllGN" id="5M3rB6B_hsP" role="37vLTJ">
-                  <node concept="2OqwBi" id="5M3rB6B_hsQ" role="3ElVtu">
-                    <node concept="37vLTw" id="5M3rB6B_hsR" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M3rB6B_hst" resolve="mpsDataTypeIter" />
+                  <node concept="2OqwBi" id="7OJcYqz1NId" role="3ElVtu">
+                    <node concept="2GrUjf" id="7OJcYqz1JEx" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="7OJcYqz0YHX" resolve="dataType" />
                     </node>
-                    <node concept="v1n4t" id="5M3rB6B_hsS" role="2OqNvi" />
+                    <node concept="liA8E" id="7OJcYqz1YZL" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKihR" resolve="getMps" />
+                    </node>
                   </node>
                   <node concept="2OqwBi" id="5M3rB6B_hsT" role="3ElQJh">
                     <node concept="Xjq3P" id="5M3rB6B_hsU" role="2Oq$k0" />
@@ -854,80 +814,38 @@
               </node>
             </node>
           </node>
-          <node concept="1Wc70l" id="5M3rB6B_hsW" role="2$JKZa">
-            <node concept="2OqwBi" id="5M3rB6B_hsX" role="3uHU7B">
-              <node concept="37vLTw" id="5M3rB6B_hsY" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6B_hst" resolve="mpsDataTypeIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6B_hsZ" role="2OqNvi" />
+        </node>
+        <node concept="2Gpval" id="7OJcYqz2$rw" role="3cqZAp">
+          <node concept="2GrKxI" id="7OJcYqz2$ry" role="2Gsz3X">
+            <property role="TrG5h" value="classifier" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqz2RVI" role="2GsD0m">
+            <node concept="37vLTw" id="7OJcYqz2NzW" role="2Oq$k0">
+              <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
             </node>
-            <node concept="2OqwBi" id="5M3rB6B_ht0" role="3uHU7w">
-              <node concept="37vLTw" id="5M3rB6B_ht1" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6B_hsA" resolve="lcDataTypeIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6B_ht2" role="2OqNvi" />
+            <node concept="liA8E" id="7OJcYqz2YfY" role="2OqNvi">
+              <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listClassifiers" />
             </node>
           </node>
-        </node>
-        <node concept="3clFbH" id="5M3rB6B_ht3" role="3cqZAp" />
-        <node concept="3cpWs8" id="5M3rB6B_ht4" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6B_ht5" role="3cpWs9">
-            <property role="TrG5h" value="mpsClassifierIter" />
-            <node concept="2OqwBi" id="5M3rB6B_ht6" role="33vP2m">
-              <node concept="2OqwBi" id="5M3rB6B_ht7" role="2Oq$k0">
-                <node concept="37vLTw" id="5M3rB6B_htJ" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="5M3rB6B_ht9" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jZ$" resolve="listMpsClassifiers" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6B_hta" role="2OqNvi" />
-            </node>
-            <node concept="uOF1S" id="5M3rB6B_htb" role="1tU5fm">
-              <node concept="3Tqbb2" id="5M3rB6B_htc" role="uOL27">
-                <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="5M3rB6B_htd" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6B_hte" role="3cpWs9">
-            <property role="TrG5h" value="lcClassifierIter" />
-            <node concept="uOF1S" id="5M3rB6B_htf" role="1tU5fm">
-              <node concept="3Tqbb2" id="5M3rB6B_htg" role="uOL27">
-                <ref role="ehGHo" to="h3y3:2ju2syjkl4i" resolve="Classifier" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5M3rB6B_hth" role="33vP2m">
-              <node concept="2OqwBi" id="5M3rB6B_hti" role="2Oq$k0">
-                <node concept="37vLTw" id="5M3rB6B_htK" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="5M3rB6B_htk" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jZs" resolve="listLcClassifiers" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6B_htl" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="2$JKZl" id="5M3rB6B_htm" role="3cqZAp">
-          <node concept="3clFbS" id="5M3rB6B_htn" role="2LFqv$">
+          <node concept="3clFbS" id="7OJcYqz2$rA" role="2LFqv$">
             <node concept="3clFbF" id="5M3rB6B_hto" role="3cqZAp">
               <node concept="37vLTI" id="5M3rB6B_htp" role="3clFbG">
-                <node concept="2OqwBi" id="5M3rB6B_htq" role="37vLTx">
-                  <node concept="37vLTw" id="5M3rB6B_htr" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5M3rB6B_hte" resolve="lcClassifierIter" />
+                <node concept="2OqwBi" id="7OJcYqz3Ph1" role="37vLTx">
+                  <node concept="2GrUjf" id="7OJcYqz3KUG" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="7OJcYqz2$ry" resolve="classifier" />
                   </node>
-                  <node concept="v1n4t" id="5M3rB6B_hts" role="2OqNvi" />
+                  <node concept="liA8E" id="7OJcYqz3VWw" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
+                  </node>
                 </node>
                 <node concept="3EllGN" id="5M3rB6B_htt" role="37vLTJ">
-                  <node concept="2OqwBi" id="5M3rB6B_htu" role="3ElVtu">
-                    <node concept="37vLTw" id="5M3rB6B_htv" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M3rB6B_ht5" resolve="mpsClassifierIter" />
+                  <node concept="2OqwBi" id="7OJcYqz3tbq" role="3ElVtu">
+                    <node concept="2GrUjf" id="7OJcYqz3qaV" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="7OJcYqz2$ry" resolve="classifier" />
                     </node>
-                    <node concept="v1n4t" id="5M3rB6B_htw" role="2OqNvi" />
+                    <node concept="liA8E" id="7OJcYqz3zVM" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKihR" resolve="getMps" />
+                    </node>
                   </node>
                   <node concept="2OqwBi" id="5M3rB6B_htx" role="3ElQJh">
                     <node concept="Xjq3P" id="5M3rB6B_hty" role="2Oq$k0" />
@@ -937,20 +855,6 @@
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="1Wc70l" id="5M3rB6B_ht$" role="2$JKZa">
-            <node concept="2OqwBi" id="5M3rB6B_ht_" role="3uHU7w">
-              <node concept="37vLTw" id="5M3rB6B_htA" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6B_hte" resolve="lcClassifierIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6B_htB" role="2OqNvi" />
-            </node>
-            <node concept="2OqwBi" id="5M3rB6B_htC" role="3uHU7B">
-              <node concept="37vLTw" id="5M3rB6B_htD" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6B_ht5" resolve="mpsClassifierIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6B_htE" role="2OqNvi" />
             </node>
           </node>
         </node>
@@ -1138,12 +1042,34 @@
                       <node concept="3clFbF" id="5AGBwuDUmGA" role="3cqZAp">
                         <node concept="3fqX7Q" id="5AGBwuDUmG$" role="3clFbG">
                           <node concept="2OqwBi" id="5AGBwuDT1cw" role="3fr31v">
-                            <node concept="2OqwBi" id="5AGBwuDSFuL" role="2Oq$k0">
-                              <node concept="37vLTw" id="5AGBwuDSxHJ" role="2Oq$k0">
-                                <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
+                            <node concept="2OqwBi" id="7OJcYqz4hbA" role="2Oq$k0">
+                              <node concept="2OqwBi" id="5AGBwuDSFuL" role="2Oq$k0">
+                                <node concept="37vLTw" id="5AGBwuDSxHJ" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
+                                </node>
+                                <node concept="liA8E" id="5AGBwuDSPkB" role="2OqNvi">
+                                  <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listClassifiers" />
+                                </node>
                               </node>
-                              <node concept="liA8E" id="5AGBwuDSPkB" role="2OqNvi">
-                                <ref role="37wK5l" to="y7p:5JNiski3jZ$" resolve="listMpsClassifiers" />
+                              <node concept="3$u5V9" id="7OJcYqz4oer" role="2OqNvi">
+                                <node concept="1bVj0M" id="7OJcYqz4oet" role="23t8la">
+                                  <node concept="3clFbS" id="7OJcYqz4oeu" role="1bW5cS">
+                                    <node concept="3clFbF" id="7OJcYqz4t_Y" role="3cqZAp">
+                                      <node concept="2OqwBi" id="7OJcYqz4xS$" role="3clFbG">
+                                        <node concept="37vLTw" id="7OJcYqz4t_X" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="7OJcYqz4oev" resolve="it" />
+                                        </node>
+                                        <node concept="liA8E" id="7OJcYqz4$QZ" role="2OqNvi">
+                                          <ref role="37wK5l" to="y7p:7OJcYqvKihR" resolve="getMps" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="Rh6nW" id="7OJcYqz4oev" role="1bW2Oz">
+                                    <property role="TrG5h" value="it" />
+                                    <node concept="2jxLKc" id="7OJcYqz4oew" role="1tU5fm" />
+                                  </node>
+                                </node>
                               </node>
                             </node>
                             <node concept="3JPx81" id="5AGBwuDTcmQ" role="2OqNvi">
@@ -1214,12 +1140,34 @@
                       <node concept="3clFbF" id="5AGBwuDUUJP" role="3cqZAp">
                         <node concept="3fqX7Q" id="5AGBwuDUUJN" role="3clFbG">
                           <node concept="2OqwBi" id="5AGBwuDVfpL" role="3fr31v">
-                            <node concept="2OqwBi" id="5AGBwuDV3Vf" role="2Oq$k0">
-                              <node concept="37vLTw" id="5AGBwuDUYKw" role="2Oq$k0">
-                                <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
+                            <node concept="2OqwBi" id="7OJcYqz4LK8" role="2Oq$k0">
+                              <node concept="2OqwBi" id="5AGBwuDV3Vf" role="2Oq$k0">
+                                <node concept="37vLTw" id="5AGBwuDUYKw" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
+                                </node>
+                                <node concept="liA8E" id="5AGBwuDV95g" role="2OqNvi">
+                                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+                                </node>
                               </node>
-                              <node concept="liA8E" id="5AGBwuDV95g" role="2OqNvi">
-                                <ref role="37wK5l" to="y7p:5JNiski3k1h" resolve="listMpsPrimitiveTypes" />
+                              <node concept="3$u5V9" id="7OJcYqz4SNM" role="2OqNvi">
+                                <node concept="1bVj0M" id="7OJcYqz4SNO" role="23t8la">
+                                  <node concept="3clFbS" id="7OJcYqz4SNP" role="1bW5cS">
+                                    <node concept="3clFbF" id="7OJcYqz4Zb5" role="3cqZAp">
+                                      <node concept="2OqwBi" id="7OJcYqz53xY" role="3clFbG">
+                                        <node concept="37vLTw" id="7OJcYqz4Zb4" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="7OJcYqz4SNQ" resolve="it" />
+                                        </node>
+                                        <node concept="liA8E" id="7OJcYqz586H" role="2OqNvi">
+                                          <ref role="37wK5l" to="y7p:7OJcYqvKihR" resolve="getMps" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="Rh6nW" id="7OJcYqz4SNQ" role="1bW2Oz">
+                                    <property role="TrG5h" value="it" />
+                                    <node concept="2jxLKc" id="7OJcYqz4SNR" role="1tU5fm" />
+                                  </node>
+                                </node>
                               </node>
                             </node>
                             <node concept="3JPx81" id="5AGBwuDVoco" role="2OqNvi">
@@ -2819,12 +2767,17 @@
                     <ref role="3Tt5mk" to="tpce:f_TJDff" resolve="extends" />
                   </node>
                 </node>
-                <node concept="2OqwBi" id="6Pr6izINgzO" role="3uHU7w">
-                  <node concept="37vLTw" id="6Pr6izINgzP" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
+                <node concept="2OqwBi" id="7OJcYqz0J75" role="3uHU7w">
+                  <node concept="2OqwBi" id="6Pr6izINgzO" role="2Oq$k0">
+                    <node concept="37vLTw" id="6Pr6izINgzP" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqz0Etn" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqwQm21" resolve="getAnnotation" />
+                    </node>
                   </node>
-                  <node concept="liA8E" id="5JNiskhKoqv" role="2OqNvi">
-                    <ref role="37wK5l" to="y7p:5JNiski3jWV" resolve="mpsAnnotationConcept" />
+                  <node concept="liA8E" id="7OJcYqz0MmL" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKqcS" resolve="getMps" />
                   </node>
                 </node>
               </node>
@@ -2914,12 +2867,17 @@
           <node concept="3clFbS" id="6Pr6izIMRYx" role="3clFbx">
             <node concept="3clFbF" id="6Pr6izIOV6J" role="3cqZAp">
               <node concept="37vLTI" id="6Pr6izIP1te" role="3clFbG">
-                <node concept="2OqwBi" id="6Pr6izIPg9j" role="37vLTx">
-                  <node concept="37vLTw" id="6Pr6izIP8Ls" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
+                <node concept="2OqwBi" id="7OJcYqz0p9T" role="37vLTx">
+                  <node concept="2OqwBi" id="6Pr6izIPg9j" role="2Oq$k0">
+                    <node concept="37vLTw" id="6Pr6izIP8Ls" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqz0kO7" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqwQm1S" resolve="getNode" />
+                    </node>
                   </node>
-                  <node concept="liA8E" id="5JNiskhKekA" role="2OqNvi">
-                    <ref role="37wK5l" to="y7p:5JNiski3jWE" resolve="mpsNodeConcept" />
+                  <node concept="liA8E" id="7OJcYqz0w_4" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKqcS" resolve="getMps" />
                   </node>
                 </node>
                 <node concept="37vLTw" id="6Pr6izIOV6H" role="37vLTJ">
@@ -4372,22 +4330,44 @@
     <node concept="3clFb_" id="2ju2syjsB72" role="jymVt">
       <property role="TrG5h" value="createPrimitiveType" />
       <node concept="3clFbS" id="2ju2syjsB73" role="3clF47">
-        <node concept="3cpWs8" id="39$JcGFPoiY" role="3cqZAp">
-          <node concept="3cpWsn" id="39$JcGFPoiZ" role="3cpWs9">
-            <property role="TrG5h" value="index" />
-            <node concept="10Oyi0" id="39$JcGFPnid" role="1tU5fm" />
-            <node concept="2OqwBi" id="39$JcGFPoj0" role="33vP2m">
-              <node concept="2OqwBi" id="39$JcGFPoj1" role="2Oq$k0">
-                <node concept="37vLTw" id="39$JcGFPoj2" role="2Oq$k0">
+        <node concept="3cpWs8" id="7OJcYqz66PJ" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqz66PK" role="3cpWs9">
+            <property role="TrG5h" value="mapping" />
+            <node concept="3uibUv" id="7OJcYqz64Ah" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqz66PL" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqz66PM" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYqz66PN" role="2Oq$k0">
                   <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
                 </node>
-                <node concept="liA8E" id="39$JcGFPoj3" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3k1h" resolve="listMpsPrimitiveTypes" />
+                <node concept="liA8E" id="7OJcYqz66PO" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
                 </node>
               </node>
-              <node concept="2WmjW8" id="39$JcGFPoj4" role="2OqNvi">
-                <node concept="37vLTw" id="39$JcGFPoj5" role="25WWJ7">
-                  <ref role="3cqZAo" node="2ju2syjsCZe" resolve="primitiveType" />
+              <node concept="1z4cxt" id="7OJcYqz66PP" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYqz66PQ" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYqz66PR" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYqz66PS" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYqz66PT" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYqz66PU" role="3uHU7w">
+                          <ref role="3cqZAo" node="2ju2syjsCZe" resolve="primitiveType" />
+                        </node>
+                        <node concept="2OqwBi" id="7OJcYqz66PV" role="3uHU7B">
+                          <node concept="37vLTw" id="7OJcYqz66PW" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqz66PY" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqz66PX" role="2OqNvi">
+                            <ref role="37wK5l" to="y7p:7OJcYqvKihR" resolve="getMps" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYqz66PY" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYqz66PZ" role="1tU5fm" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -4397,29 +4377,22 @@
           <node concept="3clFbS" id="39$JcGFPwZl" role="3clFbx">
             <node concept="3cpWs6" id="39$JcGFPHzX" role="3cqZAp">
               <node concept="2OqwBi" id="39$JcGFQ3SZ" role="3cqZAk">
-                <node concept="1y4W85" id="39$JcGFPVZX" role="2Oq$k0">
-                  <node concept="37vLTw" id="39$JcGFQ0Mc" role="1y58nS">
-                    <ref role="3cqZAo" node="39$JcGFPoiZ" resolve="index" />
+                <node concept="2OqwBi" id="7OJcYqz6FRq" role="2Oq$k0">
+                  <node concept="37vLTw" id="7OJcYqz6D0N" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqz66PK" resolve="mapping" />
                   </node>
-                  <node concept="2OqwBi" id="39$JcGFPNun" role="1y566C">
-                    <node concept="37vLTw" id="39$JcGFPKAs" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
-                    </node>
-                    <node concept="liA8E" id="39$JcGFPQtv" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3k19" resolve="listLcPrimitiveTypes" />
-                    </node>
+                  <node concept="liA8E" id="7OJcYqz6Mwz" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
                   </node>
                 </node>
                 <node concept="1$rogu" id="39$JcGFQ72Z" role="2OqNvi" />
               </node>
             </node>
           </node>
-          <node concept="2d3UOw" id="39$JcGFPBFf" role="3clFbw">
-            <node concept="3cmrfG" id="39$JcGFPEwW" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="37vLTw" id="39$JcGFP$2x" role="3uHU7B">
-              <ref role="3cqZAo" node="39$JcGFPoiZ" resolve="index" />
+          <node concept="3y3z36" id="7OJcYqz6psP" role="3clFbw">
+            <node concept="10Nm6u" id="7OJcYqz6uCM" role="3uHU7w" />
+            <node concept="37vLTw" id="7OJcYqz66Q0" role="3uHU7B">
+              <ref role="3cqZAo" node="7OJcYqz66PK" resolve="mapping" />
             </node>
           </node>
         </node>

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.mps2lioncore.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.mps2lioncore.mps
@@ -781,7 +781,7 @@
               <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
             </node>
             <node concept="liA8E" id="7OJcYqz1pGl" role="2OqNvi">
-              <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+              <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
             </node>
           </node>
           <node concept="3clFbS" id="7OJcYqz0YI1" role="2LFqv$">
@@ -824,7 +824,7 @@
               <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
             </node>
             <node concept="liA8E" id="7OJcYqz2YfY" role="2OqNvi">
-              <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listClassifiers" />
+              <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listLcClassifiers" />
             </node>
           </node>
           <node concept="3clFbS" id="7OJcYqz2$rA" role="2LFqv$">
@@ -1048,7 +1048,7 @@
                                   <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
                                 </node>
                                 <node concept="liA8E" id="5AGBwuDSPkB" role="2OqNvi">
-                                  <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listClassifiers" />
+                                  <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listLcClassifiers" />
                                 </node>
                               </node>
                               <node concept="3$u5V9" id="7OJcYqz4oer" role="2OqNvi">
@@ -1146,7 +1146,7 @@
                                   <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
                                 </node>
                                 <node concept="liA8E" id="5AGBwuDV95g" role="2OqNvi">
-                                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+                                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
                                 </node>
                               </node>
                               <node concept="3$u5V9" id="7OJcYqz4SNM" role="2OqNvi">
@@ -4332,9 +4332,9 @@
       <node concept="3clFbS" id="2ju2syjsB73" role="3clF47">
         <node concept="3cpWs8" id="7OJcYqz66PJ" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqz66PK" role="3cpWs9">
-            <property role="TrG5h" value="mapping" />
+            <property role="TrG5h" value="staple" />
             <node concept="3uibUv" id="7OJcYqz64Ah" role="1tU5fm">
-              <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+              <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
             </node>
             <node concept="2OqwBi" id="7OJcYqz66PL" role="33vP2m">
               <node concept="2OqwBi" id="7OJcYqz66PM" role="2Oq$k0">
@@ -4342,7 +4342,7 @@
                   <ref role="3cqZAo" node="3ePT3MaWqL3" resolve="constants" />
                 </node>
                 <node concept="liA8E" id="7OJcYqz66PO" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+                  <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
                 </node>
               </node>
               <node concept="1z4cxt" id="7OJcYqz66PP" role="2OqNvi">
@@ -4379,7 +4379,7 @@
               <node concept="2OqwBi" id="39$JcGFQ3SZ" role="3cqZAk">
                 <node concept="2OqwBi" id="7OJcYqz6FRq" role="2Oq$k0">
                   <node concept="37vLTw" id="7OJcYqz6D0N" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7OJcYqz66PK" resolve="mapping" />
+                    <ref role="3cqZAo" node="7OJcYqz66PK" resolve="staple" />
                   </node>
                   <node concept="liA8E" id="7OJcYqz6Mwz" role="2OqNvi">
                     <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
@@ -4392,7 +4392,7 @@
           <node concept="3y3z36" id="7OJcYqz6psP" role="3clFbw">
             <node concept="10Nm6u" id="7OJcYqz6uCM" role="3uHU7w" />
             <node concept="37vLTw" id="7OJcYqz66Q0" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYqz66PK" resolve="mapping" />
+              <ref role="3cqZAo" node="7OJcYqz66PK" resolve="staple" />
             </node>
           </node>
         </node>

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.util.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.util.mps
@@ -294,11 +294,6 @@
         <reference id="7256306938026143658" name="target" index="2aWVGs" />
       </concept>
     </language>
-    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
-      <concept id="6332851714983831325" name="jetbrains.mps.baseLanguage.logging.structure.MsgStatement" flags="ng" index="2xdQw9">
-        <child id="5721587534047265374" name="message" index="9lYJi" />
-      </concept>
-    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
@@ -2990,16 +2985,6 @@
         </node>
       </node>
       <node concept="3clFbS" id="24j7TNHlXr6" role="3clF47">
-        <node concept="2xdQw9" id="5M8g5cSY3aB" role="3cqZAp">
-          <node concept="3cpWs3" id="5M8g5cSY5wh" role="9lYJi">
-            <node concept="37vLTw" id="5M8g5cSY6fm" role="3uHU7w">
-              <ref role="3cqZAo" node="24j7TNHlXsl" resolve="abstractConcept" />
-            </node>
-            <node concept="Xl_RD" id="5M8g5cSY3aD" role="3uHU7B">
-              <property role="Xl_RC" value="bla: " />
-            </node>
-          </node>
-        </node>
         <node concept="3clFbF" id="3M8YG$9TnVR" role="3cqZAp">
           <node concept="22lmx$" id="5M8g5cSDq7h" role="3clFbG">
             <node concept="22lmx$" id="3M8YG$9TtV0" role="3uHU7B">
@@ -3456,16 +3441,6 @@
                 </node>
               </node>
             </node>
-            <node concept="2xdQw9" id="5M8g5cSXADg" role="3cqZAp">
-              <node concept="3cpWs3" id="5M8g5cSXCZe" role="9lYJi">
-                <node concept="37vLTw" id="5M8g5cSXDT7" role="3uHU7w">
-                  <ref role="3cqZAo" node="5M8g5cSD9i3" resolve="concept" />
-                </node>
-                <node concept="Xl_RD" id="5M8g5cSXADi" role="3uHU7B">
-                  <property role="Xl_RC" value="annotations: " />
-                </node>
-              </node>
-            </node>
             <node concept="3clFbJ" id="5M8g5cSD7Kq" role="3cqZAp">
               <node concept="3clFbS" id="5M8g5cSD7Ks" role="3clFbx">
                 <node concept="3cpWs6" id="5M8g5cSDccY" role="3cqZAp">
@@ -3497,26 +3472,6 @@
                                 <ref role="37wK5l" node="39$JcGGLJm2" resolve="isInBuiltins" />
                                 <node concept="37vLTw" id="5M8g5cSX2DI" role="37wK5m">
                                   <ref role="3cqZAo" node="5M8g5cSDg9i" resolve="it" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="2xdQw9" id="5M8g5cSX4sR" role="3cqZAp">
-                            <node concept="3cpWs3" id="5M8g5cSXbWG" role="9lYJi">
-                              <node concept="37vLTw" id="5M8g5cSXcQk" role="3uHU7w">
-                                <ref role="3cqZAo" node="5M8g5cSX2DG" resolve="inBuiltins" />
-                              </node>
-                              <node concept="3cpWs3" id="5M8g5cSX9MT" role="3uHU7B">
-                                <node concept="3cpWs3" id="5M8g5cSX86l" role="3uHU7B">
-                                  <node concept="Xl_RD" id="5M8g5cSX4sT" role="3uHU7B">
-                                    <property role="Xl_RC" value="inBuiltins: " />
-                                  </node>
-                                  <node concept="37vLTw" id="5M8g5cSX8YB" role="3uHU7w">
-                                    <ref role="3cqZAo" node="5M8g5cSDg9i" resolve="it" />
-                                  </node>
-                                </node>
-                                <node concept="Xl_RD" id="5M8g5cSXajg" role="3uHU7w">
-                                  <property role="Xl_RC" value=": " />
                                 </node>
                               </node>
                             </node>

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.util.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.util.mps
@@ -3588,7 +3588,7 @@
                       <ref role="3cqZAo" node="24j7TNHl0Pp" resolve="constants" />
                     </node>
                     <node concept="liA8E" id="24j7TNHaqWl" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listClassifiers" />
+                      <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listLcClassifiers" />
                     </node>
                   </node>
                   <node concept="3$u5V9" id="7OJcYqz8XGG" role="2OqNvi">

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.util.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.util.mps
@@ -2146,6 +2146,10 @@
     <property role="TrG5h" value="IModifyingLanguageLookup" />
     <node concept="3clFb_" id="59Df55laZKQ" role="jymVt">
       <property role="TrG5h" value="createLanguage" />
+      <node concept="15s5l7" id="7OJcYqyLbtB" role="lGtFl">
+        <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;reference scopes (reference scopes)&quot;;FLAVOUR_MESSAGE=&quot;The reference  ILanguageCreator (classifier) is out of search scope&quot;;FLAVOUR_NODE_FEATURE=&quot;classifier&quot;;FLAVOUR_RULE_ID=&quot;[r:28bcf003-0004-46b6-9fe7-2093e7fb1368(jetbrains.mps.baseLanguage.javadoc.constraints)/6836281137582713718]&quot;;" />
+        <property role="huDt6" value="The reference  ILanguageCreator (classifier) is out of search scope" />
+      </node>
       <node concept="15s5l7" id="3M8YG$b6x9v" role="lGtFl">
         <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;reference scopes (reference scopes)&quot;;FLAVOUR_MESSAGE=&quot;The reference  ILanguageCreator (classifier) is out of search scope&quot;;FLAVOUR_NODE_FEATURE=&quot;classifier&quot;;FLAVOUR_RULE_ID=&quot;[r:28bcf003-0004-46b6-9fe7-2093e7fb1368(jetbrains.mps.baseLanguage.javadoc.constraints)/6836281137582713718]&quot;;" />
         <property role="huDt6" value="The reference  ILanguageCreator (classifier) is out of search scope" />
@@ -3061,12 +3065,34 @@
               <ref role="3cqZAo" node="4$L4A$sYKSb" resolve="input" />
             </node>
             <node concept="66VNe" id="4$L4A$sYMa_" role="2OqNvi">
-              <node concept="2OqwBi" id="3M8YG$9WrZI" role="576Qk">
-                <node concept="37vLTw" id="3M8YG$9WrZJ" role="2Oq$k0">
-                  <ref role="3cqZAo" node="24j7TNHl0Pp" resolve="constants" />
+              <node concept="2OqwBi" id="7OJcYqz8q6E" role="576Qk">
+                <node concept="2OqwBi" id="3M8YG$9WrZI" role="2Oq$k0">
+                  <node concept="37vLTw" id="3M8YG$9WrZJ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="24j7TNHl0Pp" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="3M8YG$9WrZK" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwXhGH" resolve="listLcLanguages" />
+                  </node>
                 </node>
-                <node concept="liA8E" id="3M8YG$9WrZK" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jYA" resolve="listSLanguages" />
+                <node concept="3$u5V9" id="7OJcYqz8rOv" role="2OqNvi">
+                  <node concept="1bVj0M" id="7OJcYqz8rOx" role="23t8la">
+                    <node concept="3clFbS" id="7OJcYqz8rOy" role="1bW5cS">
+                      <node concept="3clFbF" id="7OJcYqz8sC1" role="3cqZAp">
+                        <node concept="2OqwBi" id="7OJcYqz8tPP" role="3clFbG">
+                          <node concept="37vLTw" id="7OJcYqz8sC0" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqz8rOz" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqz8v9r" role="2OqNvi">
+                            <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="7OJcYqz8rOz" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="7OJcYqz8rO$" role="1tU5fm" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -3556,12 +3582,39 @@
           <node concept="1Wc70l" id="4$L4A$sWSEv" role="3clFbG">
             <node concept="3fqX7Q" id="4$L4A$sWTeu" role="3uHU7w">
               <node concept="2OqwBi" id="24j7TNHavVt" role="3fr31v">
-                <node concept="2OqwBi" id="24j7TNHam7t" role="2Oq$k0">
-                  <node concept="37vLTw" id="24j7TNHajvi" role="2Oq$k0">
-                    <ref role="3cqZAo" node="24j7TNHl0Pp" resolve="constants" />
+                <node concept="2OqwBi" id="7OJcYqz8W0K" role="2Oq$k0">
+                  <node concept="2OqwBi" id="24j7TNHam7t" role="2Oq$k0">
+                    <node concept="37vLTw" id="24j7TNHajvi" role="2Oq$k0">
+                      <ref role="3cqZAo" node="24j7TNHl0Pp" resolve="constants" />
+                    </node>
+                    <node concept="liA8E" id="24j7TNHaqWl" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqwYDTB" resolve="listClassifiers" />
+                    </node>
                   </node>
-                  <node concept="liA8E" id="24j7TNHaqWl" role="2OqNvi">
-                    <ref role="37wK5l" to="y7p:5JNiski3jZG" resolve="listSLanguageClassifiers" />
+                  <node concept="3$u5V9" id="7OJcYqz8XGG" role="2OqNvi">
+                    <node concept="1bVj0M" id="7OJcYqz8XGI" role="23t8la">
+                      <node concept="3clFbS" id="7OJcYqz8XGJ" role="1bW5cS">
+                        <node concept="3clFbF" id="7OJcYqz8YRt" role="3cqZAp">
+                          <node concept="10QFUN" id="7OJcYq$cU4y" role="3clFbG">
+                            <node concept="2OqwBi" id="7OJcYq$cU4v" role="10QFUP">
+                              <node concept="37vLTw" id="7OJcYq$cU4w" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7OJcYqz8XGK" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="7OJcYq$cU4x" role="2OqNvi">
+                                <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
+                              </node>
+                            </node>
+                            <node concept="3uibUv" id="7OJcYq$cVhg" role="10QFUM">
+                              <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="7OJcYqz8XGK" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7OJcYqz8XGL" role="1tU5fm" />
+                      </node>
+                    </node>
                   </node>
                 </node>
                 <node concept="3JPx81" id="24j7TNHaAmS" role="2OqNvi">
@@ -3572,12 +3625,34 @@
               </node>
             </node>
             <node concept="2OqwBi" id="4R9posq9FHn" role="3uHU7B">
-              <node concept="2OqwBi" id="4R9posq9DWs" role="2Oq$k0">
-                <node concept="37vLTw" id="4R9posq9Dnf" role="2Oq$k0">
-                  <ref role="3cqZAo" node="24j7TNHl0Pp" resolve="constants" />
+              <node concept="2OqwBi" id="7OJcYqz8xYT" role="2Oq$k0">
+                <node concept="2OqwBi" id="4R9posq9DWs" role="2Oq$k0">
+                  <node concept="37vLTw" id="4R9posq9Dnf" role="2Oq$k0">
+                    <ref role="3cqZAo" node="24j7TNHl0Pp" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="4R9posq9Ezn" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwXhGH" resolve="listLcLanguages" />
+                  </node>
                 </node>
-                <node concept="liA8E" id="4R9posq9Ezn" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jYA" resolve="listSLanguages" />
+                <node concept="3$u5V9" id="7OJcYqz8PO9" role="2OqNvi">
+                  <node concept="1bVj0M" id="7OJcYqz8POb" role="23t8la">
+                    <node concept="3clFbS" id="7OJcYqz8POc" role="1bW5cS">
+                      <node concept="3clFbF" id="7OJcYqz8QF0" role="3cqZAp">
+                        <node concept="2OqwBi" id="7OJcYqz8RJs" role="3clFbG">
+                          <node concept="37vLTw" id="7OJcYqz8QEZ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqz8POd" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqz8T5R" role="2OqNvi">
+                            <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="7OJcYqz8POd" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="7OJcYqz8POe" role="1tU5fm" />
+                    </node>
+                  </node>
                 </node>
               </node>
               <node concept="3JPx81" id="4R9posq9GU7" role="2OqNvi">
@@ -4231,12 +4306,17 @@
               </node>
             </node>
             <node concept="17QLQc" id="1q44RFT1y8n" role="3uHU7B">
-              <node concept="2OqwBi" id="1q44RFTa_ko" role="3uHU7w">
-                <node concept="37vLTw" id="1q44RFTa$JA" role="2Oq$k0">
-                  <ref role="3cqZAo" node="1q44RFTawS7" resolve="constants" />
+              <node concept="2OqwBi" id="7OJcYqz7Zr$" role="3uHU7w">
+                <node concept="2OqwBi" id="1q44RFTa_ko" role="2Oq$k0">
+                  <node concept="37vLTw" id="1q44RFTa$JA" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1q44RFTawS7" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="5JNiskhKvvH" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqxK_pb" resolve="getCoreLanguage" />
+                  </node>
                 </node>
-                <node concept="liA8E" id="5JNiskhKvvH" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jYb" resolve="slangCoreLanguageId" />
+                <node concept="liA8E" id="7OJcYqz80ax" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqw7aei" resolve="getSlangId" />
                 </node>
               </node>
               <node concept="2OqwBi" id="1q44RFTaBhy" role="3uHU7B">

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.util.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.util.mps
@@ -9,7 +9,6 @@
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
     <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
-    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
   </languages>
   <imports>
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />

--- a/solutions/io.lionweb.mps.json.test.support/models/io.lionweb.mps.json.test.support.mps
+++ b/solutions/io.lionweb.mps.json.test.support/models/io.lionweb.mps.json.test.support.mps
@@ -526,6 +526,14 @@
         <ref role="3uigEE" to="guwi:~File" resolve="File" />
       </node>
     </node>
+    <node concept="312cEg" id="7OJcYqy6BQK" role="jymVt">
+      <property role="TrG5h" value="constants" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqy6BQL" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqy6BhR" role="1tU5fm">
+        <ref role="3uigEE" to="y7p:DUXtGZOlwJ" resolve="LionCoreConstants" />
+      </node>
+    </node>
     <node concept="312cEg" id="4R9posp6ex8" role="jymVt">
       <property role="TrG5h" value="replacements" />
       <property role="3TUv4t" value="true" />
@@ -584,10 +592,36 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbF" id="7OJcYqy6Bzo" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqy6Bzq" role="3clFbG">
+            <node concept="2ShNRf" id="7OJcYqy6BtR" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqy6BtS" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                <node concept="2OqwBi" id="7OJcYqy6BtT" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqy6BtU" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqy6_fl" resolve="model" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqy6BtV" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="7OJcYqy6Bzu" role="37vLTJ">
+              <ref role="3cqZAo" node="7OJcYqy6BQK" resolve="constants" />
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="37vLTG" id="4R9posp6ex_" role="3clF46">
         <property role="TrG5h" value="testFile" />
         <node concept="17QB3L" id="4R9posp6exA" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="7OJcYqy6_fl" role="3clF46">
+        <property role="TrG5h" value="model" />
+        <node concept="3uibUv" id="7OJcYqy6ATN" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="4R9posp6exB" role="jymVt" />
@@ -800,6 +834,9 @@
                       <node concept="HV5vD" id="7weWCFlyJjA" role="2ShVmc">
                         <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
                       </node>
+                    </node>
+                    <node concept="37vLTw" id="7OJcYqy6D$O" role="37wK5m">
+                      <ref role="3cqZAo" node="7OJcYqy6BQK" resolve="constants" />
                     </node>
                   </node>
                 </node>
@@ -2404,24 +2441,9 @@
           <node concept="2YIFZM" id="3FWZcLVUNJI" role="3clFbG">
             <ref role="37wK5l" to="xfsv:~UsedLanguage.fromLanguage(io.lionweb.lioncore.java.language.Language)" resolve="fromLanguage" />
             <ref role="1Pybhc" to="xfsv:~UsedLanguage" resolve="UsedLanguage" />
-            <node concept="2OqwBi" id="3FWZcLVUNuo" role="37wK5m">
-              <node concept="2ShNRf" id="3FWZcLVUMmV" role="2Oq$k0">
-                <node concept="1pGfFk" id="3FWZcLVUMKJ" role="2ShVmc">
-                  <ref role="37wK5l" to="6peh:5JNiskj4SJa" resolve="JsonConstants" />
-                  <node concept="2YIFZM" id="3FWZcLVUO03" role="37wK5m">
-                    <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
-                    <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
-                  </node>
-                  <node concept="2ShNRf" id="7weWCFlz02_" role="37wK5m">
-                    <node concept="HV5vD" id="7weWCFlz02A" role="2ShVmc">
-                      <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="liA8E" id="3FWZcLVUNHi" role="2OqNvi">
-                <ref role="37wK5l" to="6peh:4Yo3buYJQ9P" resolve="getBuiltins" />
-              </node>
+            <node concept="2YIFZM" id="3FWZcLVUO03" role="37wK5m">
+              <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+              <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
             </node>
           </node>
         </node>

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2lioncore@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2lioncore@tests.mps
@@ -266,6 +266,61 @@
         </node>
         <node concept="3J1_TO" id="5ocQ9W1xKKk" role="3cqZAp">
           <node concept="3clFbS" id="5ocQ9W1xKKl" role="1zxBo7">
+            <node concept="3cpWs8" id="5ocQ9W1xKKA" role="3cqZAp">
+              <node concept="3cpWsn" id="5ocQ9W1xKKB" role="3cpWs9">
+                <property role="TrG5h" value="repository" />
+                <node concept="3uibUv" id="5ocQ9W1xKKC" role="1tU5fm">
+                  <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+                </node>
+                <node concept="2OqwBi" id="5ocQ9W1xKKD" role="33vP2m">
+                  <node concept="1jGwE1" id="5ocQ9W1xKKE" role="2Oq$k0" />
+                  <node concept="liA8E" id="5ocQ9W1xKKF" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="7OJcYqxWWvL" role="3cqZAp">
+              <node concept="3cpWsn" id="7OJcYqxWWvM" role="3cpWs9">
+                <property role="TrG5h" value="constants" />
+                <node concept="3uibUv" id="7OJcYqxWWly" role="1tU5fm">
+                  <ref role="3uigEE" to="y7p:DUXtGZOlwJ" resolve="LionCoreConstants" />
+                </node>
+                <node concept="2ShNRf" id="7OJcYqxWWvN" role="33vP2m">
+                  <node concept="1pGfFk" id="7OJcYqxWWvO" role="2ShVmc">
+                    <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                    <node concept="37vLTw" id="7OJcYqxWWvP" role="37wK5m">
+                      <ref role="3cqZAo" node="5ocQ9W1xKKB" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="7OJcYqxWWKP" role="3cqZAp">
+              <node concept="3cpWsn" id="7OJcYqxWWKQ" role="3cpWs9">
+                <property role="TrG5h" value="jsonConstants" />
+                <node concept="3uibUv" id="7OJcYqxWWDf" role="1tU5fm">
+                  <ref role="3uigEE" to="6peh:5JNiskj4S1d" resolve="JsonConstants" />
+                </node>
+                <node concept="2ShNRf" id="7OJcYqxWWKR" role="33vP2m">
+                  <node concept="1pGfFk" id="7OJcYqxWWKS" role="2ShVmc">
+                    <ref role="37wK5l" to="6peh:5JNiskj4SJa" resolve="JsonConstants" />
+                    <node concept="2YIFZM" id="7OJcYqxWWKT" role="37wK5m">
+                      <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
+                      <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                    </node>
+                    <node concept="2ShNRf" id="7OJcYqxWWKU" role="37wK5m">
+                      <node concept="HV5vD" id="7OJcYqxWWKV" role="2ShVmc">
+                        <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="7OJcYqxWWKW" role="37wK5m">
+                      <ref role="3cqZAo" node="7OJcYqxWWvM" resolve="constants" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
             <node concept="3cpWs8" id="5ocQ9W1xKKm" role="3cqZAp">
               <node concept="3cpWsn" id="5ocQ9W1xKKn" role="3cpWs9">
                 <property role="TrG5h" value="deserializer" />
@@ -283,19 +338,8 @@
                         </node>
                       </node>
                     </node>
-                    <node concept="2ShNRf" id="5hsSXrmD6rv" role="37wK5m">
-                      <node concept="1pGfFk" id="5hsSXrmDcUm" role="2ShVmc">
-                        <ref role="37wK5l" to="6peh:5JNiskj4SJa" resolve="JsonConstants" />
-                        <node concept="2YIFZM" id="5hsSXrmDeQ3" role="37wK5m">
-                          <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
-                          <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
-                        </node>
-                        <node concept="2ShNRf" id="7weWCFlyI7w" role="37wK5m">
-                          <node concept="HV5vD" id="7weWCFlyJjA" role="2ShVmc">
-                            <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
-                          </node>
-                        </node>
-                      </node>
+                    <node concept="37vLTw" id="7OJcYqxWWKX" role="37wK5m">
+                      <ref role="3cqZAo" node="7OJcYqxWWKQ" resolve="jsonConstants" />
                     </node>
                   </node>
                 </node>
@@ -320,20 +364,6 @@
               </node>
             </node>
             <node concept="3clFbH" id="5ocQ9W1xKK_" role="3cqZAp" />
-            <node concept="3cpWs8" id="5ocQ9W1xKKA" role="3cqZAp">
-              <node concept="3cpWsn" id="5ocQ9W1xKKB" role="3cpWs9">
-                <property role="TrG5h" value="repository" />
-                <node concept="3uibUv" id="5ocQ9W1xKKC" role="1tU5fm">
-                  <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
-                </node>
-                <node concept="2OqwBi" id="5ocQ9W1xKKD" role="33vP2m">
-                  <node concept="1jGwE1" id="5ocQ9W1xKKE" role="2Oq$k0" />
-                  <node concept="liA8E" id="5ocQ9W1xKKF" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="3cpWs8" id="5ocQ9W1xKKG" role="3cqZAp">
               <node concept="3cpWsn" id="5ocQ9W1xKKH" role="3cpWs9">
                 <property role="TrG5h" value="converter" />
@@ -343,27 +373,11 @@
                 <node concept="2ShNRf" id="5ocQ9W1xKKJ" role="33vP2m">
                   <node concept="1pGfFk" id="5ocQ9W1xKKK" role="2ShVmc">
                     <ref role="37wK5l" to="9pi3:z1IqfFwVBn" resolve="Json2LionCoreConverter" />
-                    <node concept="2ShNRf" id="5ocQ9W1xKKL" role="37wK5m">
-                      <node concept="1pGfFk" id="5ocQ9W1xKKM" role="2ShVmc">
-                        <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
-                        <node concept="37vLTw" id="5ocQ9W1xKKN" role="37wK5m">
-                          <ref role="3cqZAo" node="5ocQ9W1xKKB" resolve="repository" />
-                        </node>
-                      </node>
+                    <node concept="37vLTw" id="7OJcYqxWWvR" role="37wK5m">
+                      <ref role="3cqZAo" node="7OJcYqxWWvM" resolve="constants" />
                     </node>
-                    <node concept="2ShNRf" id="5TNjoy1z1Ew" role="37wK5m">
-                      <node concept="1pGfFk" id="5TNjoy1z23O" role="2ShVmc">
-                        <ref role="37wK5l" to="6peh:5JNiskj4SJa" resolve="JsonConstants" />
-                        <node concept="2YIFZM" id="5ocQ9W1xKKO" role="37wK5m">
-                          <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
-                          <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
-                        </node>
-                        <node concept="2ShNRf" id="7weWCFlyWof" role="37wK5m">
-                          <node concept="HV5vD" id="7weWCFlyWog" role="2ShVmc">
-                            <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
-                          </node>
-                        </node>
-                      </node>
+                    <node concept="37vLTw" id="7OJcYqxWYOF" role="37wK5m">
+                      <ref role="3cqZAo" node="7OJcYqxWWKQ" resolve="jsonConstants" />
                     </node>
                     <node concept="2ShNRf" id="5ocQ9W1xKKP" role="37wK5m">
                       <node concept="1pGfFk" id="5ocQ9W1xKKQ" role="2ShVmc">
@@ -541,6 +555,14 @@
                         <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
                       </node>
                     </node>
+                    <node concept="2ShNRf" id="7OJcYqxWU5C" role="37wK5m">
+                      <node concept="1pGfFk" id="7OJcYqxWU$b" role="2ShVmc">
+                        <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                        <node concept="37vLTw" id="7OJcYqxWW1H" role="37wK5m">
+                          <ref role="3cqZAo" node="1xqd6pt3WYM" resolve="repository" />
+                        </node>
+                      </node>
+                    </node>
                   </node>
                 </node>
                 <node concept="2ShNRf" id="1xqd6pt3WZ0" role="37wK5m">
@@ -714,6 +736,14 @@
                     <node concept="2ShNRf" id="7weWCFlyXdF" role="37wK5m">
                       <node concept="HV5vD" id="7weWCFlyXdG" role="2ShVmc">
                         <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                      </node>
+                    </node>
+                    <node concept="2ShNRf" id="7OJcYqxWZmM" role="37wK5m">
+                      <node concept="1pGfFk" id="7OJcYqxWZmN" role="2ShVmc">
+                        <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                        <node concept="37vLTw" id="7OJcYqxWZmO" role="37wK5m">
+                          <ref role="3cqZAo" node="6_BZUoIhBEk" resolve="repository" />
+                        </node>
                       </node>
                     </node>
                   </node>

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2lionweb@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2lionweb@tests.mps
@@ -988,6 +988,7 @@
                 <node concept="Xl_RD" id="4R9posp6nTM" role="37wK5m">
                   <property role="Xl_RC" value="bobs-library-closure.json" />
                 </node>
+                <node concept="1jGwE1" id="7OJcYqy6FDV" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -1437,6 +1438,7 @@
                 <node concept="37vLTw" id="4R9posp6MqW" role="37wK5m">
                   <ref role="3cqZAo" node="4R9posp5BS$" resolve="fileName" />
                 </node>
+                <node concept="1jGwE1" id="7OJcYqy6FWW" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -2037,6 +2039,7 @@
                 <node concept="Xl_RD" id="4R9pospk4hw" role="37wK5m">
                   <property role="Xl_RC" value="test3-keyed.json" />
                 </node>
+                <node concept="1jGwE1" id="7OJcYqy6GPc" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -2155,6 +2158,7 @@
                 <node concept="Xl_RD" id="4R9pospkn5m" role="37wK5m">
                   <property role="Xl_RC" value="test3-unkeyed.json" />
                 </node>
+                <node concept="1jGwE1" id="7OJcYqy6GZN" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -2731,6 +2735,7 @@
                 <node concept="Xl_RD" id="4R9pospn6MA" role="37wK5m">
                   <property role="Xl_RC" value="test2-keyed.json" />
                 </node>
+                <node concept="1jGwE1" id="7OJcYqy6Gk3" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -2849,6 +2854,7 @@
                 <node concept="Xl_RD" id="4R9pospn6Np" role="37wK5m">
                   <property role="Xl_RC" value="test2-unkeyed.json" />
                 </node>
+                <node concept="1jGwE1" id="7OJcYqy6GuE" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -3166,6 +3172,7 @@
                 <node concept="Xl_RD" id="4R9posq6KPm" role="37wK5m">
                   <property role="Xl_RC" value="customDatatype.json" />
                 </node>
+                <node concept="1jGwE1" id="7OJcYqy6Fjs" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -3583,6 +3590,7 @@
                 <node concept="Xl_RD" id="18UigYOMc3r" role="37wK5m">
                   <property role="Xl_RC" value="multiRef.json" />
                 </node>
+                <node concept="1jGwE1" id="7OJcYqy6HAE" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -4305,6 +4313,7 @@
                 <node concept="Xl_RD" id="1xqd6ptaZxE" role="37wK5m">
                   <property role="Xl_RC" value="TestAnnotation.json" />
                 </node>
+                <node concept="1jGwE1" id="7OJcYqy6EC8" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -4742,6 +4751,7 @@
                 <node concept="Xl_RD" id="5TNjoy203EX" role="37wK5m">
                   <property role="Xl_RC" value="TestReferences.json" />
                 </node>
+                <node concept="1jGwE1" id="7OJcYqy6JmM" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -5160,6 +5170,7 @@
                 <node concept="Xl_RD" id="5TNjoy2nGWv" role="37wK5m">
                   <property role="Xl_RC" value="TestRefs-merge.json" />
                 </node>
+                <node concept="1jGwE1" id="7OJcYqy6Kwr" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -7050,6 +7061,7 @@
                 <node concept="Xl_RD" id="5JNiskiVWMe" role="37wK5m">
                   <property role="Xl_RC" value="TestBaseConceptProperties.json" />
                 </node>
+                <node concept="1jGwE1" id="7OJcYqy6EYe" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -7515,6 +7527,7 @@
                 <node concept="Xl_RD" id="3FWZcLW7bpc" role="37wK5m">
                   <property role="Xl_RC" value="TestLang-instance.json" />
                 </node>
+                <node concept="1jGwE1" id="7OJcYqy6Lby" role="37wK5m" />
               </node>
             </node>
           </node>

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2slanguage@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2slanguage@tests.mps
@@ -184,6 +184,11 @@
         <child id="1235573175711" name="elementType" index="2HTBi0" />
         <child id="1235573187520" name="singletonValue" index="2HTEbv" />
       </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
         <child id="1197683466920" name="keyType" index="3rvQeY" />
@@ -772,6 +777,270 @@
                 <property role="Xl_RC" value="TestLanguageAnnotation-metamodel.json" />
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6rp9bELPAae" role="1SL9yI">
+      <property role="TrG5h" value="MpsLangStructure" />
+      <node concept="3cqZAl" id="6rp9bELPAaf" role="3clF45" />
+      <node concept="3clFbS" id="6rp9bELPAag" role="3clF47">
+        <node concept="3cpWs8" id="6rp9bELPE_U" role="3cqZAp">
+          <node concept="3cpWsn" id="6rp9bELPE_V" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6rp9bELPE_W" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6rp9bELPE_X" role="33vP2m">
+              <node concept="1jGwE1" id="6rp9bELPE_Y" role="2Oq$k0" />
+              <node concept="liA8E" id="6rp9bELPE_Z" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6rp9bELPEA0" role="3cqZAp">
+          <node concept="3cpWsn" id="6rp9bELPEA1" role="3cpWs9">
+            <property role="TrG5h" value="converter" />
+            <node concept="3uibUv" id="6rp9bELPEA2" role="1tU5fm">
+              <ref role="3uigEE" to="6peh:24j7TNH1_mG" resolve="M2ToJson" />
+            </node>
+            <node concept="2ShNRf" id="6rp9bELPEA3" role="33vP2m">
+              <node concept="1pGfFk" id="6rp9bELPEA4" role="2ShVmc">
+                <ref role="37wK5l" to="6peh:24j7TNH1A2A" resolve="M2ToJson" />
+                <node concept="37vLTw" id="6rp9bELPEA5" role="37wK5m">
+                  <ref role="3cqZAo" node="6rp9bELPE_V" resolve="repository" />
+                </node>
+                <node concept="2ShNRf" id="6rp9bELPEA6" role="37wK5m">
+                  <node concept="Tc6Ow" id="6rp9bELPGCI" role="2ShVmc">
+                    <node concept="3uibUv" id="6rp9bELPHlO" role="HW$YZ">
+                      <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+                    </node>
+                    <node concept="pHN19" id="6rp9bELPEHt" role="HW$Y0">
+                      <node concept="2V$Bhx" id="6rp9bELPEHu" role="2V$M_3">
+                        <property role="2V$B1T" value="c72da2b9-7cce-4447-8389-f407dc1158b7" />
+                        <property role="2V$B1Q" value="jetbrains.mps.lang.structure" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6rp9bELPEAa" role="3cqZAp">
+          <node concept="2OqwBi" id="6rp9bELPEAb" role="3clFbG">
+            <node concept="37vLTw" id="6rp9bELPEAc" role="2Oq$k0">
+              <ref role="3cqZAo" node="6rp9bELPEA1" resolve="converter" />
+            </node>
+            <node concept="liA8E" id="6rp9bELPEAd" role="2OqNvi">
+              <ref role="37wK5l" to="6peh:5M8g5cT5Ngm" resolve="setExportDescriptionAnnotations" />
+              <node concept="3clFbT" id="6rp9bELPEAe" role="37wK5m">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6rp9bELPEAf" role="3cqZAp">
+          <node concept="3cpWsn" id="6rp9bELPEAg" role="3cpWs9">
+            <property role="TrG5h" value="languages" />
+            <node concept="A3Dl8" id="6rp9bELPEAh" role="1tU5fm">
+              <node concept="3uibUv" id="6rp9bELPEAi" role="A3Ik2">
+                <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6rp9bELPEAj" role="33vP2m">
+              <node concept="37vLTw" id="6rp9bELPEAk" role="2Oq$k0">
+                <ref role="3cqZAo" node="6rp9bELPEA1" resolve="converter" />
+              </node>
+              <node concept="liA8E" id="6rp9bELPEAl" role="2OqNvi">
+                <ref role="37wK5l" to="6peh:24j7TNH1Bia" resolve="convert" />
+                <node concept="Rm8GO" id="6rp9bELPIvF" role="37wK5m">
+                  <ref role="Rm8GQ" to="6peh:utjSYFI7F7" resolve="fineGrainedClosure" />
+                  <ref role="1Px2BO" to="6peh:24j7TNH1AVU" resolve="M2ToJson.Scope" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6rp9bELPEAn" role="3cqZAp">
+          <node concept="2OqwBi" id="6rp9bELPEAp" role="3tpDZA">
+            <node concept="37vLTw" id="6rp9bELPEAq" role="2Oq$k0">
+              <ref role="3cqZAo" node="6rp9bELPEAg" resolve="languages" />
+            </node>
+            <node concept="34oBXx" id="6rp9bELPEAr" role="2OqNvi" />
+          </node>
+          <node concept="3cmrfG" id="6rp9bELPLjS" role="3tpDZB">
+            <property role="3cmrfH" value="3" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6rp9bELPEAs" role="3cqZAp">
+          <node concept="3cpWsn" id="6rp9bELPEAt" role="3cpWs9">
+            <property role="TrG5h" value="comparer" />
+            <node concept="3uibUv" id="6rp9bELPEAu" role="1tU5fm">
+              <ref role="3uigEE" to="kte7:24j7TNH2adn" resolve="M2JsonComparer" />
+            </node>
+            <node concept="2ShNRf" id="6rp9bELPEAv" role="33vP2m">
+              <node concept="1pGfFk" id="6rp9bELPEAw" role="2ShVmc">
+                <ref role="37wK5l" to="kte7:24j7TNH2adB" resolve="M2JsonComparer" />
+                <node concept="Xl_RD" id="6rp9bELPII8" role="37wK5m">
+                  <property role="Xl_RC" value="MpsLangStructure-metamodel-annotated.json" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6rp9bELPEAy" role="3cqZAp">
+          <node concept="2OqwBi" id="6rp9bELPEAz" role="3clFbG">
+            <node concept="37vLTw" id="6rp9bELPEA$" role="2Oq$k0">
+              <ref role="3cqZAo" node="6rp9bELPEAt" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6rp9bELPEA_" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:5TNjoy24N5P" resolve="assertSortedEquals" />
+              <node concept="37vLTw" id="6rp9bELPEAA" role="37wK5m">
+                <ref role="3cqZAo" node="6rp9bELPEAg" resolve="languages" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6rp9bELPAah" role="3cqZAp">
+          <node concept="2OqwBi" id="6rp9bELPEAK" role="3clFbG">
+            <node concept="37vLTw" id="6rp9bELPEAL" role="2Oq$k0">
+              <ref role="3cqZAo" node="6rp9bELPEAg" resolve="languages" />
+            </node>
+            <node concept="1uHKPH" id="6rp9bELPEAM" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6rp9bELPR8c" role="1SL9yI">
+      <property role="TrG5h" value="MpsLangCore" />
+      <node concept="3cqZAl" id="6rp9bELPR8d" role="3clF45" />
+      <node concept="3clFbS" id="6rp9bELPR8e" role="3clF47">
+        <node concept="3cpWs8" id="6rp9bELPR8f" role="3cqZAp">
+          <node concept="3cpWsn" id="6rp9bELPR8g" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6rp9bELPR8h" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6rp9bELPR8i" role="33vP2m">
+              <node concept="1jGwE1" id="6rp9bELPR8j" role="2Oq$k0" />
+              <node concept="liA8E" id="6rp9bELPR8k" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6rp9bELPR8l" role="3cqZAp">
+          <node concept="3cpWsn" id="6rp9bELPR8m" role="3cpWs9">
+            <property role="TrG5h" value="converter" />
+            <node concept="3uibUv" id="6rp9bELPR8n" role="1tU5fm">
+              <ref role="3uigEE" to="6peh:24j7TNH1_mG" resolve="M2ToJson" />
+            </node>
+            <node concept="2ShNRf" id="6rp9bELPR8o" role="33vP2m">
+              <node concept="1pGfFk" id="6rp9bELPR8p" role="2ShVmc">
+                <ref role="37wK5l" to="6peh:24j7TNH1A2A" resolve="M2ToJson" />
+                <node concept="37vLTw" id="6rp9bELPR8q" role="37wK5m">
+                  <ref role="3cqZAo" node="6rp9bELPR8g" resolve="repository" />
+                </node>
+                <node concept="2ShNRf" id="6rp9bELPR8r" role="37wK5m">
+                  <node concept="Tc6Ow" id="6rp9bELPR8s" role="2ShVmc">
+                    <node concept="3uibUv" id="6rp9bELPR8t" role="HW$YZ">
+                      <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+                    </node>
+                    <node concept="pHN19" id="6rp9bELPR8u" role="HW$Y0">
+                      <node concept="2V$Bhx" id="6rp9bELPRqw" role="2V$M_3">
+                        <property role="2V$B1T" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
+                        <property role="2V$B1Q" value="jetbrains.mps.lang.core" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6rp9bELPR8w" role="3cqZAp">
+          <node concept="2OqwBi" id="6rp9bELPR8x" role="3clFbG">
+            <node concept="37vLTw" id="6rp9bELPR8y" role="2Oq$k0">
+              <ref role="3cqZAo" node="6rp9bELPR8m" resolve="converter" />
+            </node>
+            <node concept="liA8E" id="6rp9bELPR8z" role="2OqNvi">
+              <ref role="37wK5l" to="6peh:5M8g5cT5Ngm" resolve="setExportDescriptionAnnotations" />
+              <node concept="3clFbT" id="6rp9bELPR8$" role="37wK5m">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6rp9bELPR8_" role="3cqZAp">
+          <node concept="3cpWsn" id="6rp9bELPR8A" role="3cpWs9">
+            <property role="TrG5h" value="languages" />
+            <node concept="A3Dl8" id="6rp9bELPR8B" role="1tU5fm">
+              <node concept="3uibUv" id="6rp9bELPR8C" role="A3Ik2">
+                <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6rp9bELPR8D" role="33vP2m">
+              <node concept="37vLTw" id="6rp9bELPR8E" role="2Oq$k0">
+                <ref role="3cqZAo" node="6rp9bELPR8m" resolve="converter" />
+              </node>
+              <node concept="liA8E" id="6rp9bELPR8F" role="2OqNvi">
+                <ref role="37wK5l" to="6peh:24j7TNH1Bia" resolve="convert" />
+                <node concept="Rm8GO" id="6rp9bELPR8G" role="37wK5m">
+                  <ref role="Rm8GQ" to="6peh:utjSYFI7F7" resolve="fineGrainedClosure" />
+                  <ref role="1Px2BO" to="6peh:24j7TNH1AVU" resolve="M2ToJson.Scope" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6rp9bELPR8H" role="3cqZAp">
+          <node concept="2OqwBi" id="6rp9bELPR8I" role="3tpDZA">
+            <node concept="37vLTw" id="6rp9bELPR8J" role="2Oq$k0">
+              <ref role="3cqZAo" node="6rp9bELPR8A" resolve="languages" />
+            </node>
+            <node concept="34oBXx" id="6rp9bELPR8K" role="2OqNvi" />
+          </node>
+          <node concept="3cmrfG" id="6rp9bELPR8L" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6rp9bELPR8M" role="3cqZAp">
+          <node concept="3cpWsn" id="6rp9bELPR8N" role="3cpWs9">
+            <property role="TrG5h" value="comparer" />
+            <node concept="3uibUv" id="6rp9bELPR8O" role="1tU5fm">
+              <ref role="3uigEE" to="kte7:24j7TNH2adn" resolve="M2JsonComparer" />
+            </node>
+            <node concept="2ShNRf" id="6rp9bELPR8P" role="33vP2m">
+              <node concept="1pGfFk" id="6rp9bELPR8Q" role="2ShVmc">
+                <ref role="37wK5l" to="kte7:24j7TNH2adB" resolve="M2JsonComparer" />
+                <node concept="Xl_RD" id="6rp9bELPR8R" role="37wK5m">
+                  <property role="Xl_RC" value="MpsLangCore-metamodel-annotated.json" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6rp9bELPR8S" role="3cqZAp">
+          <node concept="2OqwBi" id="6rp9bELPR8T" role="3clFbG">
+            <node concept="37vLTw" id="6rp9bELPR8U" role="2Oq$k0">
+              <ref role="3cqZAo" node="6rp9bELPR8N" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6rp9bELPR8V" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:5TNjoy24N5P" resolve="assertSortedEquals" />
+              <node concept="37vLTw" id="6rp9bELPR8W" role="37wK5m">
+                <ref role="3cqZAo" node="6rp9bELPR8A" resolve="languages" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6rp9bELPR8X" role="3cqZAp">
+          <node concept="2OqwBi" id="6rp9bELPR8Y" role="3clFbG">
+            <node concept="37vLTw" id="6rp9bELPR8Z" role="2Oq$k0">
+              <ref role="3cqZAo" node="6rp9bELPR8A" resolve="languages" />
+            </node>
+            <node concept="1uHKPH" id="6rp9bELPR90" role="2OqNvi" />
           </node>
         </node>
       </node>

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2slanguage@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2slanguage@tests.mps
@@ -18,6 +18,7 @@
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="kte7" ref="r:2b2fbaa9-e628-460c-aea7-59a3006590c9(io.lionweb.mps.json.test.support)" />
+    <import index="y7p" ref="r:3303ef0b-a58e-4f50-b3cb-bd3d7aaf3653(io.lionweb.mps.m3.runtime)" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -1085,6 +1086,20 @@
         </node>
         <node concept="3J1_TO" id="5ocQ9W1vI8z" role="3cqZAp">
           <node concept="3clFbS" id="5ocQ9W1vI8$" role="1zxBo7">
+            <node concept="3cpWs8" id="4R9posqYZ0B" role="3cqZAp">
+              <node concept="3cpWsn" id="4R9posqYZ0C" role="3cpWs9">
+                <property role="TrG5h" value="repository" />
+                <node concept="3uibUv" id="4R9posqYWF_" role="1tU5fm">
+                  <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+                </node>
+                <node concept="2OqwBi" id="4R9posqYZ0D" role="33vP2m">
+                  <node concept="1jGwE1" id="4R9posqYZ0E" role="2Oq$k0" />
+                  <node concept="liA8E" id="4R9posqYZ0F" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
             <node concept="3cpWs8" id="5ocQ9W1vI8_" role="3cqZAp">
               <node concept="3cpWsn" id="5ocQ9W1vI8A" role="3cpWs9">
                 <property role="TrG5h" value="deserializer" />
@@ -1112,6 +1127,14 @@
                         <node concept="2ShNRf" id="7weWCFlyI7w" role="37wK5m">
                           <node concept="HV5vD" id="7weWCFlyJjA" role="2ShVmc">
                             <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                          </node>
+                        </node>
+                        <node concept="2ShNRf" id="7OJcYqxWU5C" role="37wK5m">
+                          <node concept="1pGfFk" id="7OJcYqxWU$b" role="2ShVmc">
+                            <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                            <node concept="37vLTw" id="7OJcYqxWW1H" role="37wK5m">
+                              <ref role="3cqZAo" node="4R9posqYZ0C" resolve="repository" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -1166,20 +1189,6 @@
               </node>
             </node>
             <node concept="3clFbH" id="5ocQ9W1vI90" role="3cqZAp" />
-            <node concept="3cpWs8" id="4R9posqYZ0B" role="3cqZAp">
-              <node concept="3cpWsn" id="4R9posqYZ0C" role="3cpWs9">
-                <property role="TrG5h" value="repository" />
-                <node concept="3uibUv" id="4R9posqYWF_" role="1tU5fm">
-                  <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
-                </node>
-                <node concept="2OqwBi" id="4R9posqYZ0D" role="33vP2m">
-                  <node concept="1jGwE1" id="4R9posqYZ0E" role="2Oq$k0" />
-                  <node concept="liA8E" id="4R9posqYZ0F" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="3clFbH" id="1xqd6ptvjLA" role="3cqZAp" />
             <node concept="3cpWs8" id="5ocQ9W1vI9q" role="3cqZAp">
               <node concept="3cpWsn" id="5ocQ9W1vI9r" role="3cpWs9">

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.metapointer@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.metapointer@tests.mps
@@ -3598,7 +3598,7 @@
             <node concept="1pGfFk" id="1ryFPTS4wqp" role="2ShVmc">
               <ref role="37wK5l" to="xfsv:~MetaPointer.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String)" resolve="MetaPointer" />
               <node concept="Xl_RD" id="1ryFPTS4wqq" role="37wK5m">
-                <property role="Xl_RC" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
+                <property role="Xl_RC" value="LionCore-builtins" />
               </node>
               <node concept="Xl_RD" id="1ryFPTS4wqr" role="37wK5m">
                 <property role="Xl_RC" value="2023.1" />
@@ -3634,7 +3634,7 @@
             <node concept="1pGfFk" id="1ryFPTS7Us$" role="2ShVmc">
               <ref role="37wK5l" to="xfsv:~MetaPointer.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String)" resolve="MetaPointer" />
               <node concept="Xl_RD" id="1ryFPTS7Us_" role="37wK5m">
-                <property role="Xl_RC" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
+                <property role="Xl_RC" value="LionCore-builtins" />
               </node>
               <node concept="Xl_RD" id="1ryFPTS7UsA" role="37wK5m">
                 <property role="Xl_RC" value="2023.1" />
@@ -3670,7 +3670,7 @@
             <node concept="1pGfFk" id="1ryFPTS4zkc" role="2ShVmc">
               <ref role="37wK5l" to="xfsv:~MetaPointer.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String)" resolve="MetaPointer" />
               <node concept="Xl_RD" id="1ryFPTS4zkd" role="37wK5m">
-                <property role="Xl_RC" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
+                <property role="Xl_RC" value="LionCore-builtins" />
               </node>
               <node concept="Xl_RD" id="1ryFPTS4zke" role="37wK5m">
                 <property role="Xl_RC" value="2023.1" />

--- a/solutions/io.lionweb.mps.json.test/resources/MpsLangCore-metamodel-annotated.json
+++ b/solutions/io.lionweb.mps.json.test/resources/MpsLangCore-metamodel-annotated.json
@@ -1,0 +1,3824 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-M3",
+      "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "io-lionweb-mps-specific",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Language"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-version"
+          },
+          "value": "2"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "jetbrains.mps.lang.core"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-entities"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzE1NTA4NzU0MjAyNzQ0NzYyMQ",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzE4MzU2MjEwNjIxOTA2NjM4MTk",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEwNDc0MDg4MjI0MDk2MDE2NDc",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzExOTY5Nzg2MzAyMTQ",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjE2NDcwOTM4MTI",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjQ2MDg4MzQ0NDU",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzMxNjAyOTY1OTc",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzQ5NzEzNTg0NTA",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMwNzc3MTk",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMxNTE0Nzk",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDY2NjEwNjU",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDc2MTQ5MjA",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzIwMTUzNzM2Nzg4MTA3MTkzMA",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzIyMTY3NjA0NjQxOTk1MDI0MjI",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzM3MTczMDExNTYxOTc2MjYyNzk",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzM3MzQxMTYyMTMxMjk3OTI0OTk",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjE0NzUzNzUxNTc0NjY1NTg",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDU",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDg",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NTA",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODY",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQ0NTI5NjE5MDgyMDI1NTY5MDc",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQwNTgxNzc1NjkzNzUxNTAwMzg",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQxMjMxMjA3MzA5MzU0ODg0MzI",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQyMjIzMTg4MDY4MDI0MjUyOTg",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzU4MzE4ODc2MTUyOTk0NTcwOTE",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUxNjk5OTU1ODMxODQ1OTExNjE",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUyNTk2MzA5MjM1MDU3NzA2NjU",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzY5OTk3MzgyODg3Mzg0MjcxOTA",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzM2OTE2NQ",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzcwMDA3Ng",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTQ5MjYxOTIyMzQwMzYxODQ",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTc0NjkzNjAyNjQ2NjM5NA",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5Nzg2Njg5NDU",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyMzg",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyNTE"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-dependsOn"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": null
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzE1NTA4NzU0MjAyNzQ0NzYyMQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzE1NTA4NzU0MjAyNzQ0NzYyMQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IStubForAnotherConcept"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "InterfacePart",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzE4MzU2MjEwNjIxOTA2NjM4MTk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzE4MzU2MjEwNjIxOTA2NjM4MTk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IDontSubstituteByDefault"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEwNDc0MDg4MjI0MDk2MDE2NDc",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEwNDc0MDg4MjI0MDk2MDE2NDc"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IAntisuppressErrors"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzExOTY5Nzg2MzAyMTQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzExOTY5Nzg2MzAyMTQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IResolveInfo"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzExOTY5Nzg2MzAyMTQvMTE5Njk3ODY1NjI3Nw"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzExOTY5Nzg2MzAyMTQvMTE5Njk3ODY1NjI3Nw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzExOTY5Nzg2MzAyMTQvMTE5Njk3ODY1NjI3Nw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "resolveInfo"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzExOTY5Nzg2MzAyMTQ"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjE2NDcwOTM4MTI",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjE2NDcwOTM4MTI"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IWrapper"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjQ2MDg4MzQ0NDU",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjQ2MDg4MzQ0NDU"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IDeprecatable"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzMxNjAyOTY1OTc",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzMxNjAyOTY1OTc"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IContainer"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzQ5NzEzNTg0NTA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzQ5NzEzNTg0NTA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IType"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMwNzc3MTk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMwNzc3MTk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ImplementationPart"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "ScopeFacade",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjE0NzUzNzUxNTc0NjY1NTg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMxNTE0Nzk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMxNTE0Nzk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ImplementationContainer"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "InterfacePart"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDY2NjEwNjU",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDY2NjEwNjU"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ReviewMigration_old"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDY2NjEwNjUvMjQ4MjYxMTA3NDM0NjY2MTA3Mw",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDY2NjEwNjUvMjQ4MjYxMTA3NDM0NjY2MTA3OA",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDY2NjEwNjUvMjQ4MjYxMTA3NDM0NzE2OTUxNA"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "NodeAttribute",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDg"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "MigrationAnnotation_old",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDc2MTQ5MjA"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDY2NjEwNjUvMjQ4MjYxMTA3NDM0NjY2MTA3Mw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDY2NjEwNjUvMjQ4MjYxMTA3NDM0NjY2MTA3Mw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "todo"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDY2NjEwNjU"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDY2NjEwNjUvMjQ4MjYxMTA3NDM0NjY2MTA3OA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDY2NjEwNjUvMjQ4MjYxMTA3NDM0NjY2MTA3OA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "reasonShort"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDY2NjEwNjU"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDY2NjEwNjUvMjQ4MjYxMTA3NDM0NzE2OTUxNA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDY2NjEwNjUvMjQ4MjYxMTA3NDM0NzE2OTUxNA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "readableId"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDY2NjEwNjU"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDc2MTQ5MjA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDc2MTQ5MjA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "MigrationAnnotation_old"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzIwMTUzNzM2Nzg4MTA3MTkzMA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzIwMTUzNzM2Nzg4MTA3MTkzMA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IMetaLevelChanger"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzIyMTY3NjA0NjQxOTk1MDI0MjI",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzIyMTY3NjA0NjQxOTk1MDI0MjI"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IDontApplyTypesystemRules"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzM3MTczMDExNTYxOTc2MjYyNzk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzM3MTczMDExNTYxOTc2MjYyNzk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "BasePlaceholder"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzM3MTczMDExNTYxOTc2MjYyNzkvMzcxNzMwMTE1NjE5NzYyNjMwMQ"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "ChildAttribute",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTc0NjkzNjAyNjQ2NjM5NA"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzM3MTczMDExNTYxOTc2MjYyNzkvMzcxNzMwMTE1NjE5NzYyNjMwMQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzM3MTczMDExNTYxOTc2MjYyNzkvMzcxNzMwMTE1NjE5NzYyNjMwMQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "content"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "IPlaceholderContent",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQwNTgxNzc1NjkzNzUxNTAwMzg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzM3MTczMDExNTYxOTc2MjYyNzk"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzM3MzQxMTYyMTMxMjk3OTI0OTk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzM3MzQxMTYyMTMxMjk3OTI0OTk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ScopeProvider"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjE0NzUzNzUxNTc0NjY1NTg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjE0NzUzNzUxNTc0NjY1NTg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ScopeFacade"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDU",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDU"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "LinkAttribute"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDUvMTM0MTg2MDkwMDQ4ODAxOTAzNg",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDUvMTc1NzY5OTQ3NjY5MTIzNjExNg"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Attribute",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUxNjk5OTU1ODMxODQ1OTExNjE"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDUvMTM0MTg2MDkwMDQ4ODAxOTAzNg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDUvMTM0MTg2MDkwMDQ4ODAxOTAzNg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "linkId"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDU"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDUvMTc1NzY5OTQ3NjY5MTIzNjExNg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDUvMTc1NzY5OTQ3NjY5MTIzNjExNg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "role_DebugInfo"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDU"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "NodeAttribute"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Attribute",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUxNjk5OTU1ODMxODQ1OTExNjE"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NTA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NTA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "PropertyAttribute"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NTAvMTE4OTQyNDQ1NTI1NDYzMzAwNw",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NTAvMTM0MTg2MDkwMDQ4NzY0ODYyMQ",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NTAvMTc1NzY5OTQ3NjY5MTIzNjExNw"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Attribute",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUxNjk5OTU1ODMxODQ1OTExNjE"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NTAvMTE4OTQyNDQ1NTI1NDYzMzAwNw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NTAvMTE4OTQyNDQ1NTI1NDYzMzAwNw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "enumUsageMigrated"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Boolean",
+              "reference": "LionCore-builtins-Boolean"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NTA"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NTAvMTM0MTg2MDkwMDQ4NzY0ODYyMQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NTAvMTM0MTg2MDkwMDQ4NzY0ODYyMQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "propertyId"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NTA"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NTAvMTc1NzY5OTQ3NjY5MTIzNjExNw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NTAvMTc1NzY5OTQ3NjY5MTIzNjExNw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "name_DebugInfo"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NTA"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODY",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODY"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ICanSuppressErrors"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ISuppressErrors"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQ0NTI5NjE5MDgyMDI1NTY5MDc",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQ0NTI5NjE5MDgyMDI1NTY5MDc"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "BaseCommentAttribute"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQ0NTI5NjE5MDgyMDI1NTY5MDcvMzA3ODY2NjY5OTA0MzAzOTM4OQ"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "ChildAttribute",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTc0NjkzNjAyNjQ2NjM5NA"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "IDontApplyTypesystemRules",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzIyMTY3NjA0NjQxOTk1MDI0MjI"
+            },
+            {
+              "resolveInfo": "ISuppressErrors",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc"
+            },
+            {
+              "resolveInfo": "ISkipConstraintsChecking",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzU4MzE4ODc2MTUyOTk0NTcwOTE"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQ0NTI5NjE5MDgyMDI1NTY5MDcvMzA3ODY2NjY5OTA0MzAzOTM4OQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQ0NTI5NjE5MDgyMDI1NTY5MDcvMzA3ODY2NjY5OTA0MzAzOTM4OQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "commentedNode"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQ0NTI5NjE5MDgyMDI1NTY5MDc"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQwNTgxNzc1NjkzNzUxNTAwMzg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQwNTgxNzc1NjkzNzUxNTAwMzg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IPlaceholderContent"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQxMjMxMjA3MzA5MzU0ODg0MzI",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQxMjMxMjA3MzA5MzU0ODg0MzI"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IOldCommentContainer"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQyMjIzMTg4MDY4MDI0MjUyOTg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQyMjIzMTg4MDY4MDI0MjUyOTg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "SuppressErrorsAnnotation"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQyMjIzMTg4MDY4MDI0MjUyOTgvMjQyMzQxNzM0NTY2OTc1NTYyOQ",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQyMjIzMTg4MDY4MDI0MjUyOTgvODU3NTMyODM1MDU0MzQ5MzM2NQ",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQyMjIzMTg4MDY4MDI0MjUyOTgvODU3NTMyODM1MDU0MzQ5MzM3MQ"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "NodeAttribute",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDg"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "ISuppressErrors",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQyMjIzMTg4MDY4MDI0MjUyOTgvMjQyMzQxNzM0NTY2OTc1NTYyOQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQyMjIzMTg4MDY4MDI0MjUyOTgvMjQyMzQxNzM0NTY2OTc1NTYyOQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "filter"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQyMjIzMTg4MDY4MDI0MjUyOTg"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQyMjIzMTg4MDY4MDI0MjUyOTgvODU3NTMyODM1MDU0MzQ5MzM2NQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQyMjIzMTg4MDY4MDI0MjUyOTgvODU3NTMyODM1MDU0MzQ5MzM2NQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "message"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQyMjIzMTg4MDY4MDI0MjUyOTg"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQyMjIzMTg4MDY4MDI0MjUyOTgvODU3NTMyODM1MDU0MzQ5MzM3MQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQyMjIzMTg4MDY4MDI0MjUyOTgvODU3NTMyODM1MDU0MzQ5MzM3MQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "comment"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzQyMjIzMTg4MDY4MDI0MjUyOTg"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzU4MzE4ODc2MTUyOTk0NTcwOTE",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzU4MzE4ODc2MTUyOTk0NTcwOTE"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ISkipConstraintsChecking"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUxNjk5OTU1ODMxODQ1OTExNjE",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUxNjk5OTU1ODMxODQ1OTExNjE"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "Attribute"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUyNTk2MzA5MjM1MDU3NzA2NjU",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUyNTk2MzA5MjM1MDU3NzA2NjU"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "TypeAnnotated"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUyNTk2MzA5MjM1MDU3NzA2NjUvNTI1OTYzMDkyMzUwNTc3MDY2Ng"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [
+        "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUyNTk2MzA5MjM1MDU3NzA2NjU-ConceptDescription"
+      ],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUyNTk2MzA5MjM1MDU3NzA2NjU-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "_:"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUyNTk2MzA5MjM1MDU3NzA2NjU"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUyNTk2MzA5MjM1MDU3NzA2NjUvNTI1OTYzMDkyMzUwNTc3MDY2Ng",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUyNTk2MzA5MjM1MDU3NzA2NjUvNTI1OTYzMDkyMzUwNTc3MDY2Ng"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "annotation"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUyNTk2MzA5MjM1MDU3NzA2NjU"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzY5OTk3MzgyODg3Mzg0MjcxOTA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzY5OTk3MzgyODg3Mzg0MjcxOTA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ImplementationWithStubPart"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "ImplementationPart",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMwNzc3MTk"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzM2OTE2NQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzM2OTE2NQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "SideTransformInfo"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzM2OTE2NS83NzkxMjg0OTI4NTM2OTkzNjE",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzM2OTE2NS83NzkxMjg0OTI4NTM5MzQ1MjM",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzM2OTE2NS83NzkxMjg0OTI4NTM5MzU5NjA"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "NodeAttribute",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDg"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzM2OTE2NS83NzkxMjg0OTI4NTM2OTkzNjE",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzM2OTE2NS83NzkxMjg0OTI4NTM2OTkzNjE"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "side"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "SideTransformSide",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzcwMDA3Ng"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzM2OTE2NQ"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzM2OTE2NS83NzkxMjg0OTI4NTM5MzQ1MjM",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzM2OTE2NS83NzkxMjg0OTI4NTM5MzQ1MjM"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "cellId"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzM2OTE2NQ"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzM2OTE2NS83NzkxMjg0OTI4NTM5MzU5NjA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzM2OTE2NS83NzkxMjg0OTI4NTM5MzU5NjA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "anchorTag"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzM2OTE2NQ"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzcwMDA3Ng",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Enumeration"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzcwMDA3Ng"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "SideTransformSide"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Enumeration-literals"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzcwMDA3Ni83NzkxMjg0OTI4NTM3MDAwNzc",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzcwMDA3Ni83NzkxMjg0OTI4NTM3MDIyMjM"
+          ]
+        }
+      ],
+      "references": [],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzcwMDA3Ni83NzkxMjg0OTI4NTM3MDAwNzc",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzcwMDA3Ni83NzkxMjg0OTI4NTM3MDAwNzc"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "right"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzcwMDA3Ng"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzcwMDA3Ni83NzkxMjg0OTI4NTM3MDIyMjM",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzcwMDA3Ni83NzkxMjg0OTI4NTM3MDIyMjM"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "left"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzc3OTEyODQ5Mjg1MzcwMDA3Ng"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTQ5MjYxOTIyMzQwMzYxODQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTQ5MjYxOTIyMzQwMzYxODQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ISmartReferent"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTc0NjkzNjAyNjQ2NjM5NA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTc0NjkzNjAyNjQ2NjM5NA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ChildAttribute"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTc0NjkzNjAyNjQ2NjM5NC83MDk3NDY5MzYwMjY2MDkwMjk",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTc0NjkzNjAyNjQ2NjM5NC83MDk3NDY5MzYwMjY2MDkwMzE"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Attribute",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzUxNjk5OTU1ODMxODQ1OTExNjE"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTc0NjkzNjAyNjQ2NjM5NC83MDk3NDY5MzYwMjY2MDkwMjk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTc0NjkzNjAyNjQ2NjM5NC83MDk3NDY5MzYwMjY2MDkwMjk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "role_DebugInfo"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTc0NjkzNjAyNjQ2NjM5NA"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTc0NjkzNjAyNjQ2NjM5NC83MDk3NDY5MzYwMjY2MDkwMzE",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTc0NjkzNjAyNjQ2NjM5NC83MDk3NDY5MzYwMjY2MDkwMzE"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "linkId"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTc0NjkzNjAyNjQ2NjM5NA"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5Nzg2Njg5NDU",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5Nzg2Njg5NDU"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "MigrationDataAnnotation"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5Nzg2Njg5NDUvNjgwNzkzMzQ0ODQ3MDMzMDU3NA"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "NodeAttribute",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDg"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "MigrationAnnotation",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyNTE"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5Nzg2Njg5NDUvNjgwNzkzMzQ0ODQ3MDMzMDU3NA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5Nzg2Njg5NDUvNjgwNzkzMzQ0ODQ3MDMzMDU3NA"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "dataNode"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5Nzg2Njg5NDU"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyMzg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyMzg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ReviewMigration"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyMzgvODcwMzE3OTQzNjk3OTM1OTI0MA",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyMzgvODcwMzE3OTQzNjk3OTM1OTI0MQ",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyMzgvODcwMzE3OTQzNjk3OTM1OTIzOQ"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "NodeAttribute",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjQ2NjA2MzgwNDgwNDk3NDg"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "MigrationAnnotation",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyNTE"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyMzgvODcwMzE3OTQzNjk3OTM1OTI0MA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyMzgvODcwMzE3OTQzNjk3OTM1OTI0MA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "todo"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyMzg"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyMzgvODcwMzE3OTQzNjk3OTM1OTI0MQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyMzgvODcwMzE3OTQzNjk3OTM1OTI0MQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "readableId"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyMzg"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyMzgvODcwMzE3OTQzNjk3OTM1OTIzOQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyMzgvODcwMzE3OTQzNjk3OTM1OTIzOQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "reasonShort"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyMzg"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyNTE",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyNTE"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "MigrationAnnotation"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyNTEvODcwMzE3OTQzNjk3OTM1OTI1Mg"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "MigrationAnnotation_old",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzI0ODI2MTEwNzQzNDc2MTQ5MjA"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyNTEvODcwMzE3OTQzNjk3OTM1OTI1Mg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyNTEvODcwMzE3OTQzNjk3OTM1OTI1Mg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "createdByScript"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzg3MDMxNzk0MzY5NzkzNTkyNTE"
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/MpsLangStructure-metamodel-annotated.json
+++ b/solutions/io.lionweb.mps.json.test/resources/MpsLangStructure-metamodel-annotated.json
@@ -16,67 +16,6 @@
   ],
   "nodes": [
     {
-      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj",
-      "classifier": {
-        "language": "LionCore-M3",
-        "version": "2023.1",
-        "key": "Language"
-      },
-      "properties": [
-        {
-          "property": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "IKeyed-key"
-          },
-          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
-        },
-        {
-          "property": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Language-version"
-          },
-          "value": "2"
-        },
-        {
-          "property": {
-            "language": "LionCore-builtins",
-            "version": "2023.1",
-            "key": "LionCore-builtins-INamed-name"
-          },
-          "value": "jetbrains.mps.lang.core"
-        }
-      ],
-      "containments": [
-        {
-          "containment": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Language-entities"
-          },
-          "children": [
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjQ2MDg4MzQ0NDU",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTQ5MjYxOTIyMzQwMzYxODQ"
-          ]
-        }
-      ],
-      "references": [
-        {
-          "reference": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Language-dependsOn"
-          },
-          "targets": []
-        }
-      ],
-      "annotations": [],
-      "parent": null
-    },
-    {
       "id": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1",
       "classifier": {
         "language": "LionCore-M3",
@@ -518,6 +457,67 @@
       "parent": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1"
     },
     {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Language"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-version"
+          },
+          "value": "2"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "jetbrains.mps.lang.core"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-entities"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjQ2MDg4MzQ0NDU",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTQ5MjYxOTIyMzQwMzYxODQ"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-dependsOn"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": null
+    },
+    {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjQ2MDg4MzQ0NDU",
       "classifier": {
         "language": "LionCore-M3",
@@ -611,7 +611,7 @@
         }
       ],
       "annotations": [],
-      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc",
@@ -806,12 +806,12 @@
           },
           "targets": [
             {
-              "resolveInfo": "jetbrains.mps.lang.core",
-              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
-            },
-            {
               "resolveInfo": "jetbrains.mps.lang.resources",
               "reference": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1"
+            },
+            {
+              "resolveInfo": "jetbrains.mps.lang.core",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
             }
           ]
         }

--- a/solutions/io.lionweb.mps.json.test/resources/MpsLangStructure-metamodel-annotated.json
+++ b/solutions/io.lionweb.mps.json.test/resources/MpsLangStructure-metamodel-annotated.json
@@ -1,0 +1,8813 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-M3",
+      "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "io-lionweb-mps-specific",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Language"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-version"
+          },
+          "value": "2"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "jetbrains.mps.lang.core"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-entities"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjQ2MDg4MzQ0NDU",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTQ5MjYxOTIyMzQwMzYxODQ"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-dependsOn"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": null
+    },
+    {
+      "id": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Language"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-version"
+          },
+          "value": "2"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "jetbrains.mps.lang.resources"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-entities"
+          },
+          "children": [
+            "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzI3NTY2MjEwMjQ1NDEzMTg4OTQ",
+            "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzQ3MjY0ODA4OTk1MzQzNzA5OTk",
+            "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzUxNzcxNjIxMDQ1NjkwNTgxOTk",
+            "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1Lzg5NzQyNzYxODc0MDAwMjk4OTg"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-dependsOn"
+          },
+          "targets": [
+            {
+              "resolveInfo": "jetbrains.mps.lang.structure",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": null
+    },
+    {
+      "id": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzI3NTY2MjEwMjQ1NDEzMTg4OTQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzI3NTY2MjEwMjQ1NDEzMTg4OTQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "Icon"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Resource",
+              "reference": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1Lzg5NzQyNzYxODc0MDAwMjk4OTg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1"
+    },
+    {
+      "id": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzQ3MjY0ODA4OTk1MzQzNzA5OTk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzQ3MjY0ODA4OTk1MzQzNzA5OTk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "BaseURL"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "INamedAspect",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc5NTQxNDc1NjMwNDUyODMyOTY"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1"
+    },
+    {
+      "id": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzUxNzcxNjIxMDQ1NjkwNTgxOTk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzUxNzcxNjIxMDQ1NjkwNTgxOTk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "HelpURL"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzUxNzcxNjIxMDQ1NjkwNTgxOTkvNDcyNjQ4MDg5OTUzNDMxNzI1Mg",
+            "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzUxNzcxNjIxMDQ1NjkwNTgxOTkvNTE3NzE2MjEwNDU2OTA1ODIwMA"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1"
+    },
+    {
+      "id": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzUxNzcxNjIxMDQ1NjkwNTgxOTkvNDcyNjQ4MDg5OTUzNDMxNzI1Mg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzUxNzcxNjIxMDQ1NjkwNTgxOTkvNDcyNjQ4MDg5OTUzNDMxNzI1Mg"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "baseURL"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "BaseURL",
+              "reference": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzQ3MjY0ODA4OTk1MzQzNzA5OTk"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzUxNzcxNjIxMDQ1NjkwNTgxOTk"
+    },
+    {
+      "id": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzUxNzcxNjIxMDQ1NjkwNTgxOTkvNTE3NzE2MjEwNDU2OTA1ODIwMA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzUxNzcxNjIxMDQ1NjkwNTgxOTkvNTE3NzE2MjEwNDU2OTA1ODIwMA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "url"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzUxNzcxNjIxMDQ1NjkwNTgxOTk"
+    },
+    {
+      "id": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1Lzg5NzQyNzYxODc0MDAwMjk4OTg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1Lzg5NzQyNzYxODc0MDAwMjk4OTg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "Resource"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjQ2MDg4MzQ0NDU",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjQ2MDg4MzQ0NDU"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IDeprecatable"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "InterfacePart"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ISuppressErrors"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTQ5MjYxOTIyMzQwMzYxODQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTQ5MjYxOTIyMzQwMzYxODQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ISmartReferent"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Language"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-version"
+          },
+          "value": "9"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "jetbrains.mps.lang.structure"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-entities"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODA2Mjk2NTM",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODA3MDYyNzA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODQ3OTcwMzA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTk",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzUwMTA0NTE2NTM2NjczMDE",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5Nzg0OTkxMjc",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTk",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMyNDMxNTkwNzk",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjI",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTkxNzk3MDM",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU5ODk1NTE",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjc2MjIxNjg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExOTc1OTA4ODQ2MTM",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQ4NDgzMjQ3Mzc",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQyNDA4MzYxODA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI2MjE0NDk0MTIwNDAxMzM3NjQ",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDk",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMyMjA1NTk3NjQ3MTc3NjY5OTM",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0Nzk",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDU",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMTk",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQxODA0OTI1MTg1Njc5OTgxMw",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQyNjk4NDI1MDM3MjYyMDc4MTg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU0MDQ2NzE2MTk2MTYyNDY3NTk",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU3MTcxODgxMjA2ODkwMTg5MzY",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU3MTcxODgxMjA2ODkwMTk0NDE",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzI0NjMyNzU",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NTA2ODg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzM",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzYwNTQ1MjM0NjQ2MjY4NjIwNDQ",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzYwNTQ1MjM0NjQ2Mjc5NjQ3NDU",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMDk",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMTQ",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMjE",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc5NTQxNDc1NjMwNDUyODMyOTY",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDg0NjQ5OTA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDgyMDc1OTI",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzgwODcwNDczMDUwODA3NzQ5MDQ"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-dependsOn"
+          },
+          "targets": [
+            {
+              "resolveInfo": "jetbrains.mps.lang.core",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+            },
+            {
+              "resolveInfo": "jetbrains.mps.lang.resources",
+              "reference": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": null
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODA2Mjk2NTM",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODA2Mjk2NTM"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "INamedStructureElement"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "INamed",
+              "reference": "LionCore-builtins-INamed"
+            },
+            {
+              "resolveInfo": "IStructureElement",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODA3MDYyNzA"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODA3MDYyNzA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODA3MDYyNzA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IStructureElement"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODQ3OTcwMzA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODQ3OTcwMzA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumMigrationInfo"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODQ3OTcwMzAvNjQ5MTA3Nzk1OTYzMjQ1MTk5Ng",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODQ3OTcwMzAvNjQ5MTA3Nzk1OTYzNDY1MDY3MA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODQ3OTcwMzAvNjQ5MTA3Nzk1OTYzNDY2MjM3Mg"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "EnumerationDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0Nzk"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "ISuppressErrors",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODQ3OTcwMzAvNjQ5MTA3Nzk1OTYzMjQ1MTk5Ng",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODQ3OTcwMzAvNjQ5MTA3Nzk1OTYzMjQ1MTk5Ng"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "oldEnum"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "EnumerationDataTypeDeclaration_Old",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTk"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODQ3OTcwMzA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODQ3OTcwMzAvNjQ5MTA3Nzk1OTYzNDY1MDY3MA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODQ3OTcwMzAvNjQ5MTA3Nzk1OTYzNDY1MDY3MA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "nameOpMigration"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "NameOperationMigrationStrategy",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NTA2ODg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODQ3OTcwMzA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODQ3OTcwMzAvNjQ5MTA3Nzk1OTYzNDY2MjM3Mg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODQ3OTcwMzAvNjQ5MTA3Nzk1OTYzNDY2MjM3Mg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "valueOpMigration"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "ValueOperationMigrationStrategy",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzM"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODQ3OTcwMzA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ConceptDeclaration"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvMTA3MTQ4OTM4OTUxOQ",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvMTA5NjQ1NDEwMDU1Mg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvMTE2MDQ4ODQ5MTIyOQ",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvMTE2OTEyOTU2NDQ3OA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvNTQwNDY3MTYxOTYxNjI0NjM0NA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvNjMyNzM2MjUyNDg3NTMwMDU5Nw"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "AbstractConceptDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "ISmartReferent",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTQ5MjYxOTIyMzQwMzYxODQ"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDA-ConceptDescription"
+      ],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDA-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "Concept"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvMTA3MTQ4OTM4OTUxOQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvMTA3MTQ4OTM4OTUxOQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "extends"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "ConceptDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDA"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvMTA5NjQ1NDEwMDU1Mg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvMTA5NjQ1NDEwMDU1Mg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "rootable"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Boolean",
+              "reference": "LionCore-builtins-Boolean"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvMTE2MDQ4ODQ5MTIyOQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvMTE2MDQ4ODQ5MTIyOQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "iconPath"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvMTE2OTEyOTU2NDQ3OA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvMTE2OTEyOTU2NDQ3OA"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "implements"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "InterfaceConceptReference",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjc2MjIxNjg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvNTQwNDY3MTYxOTYxNjI0NjM0NA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvNTQwNDY3MTYxOTYxNjI0NjM0NA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "staticScope"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "StaticScope",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU0MDQ2NzE2MTk2MTYyNDY3NTk"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvNjMyNzM2MjUyNDg3NTMwMDU5Nw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDAvNjMyNzM2MjUyNDg3NTMwMDU5Nw"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "icon"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Icon",
+              "reference": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzI3NTY2MjEwMjQ1NDEzMTg4OTQ"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkwOTA2NDA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "LinkDeclaration"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMTA3MTU5OTY5ODUwMA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMTA3MTU5OTc3NjU2Mw",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMTA3MTU5OTg5MzI1Mg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMTA3MTU5OTk3NjE3Ng",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMTA3MTU5OTkzNzgzMQ",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMjM5NTU4NTYyODkyODQ1OTMxNA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMjQxNjQ3NjA4Mjk5NDMxMTQw"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "InterfacePart",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY"
+            },
+            {
+              "resolveInfo": "INamedStructureElement",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODA2Mjk2NTM"
+            },
+            {
+              "resolveInfo": "IStructureDeprecatable",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQ4NDgzMjQ3Mzc"
+            },
+            {
+              "resolveInfo": "DocumentationObjective",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMTQ"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMTA3MTU5OTY5ODUwMA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMTA3MTU5OTY5ODUwMA"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "specializedLink"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "LinkDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTg"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMTA3MTU5OTc3NjU2Mw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMTA3MTU5OTc3NjU2Mw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "role"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTg"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMTA3MTU5OTg5MzI1Mg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMTA3MTU5OTg5MzI1Mg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "sourceCardinality"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Cardinality",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjI"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTg"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMTA3MTU5OTk3NjE3Ng",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMTA3MTU5OTk3NjE3Ng"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "target"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "AbstractConceptDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTg"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMTA3MTU5OTkzNzgzMQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMTA3MTU5OTkzNzgzMQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "metaClass"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "LinkMetaclass",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTkxNzk3MDM"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTg"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMjM5NTU4NTYyODkyODQ1OTMxNA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMjM5NTU4NTYyODkyODQ1OTMxNA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "unordered"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Boolean",
+              "reference": "LionCore-builtins-Boolean"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTg"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMjQxNjQ3NjA4Mjk5NDMxMTQw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTgvMjQxNjQ3NjA4Mjk5NDMxMTQw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "linkId"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "IDNumber",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQyNjk4NDI1MDM3MjYyMDc4MTg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTg"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "PropertyDeclaration"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTkvMTA4Mjk4NTI5NTg0NQ",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTkvMjQxNjQ3NjA4Mjk5NDMxMTI5"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "InterfacePart",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY"
+            },
+            {
+              "resolveInfo": "INamedStructureElement",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODA2Mjk2NTM"
+            },
+            {
+              "resolveInfo": "IStructureDeprecatable",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQ4NDgzMjQ3Mzc"
+            },
+            {
+              "resolveInfo": "DocumentationObjective",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMTQ"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTkvMTA4Mjk4NTI5NTg0NQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTkvMTA4Mjk4NTI5NTg0NQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "dataType"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "DataTypeDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTkvMjQxNjQ3NjA4Mjk5NDMxMTI5",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTkvMjQxNjQ3NjA4Mjk5NDMxMTI5"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "propertyId"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "IDNumber",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQyNjk4NDI1MDM3MjYyMDc4MTg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzUwMTA0NTE2NTM2NjczMDE",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzUwMTA0NTE2NTM2NjczMDE"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IEnumeration"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "INamed",
+              "reference": "LionCore-builtins-INamed"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5Nzg0OTkxMjc",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5Nzg0OTkxMjc"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ConstrainedDataTypeDeclaration"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5Nzg0OTkxMjcvMTA4MzA2NjA4OTIxOA"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "DataTypeDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTg"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [
+        "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5Nzg0OTkxMjc-ConceptDescription"
+      ],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5Nzg0OTkxMjc-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "Constrained Data Type"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5Nzg0OTkxMjc"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5Nzg0OTkxMjcvMTA4MzA2NjA4OTIxOA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5Nzg0OTkxMjcvMTA4MzA2NjA4OTIxOA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "constraint"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5Nzg0OTkxMjc"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DataTypeDeclaration"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTgvNzc5MTEwOTA2NTYyNjg5NTM2Mw",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTgvNzc5MTEwOTA2NTYyNjg5NTM2NA"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "INamedStructureElement",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODA2Mjk2NTM"
+            },
+            {
+              "resolveInfo": "IStructureDeprecatable",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQ4NDgzMjQ3Mzc"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTgvNzc5MTEwOTA2NTYyNjg5NTM2Mw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTgvNzc5MTEwOTA2NTYyNjg5NTM2Mw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "datatypeId"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "IDNumber",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQyNjk4NDI1MDM3MjYyMDc4MTg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTg"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTgvNzc5MTEwOTA2NTYyNjg5NTM2NA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTgvNzc5MTEwOTA2NTYyNjg5NTM2NA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "languageId"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTg"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumerationDataTypeDeclaration_Old"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTA4MzE3MTcyOTE1Nw",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTA4MzE3MjAwMzU4Mg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTA4MzI0MTk2NTQzNw",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTE5NzU5MTE1NDg4Mg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTIxMjA4MDg0NDc2Mg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTIxMjA4NzQ0OTI1NA"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "DataTypeDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTg"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "IEnumeration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzUwMTA0NTE2NTM2NjczMDE"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTk-ConceptDescription"
+      ],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTk-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "Enum Data Type"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTA4MzE3MTcyOTE1Nw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTA4MzE3MTcyOTE1Nw"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "memberDataType"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "PrimitiveDataTypeDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMyNDMxNTkwNzk"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTA4MzE3MjAwMzU4Mg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTA4MzE3MjAwMzU4Mg"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "member"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "EnumerationMemberDeclaration_Old",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTA4MzI0MTk2NTQzNw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTA4MzI0MTk2NTQzNw"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "defaultMember"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "EnumerationMemberDeclaration_Old",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTE5NzU5MTE1NDg4Mg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTE5NzU5MTE1NDg4Mg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "memberIdentifierPolicy"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "EnumerationMemberIdentifierPolicy",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExOTc1OTA4ODQ2MTM"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTIxMjA4MDg0NDc2Mg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTIxMjA4MDg0NDc2Mg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "hasNoDefaultMember"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Boolean",
+              "reference": "LionCore-builtins-Boolean"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTIxMjA4NzQ0OTI1NA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTkvMTIxMjA4NzQ0OTI1NA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "noValueText"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumerationMemberDeclaration_Old"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTgvMTA4MzkyMzUyMzE3MQ",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTgvMTA4MzkyMzUyMzE3Mg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTgvMTE5MjExNjk3ODgwOQ"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "InterfacePart",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTgvMTA4MzkyMzUyMzE3MQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTgvMTA4MzkyMzUyMzE3MQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "internalValue"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTg"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTgvMTA4MzkyMzUyMzE3Mg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTgvMTA4MzkyMzUyMzE3Mg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "externalValue"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTg"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTgvMTE5MjExNjk3ODgwOQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTgvMTE5MjExNjk3ODgwOQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "javaIdentifier"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTg"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMyNDMxNTkwNzk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMyNDMxNTkwNzk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "PrimitiveDataTypeDeclaration"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "DataTypeDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTg"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [
+        "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMyNDMxNTkwNzk-ConceptDescription"
+      ],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMyNDMxNTkwNzk-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "Primitive Datatype"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMyNDMxNTkwNzk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjI",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Enumeration"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjI"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "Cardinality"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Enumeration-literals"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjIvMTA4NDE5Nzc4MjcyMw",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjIvMTA4NDE5Nzc4MjcyNA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjIvMTA4NDE5Nzc4MjcyNQ",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjIvMTA4NDE5Nzc4MjcyNg"
+          ]
+        }
+      ],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjIvMTA4NDE5Nzc4MjcyMw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjIvMTA4NDE5Nzc4MjcyMw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "_0__1"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjI"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjIvMTA4NDE5Nzc4MjcyNA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjIvMTA4NDE5Nzc4MjcyNA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "_1"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjI"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjIvMTA4NDE5Nzc4MjcyNQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjIvMTA4NDE5Nzc4MjcyNQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "_0__n"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjI"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjIvMTA4NDE5Nzc4MjcyNg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjIvMTA4NDE5Nzc4MjcyNg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "_1__n"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTc3ODI3MjI"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTkxNzk3MDM",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Enumeration"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTkxNzk3MDM"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "LinkMetaclass"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Enumeration-literals"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTkxNzk3MDMvMTA4NDE5OTE3OTcwNA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTkxNzk3MDMvMTA4NDE5OTE3OTcwNQ"
+          ]
+        }
+      ],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTkxNzk3MDMvMTA4NDE5OTE3OTcwNA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTkxNzk3MDMvMTA4NDE5OTE3OTcwNA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "reference"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTkxNzk3MDM"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTkxNzk3MDMvMTA4NDE5OTE3OTcwNQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTkxNzk3MDMvMTA4NDE5OTE3OTcwNQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "aggregation"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODQxOTkxNzk3MDM"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "AbstractConceptDeclaration"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvMTA3MTQ4OTcyNzA4Mw",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvMTA3MTQ4OTcyNzA4NA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvMTU4NzkxNjk5MTk2OTQ2NTM2OQ",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvMTc4MDE3NzExMzE3MDIwNDE1NQ",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvMjQ2NTY1NDUzNTQ3MzAzNDU4OA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNDYyODA2NzM5MDc2NTk1NjgwMg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNDYyODA2NzM5MDc2NTk1NjgwNw",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNDYyODA2NzM5MDc2NTkwNzQ4OA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNTA5MjE3NTcxNTgwNDkzNTM3MA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNTAyMzk1MDY4NTU5MjUxNzQyMA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNjcxNDQxMDE2OTI2MTg1Mzg4OA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvOTAwNTMwODY2NTczOTMxMDExNQ"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "InterfacePart",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY"
+            },
+            {
+              "resolveInfo": "INamedStructureElement",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODA2Mjk2NTM"
+            },
+            {
+              "resolveInfo": "IStructureDeprecatable",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQ4NDgzMjQ3Mzc"
+            },
+            {
+              "resolveInfo": "DocumentationObjective",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMTQ"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvMTA3MTQ4OTcyNzA4Mw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvMTA3MTQ4OTcyNzA4Mw"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "linkDeclaration"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "LinkDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvMTA3MTQ4OTcyNzA4NA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvMTA3MTQ4OTcyNzA4NA"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "propertyDeclaration"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "PropertyDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTk"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvMTU4NzkxNjk5MTk2OTQ2NTM2OQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvMTU4NzkxNjk5MTk2OTQ2NTM2OQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "intConceptId"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Integer",
+              "reference": "LionCore-builtins-Integer"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvMTc4MDE3NzExMzE3MDIwNDE1NQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvMTc4MDE3NzExMzE3MDIwNDE1NQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "helpURL"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "HelpURL",
+              "reference": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1LzUxNzcxNjIxMDQ1NjkwNTgxOTk"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvMjQ2NTY1NDUzNTQ3MzAzNDU4OA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvMjQ2NTY1NDUzNTQ3MzAzNDU4OA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "oldHelpURL"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNDYyODA2NzM5MDc2NTk1NjgwMg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNDYyODA2NzM5MDc2NTk1NjgwMg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "abstract"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Boolean",
+              "reference": "LionCore-builtins-Boolean"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNDYyODA2NzM5MDc2NTk1NjgwNw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNDYyODA2NzM5MDc2NTk1NjgwNw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "final"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Boolean",
+              "reference": "LionCore-builtins-Boolean"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNDYyODA2NzM5MDc2NTkwNzQ4OA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNDYyODA2NzM5MDc2NTkwNzQ4OA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "conceptShortDescription"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNTA5MjE3NTcxNTgwNDkzNTM3MA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNTA5MjE3NTcxNTgwNDkzNTM3MA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "conceptAlias"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNTAyMzk1MDY4NTU5MjUxNzQyMA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNTAyMzk1MDY4NTU5MjUxNzQyMA"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "sourceNode"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNjcxNDQxMDE2OTI2MTg1Mzg4OA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvNjcxNDQxMDE2OTI2MTg1Mzg4OA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "conceptId"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "IDNumber",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQyNjk4NDI1MDM3MjYyMDc4MTg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvOTAwNTMwODY2NTczOTMxMDExNQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzUvOTAwNTMwODY2NTczOTMxMDExNQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "languageId"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU5ODk1NTE",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU5ODk1NTE"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "InterfaceConceptDeclaration"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU5ODk1NTEvMTE2OTEyNzU0NjM1Ng"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "AbstractConceptDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [
+        "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU5ODk1NTE-ConceptDescription"
+      ],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU5ODk1NTE-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "Interface Concept"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU5ODk1NTE"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU5ODk1NTEvMTE2OTEyNzU0NjM1Ng",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU5ODk1NTEvMTE2OTEyNzU0NjM1Ng"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "extends"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "InterfaceConceptReference",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjc2MjIxNjg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU5ODk1NTE"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjc2MjIxNjg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjc2MjIxNjg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "InterfaceConceptReference"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjc2MjIxNjgvMTE2OTEyNzYyODg0MQ"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "InterfacePart",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjc2MjIxNjgvMTE2OTEyNzYyODg0MQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjc2MjIxNjgvMTE2OTEyNzYyODg0MQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "intfc"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "InterfaceConceptDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU5ODk1NTE"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjc2MjIxNjg"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExOTc1OTA4ODQ2MTM",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Enumeration"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExOTc1OTA4ODQ2MTM"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumerationMemberIdentifierPolicy"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Enumeration-literals"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExOTc1OTA4ODQ2MTMvMTE5NzU5MDg4NDYxNA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExOTc1OTA4ODQ2MTMvMTE5NzU5MTA0ODYzMA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExOTc1OTA4ODQ2MTMvMTE5NzU5MTA3NTQ5MQ"
+          ]
+        }
+      ],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExOTc1OTA4ODQ2MTMvMTE5NzU5MDg4NDYxNA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExOTc1OTA4ODQ2MTMvMTE5NzU5MDg4NDYxNA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "derive_from_presentation"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExOTc1OTA4ODQ2MTM"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExOTc1OTA4ODQ2MTMvMTE5NzU5MTA0ODYzMA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExOTc1OTA4ODQ2MTMvMTE5NzU5MTA0ODYzMA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "derive_from_internal_value"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExOTc1OTA4ODQ2MTM"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExOTc1OTA4ODQ2MTMvMTE5NzU5MTA3NTQ5MQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExOTc1OTA4ODQ2MTMvMTE5NzU5MTA3NTQ5MQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "custom"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExOTc1OTA4ODQ2MTM"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQ4NDgzMjQ3Mzc",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQ4NDgzMjQ3Mzc"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IStructureDeprecatable"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "IDeprecatable",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjQ2MDg4MzQ0NDU"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQyNDA4MzYxODA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQyNDA4MzYxODA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DeprecatedNodeAnnotation"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQyNDA4MzYxODAvMTIyNTExODkyOTQxMQ",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQyNDA4MzYxODAvMTIyNTExODkzMzIyNA"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "IStructureDeprecatable",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQ4NDgzMjQ3Mzc"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "INamed",
+              "reference": "LionCore-builtins-INamed"
+            },
+            {
+              "resolveInfo": "InterfacePart",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQyNDA4MzYxODAvMTIyNTExODkyOTQxMQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQyNDA4MzYxODAvMTIyNTExODkyOTQxMQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "build"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQyNDA4MzYxODA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQyNDA4MzYxODAvMTIyNTExODkzMzIyNA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQyNDA4MzYxODAvMTIyNTExODkzMzIyNA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "comment"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEyMjQyNDA4MzYxODA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI2MjE0NDk0MTIwNDAxMzM3NjQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI2MjE0NDk0MTIwNDAxMzM3NjQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IConceptAspect"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "AttributeInfo"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDkvNzU4ODQyODgzMTk0Nzk1OTMxMA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDkvNzU4ODQyODgzMTk1NTU1MDE4Ng",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDkvNzU4ODQyODgzMTk1NTU1MDY2Mw"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Concept",
+              "reference": "-id-Concept"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [
+        "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDk-ConceptDescription"
+      ],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDk-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "@attribute info"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDkvNzU4ODQyODgzMTk0Nzk1OTMxMA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDkvNzU4ODQyODgzMTk0Nzk1OTMxMA"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "attributed"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "AttributeInfo_AttributedConcept",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzYwNTQ1MjM0NjQ2Mjc5NjQ3NDU"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDkvNzU4ODQyODgzMTk1NTU1MDE4Ng",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDkvNzU4ODQyODgzMTk1NTU1MDE4Ng"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "multiple"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "AttributeInfo_IsMultiple",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzYwNTQ1MjM0NjQ2MjY4NjIwNDQ"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDkvNzU4ODQyODgzMTk1NTU1MDY2Mw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDkvNzU4ODQyODgzMTk1NTU1MDY2Mw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "role"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzI5OTI4MTE3NTg2NzcyOTU1MDk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMyMjA1NTk3NjQ3MTc3NjY5OTM",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Enumeration"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMyMjA1NTk3NjQ3MTc3NjY5OTM"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ChildrenIncomingReferencesPolicy"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Enumeration-literals"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMyMjA1NTk3NjQ3MTc3NjY5OTMvMzIyMDU1OTc2NDcxNzc2Njk5NA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMyMjA1NTk3NjQ3MTc3NjY5OTMvMzIyMDU1OTc2NDcxNzc2Njk5NQ",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMyMjA1NTk3NjQ3MTc3NjY5OTMvMzIyMDU1OTc2NDcxNzc2Njk5OA"
+          ]
+        }
+      ],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMyMjA1NTk3NjQ3MTc3NjY5OTMvMzIyMDU1OTc2NDcxNzc2Njk5NA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMyMjA1NTk3NjQ3MTc3NjY5OTMvMzIyMDU1OTc2NDcxNzc2Njk5NA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "allowed"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMyMjA1NTk3NjQ3MTc3NjY5OTM"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMyMjA1NTk3NjQ3MTc3NjY5OTMvMzIyMDU1OTc2NDcxNzc2Njk5NQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMyMjA1NTk3NjQ3MTc3NjY5OTMvMzIyMDU1OTc2NDcxNzc2Njk5NQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "local"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMyMjA1NTk3NjQ3MTc3NjY5OTM"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMyMjA1NTk3NjQ3MTc3NjY5OTMvMzIyMDU1OTc2NDcxNzc2Njk5OA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMyMjA1NTk3NjQ3MTc3NjY5OTMvMzIyMDU1OTc2NDcxNzc2Njk5OA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "forbidden"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMyMjA1NTk3NjQ3MTc3NjY5OTM"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0Nzk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0Nzk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumerationDeclaration"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0NzkvMTA3NTAxMDQ1MTY0MjY0Njg5Mg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0NzkvMzM0ODE1ODc0MjkzNjk3NjU3Nw"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "DataTypeDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODI5NzgxNjQyMTg"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "IEnumeration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzUwMTA0NTE2NTM2NjczMDE"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0Nzk-ConceptDescription"
+      ],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0Nzk-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "Enumeration"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0Nzk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0NzkvMTA3NTAxMDQ1MTY0MjY0Njg5Mg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0NzkvMTA3NTAxMDQ1MTY0MjY0Njg5Mg"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "defaultMember"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "EnumerationMemberDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODA"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0Nzk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0NzkvMzM0ODE1ODc0MjkzNjk3NjU3Nw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0NzkvMzM0ODE1ODc0MjkzNjk3NjU3Nw"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "members"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "EnumerationMemberDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODA"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0Nzk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumerationMemberDeclaration"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODAvMTQyMTE1NzI1MjM4NDE2NTQzMg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODAvNjcyMDM3MTUxMTg2NDkxNTI4",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODAvODk5MDY5MjIyMTA2MDkxODcx"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "INamedStructureElement",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzE1ODgzNjgxNjI4ODA2Mjk2NTM"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODA-ConceptDescription"
+      ],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODA-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "member"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODAvMTQyMTE1NzI1MjM4NDE2NTQzMg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODAvMTQyMTE1NzI1MjM4NDE2NTQzMg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "memberId"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "IDNumber",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQyNjk4NDI1MDM3MjYyMDc4MTg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODAvNjcyMDM3MTUxMTg2NDkxNTI4",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODAvNjcyMDM3MTUxMTg2NDkxNTI4"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "presentation"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODAvODk5MDY5MjIyMTA2MDkxODcx",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODAvODk5MDY5MjIyMTA2MDkxODcx"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "oldMember"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "EnumerationMemberDeclaration_Old",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwODMxNzE4NzcyOTg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0ODA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDU",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Enumeration"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDU"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumCustomMethodReplacementKind"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Enumeration-literals"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDUvMzM1NTgwNTkyOTQzMjAxNzIwNg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDUvMzM1NTgwNTkyOTQzMjAxNzIwNw",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDUvMzM1NTgwNTkyOTQzMjAxNzIxMA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDUvMzM1NTgwNTkyOTQzMjAxNzIxNA"
+          ]
+        }
+      ],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDUvMzM1NTgwNTkyOTQzMjAxNzIwNg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDUvMzM1NTgwNTkyOTQzMjAxNzIwNg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "memberToValue"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDUvMzM1NTgwNTkyOTQzMjAxNzIwNw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDUvMzM1NTgwNTkyOTQzMjAxNzIwNw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "valueToMember"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDUvMzM1NTgwNTkyOTQzMjAxNzIxMA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDUvMzM1NTgwNTkyOTQzMjAxNzIxMA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "memberToName"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDUvMzM1NTgwNTkyOTQzMjAxNzIxNA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDUvMzM1NTgwNTkyOTQzMjAxNzIxNA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "nameToMember"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMTk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMTk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumCustomMethodReplacementInfo"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMTkvMzM1NTgwNTkyOTQzMjAxNzIyMg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMTkvMzM1NTgwNTkyOTQzMjAxNzIyNA"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMTkvMzM1NTgwNTkyOTQzMjAxNzIyMg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMTkvMzM1NTgwNTkyOTQzMjAxNzIyMg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "kind"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "EnumCustomMethodReplacementKind",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMDU"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMTk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMTkvMzM1NTgwNTkyOTQzMjAxNzIyNA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMTkvMzM1NTgwNTkyOTQzMjAxNzIyNA"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "enum"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "EnumerationDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNDgxNTg3NDI5MzY5NzY0Nzk"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzMzNTU4MDU5Mjk0MzIwMTcyMTk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQxODA0OTI1MTg1Njc5OTgxMw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQxODA0OTI1MTg1Njc5OTgxMw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ExperimentalAPINodeAttribute"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQxODA0OTI1MTg1Njc5OTgxMy80MTgwNDkyNTE4NTY3OTk4MTY",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQxODA0OTI1MTg1Njc5OTgxMy80MTgwNDkyNTE4NTY3OTk4MTc"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Classifier",
+              "reference": "-id-Classifier"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "INamed",
+              "reference": "LionCore-builtins-INamed"
+            },
+            {
+              "resolveInfo": "InterfacePart",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQxODA0OTI1MTg1Njc5OTgxMy80MTgwNDkyNTE4NTY3OTk4MTY",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQxODA0OTI1MTg1Njc5OTgxMy80MTgwNDkyNTE4NTY3OTk4MTY"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "build"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQxODA0OTI1MTg1Njc5OTgxMw"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQxODA0OTI1MTg1Njc5OTgxMy80MTgwNDkyNTE4NTY3OTk4MTc",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQxODA0OTI1MTg1Njc5OTgxMy80MTgwNDkyNTE4NTY3OTk4MTc"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "comment"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQxODA0OTI1MTg1Njc5OTgxMw"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQyNjk4NDI1MDM3MjYyMDc4MTg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "PrimitiveType"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzQyNjk4NDI1MDM3MjYyMDc4MTg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "IDNumber"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU0MDQ2NzE2MTk2MTYyNDY3NTk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Enumeration"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU0MDQ2NzE2MTk2MTYyNDY3NTk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "StaticScope"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Enumeration-literals"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU0MDQ2NzE2MTk2MTYyNDY3NTkvNTQwNDY3MTYxOTYxNjI0Njc2MA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU0MDQ2NzE2MTk2MTYyNDY3NTkvNTQwNDY3MTYxOTYxNjI0Njc2MQ",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU0MDQ2NzE2MTk2MTYyNDY3NTkvNTQwNDY3MTYxOTYxNjI0Njc2NA"
+          ]
+        }
+      ],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU0MDQ2NzE2MTk2MTYyNDY3NTkvNTQwNDY3MTYxOTYxNjI0Njc2MA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU0MDQ2NzE2MTk2MTYyNDY3NTkvNTQwNDY3MTYxOTYxNjI0Njc2MA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "global"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU0MDQ2NzE2MTk2MTYyNDY3NTk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU0MDQ2NzE2MTk2MTYyNDY3NTkvNTQwNDY3MTYxOTYxNjI0Njc2MQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU0MDQ2NzE2MTk2MTYyNDY3NTkvNTQwNDY3MTYxOTYxNjI0Njc2MQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "root"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU0MDQ2NzE2MTk2MTYyNDY3NTk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU0MDQ2NzE2MTk2MTYyNDY3NTkvNTQwNDY3MTYxOTYxNjI0Njc2NA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU0MDQ2NzE2MTk2MTYyNDY3NTkvNTQwNDY3MTYxOTYxNjI0Njc2NA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "none"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU0MDQ2NzE2MTk2MTYyNDY3NTk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU3MTcxODgxMjA2ODkwMTg5MzY",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU3MTcxODgxMjA2ODkwMTg5MzY"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ReferenceLinkDeclartionScopeKind"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU3MTcxODgxMjA2ODkwMTk0NDE",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzU3MTcxODgxMjA2ODkwMTk0NDE"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "AggregationLinkDeclarationScopeKind"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzI0NjMyNzU",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzI0NjMyNzU"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumPropertyMigrationInfo"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzI0NjMyNzUvNjQ5MTA3Nzk1OTYzMjQ2MzI4Ng"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "PropertyDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTk"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "ISuppressErrors",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzI0NjMyNzUvNjQ5MTA3Nzk1OTYzMjQ2MzI4Ng",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzI0NjMyNzUvNjQ5MTA3Nzk1OTYzMjQ2MzI4Ng"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "oldProperty"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "PropertyDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTk"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzI0NjMyNzU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NTA2ODg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Enumeration"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NTA2ODg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "NameOperationMigrationStrategy"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Enumeration-literals"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NTA2ODgvNjQ5MTA3Nzk1OTYzNDY1MDY4OQ",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NTA2ODgvNjQ5MTA3Nzk1OTYzNDY1MDY5MA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NTA2ODgvNjQ5MTA3Nzk1OTYzNDY1MDY5Mw"
+          ]
+        }
+      ],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NTA2ODgvNjQ5MTA3Nzk1OTYzNDY1MDY4OQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NTA2ODgvNjQ5MTA3Nzk1OTYzNDY1MDY4OQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "by_name"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NTA2ODg"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NTA2ODgvNjQ5MTA3Nzk1OTYzNDY1MDY5MA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NTA2ODgvNjQ5MTA3Nzk1OTYzNDY1MDY5MA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "by_presentation"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NTA2ODg"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NTA2ODgvNjQ5MTA3Nzk1OTYzNDY1MDY5Mw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NTA2ODgvNjQ5MTA3Nzk1OTYzNDY1MDY5Mw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "by_custom_methods"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NTA2ODg"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzM",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Enumeration"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzM"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "ValueOperationMigrationStrategy"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Enumeration-literals"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjM0Mg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjM0Nw",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjM1Mw",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjM2MA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjMzNA",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjMzNQ"
+          ]
+        }
+      ],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjM0Mg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjM0Mg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "boolean"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzM"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjM0Nw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjM0Nw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "int_ordinal"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzM"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjM1Mw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjM1Mw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "int_ordinal_plus_one"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzM"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjM2MA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjM2MA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "by_custom_methods"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzM"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjMzNA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjMzNA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "string_name"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzM"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjMzNQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzMvNjQ5MTA3Nzk1OTYzNDY2MjMzNQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "string_presentation"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzY0OTEwNzc5NTk2MzQ2NjIzMzM"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzYwNTQ1MjM0NjQ2MjY4NjIwNDQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzYwNTQ1MjM0NjQ2MjY4NjIwNDQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "AttributeInfo_IsMultiple"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzYwNTQ1MjM0NjQ2MjY4NjIwNDQvNjA1NDUyMzQ2NDYyNjg3NTg1NA"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzYwNTQ1MjM0NjQ2MjY4NjIwNDQvNjA1NDUyMzQ2NDYyNjg3NTg1NA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzYwNTQ1MjM0NjQ2MjY4NjIwNDQvNjA1NDUyMzQ2NDYyNjg3NTg1NA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "value"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Boolean",
+              "reference": "LionCore-builtins-Boolean"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzYwNTQ1MjM0NjQ2MjY4NjIwNDQ"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzYwNTQ1MjM0NjQ2Mjc5NjQ3NDU",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzYwNTQ1MjM0NjQ2Mjc5NjQ3NDU"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "AttributeInfo_AttributedConcept"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzYwNTQ1MjM0NjQ2Mjc5NjQ3NDUvNjA1NDUyMzQ2NDYyNzk2NTA4MQ"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzYwNTQ1MjM0NjQ2Mjc5NjQ3NDUvNjA1NDUyMzQ2NDYyNzk2NTA4MQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzYwNTQ1MjM0NjQ2Mjc5NjQ3NDUvNjA1NDUyMzQ2NDYyNzk2NTA4MQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "concept"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "AbstractConceptDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzExNjkxMjU3ODcxMzU"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzYwNTQ1MjM0NjQ2Mjc5NjQ3NDU"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMDk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMDk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DocumentedNodeAnnotation"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMDkvNzg2MjcxMTgzOTQyMjYxNTIxNw",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMDkvNzg2MjcxMTgzOTQyMjYxNTIyNA"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "DocumentationObjective",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMTQ"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMDkvNzg2MjcxMTgzOTQyMjYxNTIxNw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMDkvNzg2MjcxMTgzOTQyMjYxNTIxNw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "text"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMDk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMDkvNzg2MjcxMTgzOTQyMjYxNTIyNA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMDkvNzg2MjcxMTgzOTQyMjYxNTIyNA"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "seeAlso"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "DocumentationObjectiveRef",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMjE"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMDk"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMTQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMTQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DocumentationObjective"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMjE",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMjE"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DocumentationObjectiveRef"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMjEvNzg2MjcxMTgzOTQyMjYxNTIyMg"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [
+        "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMjE-ConceptDescription"
+      ],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMjE-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": "smart reference to documentable target"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMjE"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMjEvNzg2MjcxMTgzOTQyMjYxNTIyMg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMjEvNzg2MjcxMTgzOTQyMjYxNTIyMg"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "target"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "DocumentationObjective",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMTQ"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc4NjI3MTE4Mzk0MjI2MTUyMjE"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc5NTQxNDc1NjMwNDUyODMyOTY",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzc5NTQxNDc1NjMwNDUyODMyOTY"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "INamedAspect"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "INamed",
+              "reference": "LionCore-builtins-INamed"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDg0NjQ5OTA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDg0NjQ5OTA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "RefPresentationTemplate"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDg0NjQ5OTAvNDMwNzc1ODY1NDY5NzUyNDA1Nw",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDg0NjQ5OTAvNDMwNzc1ODY1NDY5NzUyNDA2MA"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [
+        "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDg0NjQ5OTA-ConceptDescription"
+      ],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDg0NjQ5OTA-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "template"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDg0NjQ5OTA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDg0NjQ5OTAvNDMwNzc1ODY1NDY5NzUyNDA1Nw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDg0NjQ5OTAvNDMwNzc1ODY1NDY5NzUyNDA1Nw"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "prefix"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDg0NjQ5OTA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDg0NjQ5OTAvNDMwNzc1ODY1NDY5NzUyNDA2MA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDg0NjQ5OTAvNDMwNzc1ODY1NDY5NzUyNDA2MA"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "suffix"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDg0NjQ5OTA"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDgyMDc1OTI",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDgyMDc1OTI"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "SmartReferenceAttribute"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDgyMDc1OTIvODg0MjczMjc3Nzc0ODIwNzU5Nw",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDgyMDc1OTIvODg0MjczMjc3Nzc0ODQ3NDkzNQ"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Concept",
+              "reference": "-id-Concept"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [
+        "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDgyMDc1OTI-ConceptDescription"
+      ],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDgyMDc1OTI-ConceptDescription",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "ConceptDescription"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptAlias"
+          },
+          "value": "@smart reference"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "ConceptDescription-conceptShortDescription"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDgyMDc1OTI"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDgyMDc1OTIvODg0MjczMjc3Nzc0ODIwNzU5Nw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDgyMDc1OTIvODg0MjczMjc3Nzc0ODIwNzU5Nw"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "charactersticReference"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "LinkDeclaration",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzEwNzE0ODkyODgyOTg"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDgyMDc1OTI"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDgyMDc1OTIvODg0MjczMjc3Nzc0ODQ3NDkzNQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDgyMDc1OTIvODg0MjczMjc3Nzc0ODQ3NDkzNQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "refPresentationTemplate"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "RefPresentationTemplate",
+              "reference": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDg0NjQ5OTA"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3Lzg4NDI3MzI3Nzc3NDgyMDc1OTI"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzgwODcwNDczMDUwODA3NzQ5MDQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Enumeration"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzgwODcwNDczMDUwODA3NzQ5MDQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "InstanceIncomingReferencesPolicy"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Enumeration-literals"
+          },
+          "children": [
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzgwODcwNDczMDUwODA3NzQ5MDQvODA4NzA0NzMwNTA4MDc3NTI4Mg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzgwODcwNDczMDUwODA3NzQ5MDQvODA4NzA0NzMwNTA4MDc3NTQxMg",
+            "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzgwODcwNDczMDUwODA3NzQ5MDQvODA4NzA0NzMwNTA4MDc3NTQxNg"
+          ]
+        }
+      ],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzgwODcwNDczMDUwODA3NzQ5MDQvODA4NzA0NzMwNTA4MDc3NTI4Mg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzgwODcwNDczMDUwODA3NzQ5MDQvODA4NzA0NzMwNTA4MDc3NTI4Mg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "allowed"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzgwODcwNDczMDUwODA3NzQ5MDQ"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzgwODcwNDczMDUwODA3NzQ5MDQvODA4NzA0NzMwNTA4MDc3NTQxMg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzgwODcwNDczMDUwODA3NzQ5MDQvODA4NzA0NzMwNTA4MDc3NTQxMg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "local"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzgwODcwNDczMDUwODA3NzQ5MDQ"
+    },
+    {
+      "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzgwODcwNDczMDUwODA3NzQ5MDQvODA4NzA0NzMwNTA4MDc3NTQxNg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzgwODcwNDczMDUwODA3NzQ5MDQvODA4NzA0NzMwNTA4MDc3NTQxNg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "forbidden"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3LzgwODcwNDczMDUwODA3NzQ5MDQ"
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/TestDeps-PluginStandalone-annotated.json
+++ b/solutions/io.lionweb.mps.json.test/resources/TestDeps-PluginStandalone-annotated.json
@@ -16,76 +16,6 @@
   ],
   "nodes": [
     {
-      "id": "LionCore-builtins",
-      "classifier": {
-        "language": "LionCore-M3",
-        "version": "2023.1",
-        "key": "Language"
-      },
-      "properties": [
-        {
-          "property": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "IKeyed-key"
-          },
-          "value": "LionCore-builtins"
-        },
-        {
-          "property": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Language-version"
-          },
-          "value": "2"
-        },
-        {
-          "property": {
-            "language": "LionCore-builtins",
-            "version": "2023.1",
-            "key": "LionCore-builtins-INamed-name"
-          },
-          "value": "jetbrains.mps.lang.core"
-        }
-      ],
-      "containments": [
-        {
-          "containment": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Language-entities"
-          },
-          "children": [
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzExOTY5Nzg2MzAyMTQ",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjQ2MDg4MzQ0NDU",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzMxNjAyOTY1OTc",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzQ5NzEzNTg0NTA",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMwNzc3MTk",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMxNTE0Nzk",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzM3MzQxMTYyMTMxMjk3OTI0OTk",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjE0NzUzNzUxNTc0NjY1NTg",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODY",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzY5OTk3MzgyODg3Mzg0MjcxOTA",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTQ5MjYxOTIyMzQwMzYxODQ"
-          ]
-        }
-      ],
-      "references": [
-        {
-          "reference": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Language-dependsOn"
-          },
-          "targets": []
-        }
-      ],
-      "annotations": [],
-      "parent": null
-    },
-    {
       "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIx",
       "classifier": {
         "language": "LionCore-M3",
@@ -153,16 +83,16 @@
           },
           "targets": [
             {
-              "resolveInfo": "jetbrains.mps.lang.core",
-              "reference": "LionCore-builtins"
-            },
-            {
               "resolveInfo": "jetbrains.mps.baseLanguage.classifiers",
               "reference": "NDQzZjRjMzYtZmNmNS00ZWI2LTk1MDAtOGQwNmVkMjU5ZTNl"
             },
             {
               "resolveInfo": "jetbrains.mps.lang.resources",
               "reference": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1"
+            },
+            {
+              "resolveInfo": "jetbrains.mps.lang.core",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
             },
             {
               "resolveInfo": "jetbrains.mps.lang.structure",
@@ -2997,7 +2927,7 @@
           "targets": [
             {
               "resolveInfo": "jetbrains.mps.lang.core",
-              "reference": "LionCore-builtins"
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
             },
             {
               "resolveInfo": "jetbrains.mps.baseLanguage",
@@ -3738,6 +3668,76 @@
       "parent": "OWRlZDA5OGItYWQ2YS00NjU3LWJmZDktNDg2MzZjZmU4YmMz"
     },
     {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Language"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-version"
+          },
+          "value": "2"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "jetbrains.mps.lang.core"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-entities"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzExOTY5Nzg2MzAyMTQ",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjQ2MDg4MzQ0NDU",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzMxNjAyOTY1OTc",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzQ5NzEzNTg0NTA",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMwNzc3MTk",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMxNTE0Nzk",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzM3MzQxMTYyMTMxMjk3OTI0OTk",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjE0NzUzNzUxNTc0NjY1NTg",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODY",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzY5OTk3MzgyODg3Mzg0MjcxOTA",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTQ5MjYxOTIyMzQwMzYxODQ"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-dependsOn"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": null
+    },
+    {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzExOTY5Nzg2MzAyMTQ",
       "classifier": {
         "language": "LionCore-M3",
@@ -3785,7 +3785,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzExOTY5Nzg2MzAyMTQvMTE5Njk3ODY1NjI3Nw",
@@ -3885,7 +3885,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzMxNjAyOTY1OTc",
@@ -3933,7 +3933,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzQ5NzEzNTg0NTA",
@@ -3981,7 +3981,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMwNzc3MTk",
@@ -4034,7 +4034,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMxNTE0Nzk",
@@ -4082,7 +4082,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY",
@@ -4130,7 +4130,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzM3MzQxMTYyMTMxMjk3OTI0OTk",
@@ -4178,7 +4178,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjE0NzUzNzUxNTc0NjY1NTg",
@@ -4226,7 +4226,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODY",
@@ -4274,7 +4274,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc",
@@ -4322,7 +4322,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzY5OTk3MzgyODg3Mzg0MjcxOTA",
@@ -4375,7 +4375,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTQ5MjYxOTIyMzQwMzYxODQ",
@@ -4423,7 +4423,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3",
@@ -4479,12 +4479,12 @@
           },
           "targets": [
             {
-              "resolveInfo": "jetbrains.mps.lang.core",
-              "reference": "LionCore-builtins"
-            },
-            {
               "resolveInfo": "jetbrains.mps.lang.resources",
               "reference": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1"
+            },
+            {
+              "resolveInfo": "jetbrains.mps.lang.core",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
             }
           ]
         }

--- a/solutions/io.lionweb.mps.json.test/resources/TestDeps-PluginStandalone.json
+++ b/solutions/io.lionweb.mps.json.test/resources/TestDeps-PluginStandalone.json
@@ -12,76 +12,6 @@
   ],
   "nodes": [
     {
-      "id": "LionCore-builtins",
-      "classifier": {
-        "language": "LionCore-M3",
-        "version": "2023.1",
-        "key": "Language"
-      },
-      "properties": [
-        {
-          "property": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "IKeyed-key"
-          },
-          "value": "LionCore-builtins"
-        },
-        {
-          "property": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Language-version"
-          },
-          "value": "2"
-        },
-        {
-          "property": {
-            "language": "LionCore-builtins",
-            "version": "2023.1",
-            "key": "LionCore-builtins-INamed-name"
-          },
-          "value": "jetbrains.mps.lang.core"
-        }
-      ],
-      "containments": [
-        {
-          "containment": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Language-entities"
-          },
-          "children": [
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzExOTY5Nzg2MzAyMTQ",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjQ2MDg4MzQ0NDU",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzMxNjAyOTY1OTc",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzQ5NzEzNTg0NTA",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMwNzc3MTk",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMxNTE0Nzk",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzM3MzQxMTYyMTMxMjk3OTI0OTk",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjE0NzUzNzUxNTc0NjY1NTg",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODY",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzY5OTk3MzgyODg3Mzg0MjcxOTA",
-            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTQ5MjYxOTIyMzQwMzYxODQ"
-          ]
-        }
-      ],
-      "references": [
-        {
-          "reference": {
-            "language": "LionCore-M3",
-            "version": "2023.1",
-            "key": "Language-dependsOn"
-          },
-          "targets": []
-        }
-      ],
-      "annotations": [],
-      "parent": null
-    },
-    {
       "id": "MjhmOWU0OTctM2I0Mi00MjkxLWFlYmEtMGExMDM5MTUzYWIx",
       "classifier": {
         "language": "LionCore-M3",
@@ -149,16 +79,16 @@
           },
           "targets": [
             {
-              "resolveInfo": "jetbrains.mps.lang.core",
-              "reference": "LionCore-builtins"
-            },
-            {
               "resolveInfo": "jetbrains.mps.baseLanguage.classifiers",
               "reference": "NDQzZjRjMzYtZmNmNS00ZWI2LTk1MDAtOGQwNmVkMjU5ZTNl"
             },
             {
               "resolveInfo": "jetbrains.mps.lang.resources",
               "reference": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1"
+            },
+            {
+              "resolveInfo": "jetbrains.mps.lang.core",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
             },
             {
               "resolveInfo": "jetbrains.mps.lang.structure",
@@ -2705,7 +2635,7 @@
           "targets": [
             {
               "resolveInfo": "jetbrains.mps.lang.core",
-              "reference": "LionCore-builtins"
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
             },
             {
               "resolveInfo": "jetbrains.mps.baseLanguage",
@@ -3446,6 +3376,76 @@
       "parent": "OWRlZDA5OGItYWQ2YS00NjU3LWJmZDktNDg2MzZjZmU4YmMz"
     },
     {
+      "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Language"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-version"
+          },
+          "value": "2"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "jetbrains.mps.lang.core"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-entities"
+          },
+          "children": [
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzExOTY5Nzg2MzAyMTQ",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMjQ2MDg4MzQ0NDU",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzMxNjAyOTY1OTc",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzQ5NzEzNTg0NTA",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMwNzc3MTk",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMxNTE0Nzk",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzM3MzQxMTYyMTMxMjk3OTI0OTk",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjE0NzUzNzUxNTc0NjY1NTg",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODY",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzY5OTk3MzgyODg3Mzg0MjcxOTA",
+            "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTQ5MjYxOTIyMzQwMzYxODQ"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-dependsOn"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": null
+    },
+    {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzExOTY5Nzg2MzAyMTQ",
       "classifier": {
         "language": "LionCore-M3",
@@ -3493,7 +3493,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzExOTY5Nzg2MzAyMTQvMTE5Njk3ODY1NjI3Nw",
@@ -3593,7 +3593,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzMxNjAyOTY1OTc",
@@ -3641,7 +3641,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEyMzQ5NzEzNTg0NTA",
@@ -3689,7 +3689,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMwNzc3MTk",
@@ -3742,7 +3742,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODMxNTE0Nzk",
@@ -3790,7 +3790,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzEzMTk3MjgyNzQ3ODQ5NzMwOTY",
@@ -3838,7 +3838,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzM3MzQxMTYyMTMxMjk3OTI0OTk",
@@ -3886,7 +3886,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzNjE0NzUzNzUxNTc0NjY1NTg",
@@ -3934,7 +3934,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODY",
@@ -3982,7 +3982,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzMzOTMxNjUxMjE4NDYwOTE1ODc",
@@ -4030,7 +4030,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzY5OTk3MzgyODg3Mzg0MjcxOTA",
@@ -4083,7 +4083,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBjLzcwOTQ5MjYxOTIyMzQwMzYxODQ",
@@ -4131,7 +4131,7 @@
         }
       ],
       "annotations": [],
-      "parent": "LionCore-builtins"
+      "parent": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
     },
     {
       "id": "YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3",
@@ -4187,12 +4187,12 @@
           },
           "targets": [
             {
-              "resolveInfo": "jetbrains.mps.lang.core",
-              "reference": "LionCore-builtins"
-            },
-            {
               "resolveInfo": "jetbrains.mps.lang.resources",
               "reference": "OTgyZWI4ZGYtMmM5Ni00YmQ3LTk5NjMtMTE3MTJlYTYyMmU1"
+            },
+            {
+              "resolveInfo": "jetbrains.mps.lang.core",
+              "reference": "Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj"
             }
           ]
         }

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.lionweb2mps.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.lionweb2mps.mps
@@ -702,7 +702,7 @@
                       <ref role="2Gs0qQ" node="7OJcYqyLKMb" resolve="prop" />
                     </node>
                     <node concept="liA8E" id="7OJcYqyMsdv" role="2OqNvi">
-                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getStaple" />
                     </node>
                   </node>
                   <node concept="liA8E" id="7OJcYqyMxm2" role="2OqNvi">
@@ -734,7 +734,7 @@
               <ref role="3cqZAo" node="5JNiskj75AZ" resolve="jsonConstants" />
             </node>
             <node concept="liA8E" id="7OJcYqyMPkU" role="2OqNvi">
-              <ref role="37wK5l" to="6peh:5JNiskjpjYQ" resolve="listSpecificAnnotationMembers" />
+              <ref role="37wK5l" to="6peh:5JNiskjpjYQ" resolve="listMpsM1AnnotationPropertyMembers" />
             </node>
           </node>
         </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.lionweb2mps.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.lionweb2mps.mps
@@ -50,9 +50,6 @@
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
-      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
-        <child id="1076505808688" name="condition" index="2$JKZa" />
-      </concept>
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
@@ -273,12 +270,6 @@
       <concept id="1207233427108" name="jetbrains.mps.baseLanguage.collections.structure.MapRemoveOperation" flags="nn" index="kI3uX">
         <child id="1207233489861" name="key" index="kIiFs" />
       </concept>
-      <concept id="1237467461002" name="jetbrains.mps.baseLanguage.collections.structure.GetIteratorOperation" flags="nn" index="uNJiE" />
-      <concept id="1237467705688" name="jetbrains.mps.baseLanguage.collections.structure.IteratorType" flags="in" index="uOF1S">
-        <child id="1237467730343" name="elementType" index="uOL27" />
-      </concept>
-      <concept id="1237470895604" name="jetbrains.mps.baseLanguage.collections.structure.HasNextOperation" flags="nn" index="v0PNk" />
-      <concept id="1237471031357" name="jetbrains.mps.baseLanguage.collections.structure.GetNextOperation" flags="nn" index="v1n4t" />
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -674,27 +665,6 @@
       </node>
       <node concept="3clFbS" id="5JNiskjdXnb" role="3clF47">
         <node concept="3clFbH" id="5JNiskjrp1A" role="3cqZAp" />
-        <node concept="3cpWs8" id="5JNiskjdXnc" role="3cqZAp">
-          <node concept="3cpWsn" id="5JNiskjdXnd" role="3cpWs9">
-            <property role="TrG5h" value="conceptWithMetaPointer" />
-            <node concept="3rvAFt" id="5JNiskjdXne" role="1tU5fm">
-              <node concept="3uibUv" id="5JNiskjdXnf" role="3rvQeY">
-                <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-              </node>
-              <node concept="3uibUv" id="5JNiskjdXng" role="3rvSg0">
-                <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5JNiskj_uY_" role="33vP2m">
-              <node concept="37vLTw" id="5JNiskj_svF" role="2Oq$k0">
-                <ref role="3cqZAo" node="5JNiskj75AZ" resolve="jsonConstants" />
-              </node>
-              <node concept="liA8E" id="5JNiskj_x2P" role="2OqNvi">
-                <ref role="37wK5l" to="6peh:5JNiskjt_st" resolve="mapSpecificAnnotationMembers" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3clFbH" id="5JNiskjsjWl" role="3cqZAp" />
         <node concept="3cpWs8" id="5JNiskjdXnC" role="3cqZAp">
           <node concept="3cpWsn" id="5JNiskjdXnD" role="3cpWs9">
@@ -719,109 +689,77 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="5JNiskjq4Ja" role="3cqZAp">
-          <node concept="3cpWsn" id="5JNiskjq4Jb" role="3cpWs9">
-            <property role="TrG5h" value="conceptIter" />
-            <node concept="uOF1S" id="5JNiskj_KCX" role="1tU5fm">
-              <node concept="3uibUv" id="5JNiskj_MtK" role="uOL27">
-                <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5JNiskjq4Jc" role="33vP2m">
-              <node concept="2OqwBi" id="5JNiskj_OnV" role="2Oq$k0">
-                <node concept="2OqwBi" id="5JNiskj_OnW" role="2Oq$k0">
-                  <node concept="37vLTw" id="5JNiskj_OnX" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5JNiskj75AZ" resolve="jsonConstants" />
+        <node concept="2Gpval" id="7OJcYqyLKM9" role="3cqZAp">
+          <node concept="2GrKxI" id="7OJcYqyLKMb" role="2Gsz3X">
+            <property role="TrG5h" value="prop" />
+          </node>
+          <node concept="3clFbS" id="7OJcYqyLKMf" role="2LFqv$">
+            <node concept="3clFbF" id="7OJcYqyLS$b" role="3cqZAp">
+              <node concept="37vLTI" id="7OJcYqyMPkP" role="3clFbG">
+                <node concept="2OqwBi" id="7OJcYqyMuyH" role="37vLTx">
+                  <node concept="2OqwBi" id="7OJcYqyMpwj" role="2Oq$k0">
+                    <node concept="2GrUjf" id="7OJcYqyMn2u" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="7OJcYqyLKMb" resolve="prop" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqyMsdv" role="2OqNvi">
+                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                    </node>
                   </node>
-                  <node concept="liA8E" id="5JNiskj_OnY" role="2OqNvi">
-                    <ref role="37wK5l" to="6peh:5JNiskjpjPN" resolve="listSpecificAnnotations" />
+                  <node concept="liA8E" id="7OJcYqyMxm2" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
                   </node>
                 </node>
-                <node concept="3$u5V9" id="5JNiskj_OnZ" role="2OqNvi">
-                  <node concept="1bVj0M" id="5JNiskj_Oo0" role="23t8la">
-                    <node concept="3clFbS" id="5JNiskj_Oo1" role="1bW5cS">
-                      <node concept="3clFbF" id="5JNiskj_Oo2" role="3cqZAp">
-                        <node concept="2YIFZM" id="5JNiskj_Oo3" role="3clFbG">
-                          <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-                          <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.LanguageEntity)" resolve="from" />
-                          <node concept="37vLTw" id="5JNiskj_Oo4" role="37wK5m">
-                            <ref role="3cqZAo" node="5JNiskj_Oo5" resolve="it" />
-                          </node>
-                        </node>
+                <node concept="3EllGN" id="7OJcYqyMPkQ" role="37vLTJ">
+                  <node concept="2YIFZM" id="7OJcYqyLZbu" role="3ElVtu">
+                    <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
+                    <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.Feature)" resolve="from" />
+                    <node concept="2OqwBi" id="7OJcYqyM3ec" role="37wK5m">
+                      <node concept="2GrUjf" id="7OJcYqyM19Y" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="7OJcYqyLKMb" resolve="prop" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYqyMh2X" role="2OqNvi">
+                        <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
                       </node>
                     </node>
-                    <node concept="Rh6nW" id="5JNiskj_Oo5" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="5JNiskj_Oo6" role="1tU5fm" />
-                    </node>
                   </node>
-                </node>
-              </node>
-              <node concept="uNJiE" id="5JNiskjq4Jg" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="5JNiskjqkVL" role="3cqZAp">
-          <node concept="3cpWsn" id="5JNiskjqkVM" role="3cpWs9">
-            <property role="TrG5h" value="propertyIter" />
-            <node concept="uOF1S" id="5JNiskj_W4S" role="1tU5fm">
-              <node concept="3uibUv" id="5JNiskj_Y9S" role="uOL27">
-                <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5JNiskjqkVN" role="33vP2m">
-              <node concept="2OqwBi" id="5JNiskjqkVO" role="2Oq$k0">
-                <node concept="37vLTw" id="5JNiskjqkVP" role="2Oq$k0">
-                  <ref role="3cqZAo" node="4WflrVakKoY" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="5JNiskjqkVQ" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiskjpaH9" resolve="listSpecificAnnotationProperties" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5JNiskjqkVR" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="2$JKZl" id="5JNiskjqsJB" role="3cqZAp">
-          <node concept="3clFbS" id="5JNiskjqsJD" role="2LFqv$">
-            <node concept="3clFbF" id="5JNiskjqMZd" role="3cqZAp">
-              <node concept="37vLTI" id="5JNiskjrALJ" role="3clFbG">
-                <node concept="2OqwBi" id="5JNiskjrEXb" role="37vLTx">
-                  <node concept="37vLTw" id="5JNiskjrCOD" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5JNiskjqkVM" resolve="propertyIter" />
-                  </node>
-                  <node concept="v1n4t" id="5JNiskjrGHz" role="2OqNvi" />
-                </node>
-                <node concept="3EllGN" id="5JNiskjruX0" role="37vLTJ">
-                  <node concept="2OqwBi" id="5JNiskjryQl" role="3ElVtu">
-                    <node concept="37vLTw" id="5JNiskjrwPt" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5JNiskjq4Jb" resolve="conceptIter" />
-                    </node>
-                    <node concept="v1n4t" id="5JNiskjr$Kk" role="2OqNvi" />
-                  </node>
-                  <node concept="37vLTw" id="5JNiskjqMZc" role="3ElQJh">
+                  <node concept="37vLTw" id="7OJcYqyMPkR" role="3ElQJh">
                     <ref role="3cqZAo" node="5JNiskjdXnD" resolve="conceptWithProperty" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="1Wc70l" id="5JNiskjqzsZ" role="2$JKZa">
-            <node concept="2OqwBi" id="5JNiskjqADo" role="3uHU7w">
-              <node concept="37vLTw" id="5JNiskjq_5M" role="2Oq$k0">
-                <ref role="3cqZAo" node="5JNiskjqkVM" resolve="propertyIter" />
-              </node>
-              <node concept="v0PNk" id="5JNiskjqC$B" role="2OqNvi" />
+          <node concept="2OqwBi" id="7OJcYqyMPkS" role="2GsD0m">
+            <node concept="37vLTw" id="7OJcYqyMPkT" role="2Oq$k0">
+              <ref role="3cqZAo" node="5JNiskj75AZ" resolve="jsonConstants" />
             </node>
-            <node concept="2OqwBi" id="5JNiskjqwb$" role="3uHU7B">
-              <node concept="37vLTw" id="5JNiskjquCu" role="2Oq$k0">
-                <ref role="3cqZAo" node="5JNiskjq4Jb" resolve="conceptIter" />
-              </node>
-              <node concept="v0PNk" id="5JNiskjqxS5" role="2OqNvi" />
+            <node concept="liA8E" id="7OJcYqyMPkU" role="2OqNvi">
+              <ref role="37wK5l" to="6peh:5JNiskjpjYQ" resolve="listSpecificAnnotationMembers" />
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="5JNiskjdXo2" role="3cqZAp" />
+        <node concept="3cpWs8" id="5JNiskjdXnc" role="3cqZAp">
+          <node concept="3cpWsn" id="5JNiskjdXnd" role="3cpWs9">
+            <property role="TrG5h" value="conceptWithMetaPointer" />
+            <node concept="3rvAFt" id="5JNiskjdXne" role="1tU5fm">
+              <node concept="3uibUv" id="5JNiskjdXnf" role="3rvQeY">
+                <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
+              </node>
+              <node concept="3uibUv" id="5JNiskjdXng" role="3rvSg0">
+                <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="5JNiskj_uY_" role="33vP2m">
+              <node concept="37vLTw" id="5JNiskj_svF" role="2Oq$k0">
+                <ref role="3cqZAo" node="5JNiskj75AZ" resolve="jsonConstants" />
+              </node>
+              <node concept="liA8E" id="5JNiskj_x2P" role="2OqNvi">
+                <ref role="37wK5l" to="6peh:5JNiskjt_st" resolve="mapSpecificAnnotationMembers" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="2Gpval" id="5JNiskjdXo3" role="3cqZAp">
           <node concept="2GrKxI" id="5JNiskjdXo4" role="2Gsz3X">
             <property role="TrG5h" value="internal" />
@@ -1574,12 +1512,17 @@
                     <node concept="37vLTw" id="jyNOuY_yxf" role="37wK5m">
                       <ref role="3cqZAo" node="2fx6VTSt4eH" resolve="mps" />
                     </node>
-                    <node concept="2OqwBi" id="4WflrVakOCb" role="37wK5m">
-                      <node concept="37vLTw" id="4WflrVakNcq" role="2Oq$k0">
-                        <ref role="3cqZAo" node="4WflrVakKoY" resolve="constants" />
+                    <node concept="2OqwBi" id="7OJcYqyMUi9" role="37wK5m">
+                      <node concept="2OqwBi" id="4WflrVakOCb" role="2Oq$k0">
+                        <node concept="37vLTw" id="4WflrVakNcq" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4WflrVakKoY" resolve="constants" />
+                        </node>
+                        <node concept="liA8E" id="5JNiskhTEJy" role="2OqNvi">
+                          <ref role="37wK5l" to="y7p:7OJcYqwQm2a" resolve="getAnnotationContainment" />
+                        </node>
                       </node>
-                      <node concept="liA8E" id="5JNiskhTEJy" role="2OqNvi">
-                        <ref role="37wK5l" to="y7p:5JNiski3jX7" resolve="slangAnnotationContainment" />
+                      <node concept="liA8E" id="7OJcYqyMWuk" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
                       </node>
                     </node>
                     <node concept="2GrUjf" id="jyNOuY_BV2" role="37wK5m">

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.lionweb2mps.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.lionweb2mps.mps
@@ -666,100 +666,6 @@
       <node concept="3clFbS" id="5JNiskjdXnb" role="3clF47">
         <node concept="3clFbH" id="5JNiskjrp1A" role="3cqZAp" />
         <node concept="3clFbH" id="5JNiskjsjWl" role="3cqZAp" />
-        <node concept="3cpWs8" id="5JNiskjdXnC" role="3cqZAp">
-          <node concept="3cpWsn" id="5JNiskjdXnD" role="3cpWs9">
-            <property role="TrG5h" value="conceptWithProperty" />
-            <node concept="3rvAFt" id="5JNiskjdXnE" role="1tU5fm">
-              <node concept="3uibUv" id="5JNiskjdXnF" role="3rvQeY">
-                <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-              </node>
-              <node concept="3uibUv" id="5JNiskjdXnG" role="3rvSg0">
-                <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-              </node>
-            </node>
-            <node concept="2ShNRf" id="5JNiskjdXnH" role="33vP2m">
-              <node concept="32Fmki" id="5JNiskjdXnI" role="2ShVmc">
-                <node concept="3uibUv" id="5JNiskjdXnJ" role="3rHrn6">
-                  <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-                </node>
-                <node concept="3uibUv" id="5JNiskjdXnK" role="3rHtpV">
-                  <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2Gpval" id="7OJcYqyLKM9" role="3cqZAp">
-          <node concept="2GrKxI" id="7OJcYqyLKMb" role="2Gsz3X">
-            <property role="TrG5h" value="prop" />
-          </node>
-          <node concept="3clFbS" id="7OJcYqyLKMf" role="2LFqv$">
-            <node concept="3clFbF" id="7OJcYqyLS$b" role="3cqZAp">
-              <node concept="37vLTI" id="7OJcYqyMPkP" role="3clFbG">
-                <node concept="2OqwBi" id="7OJcYqyMuyH" role="37vLTx">
-                  <node concept="2OqwBi" id="7OJcYqyMpwj" role="2Oq$k0">
-                    <node concept="2GrUjf" id="7OJcYqyMn2u" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="7OJcYqyLKMb" resolve="prop" />
-                    </node>
-                    <node concept="liA8E" id="7OJcYqyMsdv" role="2OqNvi">
-                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getStaple" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="7OJcYqyMxm2" role="2OqNvi">
-                    <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
-                  </node>
-                </node>
-                <node concept="3EllGN" id="7OJcYqyMPkQ" role="37vLTJ">
-                  <node concept="2YIFZM" id="7OJcYqyLZbu" role="3ElVtu">
-                    <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-                    <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.Feature)" resolve="from" />
-                    <node concept="2OqwBi" id="7OJcYqyM3ec" role="37wK5m">
-                      <node concept="2GrUjf" id="7OJcYqyM19Y" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="7OJcYqyLKMb" resolve="prop" />
-                      </node>
-                      <node concept="liA8E" id="7OJcYqyMh2X" role="2OqNvi">
-                        <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="37vLTw" id="7OJcYqyMPkR" role="3ElQJh">
-                    <ref role="3cqZAo" node="5JNiskjdXnD" resolve="conceptWithProperty" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="2OqwBi" id="7OJcYqyMPkS" role="2GsD0m">
-            <node concept="37vLTw" id="7OJcYqyMPkT" role="2Oq$k0">
-              <ref role="3cqZAo" node="5JNiskj75AZ" resolve="jsonConstants" />
-            </node>
-            <node concept="liA8E" id="7OJcYqyMPkU" role="2OqNvi">
-              <ref role="37wK5l" to="6peh:5JNiskjpjYQ" resolve="listMpsM1AnnotationPropertyMembers" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5JNiskjdXo2" role="3cqZAp" />
-        <node concept="3cpWs8" id="5JNiskjdXnc" role="3cqZAp">
-          <node concept="3cpWsn" id="5JNiskjdXnd" role="3cpWs9">
-            <property role="TrG5h" value="conceptWithMetaPointer" />
-            <node concept="3rvAFt" id="5JNiskjdXne" role="1tU5fm">
-              <node concept="3uibUv" id="5JNiskjdXnf" role="3rvQeY">
-                <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-              </node>
-              <node concept="3uibUv" id="5JNiskjdXng" role="3rvSg0">
-                <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5JNiskj_uY_" role="33vP2m">
-              <node concept="37vLTw" id="5JNiskj_svF" role="2Oq$k0">
-                <ref role="3cqZAo" node="5JNiskj75AZ" resolve="jsonConstants" />
-              </node>
-              <node concept="liA8E" id="5JNiskj_x2P" role="2OqNvi">
-                <ref role="37wK5l" to="6peh:5JNiskjt_st" resolve="mapSpecificAnnotationMembers" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="2Gpval" id="5JNiskjdXo3" role="3cqZAp">
           <node concept="2GrKxI" id="5JNiskjdXo4" role="2Gsz3X">
             <property role="TrG5h" value="internal" />
@@ -837,18 +743,49 @@
                 </node>
               </node>
             </node>
-            <node concept="3cpWs8" id="5JNiskjdXoA" role="3cqZAp">
-              <node concept="3cpWsn" id="5JNiskjdXoB" role="3cpWs9">
-                <property role="TrG5h" value="propertyMetaPointer" />
-                <node concept="3uibUv" id="5JNiskjdXoC" role="1tU5fm">
-                  <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
+            <node concept="3cpWs8" id="7OJcYq_5AkM" role="3cqZAp">
+              <node concept="3cpWsn" id="7OJcYq_5AkN" role="3cpWs9">
+                <property role="TrG5h" value="staple" />
+                <node concept="3uibUv" id="7OJcYq_5_Qr" role="1tU5fm">
+                  <ref role="3uigEE" to="6peh:7OJcYq_2Ogv" resolve="JsonAnnotationPropertyStaple" />
                 </node>
-                <node concept="3EllGN" id="5JNiskjdXoD" role="33vP2m">
-                  <node concept="37vLTw" id="5JNiskjdXoE" role="3ElVtu">
-                    <ref role="3cqZAo" node="5JNiskjdXox" resolve="classifier" />
+                <node concept="2OqwBi" id="7OJcYq_5AkO" role="33vP2m">
+                  <node concept="2OqwBi" id="7OJcYq_5AkP" role="2Oq$k0">
+                    <node concept="37vLTw" id="7OJcYq_5AkQ" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5JNiskj75AZ" resolve="jsonConstants" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYq_5AkR" role="2OqNvi">
+                      <ref role="37wK5l" to="6peh:5JNiskjpjPN" resolve="listMpsM1Annotations" />
+                    </node>
                   </node>
-                  <node concept="37vLTw" id="5JNiskjdXoF" role="3ElQJh">
-                    <ref role="3cqZAo" node="5JNiskjdXnd" resolve="conceptWithMetaPointer" />
+                  <node concept="1z4cxt" id="7OJcYq_5AkS" role="2OqNvi">
+                    <node concept="1bVj0M" id="7OJcYq_5AkT" role="23t8la">
+                      <node concept="3clFbS" id="7OJcYq_5AkU" role="1bW5cS">
+                        <node concept="3clFbF" id="7OJcYq_5AkV" role="3cqZAp">
+                          <node concept="17R0WA" id="7OJcYq_5AkW" role="3clFbG">
+                            <node concept="37vLTw" id="7OJcYq_5AkX" role="3uHU7w">
+                              <ref role="3cqZAo" node="5JNiskjdXox" resolve="classifier" />
+                            </node>
+                            <node concept="2YIFZM" id="7OJcYq_5AkY" role="3uHU7B">
+                              <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
+                              <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.LanguageEntity)" resolve="from" />
+                              <node concept="2OqwBi" id="7OJcYq_5AkZ" role="37wK5m">
+                                <node concept="37vLTw" id="7OJcYq_5Al0" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7OJcYq_5Al2" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="7OJcYq_5Al1" role="2OqNvi">
+                                  <ref role="37wK5l" to="6peh:7OJcYq_2Qii" resolve="getJsonAnnotation" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="7OJcYq_5Al2" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7OJcYq_5Al3" role="1tU5fm" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -859,7 +796,7 @@
               </node>
               <node concept="3clFbC" id="5JNiskjdXoJ" role="3clFbw">
                 <node concept="37vLTw" id="5JNiskjdXoK" role="3uHU7B">
-                  <ref role="3cqZAo" node="5JNiskjdXoB" resolve="propertyMetaPointer" />
+                  <ref role="3cqZAo" node="7OJcYq_5AkN" resolve="staple" />
                 </node>
                 <node concept="10Nm6u" id="5JNiskjdXoL" role="3uHU7w" />
               </node>
@@ -874,8 +811,17 @@
                   </node>
                   <node concept="liA8E" id="RuBGkv9LsA" role="2OqNvi">
                     <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getPropertyValue(io.lionweb.lioncore.java.serialization.data.MetaPointer)" resolve="getPropertyValue" />
-                    <node concept="37vLTw" id="RuBGkv9OEK" role="37wK5m">
-                      <ref role="3cqZAo" node="5JNiskjdXoB" resolve="propertyMetaPointer" />
+                    <node concept="2YIFZM" id="7OJcYq_5H1M" role="37wK5m">
+                      <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.Feature)" resolve="from" />
+                      <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
+                      <node concept="2OqwBi" id="7OJcYq_5Kcz" role="37wK5m">
+                        <node concept="37vLTw" id="7OJcYq_5IxR" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7OJcYq_5AkN" resolve="staple" />
+                        </node>
+                        <node concept="liA8E" id="7OJcYq_5Mhd" role="2OqNvi">
+                          <ref role="37wK5l" to="6peh:7OJcYqxTQ2j" resolve="getJson" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -899,12 +845,17 @@
                 </node>
                 <node concept="liA8E" id="5JNiskjdXpn" role="2OqNvi">
                   <ref role="37wK5l" to="mhbf:~SNode.setProperty(org.jetbrains.mps.openapi.language.SProperty,java.lang.String)" resolve="setProperty" />
-                  <node concept="3EllGN" id="5JNiskjdXpo" role="37wK5m">
-                    <node concept="37vLTw" id="5JNiskjdXpp" role="3ElVtu">
-                      <ref role="3cqZAo" node="5JNiskjdXox" resolve="classifier" />
+                  <node concept="2OqwBi" id="7OJcYq_5X27" role="37wK5m">
+                    <node concept="2OqwBi" id="7OJcYq_5SQR" role="2Oq$k0">
+                      <node concept="37vLTw" id="7OJcYq_5QGR" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYq_5AkN" resolve="staple" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYq_5V5d" role="2OqNvi">
+                        <ref role="37wK5l" to="6peh:7OJcYqxTQ2q" resolve="getStaple" />
+                      </node>
                     </node>
-                    <node concept="37vLTw" id="5JNiskjdXpq" role="3ElQJh">
-                      <ref role="3cqZAo" node="5JNiskjdXnD" resolve="conceptWithProperty" />
+                    <node concept="liA8E" id="7OJcYq_5ZaI" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
                     </node>
                   </node>
                   <node concept="37vLTw" id="5JNiskjdXps" role="37wK5m">

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.mps2lionweb.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.mps2lionweb.mps
@@ -126,6 +126,7 @@
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -170,7 +171,6 @@
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
-      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
@@ -315,6 +315,9 @@
       <concept id="1237909114519" name="jetbrains.mps.baseLanguage.collections.structure.GetValuesOperation" flags="nn" index="T8wYR" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="4611582986551314327" name="jetbrains.mps.baseLanguage.collections.structure.OfTypeOperation" flags="nn" index="UnYns">
+        <child id="4611582986551314344" name="requestedType" index="UnYnz" />
+      </concept>
       <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
       <concept id="1240216724530" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashMapCreator" flags="nn" index="32Fmki" />
       <concept id="1240217271293" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashSetCreator" flags="nn" index="32HrFt" />
@@ -328,10 +331,7 @@
         <child id="1197687035757" name="valueType" index="3rHtpV" />
       </concept>
       <concept id="7125221305512719026" name="jetbrains.mps.baseLanguage.collections.structure.CollectionType" flags="in" index="3vKaQO" />
-      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
-        <child id="1225711182005" name="list" index="1y566C" />
-        <child id="1225711191269" name="index" index="1y58nS" />
-      </concept>
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1240824834947" name="jetbrains.mps.baseLanguage.collections.structure.ValueAccessOperation" flags="nn" index="3AV6Ez" />
       <concept id="1240825616499" name="jetbrains.mps.baseLanguage.collections.structure.KeyAccessOperation" flags="nn" index="3AY5_j" />
@@ -1263,22 +1263,55 @@
       </node>
       <node concept="3clFbS" id="5JNiskj48ym" role="3clF47">
         <node concept="3clFbH" id="5JNiskjzN4H" role="3cqZAp" />
-        <node concept="3cpWs8" id="5JNiskjuxiJ" role="3cqZAp">
-          <node concept="3cpWsn" id="5JNiskjuxiK" role="3cpWs9">
-            <property role="TrG5h" value="index" />
-            <node concept="10Oyi0" id="5JNiskjuwfh" role="1tU5fm" />
-            <node concept="2OqwBi" id="5JNiskjuxiL" role="33vP2m">
-              <node concept="2OqwBi" id="5JNiskjuxiM" role="2Oq$k0">
-                <node concept="37vLTw" id="5JNiskjuxiN" role="2Oq$k0">
-                  <ref role="3cqZAo" node="4WflrVakKoY" resolve="constants" />
+        <node concept="3cpWs8" id="7OJcYqzRIlE" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqzRIlF" role="3cpWs9">
+            <property role="TrG5h" value="mapper" />
+            <node concept="3uibUv" id="7OJcYqzRH7N" role="1tU5fm">
+              <ref role="3uigEE" to="6peh:7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+              <node concept="3uibUv" id="7OJcYqzRH7T" role="11_B2D">
+                <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+              </node>
+              <node concept="3uibUv" id="7OJcYqzRH7S" role="11_B2D">
+                <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7OJcYqzRIlG" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqzRIlH" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYqzRIlI" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5JNiskjt9lC" resolve="jsonConstants" />
                 </node>
-                <node concept="liA8E" id="5JNiskjuxiO" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiskjpaH9" resolve="listSpecificAnnotationProperties" />
+                <node concept="liA8E" id="7OJcYqzRIlJ" role="2OqNvi">
+                  <ref role="37wK5l" to="6peh:5JNiskjpjPN" resolve="listSpecificAnnotations" />
                 </node>
               </node>
-              <node concept="2WmjW8" id="5JNiskjuxiP" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiskjuxiQ" role="25WWJ7">
-                  <ref role="3cqZAo" node="5JNiskj48$Z" resolve="mpsProp" />
+              <node concept="1z4cxt" id="7OJcYqzRIlK" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYqzRIlL" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYqzRIlM" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYqzRIlN" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYqzRIlO" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYqzRIlP" role="3uHU7w">
+                          <ref role="3cqZAo" node="5JNiskj48$Z" resolve="mpsProp" />
+                        </node>
+                        <node concept="2OqwBi" id="7OJcYqzRIlQ" role="3uHU7B">
+                          <node concept="2OqwBi" id="7OJcYqzRIlR" role="2Oq$k0">
+                            <node concept="37vLTw" id="7OJcYqzRIlS" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7OJcYqzRIlV" resolve="it" />
+                            </node>
+                            <node concept="liA8E" id="7OJcYqzRIlT" role="2OqNvi">
+                              <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="7OJcYqzRIlU" role="2OqNvi">
+                            <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYqzRIlV" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYqzRIlW" role="1tU5fm" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -1305,12 +1338,10 @@
               </node>
             </node>
           </node>
-          <node concept="3eOVzh" id="5JNiskjuRrs" role="3clFbw">
-            <node concept="3cmrfG" id="5JNiskjuVL3" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="37vLTw" id="5JNiskjuLNH" role="3uHU7B">
-              <ref role="3cqZAo" node="5JNiskjuxiK" resolve="index" />
+          <node concept="3clFbC" id="7OJcYqz_JkM" role="3clFbw">
+            <node concept="10Nm6u" id="7OJcYqz_P4S" role="3uHU7w" />
+            <node concept="37vLTw" id="7OJcYqz_DvB" role="3uHU7B">
+              <ref role="3cqZAo" node="7OJcYqzRIlF" resolve="mapper" />
             </node>
           </node>
         </node>
@@ -1321,17 +1352,12 @@
             <node concept="3uibUv" id="5JNiskjvTcf" role="1tU5fm">
               <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
             </node>
-            <node concept="1y4W85" id="5JNiskjvTXh" role="33vP2m">
-              <node concept="37vLTw" id="5JNiskjvTXi" role="1y58nS">
-                <ref role="3cqZAo" node="5JNiskjuxiK" resolve="index" />
+            <node concept="2OqwBi" id="7OJcYqzAJds" role="33vP2m">
+              <node concept="37vLTw" id="7OJcYqzADE3" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYqzRIlF" resolve="mapper" />
               </node>
-              <node concept="2OqwBi" id="5JNiskjvTXj" role="1y566C">
-                <node concept="37vLTw" id="5JNiskjvTXk" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5JNiskjt9lC" resolve="jsonConstants" />
-                </node>
-                <node concept="liA8E" id="5JNiskjvTXl" role="2OqNvi">
-                  <ref role="37wK5l" to="6peh:5JNiskjpjPN" resolve="listSpecificAnnotations" />
-                </node>
+              <node concept="liA8E" id="7OJcYqzANG0" role="2OqNvi">
+                <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
               </node>
             </node>
           </node>
@@ -1858,12 +1884,17 @@
                   </node>
                 </node>
               </node>
-              <node concept="2OqwBi" id="nWBHrKEkrK" role="2Oq$k0">
-                <node concept="37vLTw" id="nWBHrKEfAd" role="2Oq$k0">
-                  <ref role="3cqZAo" node="4WflrVakKoY" resolve="constants" />
+              <node concept="2OqwBi" id="7OJcYqyNDCA" role="2Oq$k0">
+                <node concept="2OqwBi" id="nWBHrKEkrK" role="2Oq$k0">
+                  <node concept="37vLTw" id="nWBHrKEfAd" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4WflrVakKoY" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="nWBHrKEoG9" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQm1t" resolve="getBoolean" />
+                  </node>
                 </node>
-                <node concept="liA8E" id="nWBHrKEoG9" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jVJ" resolve="slangBooleanType" />
+                <node concept="liA8E" id="7OJcYqyNIvC" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
                 </node>
               </node>
             </node>
@@ -5128,43 +5159,56 @@
         </node>
         <node concept="3clFbJ" id="7OJcYqvIvnR" role="3cqZAp">
           <node concept="3clFbS" id="7OJcYqvIvnT" role="3clFbx">
-            <node concept="3cpWs8" id="7OJcYqvI$f9" role="3cqZAp">
-              <node concept="3cpWsn" id="7OJcYqvI$fa" role="3cpWs9">
-                <property role="TrG5h" value="index" />
-                <node concept="10Oyi0" id="7OJcYqvI$fb" role="1tU5fm" />
-                <node concept="2OqwBi" id="7OJcYqvI$fc" role="33vP2m">
-                  <node concept="2OqwBi" id="7OJcYqvI$fd" role="2Oq$k0">
-                    <node concept="37vLTw" id="7OJcYqvI$fe" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
-                    </node>
-                    <node concept="liA8E" id="7OJcYqvI$ff" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:6Z_tmAegIrR" resolve="listSLanguageInternalFeatures" />
-                    </node>
-                  </node>
-                  <node concept="2WmjW8" id="7OJcYqvI$fg" role="2OqNvi">
-                    <node concept="37vLTw" id="7OJcYqvIA6r" role="25WWJ7">
-                      <ref role="3cqZAo" node="5s4Z0e0f9ky" resolve="property" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="3clFbF" id="7OJcYqvIFX4" role="3cqZAp">
               <node concept="37vLTI" id="7OJcYqvIGT5" role="3clFbG">
                 <node concept="37vLTw" id="7OJcYqvIFX2" role="37vLTJ">
                   <ref role="3cqZAo" node="7OJcYqvIBWI" resolve="key" />
                 </node>
-                <node concept="1y4W85" id="7OJcYqvI$fl" role="37vLTx">
-                  <node concept="37vLTw" id="7OJcYqvI$fm" role="1y58nS">
-                    <ref role="3cqZAo" node="7OJcYqvI$fa" resolve="index" />
+                <node concept="2OqwBi" id="7OJcYqzcyM2" role="37vLTx">
+                  <node concept="2OqwBi" id="7OJcYqzchT6" role="2Oq$k0">
+                    <node concept="2OqwBi" id="7OJcYqzcmPq" role="2Oq$k0">
+                      <node concept="2OqwBi" id="7OJcYqzcfn$" role="2Oq$k0">
+                        <node concept="37vLTw" id="7OJcYqzceyg" role="2Oq$k0">
+                          <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+                        </node>
+                        <node concept="liA8E" id="7OJcYqzcgi9" role="2OqNvi">
+                          <ref role="37wK5l" to="y7p:7OJcYqx2zDi" resolve="listMpsInternalFeature" />
+                        </node>
+                      </node>
+                      <node concept="UnYns" id="7OJcYqzcorX" role="2OqNvi">
+                        <node concept="3uibUv" id="7OJcYqzcpTO" role="UnYnz">
+                          <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyKeyMapping" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1z4cxt" id="7OJcYqzcj26" role="2OqNvi">
+                      <node concept="1bVj0M" id="7OJcYqzcj28" role="23t8la">
+                        <node concept="3clFbS" id="7OJcYqzcj29" role="1bW5cS">
+                          <node concept="3clFbF" id="7OJcYqzck9I" role="3cqZAp">
+                            <node concept="17R0WA" id="7OJcYqzcttr" role="3clFbG">
+                              <node concept="37vLTw" id="7OJcYqzcuh4" role="3uHU7w">
+                                <ref role="3cqZAo" node="5s4Z0e0f9ky" resolve="property" />
+                              </node>
+                              <node concept="2OqwBi" id="7OJcYqzcldD" role="3uHU7B">
+                                <node concept="37vLTw" id="7OJcYqzck9H" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7OJcYqzcj2a" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="7OJcYqzcs7E" role="2OqNvi">
+                                  <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="7OJcYqzcj2a" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="7OJcYqzcj2b" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
                   </node>
-                  <node concept="2OqwBi" id="7OJcYqvI$fn" role="1y566C">
-                    <node concept="37vLTw" id="7OJcYqvI$fo" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
-                    </node>
-                    <node concept="liA8E" id="7OJcYqvI$fp" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:6Z_tmAegWRd" resolve="listSClassifierInternalFeatureIds" />
-                    </node>
+                  <node concept="liA8E" id="7OJcYqzc$aJ" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKqdu" resolve="getLcKey" />
                   </node>
                 </node>
               </node>
@@ -5466,44 +5510,45 @@
           <node concept="3clFbS" id="6Z_tmAedT2o" role="3clFbx">
             <node concept="3clFbJ" id="6Z_tmAeeK0Y" role="3cqZAp">
               <node concept="3clFbS" id="6Z_tmAeeK10" role="3clFbx">
-                <node concept="3cpWs8" id="6Z_tmAeeOtn" role="3cqZAp">
-                  <node concept="3cpWsn" id="6Z_tmAeeOtq" role="3cpWs9">
-                    <property role="TrG5h" value="index" />
-                    <node concept="10Oyi0" id="6Z_tmAeeOtl" role="1tU5fm" />
-                    <node concept="2OqwBi" id="6Z_tmAeeToe" role="33vP2m">
-                      <node concept="2OqwBi" id="6Z_tmAeeRaJ" role="2Oq$k0">
-                        <node concept="37vLTw" id="6Z_tmAeeQtd" role="2Oq$k0">
+                <node concept="3cpWs6" id="6Z_tmAef2FX" role="3cqZAp">
+                  <node concept="2OqwBi" id="7OJcYqzcLz1" role="3cqZAk">
+                    <node concept="2OqwBi" id="7OJcYqzcDzr" role="2Oq$k0">
+                      <node concept="2OqwBi" id="7OJcYqzcBaG" role="2Oq$k0">
+                        <node concept="37vLTw" id="7OJcYqzcA9T" role="2Oq$k0">
                           <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
                         </node>
-                        <node concept="liA8E" id="6Z_tmAeeRQb" role="2OqNvi">
-                          <ref role="37wK5l" to="y7p:7weWCFlqTiX" resolve="listSLanguageInternalClassifiers" />
+                        <node concept="liA8E" id="7OJcYqzcCij" role="2OqNvi">
+                          <ref role="37wK5l" to="y7p:7OJcYqx1HDk" resolve="listMpsInternalClassifier" />
                         </node>
                       </node>
-                      <node concept="2WmjW8" id="6Z_tmAeeUif" role="2OqNvi">
-                        <node concept="10QFUN" id="6Z_tmAeeVQq" role="25WWJ7">
-                          <node concept="37vLTw" id="6Z_tmAeeVQp" role="10QFUP">
-                            <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
+                      <node concept="1z4cxt" id="7OJcYqzcELc" role="2OqNvi">
+                        <node concept="1bVj0M" id="7OJcYqzcELe" role="23t8la">
+                          <node concept="3clFbS" id="7OJcYqzcELf" role="1bW5cS">
+                            <node concept="3clFbF" id="7OJcYqzcFD4" role="3cqZAp">
+                              <node concept="17R0WA" id="7OJcYqzcJhQ" role="3clFbG">
+                                <node concept="37vLTw" id="7OJcYqzcK8n" role="3uHU7w">
+                                  <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
+                                </node>
+                                <node concept="2OqwBi" id="7OJcYqzcGJ4" role="3uHU7B">
+                                  <node concept="37vLTw" id="7OJcYqzcFD3" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="7OJcYqzcELg" resolve="it" />
+                                  </node>
+                                  <node concept="liA8E" id="7OJcYqzcIeG" role="2OqNvi">
+                                    <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
                           </node>
-                          <node concept="3uibUv" id="6Z_tmAeeWnl" role="10QFUM">
-                            <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                          <node concept="Rh6nW" id="7OJcYqzcELg" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="7OJcYqzcELh" role="1tU5fm" />
                           </node>
                         </node>
                       </node>
                     </node>
-                  </node>
-                </node>
-                <node concept="3cpWs6" id="6Z_tmAef2FX" role="3cqZAp">
-                  <node concept="1y4W85" id="6Z_tmAef2FZ" role="3cqZAk">
-                    <node concept="37vLTw" id="6Z_tmAef2G0" role="1y58nS">
-                      <ref role="3cqZAo" node="6Z_tmAeeOtq" resolve="index" />
-                    </node>
-                    <node concept="2OqwBi" id="6Z_tmAef2G1" role="1y566C">
-                      <node concept="37vLTw" id="6Z_tmAef2G2" role="2Oq$k0">
-                        <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
-                      </node>
-                      <node concept="liA8E" id="6Z_tmAef2G3" role="2OqNvi">
-                        <ref role="37wK5l" to="y7p:6Z_tmAeiDP1" resolve="listSLanguageInternalClassifierLanguageKeys" />
-                      </node>
+                    <node concept="liA8E" id="7OJcYqzcMCD" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKjL5" resolve="getLcKey" />
                     </node>
                   </node>
                 </node>
@@ -5519,44 +5564,45 @@
             </node>
             <node concept="3clFbJ" id="6Z_tmAef3eD" role="3cqZAp">
               <node concept="3clFbS" id="6Z_tmAef3eF" role="3clFbx">
-                <node concept="3cpWs8" id="6Z_tmAef6wj" role="3cqZAp">
-                  <node concept="3cpWsn" id="6Z_tmAef6wk" role="3cpWs9">
-                    <property role="TrG5h" value="index" />
-                    <node concept="10Oyi0" id="6Z_tmAef6wl" role="1tU5fm" />
-                    <node concept="2OqwBi" id="6Z_tmAef6wm" role="33vP2m">
-                      <node concept="2OqwBi" id="6Z_tmAef6wn" role="2Oq$k0">
-                        <node concept="37vLTw" id="6Z_tmAef6wo" role="2Oq$k0">
+                <node concept="3cpWs6" id="6Z_tmAef6wu" role="3cqZAp">
+                  <node concept="2OqwBi" id="7OJcYqzcVFO" role="3cqZAk">
+                    <node concept="2OqwBi" id="7OJcYqzcVFP" role="2Oq$k0">
+                      <node concept="2OqwBi" id="7OJcYqzcVFQ" role="2Oq$k0">
+                        <node concept="37vLTw" id="7OJcYqzcVFR" role="2Oq$k0">
                           <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
                         </node>
-                        <node concept="liA8E" id="6Z_tmAef6wp" role="2OqNvi">
-                          <ref role="37wK5l" to="y7p:5JNiski3k1p" resolve="listSLanguagePrimitiveTypes" />
+                        <node concept="liA8E" id="7OJcYqzcVFS" role="2OqNvi">
+                          <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
                         </node>
                       </node>
-                      <node concept="2WmjW8" id="6Z_tmAef6wq" role="2OqNvi">
-                        <node concept="10QFUN" id="6Z_tmAef6wr" role="25WWJ7">
-                          <node concept="37vLTw" id="6Z_tmAef6ws" role="10QFUP">
-                            <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
+                      <node concept="1z4cxt" id="7OJcYqzcVFT" role="2OqNvi">
+                        <node concept="1bVj0M" id="7OJcYqzcVFU" role="23t8la">
+                          <node concept="3clFbS" id="7OJcYqzcVFV" role="1bW5cS">
+                            <node concept="3clFbF" id="7OJcYqzcVFW" role="3cqZAp">
+                              <node concept="17R0WA" id="7OJcYqzcVFX" role="3clFbG">
+                                <node concept="37vLTw" id="7OJcYqzcVFY" role="3uHU7w">
+                                  <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
+                                </node>
+                                <node concept="2OqwBi" id="7OJcYqzcVFZ" role="3uHU7B">
+                                  <node concept="37vLTw" id="7OJcYqzcVG0" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="7OJcYqzcVG2" resolve="it" />
+                                  </node>
+                                  <node concept="liA8E" id="7OJcYqzcVG1" role="2OqNvi">
+                                    <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
                           </node>
-                          <node concept="3uibUv" id="6Z_tmAef6wt" role="10QFUM">
-                            <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+                          <node concept="Rh6nW" id="7OJcYqzcVG2" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="7OJcYqzcVG3" role="1tU5fm" />
                           </node>
                         </node>
                       </node>
                     </node>
-                  </node>
-                </node>
-                <node concept="3cpWs6" id="6Z_tmAef6wu" role="3cqZAp">
-                  <node concept="1y4W85" id="6Z_tmAef6wv" role="3cqZAk">
-                    <node concept="37vLTw" id="6Z_tmAef6ww" role="1y58nS">
-                      <ref role="3cqZAo" node="6Z_tmAef6wk" resolve="index" />
-                    </node>
-                    <node concept="2OqwBi" id="6Z_tmAef6wx" role="1y566C">
-                      <node concept="37vLTw" id="6Z_tmAef6wy" role="2Oq$k0">
-                        <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
-                      </node>
-                      <node concept="liA8E" id="6Z_tmAef6wz" role="2OqNvi">
-                        <ref role="37wK5l" to="y7p:7OJcYqvFkM2" resolve="listSLanguagePrimitiveTypeLanguageKeys" />
-                      </node>
+                    <node concept="liA8E" id="7OJcYqzcVG4" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKjL5" resolve="getLcKey" />
                     </node>
                   </node>
                 </node>
@@ -5572,44 +5618,45 @@
             </node>
             <node concept="3clFbJ" id="6Z_tmAegzvh" role="3cqZAp">
               <node concept="3clFbS" id="6Z_tmAegzvj" role="3clFbx">
-                <node concept="3cpWs8" id="6Z_tmAegArH" role="3cqZAp">
-                  <node concept="3cpWsn" id="6Z_tmAegArI" role="3cpWs9">
-                    <property role="TrG5h" value="index" />
-                    <node concept="10Oyi0" id="6Z_tmAegArJ" role="1tU5fm" />
-                    <node concept="2OqwBi" id="6Z_tmAegArK" role="33vP2m">
-                      <node concept="2OqwBi" id="6Z_tmAegArL" role="2Oq$k0">
-                        <node concept="37vLTw" id="6Z_tmAegArM" role="2Oq$k0">
+                <node concept="3cpWs6" id="6Z_tmAegArS" role="3cqZAp">
+                  <node concept="2OqwBi" id="7OJcYqzcXSs" role="3cqZAk">
+                    <node concept="2OqwBi" id="7OJcYqzcXSt" role="2Oq$k0">
+                      <node concept="2OqwBi" id="7OJcYqzcXSu" role="2Oq$k0">
+                        <node concept="37vLTw" id="7OJcYqzcXSv" role="2Oq$k0">
                           <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
                         </node>
-                        <node concept="liA8E" id="6Z_tmAegArN" role="2OqNvi">
-                          <ref role="37wK5l" to="y7p:6Z_tmAegIrR" resolve="listSLanguageInternalFeatures" />
+                        <node concept="liA8E" id="7OJcYqzcXSw" role="2OqNvi">
+                          <ref role="37wK5l" to="y7p:7OJcYqx2zDi" resolve="listMpsInternalFeature" />
                         </node>
                       </node>
-                      <node concept="2WmjW8" id="6Z_tmAegArO" role="2OqNvi">
-                        <node concept="10QFUN" id="6Z_tmAegArP" role="25WWJ7">
-                          <node concept="37vLTw" id="6Z_tmAegArQ" role="10QFUP">
-                            <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
+                      <node concept="1z4cxt" id="7OJcYqzcXSx" role="2OqNvi">
+                        <node concept="1bVj0M" id="7OJcYqzcXSy" role="23t8la">
+                          <node concept="3clFbS" id="7OJcYqzcXSz" role="1bW5cS">
+                            <node concept="3clFbF" id="7OJcYqzcXS$" role="3cqZAp">
+                              <node concept="17R0WA" id="7OJcYqzcXS_" role="3clFbG">
+                                <node concept="37vLTw" id="7OJcYqzcXSA" role="3uHU7w">
+                                  <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
+                                </node>
+                                <node concept="2OqwBi" id="7OJcYqzcXSB" role="3uHU7B">
+                                  <node concept="37vLTw" id="7OJcYqzcXSC" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="7OJcYqzcXSE" resolve="it" />
+                                  </node>
+                                  <node concept="liA8E" id="7OJcYqzcXSD" role="2OqNvi">
+                                    <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
                           </node>
-                          <node concept="3uibUv" id="6Z_tmAegArR" role="10QFUM">
-                            <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
+                          <node concept="Rh6nW" id="7OJcYqzcXSE" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="7OJcYqzcXSF" role="1tU5fm" />
                           </node>
                         </node>
                       </node>
                     </node>
-                  </node>
-                </node>
-                <node concept="3cpWs6" id="6Z_tmAegArS" role="3cqZAp">
-                  <node concept="1y4W85" id="6Z_tmAegArT" role="3cqZAk">
-                    <node concept="37vLTw" id="6Z_tmAegArU" role="1y58nS">
-                      <ref role="3cqZAo" node="6Z_tmAegArI" resolve="index" />
-                    </node>
-                    <node concept="2OqwBi" id="6Z_tmAegArV" role="1y566C">
-                      <node concept="37vLTw" id="6Z_tmAegArW" role="2Oq$k0">
-                        <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
-                      </node>
-                      <node concept="liA8E" id="6Z_tmAegArX" role="2OqNvi">
-                        <ref role="37wK5l" to="y7p:7OJcYqvFsrp" resolve="listSClassifierInternalFeatureLanguageKeys" />
-                      </node>
+                    <node concept="liA8E" id="7OJcYqzcXSG" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKjL5" resolve="getLcKey" />
                     </node>
                   </node>
                 </node>
@@ -5716,85 +5763,66 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="1ryFPTS6lpF" role="3cqZAp">
-          <node concept="3cpWsn" id="1ryFPTS6lpI" role="3cpWs9">
-            <property role="TrG5h" value="index" />
-            <node concept="10Oyi0" id="1ryFPTS6lpD" role="1tU5fm" />
-            <node concept="2OqwBi" id="1ryFPTS6pdB" role="33vP2m">
-              <node concept="2OqwBi" id="1ryFPTS6nvv" role="2Oq$k0">
-                <node concept="37vLTw" id="1ryFPTS6mUm" role="2Oq$k0">
+        <node concept="3cpWs8" id="7OJcYqzdfSj" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqzdfSk" role="3cpWs9">
+            <property role="TrG5h" value="mapping" />
+            <node concept="3uibUv" id="7OJcYqzdfDj" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqzdfSl" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqzdfSm" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYqzdfSn" role="2Oq$k0">
                   <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
                 </node>
-                <node concept="liA8E" id="1ryFPTS6ofO" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jYO" resolve="listKeyLanguages" />
+                <node concept="liA8E" id="7OJcYqzdfSo" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqwXhGH" resolve="listLcLanguages" />
                 </node>
               </node>
-              <node concept="2WmjW8" id="1ryFPTS6pWS" role="2OqNvi">
-                <node concept="37vLTw" id="1ryFPTS6qrk" role="25WWJ7">
-                  <ref role="3cqZAo" node="1ryFPTS4LVX" resolve="languageKey" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="1ryFPTS6rCl" role="3cqZAp">
-          <node concept="3clFbS" id="1ryFPTS6rCn" role="3clFbx">
-            <node concept="3clFbF" id="1ryFPTS6ulM" role="3cqZAp">
-              <node concept="37vLTI" id="1ryFPTS6viN" role="3clFbG">
-                <node concept="2OqwBi" id="1ryFPTS6yxq" role="37vLTx">
-                  <node concept="2OqwBi" id="1ryFPTS6wIB" role="2Oq$k0">
-                    <node concept="37vLTw" id="1ryFPTS6vZs" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
-                    </node>
-                    <node concept="liA8E" id="1ryFPTS6xgM" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3jYX" resolve="listSLanguageLanguageIds" />
+              <node concept="1z4cxt" id="7OJcYqzdfSp" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYqzdfSq" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYqzdfSr" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYqzdfSs" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYqzdfSt" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYqzdfSu" role="3uHU7w">
+                          <ref role="3cqZAo" node="1ryFPTS4LVX" resolve="languageKey" />
+                        </node>
+                        <node concept="2OqwBi" id="7OJcYqzdfSv" role="3uHU7B">
+                          <node concept="37vLTw" id="7OJcYqzdfSw" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqzdfSy" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqzdfSx" role="2OqNvi">
+                            <ref role="37wK5l" to="y7p:7OJcYqvKqdu" resolve="getLcKey" />
+                          </node>
+                        </node>
+                      </node>
                     </node>
                   </node>
-                  <node concept="2WmjW8" id="1ryFPTS6zp7" role="2OqNvi">
-                    <node concept="37vLTw" id="1ryFPTS6zTQ" role="25WWJ7">
-                      <ref role="3cqZAo" node="1ryFPTS4LVX" resolve="languageKey" />
-                    </node>
+                  <node concept="Rh6nW" id="7OJcYqzdfSy" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYqzdfSz" role="1tU5fm" />
                   </node>
                 </node>
-                <node concept="37vLTw" id="1ryFPTS6ulK" role="37vLTJ">
-                  <ref role="3cqZAo" node="1ryFPTS6lpI" resolve="index" />
-                </node>
               </node>
-            </node>
-          </node>
-          <node concept="3clFbC" id="1ryFPTS6tp2" role="3clFbw">
-            <node concept="3cmrfG" id="1ryFPTS6tRq" role="3uHU7w">
-              <property role="3cmrfH" value="-1" />
-            </node>
-            <node concept="37vLTw" id="1ryFPTS6s77" role="3uHU7B">
-              <ref role="3cqZAo" node="1ryFPTS6lpI" resolve="index" />
             </node>
           </node>
         </node>
         <node concept="3clFbJ" id="1ryFPTS6_bF" role="3cqZAp">
           <node concept="3clFbS" id="1ryFPTS6_bH" role="3clFbx">
             <node concept="3cpWs6" id="1ryFPTS6C2w" role="3cqZAp">
-              <node concept="1y4W85" id="1ryFPTS6Fw0" role="3cqZAk">
-                <node concept="37vLTw" id="1ryFPTS6Ggn" role="1y58nS">
-                  <ref role="3cqZAo" node="1ryFPTS6lpI" resolve="index" />
+              <node concept="2OqwBi" id="7OJcYqzdszs" role="3cqZAk">
+                <node concept="37vLTw" id="7OJcYqzdrs2" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7OJcYqzdfSk" resolve="mapping" />
                 </node>
-                <node concept="2OqwBi" id="1ryFPTS6DP7" role="1y566C">
-                  <node concept="37vLTw" id="1ryFPTS6Ddj" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
-                  </node>
-                  <node concept="liA8E" id="1ryFPTS6Ept" role="2OqNvi">
-                    <ref role="37wK5l" to="y7p:5JNiski3jZb" resolve="listVersionLanguages" />
-                  </node>
+                <node concept="liA8E" id="7OJcYqzdu03" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqvN0Qp" resolve="getLcVersion" />
                 </node>
               </node>
             </node>
           </node>
-          <node concept="3y3z36" id="1ryFPTS6B1c" role="3clFbw">
-            <node concept="3cmrfG" id="1ryFPTS6BxR" role="3uHU7w">
-              <property role="3cmrfH" value="-1" />
-            </node>
-            <node concept="37vLTw" id="1ryFPTS6_GY" role="3uHU7B">
-              <ref role="3cqZAo" node="1ryFPTS6lpI" resolve="index" />
+          <node concept="3y3z36" id="7OJcYqzdpdx" role="3clFbw">
+            <node concept="10Nm6u" id="7OJcYqzdqzV" role="3uHU7w" />
+            <node concept="37vLTw" id="7OJcYqzdo7q" role="3uHU7B">
+              <ref role="3cqZAo" node="7OJcYqzdfSk" resolve="mapping" />
             </node>
           </node>
         </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.mps2lionweb.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.mps2lionweb.mps
@@ -96,7 +96,6 @@
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
-      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
@@ -263,13 +262,6 @@
         <property id="8575328350543493365" name="message" index="huDt6" />
         <property id="2423417345669755629" name="filter" index="1eyWvh" />
       </concept>
-      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
-        <property id="709746936026609031" name="linkId" index="3V$3ak" />
-        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
-      </concept>
-      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
-        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
-      </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
       <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
@@ -318,7 +310,6 @@
       <concept id="4611582986551314327" name="jetbrains.mps.baseLanguage.collections.structure.OfTypeOperation" flags="nn" index="UnYns">
         <child id="4611582986551314344" name="requestedType" index="UnYnz" />
       </concept>
-      <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
       <concept id="1240216724530" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashMapCreator" flags="nn" index="32Fmki" />
       <concept id="1240217271293" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashSetCreator" flags="nn" index="32HrFt" />
       <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
@@ -4998,73 +4989,7 @@
           <node concept="3cpWsn" id="7OJcYqvIRpK" role="3cpWs9">
             <property role="TrG5h" value="key" />
             <node concept="17QB3L" id="7OJcYqvIR9N" role="1tU5fm" />
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqvJKZq" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbJ" id="7OJcYqvITV_" role="8Wnug">
-            <node concept="3clFbS" id="7OJcYqvITVA" role="3clFbx">
-              <node concept="3cpWs8" id="7OJcYqvITVB" role="3cqZAp">
-                <node concept="3cpWsn" id="7OJcYqvITVC" role="3cpWs9">
-                  <property role="TrG5h" value="index" />
-                  <node concept="10Oyi0" id="7OJcYqvITVD" role="1tU5fm" />
-                  <node concept="2OqwBi" id="7OJcYqvITVE" role="33vP2m">
-                    <node concept="2OqwBi" id="7OJcYqvITVF" role="2Oq$k0">
-                      <node concept="37vLTw" id="7OJcYqvITVG" role="2Oq$k0">
-                        <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
-                      </node>
-                      <node concept="liA8E" id="7OJcYqvITVH" role="2OqNvi">
-                        <ref role="37wK5l" to="y7p:7weWCFlqTiX" resolve="listSLanguageInternalClassifiers" />
-                      </node>
-                    </node>
-                    <node concept="2WmjW8" id="7OJcYqvITVI" role="2OqNvi">
-                      <node concept="37vLTw" id="7OJcYqvITVJ" role="25WWJ7">
-                        <ref role="3cqZAo" node="5s4Z0e0f9ko" resolve="concept" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2OqwBi" id="7OJcYqvITVS" role="3clFbw">
-              <node concept="37vLTw" id="7OJcYqvITVT" role="2Oq$k0">
-                <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
-              </node>
-              <node concept="liA8E" id="7OJcYqvITVU" role="2OqNvi">
-                <ref role="37wK5l" to="y7p:5JNiskiswUo" resolve="isMpsInternalElement" />
-                <node concept="37vLTw" id="7OJcYqvITVV" role="37wK5m">
-                  <ref role="3cqZAo" node="5s4Z0e0f9ko" resolve="concept" />
-                </node>
-              </node>
-            </node>
-            <node concept="9aQIb" id="7OJcYqvITVW" role="9aQIa">
-              <node concept="3clFbS" id="7OJcYqvITVX" role="9aQI4">
-                <node concept="3clFbF" id="7OJcYqvIVbB" role="3cqZAp">
-                  <node concept="37vLTI" id="7OJcYqvIVbD" role="3clFbG">
-                    <node concept="2OqwBi" id="7OJcYqvIRpL" role="37vLTx">
-                      <node concept="37vLTw" id="7OJcYqvIRpM" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5s4Z0e0f92p" resolve="idMapper" />
-                      </node>
-                      <node concept="liA8E" id="7OJcYqvIRpN" role="2OqNvi">
-                        <ref role="37wK5l" to="teza:5M3rB6Ae5mL" resolve="mapClassifier" />
-                        <node concept="37vLTw" id="7OJcYqvIRpO" role="37wK5m">
-                          <ref role="3cqZAo" node="5s4Z0e0f9ko" resolve="concept" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="37vLTw" id="7OJcYqvIVbH" role="37vLTJ">
-                      <ref role="3cqZAo" node="7OJcYqvIRpK" resolve="key" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7OJcYqvJJlB" role="3cqZAp">
-          <node concept="37vLTI" id="7OJcYqvJJlC" role="3clFbG">
-            <node concept="2OqwBi" id="7OJcYqvJJlD" role="37vLTx">
+            <node concept="2OqwBi" id="7OJcYqvJJlD" role="33vP2m">
               <node concept="37vLTw" id="7OJcYqvJJlE" role="2Oq$k0">
                 <ref role="3cqZAo" node="5s4Z0e0f92p" resolve="idMapper" />
               </node>
@@ -5074,9 +4999,6 @@
                   <ref role="3cqZAo" node="5s4Z0e0f9ko" resolve="concept" />
                 </node>
               </node>
-            </node>
-            <node concept="37vLTw" id="7OJcYqvJJlH" role="37vLTJ">
-              <ref role="3cqZAo" node="7OJcYqvIRpK" resolve="key" />
             </node>
           </node>
         </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.mps2lionweb.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.mps2lionweb.mps
@@ -1263,54 +1263,48 @@
       </node>
       <node concept="3clFbS" id="5JNiskj48ym" role="3clF47">
         <node concept="3clFbH" id="5JNiskjzN4H" role="3cqZAp" />
-        <node concept="3cpWs8" id="7OJcYqzRIlE" role="3cqZAp">
-          <node concept="3cpWsn" id="7OJcYqzRIlF" role="3cpWs9">
+        <node concept="3cpWs8" id="7OJcYq_6i0p" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_6i0q" role="3cpWs9">
             <property role="TrG5h" value="staple" />
-            <node concept="3uibUv" id="7OJcYqzRH7N" role="1tU5fm">
-              <ref role="3uigEE" to="6peh:7OJcYqxQZIZ" resolve="IJsonStaple" />
-              <node concept="3uibUv" id="7OJcYqzRH7T" role="11_B2D">
-                <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-              </node>
-              <node concept="3uibUv" id="7OJcYqzRH7S" role="11_B2D">
-                <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
-              </node>
+            <node concept="3uibUv" id="7OJcYq_6frt" role="1tU5fm">
+              <ref role="3uigEE" to="6peh:7OJcYq_2Ogv" resolve="JsonAnnotationPropertyStaple" />
             </node>
-            <node concept="2OqwBi" id="7OJcYqzRIlG" role="33vP2m">
-              <node concept="2OqwBi" id="7OJcYqzRIlH" role="2Oq$k0">
-                <node concept="37vLTw" id="7OJcYqzRIlI" role="2Oq$k0">
+            <node concept="2OqwBi" id="7OJcYq_6i0r" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYq_6i0s" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYq_6i0t" role="2Oq$k0">
                   <ref role="3cqZAo" node="5JNiskjt9lC" resolve="jsonConstants" />
                 </node>
-                <node concept="liA8E" id="7OJcYqzRIlJ" role="2OqNvi">
+                <node concept="liA8E" id="7OJcYq_6i0u" role="2OqNvi">
                   <ref role="37wK5l" to="6peh:5JNiskjpjPN" resolve="listMpsM1Annotations" />
                 </node>
               </node>
-              <node concept="1z4cxt" id="7OJcYqzRIlK" role="2OqNvi">
-                <node concept="1bVj0M" id="7OJcYqzRIlL" role="23t8la">
-                  <node concept="3clFbS" id="7OJcYqzRIlM" role="1bW5cS">
-                    <node concept="3clFbF" id="7OJcYqzRIlN" role="3cqZAp">
-                      <node concept="17R0WA" id="7OJcYqzRIlO" role="3clFbG">
-                        <node concept="37vLTw" id="7OJcYqzRIlP" role="3uHU7w">
+              <node concept="1z4cxt" id="7OJcYq_6i0v" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYq_6i0w" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYq_6i0x" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYq_6i0y" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYq_6i0z" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYq_6i0$" role="3uHU7w">
                           <ref role="3cqZAo" node="5JNiskj48$Z" resolve="mpsProp" />
                         </node>
-                        <node concept="2OqwBi" id="7OJcYqzRIlQ" role="3uHU7B">
-                          <node concept="2OqwBi" id="7OJcYqzRIlR" role="2Oq$k0">
-                            <node concept="37vLTw" id="7OJcYqzRIlS" role="2Oq$k0">
-                              <ref role="3cqZAo" node="7OJcYqzRIlV" resolve="it" />
+                        <node concept="2OqwBi" id="7OJcYq_6i0_" role="3uHU7B">
+                          <node concept="2OqwBi" id="7OJcYq_6i0A" role="2Oq$k0">
+                            <node concept="37vLTw" id="7OJcYq_6i0B" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7OJcYq_6i0E" resolve="it" />
                             </node>
-                            <node concept="liA8E" id="7OJcYqzRIlT" role="2OqNvi">
-                              <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getStaple" />
+                            <node concept="liA8E" id="7OJcYq_6i0C" role="2OqNvi">
+                              <ref role="37wK5l" to="6peh:7OJcYqxTQ2q" resolve="getStaple" />
                             </node>
                           </node>
-                          <node concept="liA8E" id="7OJcYqzRIlU" role="2OqNvi">
+                          <node concept="liA8E" id="7OJcYq_6i0D" role="2OqNvi">
                             <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
                           </node>
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="Rh6nW" id="7OJcYqzRIlV" role="1bW2Oz">
+                  <node concept="Rh6nW" id="7OJcYq_6i0E" role="1bW2Oz">
                     <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="7OJcYqzRIlW" role="1tU5fm" />
+                    <node concept="2jxLKc" id="7OJcYq_6i0F" role="1tU5fm" />
                   </node>
                 </node>
               </node>
@@ -1341,7 +1335,7 @@
           <node concept="3clFbC" id="7OJcYqz_JkM" role="3clFbw">
             <node concept="10Nm6u" id="7OJcYqz_P4S" role="3uHU7w" />
             <node concept="37vLTw" id="7OJcYqz_DvB" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYqzRIlF" resolve="staple" />
+              <ref role="3cqZAo" node="7OJcYq_6i0q" resolve="staple" />
             </node>
           </node>
         </node>
@@ -1354,10 +1348,10 @@
             </node>
             <node concept="2OqwBi" id="7OJcYqzAJds" role="33vP2m">
               <node concept="37vLTw" id="7OJcYqzADE3" role="2Oq$k0">
-                <ref role="3cqZAo" node="7OJcYqzRIlF" resolve="staple" />
+                <ref role="3cqZAo" node="7OJcYq_6i0q" resolve="staple" />
               </node>
               <node concept="liA8E" id="7OJcYqzANG0" role="2OqNvi">
-                <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
+                <ref role="37wK5l" to="6peh:7OJcYq_2Qii" resolve="getJsonAnnotation" />
               </node>
             </node>
           </node>
@@ -1383,16 +1377,15 @@
             <node concept="3uibUv" id="5JNiskjwt_7" role="1tU5fm">
               <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
             </node>
-            <node concept="3EllGN" id="5JNiskjxbpH" role="33vP2m">
-              <node concept="37vLTw" id="5JNiskjxfyr" role="3ElVtu">
-                <ref role="3cqZAo" node="5JNiskjwDHw" resolve="annMetaPointer" />
-              </node>
-              <node concept="2OqwBi" id="5JNiskjtP95" role="3ElQJh">
-                <node concept="37vLTw" id="5JNiskjtKUe" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5JNiskjt9lC" resolve="jsonConstants" />
+            <node concept="2YIFZM" id="7OJcYq_6UdX" role="33vP2m">
+              <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.Feature)" resolve="from" />
+              <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
+              <node concept="2OqwBi" id="7OJcYq_73n3" role="37wK5m">
+                <node concept="37vLTw" id="7OJcYq_6YSC" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7OJcYq_6i0q" resolve="staple" />
                 </node>
-                <node concept="liA8E" id="5JNiskjtTcl" role="2OqNvi">
-                  <ref role="37wK5l" to="6peh:5JNiskjt_st" resolve="mapSpecificAnnotationMembers" />
+                <node concept="liA8E" id="7OJcYq_78bw" role="2OqNvi">
+                  <ref role="37wK5l" to="6peh:7OJcYqxTQ2j" resolve="getJson" />
                 </node>
               </node>
             </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.mps2lionweb.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.mps2lionweb.mps
@@ -25,8 +25,8 @@
     <import index="6peh" ref="r:677983a1-6578-432d-8175-68c906e0375c(io.lionweb.mps.json)" />
     <import index="imb3" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.language(io.lionweb.lionweb.java/)" />
     <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
+    <import index="teza" ref="r:84248d29-a48a-459b-8ba9-05c71de1fb63(io.lionweb.mps.converter.m2.idmapper)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
-    <import index="teza" ref="r:84248d29-a48a-459b-8ba9-05c71de1fb63(io.lionweb.mps.converter.m2.idmapper)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -262,6 +262,13 @@
       <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7">
         <property id="8575328350543493365" name="message" index="huDt6" />
         <property id="2423417345669755629" name="filter" index="1eyWvh" />
+      </concept>
+      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
+        <property id="709746936026609031" name="linkId" index="3V$3ak" />
+        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
+      </concept>
+      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
+        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
       </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
@@ -4963,6 +4970,93 @@
         </node>
       </node>
       <node concept="3clFbS" id="5s4Z0e0f9kq" role="3clF47">
+        <node concept="3cpWs8" id="7OJcYqvIRpJ" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqvIRpK" role="3cpWs9">
+            <property role="TrG5h" value="key" />
+            <node concept="17QB3L" id="7OJcYqvIR9N" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqvJKZq" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbJ" id="7OJcYqvITV_" role="8Wnug">
+            <node concept="3clFbS" id="7OJcYqvITVA" role="3clFbx">
+              <node concept="3cpWs8" id="7OJcYqvITVB" role="3cqZAp">
+                <node concept="3cpWsn" id="7OJcYqvITVC" role="3cpWs9">
+                  <property role="TrG5h" value="index" />
+                  <node concept="10Oyi0" id="7OJcYqvITVD" role="1tU5fm" />
+                  <node concept="2OqwBi" id="7OJcYqvITVE" role="33vP2m">
+                    <node concept="2OqwBi" id="7OJcYqvITVF" role="2Oq$k0">
+                      <node concept="37vLTw" id="7OJcYqvITVG" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYqvITVH" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:7weWCFlqTiX" resolve="listSLanguageInternalClassifiers" />
+                      </node>
+                    </node>
+                    <node concept="2WmjW8" id="7OJcYqvITVI" role="2OqNvi">
+                      <node concept="37vLTw" id="7OJcYqvITVJ" role="25WWJ7">
+                        <ref role="3cqZAo" node="5s4Z0e0f9ko" resolve="concept" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7OJcYqvITVS" role="3clFbw">
+              <node concept="37vLTw" id="7OJcYqvITVT" role="2Oq$k0">
+                <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+              </node>
+              <node concept="liA8E" id="7OJcYqvITVU" role="2OqNvi">
+                <ref role="37wK5l" to="y7p:5JNiskiswUo" resolve="isMpsInternalElement" />
+                <node concept="37vLTw" id="7OJcYqvITVV" role="37wK5m">
+                  <ref role="3cqZAo" node="5s4Z0e0f9ko" resolve="concept" />
+                </node>
+              </node>
+            </node>
+            <node concept="9aQIb" id="7OJcYqvITVW" role="9aQIa">
+              <node concept="3clFbS" id="7OJcYqvITVX" role="9aQI4">
+                <node concept="3clFbF" id="7OJcYqvIVbB" role="3cqZAp">
+                  <node concept="37vLTI" id="7OJcYqvIVbD" role="3clFbG">
+                    <node concept="2OqwBi" id="7OJcYqvIRpL" role="37vLTx">
+                      <node concept="37vLTw" id="7OJcYqvIRpM" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5s4Z0e0f92p" resolve="idMapper" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYqvIRpN" role="2OqNvi">
+                        <ref role="37wK5l" to="teza:5M3rB6Ae5mL" resolve="mapClassifier" />
+                        <node concept="37vLTw" id="7OJcYqvIRpO" role="37wK5m">
+                          <ref role="3cqZAo" node="5s4Z0e0f9ko" resolve="concept" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="7OJcYqvIVbH" role="37vLTJ">
+                      <ref role="3cqZAo" node="7OJcYqvIRpK" resolve="key" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqvJJlB" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvJJlC" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvJJlD" role="37vLTx">
+              <node concept="37vLTw" id="7OJcYqvJJlE" role="2Oq$k0">
+                <ref role="3cqZAo" node="5s4Z0e0f92p" resolve="idMapper" />
+              </node>
+              <node concept="liA8E" id="7OJcYqvJJlF" role="2OqNvi">
+                <ref role="37wK5l" to="teza:5M3rB6Ae5mL" resolve="mapClassifier" />
+                <node concept="37vLTw" id="7OJcYqvJJlG" role="37wK5m">
+                  <ref role="3cqZAo" node="5s4Z0e0f9ko" resolve="concept" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="7OJcYqvJJlH" role="37vLTJ">
+              <ref role="3cqZAo" node="7OJcYqvIRpK" resolve="key" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqvITd5" role="3cqZAp" />
         <node concept="3clFbF" id="5s4Z0e0f9RT" role="3cqZAp">
           <node concept="2ShNRf" id="5s4Z0e0f9RN" role="3clFbG">
             <node concept="1pGfFk" id="5s4Z0e0fa6S" role="2ShVmc">
@@ -4979,16 +5073,8 @@
                   <ref role="3cqZAo" node="5s4Z0e0f9ko" resolve="concept" />
                 </node>
               </node>
-              <node concept="2OqwBi" id="5s4Z0e0fiC$" role="37wK5m">
-                <node concept="37vLTw" id="5s4Z0e0fi0k" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5s4Z0e0f92p" resolve="idMapper" />
-                </node>
-                <node concept="liA8E" id="5s4Z0e0fj1X" role="2OqNvi">
-                  <ref role="37wK5l" to="teza:5M3rB6Ae5mL" resolve="mapClassifier" />
-                  <node concept="37vLTw" id="5s4Z0e0fjmV" role="37wK5m">
-                    <ref role="3cqZAo" node="5s4Z0e0f9ko" resolve="concept" />
-                  </node>
-                </node>
+              <node concept="37vLTw" id="7OJcYqvIRpP" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqvIRpK" resolve="key" />
               </node>
             </node>
           </node>
@@ -5034,6 +5120,90 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="7OJcYqvIBWF" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqvIBWI" role="3cpWs9">
+            <property role="TrG5h" value="key" />
+            <node concept="17QB3L" id="7OJcYqvIBWD" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbJ" id="7OJcYqvIvnR" role="3cqZAp">
+          <node concept="3clFbS" id="7OJcYqvIvnT" role="3clFbx">
+            <node concept="3cpWs8" id="7OJcYqvI$f9" role="3cqZAp">
+              <node concept="3cpWsn" id="7OJcYqvI$fa" role="3cpWs9">
+                <property role="TrG5h" value="index" />
+                <node concept="10Oyi0" id="7OJcYqvI$fb" role="1tU5fm" />
+                <node concept="2OqwBi" id="7OJcYqvI$fc" role="33vP2m">
+                  <node concept="2OqwBi" id="7OJcYqvI$fd" role="2Oq$k0">
+                    <node concept="37vLTw" id="7OJcYqvI$fe" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqvI$ff" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:6Z_tmAegIrR" resolve="listSLanguageInternalFeatures" />
+                    </node>
+                  </node>
+                  <node concept="2WmjW8" id="7OJcYqvI$fg" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqvIA6r" role="25WWJ7">
+                      <ref role="3cqZAo" node="5s4Z0e0f9ky" resolve="property" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7OJcYqvIFX4" role="3cqZAp">
+              <node concept="37vLTI" id="7OJcYqvIGT5" role="3clFbG">
+                <node concept="37vLTw" id="7OJcYqvIFX2" role="37vLTJ">
+                  <ref role="3cqZAo" node="7OJcYqvIBWI" resolve="key" />
+                </node>
+                <node concept="1y4W85" id="7OJcYqvI$fl" role="37vLTx">
+                  <node concept="37vLTw" id="7OJcYqvI$fm" role="1y58nS">
+                    <ref role="3cqZAo" node="7OJcYqvI$fa" resolve="index" />
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqvI$fn" role="1y566C">
+                    <node concept="37vLTw" id="7OJcYqvI$fo" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqvI$fp" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:6Z_tmAegWRd" resolve="listSClassifierInternalFeatureIds" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7OJcYqvIxbC" role="3clFbw">
+            <node concept="37vLTw" id="7OJcYqvIwoF" role="2Oq$k0">
+              <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+            </node>
+            <node concept="liA8E" id="7OJcYqvIyd9" role="2OqNvi">
+              <ref role="37wK5l" to="y7p:5JNiskiswUo" resolve="isMpsInternalElement" />
+              <node concept="37vLTw" id="7OJcYqvIzdz" role="37wK5m">
+                <ref role="3cqZAo" node="5s4Z0e0f9ky" resolve="property" />
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="7OJcYqvILh4" role="9aQIa">
+            <node concept="3clFbS" id="7OJcYqvILh5" role="9aQI4">
+              <node concept="3clFbF" id="7OJcYqvIMgn" role="3cqZAp">
+                <node concept="37vLTI" id="7OJcYqvINca" role="3clFbG">
+                  <node concept="37vLTw" id="7OJcYqvIMgm" role="37vLTJ">
+                    <ref role="3cqZAo" node="7OJcYqvIBWI" resolve="key" />
+                  </node>
+                  <node concept="2OqwBi" id="5s4Z0e0fjLd" role="37vLTx">
+                    <node concept="37vLTw" id="5s4Z0e0fjLe" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5s4Z0e0f92p" resolve="idMapper" />
+                    </node>
+                    <node concept="liA8E" id="5s4Z0e0fjLf" role="2OqNvi">
+                      <ref role="37wK5l" to="teza:5M3rB6Ae5pI" resolve="mapProperty" />
+                      <node concept="37vLTw" id="5s4Z0e0fjLg" role="37wK5m">
+                        <ref role="3cqZAo" node="5s4Z0e0f9ky" resolve="property" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="5s4Z0e0fjL3" role="3cqZAp">
           <node concept="2ShNRf" id="5s4Z0e0fjL4" role="3clFbG">
             <node concept="1pGfFk" id="5s4Z0e0fjL5" role="2ShVmc">
@@ -5050,16 +5220,8 @@
                   <ref role="3cqZAo" node="5s4Z0e0lZGb" resolve="owner" />
                 </node>
               </node>
-              <node concept="2OqwBi" id="5s4Z0e0fjLd" role="37wK5m">
-                <node concept="37vLTw" id="5s4Z0e0fjLe" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5s4Z0e0f92p" resolve="idMapper" />
-                </node>
-                <node concept="liA8E" id="5s4Z0e0fjLf" role="2OqNvi">
-                  <ref role="37wK5l" to="teza:5M3rB6Ae5pI" resolve="mapProperty" />
-                  <node concept="37vLTw" id="5s4Z0e0fjLg" role="37wK5m">
-                    <ref role="3cqZAo" node="5s4Z0e0f9ky" resolve="property" />
-                  </node>
-                </node>
+              <node concept="37vLTw" id="7OJcYqvIQE1" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqvIBWI" resolve="key" />
               </node>
             </node>
           </node>
@@ -5300,6 +5462,180 @@
         </node>
       </node>
       <node concept="3clFbS" id="5s4Z0e0go9j" role="3clF47">
+        <node concept="3clFbJ" id="6Z_tmAedT2m" role="3cqZAp">
+          <node concept="3clFbS" id="6Z_tmAedT2o" role="3clFbx">
+            <node concept="3clFbJ" id="6Z_tmAeeK0Y" role="3cqZAp">
+              <node concept="3clFbS" id="6Z_tmAeeK10" role="3clFbx">
+                <node concept="3cpWs8" id="6Z_tmAeeOtn" role="3cqZAp">
+                  <node concept="3cpWsn" id="6Z_tmAeeOtq" role="3cpWs9">
+                    <property role="TrG5h" value="index" />
+                    <node concept="10Oyi0" id="6Z_tmAeeOtl" role="1tU5fm" />
+                    <node concept="2OqwBi" id="6Z_tmAeeToe" role="33vP2m">
+                      <node concept="2OqwBi" id="6Z_tmAeeRaJ" role="2Oq$k0">
+                        <node concept="37vLTw" id="6Z_tmAeeQtd" role="2Oq$k0">
+                          <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+                        </node>
+                        <node concept="liA8E" id="6Z_tmAeeRQb" role="2OqNvi">
+                          <ref role="37wK5l" to="y7p:7weWCFlqTiX" resolve="listSLanguageInternalClassifiers" />
+                        </node>
+                      </node>
+                      <node concept="2WmjW8" id="6Z_tmAeeUif" role="2OqNvi">
+                        <node concept="10QFUN" id="6Z_tmAeeVQq" role="25WWJ7">
+                          <node concept="37vLTw" id="6Z_tmAeeVQp" role="10QFUP">
+                            <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
+                          </node>
+                          <node concept="3uibUv" id="6Z_tmAeeWnl" role="10QFUM">
+                            <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="6Z_tmAef2FX" role="3cqZAp">
+                  <node concept="1y4W85" id="6Z_tmAef2FZ" role="3cqZAk">
+                    <node concept="37vLTw" id="6Z_tmAef2G0" role="1y58nS">
+                      <ref role="3cqZAo" node="6Z_tmAeeOtq" resolve="index" />
+                    </node>
+                    <node concept="2OqwBi" id="6Z_tmAef2G1" role="1y566C">
+                      <node concept="37vLTw" id="6Z_tmAef2G2" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+                      </node>
+                      <node concept="liA8E" id="6Z_tmAef2G3" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:6Z_tmAeiDP1" resolve="listSLanguageInternalClassifierLanguageKeys" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2ZW3vV" id="6Z_tmAeeLUa" role="3clFbw">
+                <node concept="3uibUv" id="6Z_tmAeeMrh" role="2ZW6by">
+                  <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                </node>
+                <node concept="37vLTw" id="6Z_tmAeeL1L" role="2ZW6bz">
+                  <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="6Z_tmAef3eD" role="3cqZAp">
+              <node concept="3clFbS" id="6Z_tmAef3eF" role="3clFbx">
+                <node concept="3cpWs8" id="6Z_tmAef6wj" role="3cqZAp">
+                  <node concept="3cpWsn" id="6Z_tmAef6wk" role="3cpWs9">
+                    <property role="TrG5h" value="index" />
+                    <node concept="10Oyi0" id="6Z_tmAef6wl" role="1tU5fm" />
+                    <node concept="2OqwBi" id="6Z_tmAef6wm" role="33vP2m">
+                      <node concept="2OqwBi" id="6Z_tmAef6wn" role="2Oq$k0">
+                        <node concept="37vLTw" id="6Z_tmAef6wo" role="2Oq$k0">
+                          <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+                        </node>
+                        <node concept="liA8E" id="6Z_tmAef6wp" role="2OqNvi">
+                          <ref role="37wK5l" to="y7p:5JNiski3k1p" resolve="listSLanguagePrimitiveTypes" />
+                        </node>
+                      </node>
+                      <node concept="2WmjW8" id="6Z_tmAef6wq" role="2OqNvi">
+                        <node concept="10QFUN" id="6Z_tmAef6wr" role="25WWJ7">
+                          <node concept="37vLTw" id="6Z_tmAef6ws" role="10QFUP">
+                            <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
+                          </node>
+                          <node concept="3uibUv" id="6Z_tmAef6wt" role="10QFUM">
+                            <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="6Z_tmAef6wu" role="3cqZAp">
+                  <node concept="1y4W85" id="6Z_tmAef6wv" role="3cqZAk">
+                    <node concept="37vLTw" id="6Z_tmAef6ww" role="1y58nS">
+                      <ref role="3cqZAo" node="6Z_tmAef6wk" resolve="index" />
+                    </node>
+                    <node concept="2OqwBi" id="6Z_tmAef6wx" role="1y566C">
+                      <node concept="37vLTw" id="6Z_tmAef6wy" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+                      </node>
+                      <node concept="liA8E" id="6Z_tmAef6wz" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:7OJcYqvFkM2" resolve="listSLanguagePrimitiveTypeLanguageKeys" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2ZW3vV" id="6Z_tmAef4TX" role="3clFbw">
+                <node concept="3uibUv" id="6Z_tmAef5tu" role="2ZW6by">
+                  <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+                </node>
+                <node concept="37vLTw" id="6Z_tmAef4ib" role="2ZW6bz">
+                  <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="6Z_tmAegzvh" role="3cqZAp">
+              <node concept="3clFbS" id="6Z_tmAegzvj" role="3clFbx">
+                <node concept="3cpWs8" id="6Z_tmAegArH" role="3cqZAp">
+                  <node concept="3cpWsn" id="6Z_tmAegArI" role="3cpWs9">
+                    <property role="TrG5h" value="index" />
+                    <node concept="10Oyi0" id="6Z_tmAegArJ" role="1tU5fm" />
+                    <node concept="2OqwBi" id="6Z_tmAegArK" role="33vP2m">
+                      <node concept="2OqwBi" id="6Z_tmAegArL" role="2Oq$k0">
+                        <node concept="37vLTw" id="6Z_tmAegArM" role="2Oq$k0">
+                          <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+                        </node>
+                        <node concept="liA8E" id="6Z_tmAegArN" role="2OqNvi">
+                          <ref role="37wK5l" to="y7p:6Z_tmAegIrR" resolve="listSLanguageInternalFeatures" />
+                        </node>
+                      </node>
+                      <node concept="2WmjW8" id="6Z_tmAegArO" role="2OqNvi">
+                        <node concept="10QFUN" id="6Z_tmAegArP" role="25WWJ7">
+                          <node concept="37vLTw" id="6Z_tmAegArQ" role="10QFUP">
+                            <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
+                          </node>
+                          <node concept="3uibUv" id="6Z_tmAegArR" role="10QFUM">
+                            <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="6Z_tmAegArS" role="3cqZAp">
+                  <node concept="1y4W85" id="6Z_tmAegArT" role="3cqZAk">
+                    <node concept="37vLTw" id="6Z_tmAegArU" role="1y58nS">
+                      <ref role="3cqZAo" node="6Z_tmAegArI" resolve="index" />
+                    </node>
+                    <node concept="2OqwBi" id="6Z_tmAegArV" role="1y566C">
+                      <node concept="37vLTw" id="6Z_tmAegArW" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+                      </node>
+                      <node concept="liA8E" id="6Z_tmAegArX" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:7OJcYqvFsrp" resolve="listSClassifierInternalFeatureLanguageKeys" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2ZW3vV" id="6Z_tmAeg_09" role="3clFbw">
+                <node concept="3uibUv" id="6Z_tmAeg__T" role="2ZW6by">
+                  <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
+                </node>
+                <node concept="37vLTw" id="6Z_tmAeg$4s" role="2ZW6bz">
+                  <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="6Z_tmAedUeC" role="3clFbw">
+            <node concept="37vLTw" id="6Z_tmAedTxC" role="2Oq$k0">
+              <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+            </node>
+            <node concept="liA8E" id="6Z_tmAedVgQ" role="2OqNvi">
+              <ref role="37wK5l" to="y7p:5JNiskiswUo" resolve="isMpsInternalElement" />
+              <node concept="37vLTw" id="6Z_tmAedVKy" role="37wK5m">
+                <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs6" id="5s4Z0e0go9k" role="3cqZAp">
           <node concept="2OqwBi" id="5s4Z0e0go9l" role="3cqZAk">
             <node concept="37vLTw" id="5s4Z0e0go9m" role="2Oq$k0">

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.mps2lionweb.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.mps2lionweb.mps
@@ -1265,14 +1265,14 @@
         <node concept="3clFbH" id="5JNiskjzN4H" role="3cqZAp" />
         <node concept="3cpWs8" id="7OJcYqzRIlE" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqzRIlF" role="3cpWs9">
-            <property role="TrG5h" value="mapper" />
+            <property role="TrG5h" value="staple" />
             <node concept="3uibUv" id="7OJcYqzRH7N" role="1tU5fm">
-              <ref role="3uigEE" to="6peh:7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+              <ref role="3uigEE" to="6peh:7OJcYqxQZIZ" resolve="IJsonStaple" />
               <node concept="3uibUv" id="7OJcYqzRH7T" role="11_B2D">
                 <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
               </node>
               <node concept="3uibUv" id="7OJcYqzRH7S" role="11_B2D">
-                <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+                <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
               </node>
             </node>
             <node concept="2OqwBi" id="7OJcYqzRIlG" role="33vP2m">
@@ -1281,7 +1281,7 @@
                   <ref role="3cqZAo" node="5JNiskjt9lC" resolve="jsonConstants" />
                 </node>
                 <node concept="liA8E" id="7OJcYqzRIlJ" role="2OqNvi">
-                  <ref role="37wK5l" to="6peh:5JNiskjpjPN" resolve="listSpecificAnnotations" />
+                  <ref role="37wK5l" to="6peh:5JNiskjpjPN" resolve="listMpsM1Annotations" />
                 </node>
               </node>
               <node concept="1z4cxt" id="7OJcYqzRIlK" role="2OqNvi">
@@ -1298,7 +1298,7 @@
                               <ref role="3cqZAo" node="7OJcYqzRIlV" resolve="it" />
                             </node>
                             <node concept="liA8E" id="7OJcYqzRIlT" role="2OqNvi">
-                              <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                              <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getStaple" />
                             </node>
                           </node>
                           <node concept="liA8E" id="7OJcYqzRIlU" role="2OqNvi">
@@ -1341,7 +1341,7 @@
           <node concept="3clFbC" id="7OJcYqz_JkM" role="3clFbw">
             <node concept="10Nm6u" id="7OJcYqz_P4S" role="3uHU7w" />
             <node concept="37vLTw" id="7OJcYqz_DvB" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYqzRIlF" resolve="mapper" />
+              <ref role="3cqZAo" node="7OJcYqzRIlF" resolve="staple" />
             </node>
           </node>
         </node>
@@ -1354,7 +1354,7 @@
             </node>
             <node concept="2OqwBi" id="7OJcYqzAJds" role="33vP2m">
               <node concept="37vLTw" id="7OJcYqzADE3" role="2Oq$k0">
-                <ref role="3cqZAo" node="7OJcYqzRIlF" resolve="mapper" />
+                <ref role="3cqZAo" node="7OJcYqzRIlF" resolve="staple" />
               </node>
               <node concept="liA8E" id="7OJcYqzANG0" role="2OqNvi">
                 <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
@@ -5172,12 +5172,12 @@
                           <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
                         </node>
                         <node concept="liA8E" id="7OJcYqzcgi9" role="2OqNvi">
-                          <ref role="37wK5l" to="y7p:7OJcYqx2zDi" resolve="listMpsInternalFeature" />
+                          <ref role="37wK5l" to="y7p:7OJcYqx2zDi" resolve="listMpsInternalFeatures" />
                         </node>
                       </node>
                       <node concept="UnYns" id="7OJcYqzcorX" role="2OqNvi">
                         <node concept="3uibUv" id="7OJcYqzcpTO" role="UnYnz">
-                          <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyKeyMapping" />
+                          <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
                         </node>
                       </node>
                     </node>
@@ -5518,7 +5518,7 @@
                           <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
                         </node>
                         <node concept="liA8E" id="7OJcYqzcCij" role="2OqNvi">
-                          <ref role="37wK5l" to="y7p:7OJcYqx1HDk" resolve="listMpsInternalClassifier" />
+                          <ref role="37wK5l" to="y7p:7OJcYqx1HDk" resolve="listMpsInternalClassifiers" />
                         </node>
                       </node>
                       <node concept="1z4cxt" id="7OJcYqzcELc" role="2OqNvi">
@@ -5572,7 +5572,7 @@
                           <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
                         </node>
                         <node concept="liA8E" id="7OJcYqzcVFS" role="2OqNvi">
-                          <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+                          <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
                         </node>
                       </node>
                       <node concept="1z4cxt" id="7OJcYqzcVFT" role="2OqNvi">
@@ -5626,7 +5626,7 @@
                           <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
                         </node>
                         <node concept="liA8E" id="7OJcYqzcXSw" role="2OqNvi">
-                          <ref role="37wK5l" to="y7p:7OJcYqx2zDi" resolve="listMpsInternalFeature" />
+                          <ref role="37wK5l" to="y7p:7OJcYqx2zDi" resolve="listMpsInternalFeatures" />
                         </node>
                       </node>
                       <node concept="1z4cxt" id="7OJcYqzcXSx" role="2OqNvi">
@@ -5765,9 +5765,9 @@
         </node>
         <node concept="3cpWs8" id="7OJcYqzdfSj" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqzdfSk" role="3cpWs9">
-            <property role="TrG5h" value="mapping" />
+            <property role="TrG5h" value="staple" />
             <node concept="3uibUv" id="7OJcYqzdfDj" role="1tU5fm">
-              <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+              <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageStaple" />
             </node>
             <node concept="2OqwBi" id="7OJcYqzdfSl" role="33vP2m">
               <node concept="2OqwBi" id="7OJcYqzdfSm" role="2Oq$k0">
@@ -5811,7 +5811,7 @@
             <node concept="3cpWs6" id="1ryFPTS6C2w" role="3cqZAp">
               <node concept="2OqwBi" id="7OJcYqzdszs" role="3cqZAk">
                 <node concept="37vLTw" id="7OJcYqzdrs2" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7OJcYqzdfSk" resolve="mapping" />
+                  <ref role="3cqZAo" node="7OJcYqzdfSk" resolve="staple" />
                 </node>
                 <node concept="liA8E" id="7OJcYqzdu03" role="2OqNvi">
                   <ref role="37wK5l" to="y7p:7OJcYqvN0Qp" resolve="getLcVersion" />
@@ -5822,7 +5822,7 @@
           <node concept="3y3z36" id="7OJcYqzdpdx" role="3clFbw">
             <node concept="10Nm6u" id="7OJcYqzdqzV" role="3uHU7w" />
             <node concept="37vLTw" id="7OJcYqzdo7q" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYqzdfSk" resolve="mapping" />
+              <ref role="3cqZAo" node="7OJcYqzdfSk" resolve="staple" />
             </node>
           </node>
         </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.mps2lionweb.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.mps2lionweb.mps
@@ -5541,7 +5541,7 @@
                       </node>
                     </node>
                     <node concept="liA8E" id="7OJcYqzcMCD" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:7OJcYqvKjL5" resolve="getLcKey" />
+                      <ref role="37wK5l" to="y7p:7OJcYq_s$7A" resolve="getLcLanguageKey" />
                     </node>
                   </node>
                 </node>
@@ -5595,7 +5595,7 @@
                       </node>
                     </node>
                     <node concept="liA8E" id="7OJcYqzcVG4" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:7OJcYqvKjL5" resolve="getLcKey" />
+                      <ref role="37wK5l" to="y7p:7OJcYq_s$7A" resolve="getLcLanguageKey" />
                     </node>
                   </node>
                 </node>
@@ -5649,7 +5649,7 @@
                       </node>
                     </node>
                     <node concept="liA8E" id="7OJcYqzcXSG" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:7OJcYqvKjL5" resolve="getLcKey" />
+                      <ref role="37wK5l" to="y7p:7OJcYq_s$7A" resolve="getLcLanguageKey" />
                     </node>
                   </node>
                 </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.language.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.language.mps
@@ -45,7 +45,6 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
-      <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
@@ -188,6 +187,9 @@
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="1171903607971" name="jetbrains.mps.baseLanguage.structure.WildCardType" flags="in" index="3qTvmN" />
+      <concept id="1171903916106" name="jetbrains.mps.baseLanguage.structure.UpperBoundType" flags="in" index="3qUE_q">
+        <child id="1171903916107" name="bound" index="3qUE_r" />
+      </concept>
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
@@ -298,12 +300,6 @@
       <concept id="1207233427108" name="jetbrains.mps.baseLanguage.collections.structure.MapRemoveOperation" flags="nn" index="kI3uX">
         <child id="1207233489861" name="key" index="kIiFs" />
       </concept>
-      <concept id="1237467461002" name="jetbrains.mps.baseLanguage.collections.structure.GetIteratorOperation" flags="nn" index="uNJiE" />
-      <concept id="1237467705688" name="jetbrains.mps.baseLanguage.collections.structure.IteratorType" flags="in" index="uOF1S">
-        <child id="1237467730343" name="elementType" index="uOL27" />
-      </concept>
-      <concept id="1237470895604" name="jetbrains.mps.baseLanguage.collections.structure.HasNextOperation" flags="nn" index="v0PNk" />
-      <concept id="1237471031357" name="jetbrains.mps.baseLanguage.collections.structure.GetNextOperation" flags="nn" index="v1n4t" />
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -333,9 +329,7 @@
       </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
-      <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
-      <concept id="1240151247486" name="jetbrains.mps.baseLanguage.collections.structure.ContainerIteratorType" flags="in" index="2YL$Hu" />
       <concept id="1240216724530" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashMapCreator" flags="nn" index="32Fmki" />
       <concept id="1240217271293" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashSetCreator" flags="nn" index="32HrFt" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
@@ -354,6 +348,7 @@
         <child id="1225711182005" name="list" index="1y566C" />
         <child id="1225711191269" name="index" index="1y58nS" />
       </concept>
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1240824834947" name="jetbrains.mps.baseLanguage.collections.structure.ValueAccessOperation" flags="nn" index="3AV6Ez" />
@@ -1024,64 +1019,41 @@
       <node concept="3Tm6S6" id="5M3rB6BBr08" role="1B3o_S" />
       <node concept="3cqZAl" id="5M3rB6BBr09" role="3clF45" />
       <node concept="3clFbS" id="5M3rB6BBqZf" role="3clF47">
-        <node concept="3cpWs8" id="5M3rB6BBqZg" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6BBqZh" role="3cpWs9">
-            <property role="TrG5h" value="jsonDataTypeIter" />
-            <node concept="uOF1S" id="5M3rB6BBqZi" role="1tU5fm">
-              <node concept="3uibUv" id="5M3rB6BBqZj" role="uOL27">
-                <ref role="3uigEE" to="imb3:~DataType" resolve="DataType" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5M3rB6BBqZk" role="33vP2m">
-              <node concept="2OqwBi" id="5TNjoy1w0dD" role="2Oq$k0">
-                <node concept="37vLTw" id="5TNjoy1vVLm" role="2Oq$k0">
-                  <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
-                </node>
-                <node concept="liA8E" id="5TNjoy1w87V" role="2OqNvi">
-                  <ref role="37wK5l" to="6peh:5JNiskj4Oxk" resolve="listPrimitiveTypes" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6BBqZn" role="2OqNvi" />
-            </node>
+        <node concept="2Gpval" id="7OJcYqyPiP5" role="3cqZAp">
+          <node concept="2GrKxI" id="7OJcYqyPiP7" role="2Gsz3X">
+            <property role="TrG5h" value="dataType" />
           </node>
-        </node>
-        <node concept="3cpWs8" id="5M3rB6BBqZo" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6BBqZp" role="3cpWs9">
-            <property role="TrG5h" value="sDataTypeIter" />
-            <node concept="uOF1S" id="5M3rB6BBqZq" role="1tU5fm">
-              <node concept="3uibUv" id="5M3rB6BBqZr" role="uOL27">
-                <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5M3rB6BBqZs" role="33vP2m">
-              <node concept="2OqwBi" id="5M3rB6BBqZt" role="2Oq$k0">
-                <node concept="37vLTw" id="5M3rB6BBr03" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="5M3rB6BBqZv" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3k1p" resolve="listSLanguagePrimitiveTypes" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6BBqZw" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="2$JKZl" id="5M3rB6BBqZx" role="3cqZAp">
-          <node concept="3clFbS" id="5M3rB6BBqZy" role="2LFqv$">
+          <node concept="3clFbS" id="7OJcYqyPiPb" role="2LFqv$">
             <node concept="3clFbF" id="5M3rB6BBqZz" role="3cqZAp">
               <node concept="37vLTI" id="5M3rB6BBqZ$" role="3clFbG">
-                <node concept="2OqwBi" id="5M3rB6BBqZ_" role="37vLTx">
-                  <node concept="37vLTw" id="5M3rB6BBqZA" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5M3rB6BBqZh" resolve="jsonDataTypeIter" />
+                <node concept="2OqwBi" id="7OJcYqyQJTV" role="37vLTx">
+                  <node concept="2GrUjf" id="7OJcYqyQEC2" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="7OJcYqyPiP7" resolve="dataType" />
                   </node>
-                  <node concept="v1n4t" id="5M3rB6BBqZB" role="2OqNvi" />
+                  <node concept="liA8E" id="7OJcYqyQPH1" role="2OqNvi">
+                    <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
+                  </node>
                 </node>
                 <node concept="3EllGN" id="5M3rB6BBqZC" role="37vLTJ">
-                  <node concept="2OqwBi" id="5M3rB6BBqZD" role="3ElVtu">
-                    <node concept="37vLTw" id="5M3rB6BBqZE" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M3rB6BBqZp" resolve="sDataTypeIter" />
+                  <node concept="1eOMI4" id="7OJcYq$hMMI" role="3ElVtu">
+                    <node concept="10QFUN" id="7OJcYq$hMMH" role="1eOMHV">
+                      <node concept="2OqwBi" id="7OJcYq$hMMC" role="10QFUP">
+                        <node concept="2OqwBi" id="7OJcYq$hMMD" role="2Oq$k0">
+                          <node concept="2GrUjf" id="7OJcYq$hMME" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="7OJcYqyPiP7" resolve="dataType" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYq$hMMF" role="2OqNvi">
+                            <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="7OJcYq$hMMG" role="2OqNvi">
+                          <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
+                        </node>
+                      </node>
+                      <node concept="3uibUv" id="7OJcYq$hUrZ" role="10QFUM">
+                        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+                      </node>
                     </node>
-                    <node concept="v1n4t" id="5M3rB6BBqZF" role="2OqNvi" />
                   </node>
                   <node concept="2OqwBi" id="5M3rB6BBqZG" role="3ElQJh">
                     <node concept="Xjq3P" id="5M3rB6BBqZH" role="2Oq$k0" />
@@ -1093,80 +1065,58 @@
               </node>
             </node>
           </node>
-          <node concept="1Wc70l" id="5M3rB6BBqZJ" role="2$JKZa">
-            <node concept="2OqwBi" id="5M3rB6BBqZK" role="3uHU7w">
-              <node concept="37vLTw" id="5M3rB6BBqZL" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6BBqZp" resolve="sDataTypeIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6BBqZM" role="2OqNvi" />
+          <node concept="2OqwBi" id="7OJcYqyP0Ho" role="2GsD0m">
+            <node concept="37vLTw" id="7OJcYqyOUTZ" role="2Oq$k0">
+              <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
             </node>
-            <node concept="2OqwBi" id="5M3rB6BBqZN" role="3uHU7B">
-              <node concept="37vLTw" id="5M3rB6BBqZO" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6BBqZh" resolve="jsonDataTypeIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6BBqZP" role="2OqNvi" />
+            <node concept="liA8E" id="7OJcYqyP7bq" role="2OqNvi">
+              <ref role="37wK5l" to="6peh:7OJcYqxTsMO" resolve="listPrimitiveTypesX" />
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="5M3rB6BBqZQ" role="3cqZAp" />
-        <node concept="3cpWs8" id="5M3rB6BDRj5" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6BDRj6" role="3cpWs9">
-            <property role="TrG5h" value="jsonClassifierIter" />
-            <node concept="2YL$Hu" id="5M3rB6BDRj7" role="1tU5fm">
-              <node concept="3uibUv" id="5M3rB6BDRj8" role="uOL27">
-                <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
-              </node>
+        <node concept="2Gpval" id="7OJcYqyR1HQ" role="3cqZAp">
+          <node concept="2GrKxI" id="7OJcYqyR1HS" role="2Gsz3X">
+            <property role="TrG5h" value="classifier" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqyRtIn" role="2GsD0m">
+            <node concept="37vLTw" id="7OJcYqyRiCe" role="2Oq$k0">
+              <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
             </node>
-            <node concept="2OqwBi" id="5M3rB6BDRj9" role="33vP2m">
-              <node concept="2OqwBi" id="5TNjoy1wsUX" role="2Oq$k0">
-                <node concept="37vLTw" id="5TNjoy1wovd" role="2Oq$k0">
-                  <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
-                </node>
-                <node concept="liA8E" id="5TNjoy1wzOf" role="2OqNvi">
-                  <ref role="37wK5l" to="6peh:5JNiskj4Oxz" resolve="listClassifiers" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6BDRjc" role="2OqNvi" />
+            <node concept="liA8E" id="7OJcYqyR$d3" role="2OqNvi">
+              <ref role="37wK5l" to="6peh:7OJcYqxTwQ8" resolve="listClassifiersX" />
             </node>
           </node>
-        </node>
-        <node concept="3cpWs8" id="5M3rB6BDRjd" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6BDRje" role="3cpWs9">
-            <property role="TrG5h" value="sClassifierIter" />
-            <node concept="uOF1S" id="5M3rB6BDRjf" role="1tU5fm">
-              <node concept="3uibUv" id="6jI_U5e$kbJ" role="uOL27">
-                <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5M3rB6BDRjh" role="33vP2m">
-              <node concept="2OqwBi" id="5M3rB6BDRji" role="2Oq$k0">
-                <node concept="37vLTw" id="5M3rB6BDRjZ" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="5M3rB6BDRjk" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jZG" resolve="listSLanguageClassifiers" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6BDRjl" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="2$JKZl" id="5M3rB6BDRjm" role="3cqZAp">
-          <node concept="3clFbS" id="5M3rB6BDRjn" role="2LFqv$">
+          <node concept="3clFbS" id="7OJcYqyR1HW" role="2LFqv$">
             <node concept="3clFbF" id="6jI_U5e$_Jl" role="3cqZAp">
               <node concept="37vLTI" id="6jI_U5e_dsn" role="3clFbG">
-                <node concept="2OqwBi" id="6jI_U5e_qE1" role="37vLTx">
-                  <node concept="37vLTw" id="6jI_U5e_klM" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5M3rB6BDRj6" resolve="jsonClassifierIter" />
+                <node concept="2OqwBi" id="7OJcYqySz1X" role="37vLTx">
+                  <node concept="2GrUjf" id="7OJcYqyStDK" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="7OJcYqyR1HS" resolve="classifier" />
                   </node>
-                  <node concept="v1n4t" id="6jI_U5e_v1a" role="2OqNvi" />
+                  <node concept="liA8E" id="7OJcYqySBkI" role="2OqNvi">
+                    <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
+                  </node>
                 </node>
                 <node concept="3EllGN" id="6jI_U5e$SHg" role="37vLTJ">
-                  <node concept="2OqwBi" id="6jI_U5e_26S" role="3ElVtu">
-                    <node concept="37vLTw" id="6jI_U5e$Ydu" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M3rB6BDRje" resolve="sClassifierIter" />
+                  <node concept="1eOMI4" id="7OJcYq$i1me" role="3ElVtu">
+                    <node concept="10QFUN" id="7OJcYq$i1md" role="1eOMHV">
+                      <node concept="2OqwBi" id="7OJcYq$i1m8" role="10QFUP">
+                        <node concept="2OqwBi" id="7OJcYq$i1m9" role="2Oq$k0">
+                          <node concept="2GrUjf" id="7OJcYq$i1ma" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="7OJcYqyR1HS" resolve="classifier" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYq$i1mb" role="2OqNvi">
+                            <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="7OJcYq$i1mc" role="2OqNvi">
+                          <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
+                        </node>
+                      </node>
+                      <node concept="3uibUv" id="7OJcYq$i8xk" role="10QFUM">
+                        <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                      </node>
                     </node>
-                    <node concept="v1n4t" id="6jI_U5e_6xK" role="2OqNvi" />
                   </node>
                   <node concept="2OqwBi" id="6jI_U5e$FZj" role="3ElQJh">
                     <node concept="Xjq3P" id="6jI_U5e$_Jj" role="2Oq$k0" />
@@ -1176,20 +1126,6 @@
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="1Wc70l" id="5M3rB6BDRjw" role="2$JKZa">
-            <node concept="2OqwBi" id="5M3rB6BDRjx" role="3uHU7w">
-              <node concept="37vLTw" id="5M3rB6BDRjy" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6BDRje" resolve="sClassifierIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6BDRjz" role="2OqNvi" />
-            </node>
-            <node concept="2OqwBi" id="5M3rB6BDRj$" role="3uHU7B">
-              <node concept="37vLTw" id="5M3rB6BDRj_" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6BDRj6" resolve="jsonClassifierIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6BDRjA" role="2OqNvi" />
             </node>
           </node>
         </node>
@@ -1735,12 +1671,17 @@
                   <ref role="3cqZAo" node="utjSYFn2k8" resolve="mpsDataTypes" />
                 </node>
                 <node concept="TSZUe" id="utjSYFn2kj" role="2OqNvi">
-                  <node concept="2OqwBi" id="utjSYFn2kk" role="25WWJ7">
-                    <node concept="37vLTw" id="utjSYFn2kl" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                  <node concept="2OqwBi" id="7OJcYqyTiPc" role="25WWJ7">
+                    <node concept="2OqwBi" id="utjSYFn2kk" role="2Oq$k0">
+                      <node concept="37vLTw" id="utjSYFn2kl" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYqyTdoS" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:7OJcYqwQm1t" resolve="getBoolean" />
+                      </node>
                     </node>
-                    <node concept="liA8E" id="utjSYFn2km" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3jVJ" resolve="slangBooleanType" />
+                    <node concept="liA8E" id="7OJcYqyTpwF" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
                     </node>
                   </node>
                 </node>
@@ -1752,12 +1693,17 @@
                   <ref role="3cqZAo" node="utjSYFn2k8" resolve="mpsDataTypes" />
                 </node>
                 <node concept="TSZUe" id="utjSYFn2kq" role="2OqNvi">
-                  <node concept="2OqwBi" id="utjSYFn2kr" role="25WWJ7">
-                    <node concept="37vLTw" id="utjSYFn2ks" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                  <node concept="2OqwBi" id="7OJcYqyTGl1" role="25WWJ7">
+                    <node concept="2OqwBi" id="utjSYFn2kr" role="2Oq$k0">
+                      <node concept="37vLTw" id="utjSYFn2ks" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYqyTBry" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:7OJcYqwQm1A" resolve="getInteger" />
+                      </node>
                     </node>
-                    <node concept="liA8E" id="utjSYFn2kt" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3jW4" resolve="slangIntegerType" />
+                    <node concept="liA8E" id="7OJcYqyTLRK" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
                     </node>
                   </node>
                 </node>
@@ -1769,12 +1715,17 @@
                   <ref role="3cqZAo" node="utjSYFn2k8" resolve="mpsDataTypes" />
                 </node>
                 <node concept="TSZUe" id="utjSYFn2kx" role="2OqNvi">
-                  <node concept="2OqwBi" id="utjSYFn2ky" role="25WWJ7">
-                    <node concept="37vLTw" id="utjSYFn2kz" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                  <node concept="2OqwBi" id="7OJcYqyU3ST" role="25WWJ7">
+                    <node concept="2OqwBi" id="utjSYFn2ky" role="2Oq$k0">
+                      <node concept="37vLTw" id="utjSYFn2kz" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYqyTZp5" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:7OJcYqwQm1k" resolve="getString" />
+                      </node>
                     </node>
-                    <node concept="liA8E" id="utjSYFn2k$" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3jVq" resolve="slangStringType" />
+                    <node concept="liA8E" id="7OJcYqyUbO7" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
                     </node>
                   </node>
                 </node>
@@ -1783,12 +1734,17 @@
             <node concept="3clFbH" id="utjSYFn2k_" role="3cqZAp" />
           </node>
           <node concept="17R0WA" id="utjSYFn2kA" role="3clFbw">
-            <node concept="2OqwBi" id="utjSYFn2kB" role="3uHU7w">
-              <node concept="37vLTw" id="utjSYFn2kC" role="2Oq$k0">
-                <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+            <node concept="2OqwBi" id="7OJcYqySTI6" role="3uHU7w">
+              <node concept="2OqwBi" id="utjSYFn2kB" role="2Oq$k0">
+                <node concept="37vLTw" id="utjSYFn2kC" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                </node>
+                <node concept="liA8E" id="utjSYFn2kD" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqxK_pb" resolve="getCoreLanguage" />
+                </node>
               </node>
-              <node concept="liA8E" id="utjSYFn2kD" role="2OqNvi">
-                <ref role="37wK5l" to="y7p:5JNiski3jYf" resolve="slangCoreLanguage" />
+              <node concept="liA8E" id="7OJcYqySZ9X" role="2OqNvi">
+                <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
               </node>
             </node>
             <node concept="37vLTw" id="utjSYFn2kN" role="3uHU7B">
@@ -3772,12 +3728,17 @@
                 <node concept="37vLTw" id="3M8YG$crwpQ" role="3uHU7B">
                   <ref role="3cqZAo" node="3M8YG$crwpK" resolve="superConcept" />
                 </node>
-                <node concept="2OqwBi" id="6Pr6izIRvJQ" role="3uHU7w">
-                  <node concept="37vLTw" id="6Pr6izIRvJR" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                <node concept="2OqwBi" id="7OJcYqyUwo0" role="3uHU7w">
+                  <node concept="2OqwBi" id="6Pr6izIRvJQ" role="2Oq$k0">
+                    <node concept="37vLTw" id="6Pr6izIRvJR" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqyUpFO" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqwQm21" resolve="getAnnotation" />
+                    </node>
                   </node>
-                  <node concept="liA8E" id="5JNiskhUZtq" role="2OqNvi">
-                    <ref role="37wK5l" to="y7p:5JNiski3jWZ" resolve="slangAnnotationConcept" />
+                  <node concept="liA8E" id="7OJcYqyUBbI" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
                   </node>
                 </node>
               </node>
@@ -3856,12 +3817,17 @@
           <node concept="3clFbS" id="6Pr6izIMRYx" role="3clFbx">
             <node concept="3clFbF" id="6Pr6izIOV6J" role="3cqZAp">
               <node concept="37vLTI" id="6Pr6izIP1te" role="3clFbG">
-                <node concept="2OqwBi" id="6Pr6izIPg9j" role="37vLTx">
-                  <node concept="37vLTw" id="6Pr6izIP8Ls" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                <node concept="2OqwBi" id="7OJcYqyUUIB" role="37vLTx">
+                  <node concept="2OqwBi" id="6Pr6izIPg9j" role="2Oq$k0">
+                    <node concept="37vLTw" id="6Pr6izIP8Ls" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqyUPfs" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqwQm1S" resolve="getNode" />
+                    </node>
                   </node>
-                  <node concept="liA8E" id="5JNiskhU6Zg" role="2OqNvi">
-                    <ref role="37wK5l" to="y7p:5JNiski3jWI" resolve="slangNodeConcept" />
+                  <node concept="liA8E" id="7OJcYqyV0zM" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
                   </node>
                 </node>
                 <node concept="37vLTw" id="6Pr6izIOV6H" role="37vLTJ">
@@ -3905,42 +3871,74 @@
         </node>
         <node concept="3clFbJ" id="7weWCFltqqx" role="3cqZAp">
           <node concept="3clFbS" id="7weWCFltqqz" role="3clFbx">
-            <node concept="3cpWs8" id="7weWCFlurS5" role="3cqZAp">
-              <node concept="3cpWsn" id="7weWCFlurS6" role="3cpWs9">
-                <property role="TrG5h" value="index" />
-                <node concept="10Oyi0" id="7weWCFlup3C" role="1tU5fm" />
-                <node concept="2OqwBi" id="7weWCFlurS7" role="33vP2m">
-                  <node concept="2OqwBi" id="7weWCFlurS8" role="2Oq$k0">
-                    <node concept="37vLTw" id="7weWCFlurS9" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
-                    </node>
-                    <node concept="liA8E" id="7weWCFlurSa" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:7weWCFlqTiX" resolve="listSLanguageInternalClassifiers" />
+            <node concept="3cpWs8" id="7OJcYqzSs4i" role="3cqZAp">
+              <node concept="3cpWsn" id="7OJcYqzSs4j" role="3cpWs9">
+                <property role="TrG5h" value="mapper" />
+                <node concept="3uibUv" id="7OJcYqzSmlX" role="1tU5fm">
+                  <ref role="3uigEE" to="6peh:7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+                  <node concept="3qUE_q" id="7OJcYqzSmmc" role="11_B2D">
+                    <node concept="3uibUv" id="7OJcYqzSmmd" role="3qUE_r">
+                      <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
                     </node>
                   </node>
-                  <node concept="2WmjW8" id="7weWCFlurSb" role="2OqNvi">
-                    <node concept="37vLTw" id="7weWCFlurSc" role="25WWJ7">
-                      <ref role="3cqZAo" node="18UigYQQoXE" resolve="annotatedConcept" />
+                  <node concept="3qUE_q" id="7OJcYqzSmma" role="11_B2D">
+                    <node concept="3uibUv" id="7OJcYqzSmmb" role="3qUE_r">
+                      <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqzSs4k" role="33vP2m">
+                  <node concept="2OqwBi" id="7OJcYqzSs4l" role="2Oq$k0">
+                    <node concept="37vLTw" id="7OJcYqzSs4m" role="2Oq$k0">
+                      <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqzSs4n" role="2OqNvi">
+                      <ref role="37wK5l" to="6peh:7OJcYqyVkp8" resolve="listReplacementMpsSpecificClassifiersX" />
+                    </node>
+                  </node>
+                  <node concept="1z4cxt" id="7OJcYqzSs4o" role="2OqNvi">
+                    <node concept="1bVj0M" id="7OJcYqzSs4p" role="23t8la">
+                      <node concept="3clFbS" id="7OJcYqzSs4q" role="1bW5cS">
+                        <node concept="3clFbF" id="7OJcYqzSs4r" role="3cqZAp">
+                          <node concept="17R0WA" id="7OJcYqzSs4s" role="3clFbG">
+                            <node concept="37vLTw" id="7OJcYqzSs4t" role="3uHU7w">
+                              <ref role="3cqZAo" node="18UigYQQoXE" resolve="annotatedConcept" />
+                            </node>
+                            <node concept="2OqwBi" id="7OJcYqzSs4u" role="3uHU7B">
+                              <node concept="2OqwBi" id="7OJcYqzSs4v" role="2Oq$k0">
+                                <node concept="37vLTw" id="7OJcYqzSs4w" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7OJcYqzSs4z" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="7OJcYqzSs4x" role="2OqNvi">
+                                  <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="7OJcYqzSs4y" role="2OqNvi">
+                                <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="7OJcYqzSs4z" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7OJcYqzSs4$" role="1tU5fm" />
+                      </node>
                     </node>
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="3clFbJ" id="7weWCFluCWT" role="3cqZAp">
-              <node concept="3clFbS" id="7weWCFluCWV" role="3clFbx">
+            <node concept="3clFbJ" id="7OJcYqyXC$y" role="3cqZAp">
+              <node concept="3clFbS" id="7OJcYqyXC$$" role="3clFbx">
                 <node concept="3clFbF" id="7weWCFlvezJ" role="3cqZAp">
                   <node concept="37vLTI" id="7weWCFlvm7j" role="3clFbG">
-                    <node concept="1y4W85" id="7weWCFl$5Et" role="37vLTx">
-                      <node concept="37vLTw" id="7weWCFl$b4i" role="1y58nS">
-                        <ref role="3cqZAo" node="7weWCFlurS6" resolve="index" />
+                    <node concept="2OqwBi" id="7OJcYqyYecA" role="37vLTx">
+                      <node concept="37vLTw" id="7OJcYqyXjte" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqzSs4j" resolve="mapper" />
                       </node>
-                      <node concept="2OqwBi" id="7weWCFlzRPO" role="1y566C">
-                        <node concept="37vLTw" id="7weWCFlzL4M" role="2Oq$k0">
-                          <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
-                        </node>
-                        <node concept="liA8E" id="7weWCFlzY_f" role="2OqNvi">
-                          <ref role="37wK5l" to="6peh:7weWCFlvJcc" resolve="listReplacementMpsSpecificClassifiers" />
-                        </node>
+                      <node concept="liA8E" id="7OJcYqyYkY0" role="2OqNvi">
+                        <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
                       </node>
                     </node>
                     <node concept="37vLTw" id="7weWCFlvezG" role="37vLTJ">
@@ -3949,12 +3947,10 @@
                   </node>
                 </node>
               </node>
-              <node concept="2d3UOw" id="7weWCFluRip" role="3clFbw">
-                <node concept="3cmrfG" id="7weWCFluY7$" role="3uHU7w">
-                  <property role="3cmrfH" value="0" />
-                </node>
-                <node concept="37vLTw" id="7weWCFluKdK" role="3uHU7B">
-                  <ref role="3cqZAo" node="7weWCFlurS6" resolve="index" />
+              <node concept="3y3z36" id="7OJcYqyXPUs" role="3clFbw">
+                <node concept="10Nm6u" id="7OJcYqyXUpc" role="3uHU7w" />
+                <node concept="37vLTw" id="7OJcYqyXJel" role="3uHU7B">
+                  <ref role="3cqZAo" node="7OJcYqzSs4j" resolve="mapper" />
                 </node>
               </node>
             </node>
@@ -4651,12 +4647,17 @@
                     </node>
                     <node concept="3clFbF" id="6jI_U5epxYM" role="3cqZAp">
                       <node concept="37vLTI" id="6jI_U5epElj" role="3clFbG">
-                        <node concept="2OqwBi" id="6jI_U5epOok" role="37vLTx">
-                          <node concept="37vLTw" id="6jI_U5epJTA" role="2Oq$k0">
-                            <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
+                        <node concept="2OqwBi" id="7OJcYqz$M1I" role="37vLTx">
+                          <node concept="2OqwBi" id="6jI_U5epOok" role="2Oq$k0">
+                            <node concept="37vLTw" id="6jI_U5epJTA" role="2Oq$k0">
+                              <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
+                            </node>
+                            <node concept="liA8E" id="5TNjoy1wHlu" role="2OqNvi">
+                              <ref role="37wK5l" to="6peh:7OJcYqxR63A" resolve="getStringX" />
+                            </node>
                           </node>
-                          <node concept="liA8E" id="5TNjoy1wHlu" role="2OqNvi">
-                            <ref role="37wK5l" to="6peh:5JNiskj4OxK" resolve="getString" />
+                          <node concept="liA8E" id="7OJcYqz$TdJ" role="2OqNvi">
+                            <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
                           </node>
                         </node>
                         <node concept="37vLTw" id="6jI_U5epxYK" role="37vLTJ">
@@ -6012,13 +6013,38 @@
                 <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
               </node>
             </node>
-            <node concept="2OqwBi" id="3IM5Sl$mTUq" role="33vP2m">
-              <node concept="37vLTw" id="3IM5Sl$mTUr" role="2Oq$k0">
-                <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+            <node concept="2OqwBi" id="7OJcYqyOAHV" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqyO5Hc" role="2Oq$k0">
+                <node concept="2OqwBi" id="3IM5Sl$mTUq" role="2Oq$k0">
+                  <node concept="37vLTw" id="3IM5Sl$mTUr" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="3IM5Sl$mTUs" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqxrfm4" resolve="listConceptDescriptionProperty" />
+                  </node>
+                </node>
+                <node concept="3$u5V9" id="7OJcYqyOdyD" role="2OqNvi">
+                  <node concept="1bVj0M" id="7OJcYqyOdyF" role="23t8la">
+                    <node concept="3clFbS" id="7OJcYqyOdyG" role="1bW5cS">
+                      <node concept="3clFbF" id="7OJcYqyOjWP" role="3cqZAp">
+                        <node concept="2OqwBi" id="7OJcYqyOph6" role="3clFbG">
+                          <node concept="37vLTw" id="7OJcYqyOjWO" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqyOdyH" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqyOw9o" role="2OqNvi">
+                            <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="7OJcYqyOdyH" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="7OJcYqyOdyI" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
               </node>
-              <node concept="liA8E" id="3IM5Sl$mTUs" role="2OqNvi">
-                <ref role="37wK5l" to="y7p:34Q84zNtsh8" resolve="listConceptDescriptionProperties" />
-              </node>
+              <node concept="ANE8D" id="7OJcYqyOHIe" role="2OqNvi" />
             </node>
           </node>
         </node>
@@ -6169,12 +6195,17 @@
                     </node>
                   </node>
                   <node concept="2OqwBi" id="3IM5Sl$oJNF" role="3uHU7w">
-                    <node concept="2OqwBi" id="3IM5Sl$oJNG" role="2Oq$k0">
-                      <node concept="37vLTw" id="3IM5Sl$oJNH" role="2Oq$k0">
-                        <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
+                    <node concept="2OqwBi" id="7OJcYqyYDu9" role="2Oq$k0">
+                      <node concept="2OqwBi" id="3IM5Sl$oJNG" role="2Oq$k0">
+                        <node concept="37vLTw" id="3IM5Sl$oJNH" role="2Oq$k0">
+                          <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
+                        </node>
+                        <node concept="liA8E" id="3IM5Sl$oJNI" role="2OqNvi">
+                          <ref role="37wK5l" to="6peh:7OJcYqyb96D" resolve="getConceptDescriptionAnnotationX" />
+                        </node>
                       </node>
-                      <node concept="liA8E" id="3IM5Sl$oJNI" role="2OqNvi">
-                        <ref role="37wK5l" to="6peh:34Q84zNB8uo" resolve="getConceptDescriptionAnnotation" />
+                      <node concept="liA8E" id="7OJcYqyYKmo" role="2OqNvi">
+                        <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
                       </node>
                     </node>
                     <node concept="liA8E" id="3IM5Sl$oJNJ" role="2OqNvi">
@@ -6182,12 +6213,17 @@
                     </node>
                   </node>
                 </node>
-                <node concept="2OqwBi" id="3IM5Sl$oJNK" role="37wK5m">
-                  <node concept="37vLTw" id="3IM5Sl$oJNL" role="2Oq$k0">
-                    <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
+                <node concept="2OqwBi" id="7OJcYqyZ4Pm" role="37wK5m">
+                  <node concept="2OqwBi" id="3IM5Sl$oJNK" role="2Oq$k0">
+                    <node concept="37vLTw" id="3IM5Sl$oJNL" role="2Oq$k0">
+                      <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
+                    </node>
+                    <node concept="liA8E" id="3IM5Sl$oJNM" role="2OqNvi">
+                      <ref role="37wK5l" to="6peh:7OJcYqyb96D" resolve="getConceptDescriptionAnnotationX" />
+                    </node>
                   </node>
-                  <node concept="liA8E" id="3IM5Sl$oJNM" role="2OqNvi">
-                    <ref role="37wK5l" to="6peh:34Q84zNB8uo" resolve="getConceptDescriptionAnnotation" />
+                  <node concept="liA8E" id="7OJcYqyZcSE" role="2OqNvi">
+                    <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
                   </node>
                 </node>
               </node>
@@ -6230,13 +6266,38 @@
                       </node>
                       <node concept="3AY5_j" id="3IM5Sl$oJO4" role="2OqNvi" />
                     </node>
-                    <node concept="2OqwBi" id="3IM5Sl$oJO5" role="1y566C">
-                      <node concept="37vLTw" id="3IM5Sl$oJO6" role="2Oq$k0">
-                        <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
+                    <node concept="2OqwBi" id="7OJcYqzBU2g" role="1y566C">
+                      <node concept="2OqwBi" id="7OJcYqzBjHi" role="2Oq$k0">
+                        <node concept="2OqwBi" id="3IM5Sl$oJO5" role="2Oq$k0">
+                          <node concept="37vLTw" id="3IM5Sl$oJO6" role="2Oq$k0">
+                            <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
+                          </node>
+                          <node concept="liA8E" id="3IM5Sl$oJO7" role="2OqNvi">
+                            <ref role="37wK5l" to="6peh:7OJcYqzAV4V" resolve="listConceptDescriptionPropertiesX" />
+                          </node>
+                        </node>
+                        <node concept="3$u5V9" id="7OJcYqzBs_e" role="2OqNvi">
+                          <node concept="1bVj0M" id="7OJcYqzBs_g" role="23t8la">
+                            <node concept="3clFbS" id="7OJcYqzBs_h" role="1bW5cS">
+                              <node concept="3clFbF" id="7OJcYqzB_uP" role="3cqZAp">
+                                <node concept="2OqwBi" id="7OJcYqzBFCZ" role="3clFbG">
+                                  <node concept="37vLTw" id="7OJcYqzB_uO" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="7OJcYqzBs_i" resolve="it" />
+                                  </node>
+                                  <node concept="liA8E" id="7OJcYqzBMZv" role="2OqNvi">
+                                    <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="Rh6nW" id="7OJcYqzBs_i" role="1bW2Oz">
+                              <property role="TrG5h" value="it" />
+                              <node concept="2jxLKc" id="7OJcYqzBs_j" role="1tU5fm" />
+                            </node>
+                          </node>
+                        </node>
                       </node>
-                      <node concept="liA8E" id="3IM5Sl$oJO7" role="2OqNvi">
-                        <ref role="37wK5l" to="6peh:34Q84zN__4k" resolve="listConceptDescriptionProperties" />
-                      </node>
+                      <node concept="ANE8D" id="7OJcYqzC1Q4" role="2OqNvi" />
                     </node>
                   </node>
                   <node concept="2OqwBi" id="3IM5Sl$oJO8" role="37wK5m">
@@ -9545,12 +9606,17 @@
                   <ref role="3cqZAo" node="utjSYF$Wva" resolve="classifiersToProcess" />
                 </node>
                 <node concept="3dhRuq" id="utjSYGae1E" role="2OqNvi">
-                  <node concept="2OqwBi" id="utjSYGae1G" role="25WWJ7">
-                    <node concept="37vLTw" id="utjSYGae1H" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                  <node concept="2OqwBi" id="7OJcYqz7lc8" role="25WWJ7">
+                    <node concept="2OqwBi" id="utjSYGae1G" role="2Oq$k0">
+                      <node concept="37vLTw" id="utjSYGae1H" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                      </node>
+                      <node concept="liA8E" id="utjSYGae1I" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:7OJcYqwQm21" resolve="getAnnotation" />
+                      </node>
                     </node>
-                    <node concept="liA8E" id="utjSYGae1I" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3jWZ" resolve="slangAnnotationConcept" />
+                    <node concept="liA8E" id="7OJcYqz7vdM" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
                     </node>
                   </node>
                 </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.language.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.language.mps
@@ -3068,7 +3068,7 @@
                   <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
                 </node>
                 <node concept="liA8E" id="6Pr6izIjQYY" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiskiswUo" resolve="isMpsInternalConcept" />
+                  <ref role="37wK5l" to="y7p:5JNiskiswUo" resolve="isMpsInternalElement" />
                   <node concept="37vLTw" id="6Pr6izIjUSy" role="37wK5m">
                     <ref role="3cqZAo" node="48csSBNReGB" resolve="mps" />
                   </node>
@@ -3444,7 +3444,7 @@
                         <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
                       </node>
                       <node concept="liA8E" id="6Pr6izImCFW" role="2OqNvi">
-                        <ref role="37wK5l" to="y7p:5JNiskiswUo" resolve="isMpsInternalConcept" />
+                        <ref role="37wK5l" to="y7p:5JNiskiswUo" resolve="isMpsInternalElement" />
                         <node concept="37vLTw" id="3M8YG$crBUW" role="37wK5m">
                           <ref role="3cqZAo" node="3M8YG$crBUQ" resolve="superConcept" />
                         </node>
@@ -8794,7 +8794,7 @@
                           <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
                         </node>
                         <node concept="liA8E" id="7weWCFlA0Kb" role="2OqNvi">
-                          <ref role="37wK5l" to="y7p:5JNiskiswUo" resolve="isMpsInternalConcept" />
+                          <ref role="37wK5l" to="y7p:5JNiskiswUo" resolve="isMpsInternalElement" />
                           <node concept="37vLTw" id="7weWCFlAcuc" role="37wK5m">
                             <ref role="3cqZAo" node="4Yo3buZb6Qj" resolve="e" />
                           </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.language.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.language.mps
@@ -1043,7 +1043,7 @@
                             <ref role="2Gs0qQ" node="7OJcYqyPiP7" resolve="dataType" />
                           </node>
                           <node concept="liA8E" id="7OJcYq$hMMF" role="2OqNvi">
-                            <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                            <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getStaple" />
                           </node>
                         </node>
                         <node concept="liA8E" id="7OJcYq$hMMG" role="2OqNvi">
@@ -1070,7 +1070,7 @@
               <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
             </node>
             <node concept="liA8E" id="7OJcYqyP7bq" role="2OqNvi">
-              <ref role="37wK5l" to="6peh:7OJcYqxTsMO" resolve="listPrimitiveTypesX" />
+              <ref role="37wK5l" to="6peh:7OJcYqxTsMO" resolve="listLcPrimitiveTypes" />
             </node>
           </node>
         </node>
@@ -1083,7 +1083,7 @@
               <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
             </node>
             <node concept="liA8E" id="7OJcYqyR$d3" role="2OqNvi">
-              <ref role="37wK5l" to="6peh:7OJcYqxTwQ8" resolve="listClassifiersX" />
+              <ref role="37wK5l" to="6peh:7OJcYqxTwQ8" resolve="listLcClassifiers" />
             </node>
           </node>
           <node concept="3clFbS" id="7OJcYqyR1HW" role="2LFqv$">
@@ -1106,7 +1106,7 @@
                             <ref role="2Gs0qQ" node="7OJcYqyR1HS" resolve="classifier" />
                           </node>
                           <node concept="liA8E" id="7OJcYq$i1mb" role="2OqNvi">
-                            <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                            <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getStaple" />
                           </node>
                         </node>
                         <node concept="liA8E" id="7OJcYq$i1mc" role="2OqNvi">
@@ -3873,9 +3873,9 @@
           <node concept="3clFbS" id="7weWCFltqqz" role="3clFbx">
             <node concept="3cpWs8" id="7OJcYqzSs4i" role="3cqZAp">
               <node concept="3cpWsn" id="7OJcYqzSs4j" role="3cpWs9">
-                <property role="TrG5h" value="mapper" />
+                <property role="TrG5h" value="staple" />
                 <node concept="3uibUv" id="7OJcYqzSmlX" role="1tU5fm">
-                  <ref role="3uigEE" to="6peh:7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+                  <ref role="3uigEE" to="6peh:7OJcYqxQZIZ" resolve="IJsonStaple" />
                   <node concept="3qUE_q" id="7OJcYqzSmmc" role="11_B2D">
                     <node concept="3uibUv" id="7OJcYqzSmmd" role="3qUE_r">
                       <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
@@ -3883,7 +3883,7 @@
                   </node>
                   <node concept="3qUE_q" id="7OJcYqzSmma" role="11_B2D">
                     <node concept="3uibUv" id="7OJcYqzSmmb" role="3qUE_r">
-                      <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+                      <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierStaple" />
                     </node>
                   </node>
                 </node>
@@ -3893,7 +3893,7 @@
                       <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
                     </node>
                     <node concept="liA8E" id="7OJcYqzSs4n" role="2OqNvi">
-                      <ref role="37wK5l" to="6peh:7OJcYqyVkp8" resolve="listReplacementMpsSpecificClassifiersX" />
+                      <ref role="37wK5l" to="6peh:7OJcYqyVkp8" resolve="listMpsInternalClassifiers" />
                     </node>
                   </node>
                   <node concept="1z4cxt" id="7OJcYqzSs4o" role="2OqNvi">
@@ -3910,7 +3910,7 @@
                                   <ref role="3cqZAo" node="7OJcYqzSs4z" resolve="it" />
                                 </node>
                                 <node concept="liA8E" id="7OJcYqzSs4x" role="2OqNvi">
-                                  <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                                  <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getStaple" />
                                 </node>
                               </node>
                               <node concept="liA8E" id="7OJcYqzSs4y" role="2OqNvi">
@@ -3935,7 +3935,7 @@
                   <node concept="37vLTI" id="7weWCFlvm7j" role="3clFbG">
                     <node concept="2OqwBi" id="7OJcYqyYecA" role="37vLTx">
                       <node concept="37vLTw" id="7OJcYqyXjte" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7OJcYqzSs4j" resolve="mapper" />
+                        <ref role="3cqZAo" node="7OJcYqzSs4j" resolve="staple" />
                       </node>
                       <node concept="liA8E" id="7OJcYqyYkY0" role="2OqNvi">
                         <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
@@ -3950,7 +3950,7 @@
               <node concept="3y3z36" id="7OJcYqyXPUs" role="3clFbw">
                 <node concept="10Nm6u" id="7OJcYqyXUpc" role="3uHU7w" />
                 <node concept="37vLTw" id="7OJcYqyXJel" role="3uHU7B">
-                  <ref role="3cqZAo" node="7OJcYqzSs4j" resolve="mapper" />
+                  <ref role="3cqZAo" node="7OJcYqzSs4j" resolve="staple" />
                 </node>
               </node>
             </node>
@@ -4653,7 +4653,7 @@
                               <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
                             </node>
                             <node concept="liA8E" id="5TNjoy1wHlu" role="2OqNvi">
-                              <ref role="37wK5l" to="6peh:7OJcYqxR63A" resolve="getStringX" />
+                              <ref role="37wK5l" to="6peh:7OJcYqxR63A" resolve="getString" />
                             </node>
                           </node>
                           <node concept="liA8E" id="7OJcYqz$TdJ" role="2OqNvi">
@@ -6020,7 +6020,7 @@
                     <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
                   </node>
                   <node concept="liA8E" id="3IM5Sl$mTUs" role="2OqNvi">
-                    <ref role="37wK5l" to="y7p:7OJcYqxrfm4" resolve="listConceptDescriptionProperty" />
+                    <ref role="37wK5l" to="y7p:7OJcYqxrfm4" resolve="listMpsM2AnnotationProperties" />
                   </node>
                 </node>
                 <node concept="3$u5V9" id="7OJcYqyOdyD" role="2OqNvi">
@@ -6201,7 +6201,7 @@
                           <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
                         </node>
                         <node concept="liA8E" id="3IM5Sl$oJNI" role="2OqNvi">
-                          <ref role="37wK5l" to="6peh:7OJcYqyb96D" resolve="getConceptDescriptionAnnotationX" />
+                          <ref role="37wK5l" to="6peh:7OJcYqyb96D" resolve="getConceptDescriptionAnnotation" />
                         </node>
                       </node>
                       <node concept="liA8E" id="7OJcYqyYKmo" role="2OqNvi">
@@ -6219,7 +6219,7 @@
                       <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
                     </node>
                     <node concept="liA8E" id="3IM5Sl$oJNM" role="2OqNvi">
-                      <ref role="37wK5l" to="6peh:7OJcYqyb96D" resolve="getConceptDescriptionAnnotationX" />
+                      <ref role="37wK5l" to="6peh:7OJcYqyb96D" resolve="getConceptDescriptionAnnotation" />
                     </node>
                   </node>
                   <node concept="liA8E" id="7OJcYqyZcSE" role="2OqNvi">
@@ -6273,7 +6273,7 @@
                             <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
                           </node>
                           <node concept="liA8E" id="3IM5Sl$oJO7" role="2OqNvi">
-                            <ref role="37wK5l" to="6peh:7OJcYqzAV4V" resolve="listConceptDescriptionPropertiesX" />
+                            <ref role="37wK5l" to="6peh:7OJcYqzAV4V" resolve="listMpsM2AnnotationProperties" />
                           </node>
                         </node>
                         <node concept="3$u5V9" id="7OJcYqzBs_e" role="2OqNvi">

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.lioncore.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.lioncore.mps
@@ -669,7 +669,7 @@
               <ref role="3cqZAo" node="39$JcGF2la_" resolve="jsonConstants" />
             </node>
             <node concept="liA8E" id="7OJcYqzhCDv" role="2OqNvi">
-              <ref role="37wK5l" to="6peh:7OJcYqxTsMO" resolve="listPrimitiveTypesX" />
+              <ref role="37wK5l" to="6peh:7OJcYqxTsMO" resolve="listLcPrimitiveTypes" />
             </node>
           </node>
           <node concept="3clFbS" id="7OJcYqzhnDD" role="2LFqv$">
@@ -690,7 +690,7 @@
                       <ref role="2Gs0qQ" node="7OJcYqzhnD_" resolve="dataType" />
                     </node>
                     <node concept="liA8E" id="7OJcYqzikPB" role="2OqNvi">
-                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getStaple" />
                     </node>
                   </node>
                   <node concept="liA8E" id="7OJcYqzitKr" role="2OqNvi">
@@ -710,7 +710,7 @@
               <ref role="3cqZAo" node="39$JcGF2la_" resolve="jsonConstants" />
             </node>
             <node concept="liA8E" id="7OJcYqziXj5" role="2OqNvi">
-              <ref role="37wK5l" to="6peh:7OJcYqxTwQ8" resolve="listClassifiersX" />
+              <ref role="37wK5l" to="6peh:7OJcYqxTwQ8" resolve="listLcClassifiers" />
             </node>
           </node>
           <node concept="3clFbS" id="7OJcYqziAsT" role="2LFqv$">
@@ -731,7 +731,7 @@
                       <ref role="2Gs0qQ" node="7OJcYqziAsP" resolve="classifier" />
                     </node>
                     <node concept="liA8E" id="7OJcYqzj_zN" role="2OqNvi">
-                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getStaple" />
                     </node>
                   </node>
                   <node concept="liA8E" id="7OJcYqzjIz1" role="2OqNvi">
@@ -2665,14 +2665,14 @@
       <node concept="3clFbS" id="z1IqfFJAFi" role="3clF47">
         <node concept="3cpWs8" id="7OJcYqzkHtB" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqzkHtC" role="3cpWs9">
-            <property role="TrG5h" value="mapper" />
+            <property role="TrG5h" value="staple" />
             <node concept="3uibUv" id="7OJcYqzkG0N" role="1tU5fm">
-              <ref role="3uigEE" to="6peh:7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+              <ref role="3uigEE" to="6peh:7OJcYqxQZIZ" resolve="IJsonStaple" />
               <node concept="3uibUv" id="7OJcYqzkG0T" role="11_B2D">
                 <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
               </node>
               <node concept="3uibUv" id="7OJcYqzkG0S" role="11_B2D">
-                <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+                <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
               </node>
             </node>
             <node concept="2OqwBi" id="7OJcYqzkHtD" role="33vP2m">
@@ -2681,7 +2681,7 @@
                   <ref role="3cqZAo" node="39$JcGF2la_" resolve="jsonConstants" />
                 </node>
                 <node concept="liA8E" id="7OJcYqzkHtG" role="2OqNvi">
-                  <ref role="37wK5l" to="6peh:7OJcYqxTsMO" resolve="listPrimitiveTypesX" />
+                  <ref role="37wK5l" to="6peh:7OJcYqxTsMO" resolve="listLcPrimitiveTypes" />
                 </node>
               </node>
               <node concept="1z4cxt" id="7OJcYqzkHtH" role="2OqNvi">
@@ -2719,10 +2719,10 @@
                 <node concept="2OqwBi" id="7OJcYqzlybn" role="2Oq$k0">
                   <node concept="2OqwBi" id="7OJcYqzlq1P" role="2Oq$k0">
                     <node concept="37vLTw" id="7OJcYqzllvn" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7OJcYqzkHtC" resolve="mapper" />
+                      <ref role="3cqZAo" node="7OJcYqzkHtC" resolve="staple" />
                     </node>
                     <node concept="liA8E" id="7OJcYqzltAw" role="2OqNvi">
-                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getStaple" />
                     </node>
                   </node>
                   <node concept="liA8E" id="7OJcYqzl_OC" role="2OqNvi">
@@ -2736,7 +2736,7 @@
           <node concept="3y3z36" id="7OJcYqzkW9Y" role="3clFbw">
             <node concept="10Nm6u" id="7OJcYqzkZf3" role="3uHU7w" />
             <node concept="37vLTw" id="7OJcYqzkTJt" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYqzkHtC" resolve="mapper" />
+              <ref role="3cqZAo" node="7OJcYqzkHtC" resolve="staple" />
             </node>
           </node>
         </node>
@@ -4072,7 +4072,7 @@
               <ref role="3cqZAo" node="39$JcGF4Bup" resolve="jsonConstants" />
             </node>
             <node concept="liA8E" id="7OJcYqzm9O3" role="2OqNvi">
-              <ref role="37wK5l" to="6peh:7OJcYqxTsMO" resolve="listPrimitiveTypesX" />
+              <ref role="37wK5l" to="6peh:7OJcYqxTsMO" resolve="listLcPrimitiveTypes" />
             </node>
           </node>
           <node concept="3clFbS" id="7OJcYqzlRYl" role="2LFqv$">
@@ -4085,7 +4085,7 @@
                       <ref role="2Gs0qQ" node="7OJcYqzlRYh" resolve="dataType" />
                     </node>
                     <node concept="liA8E" id="7OJcYqzn9ph" role="2OqNvi">
-                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getStaple" />
                     </node>
                   </node>
                   <node concept="liA8E" id="7OJcYqznfFh" role="2OqNvi">
@@ -4113,7 +4113,7 @@
               <ref role="3cqZAo" node="39$JcGF4Bup" resolve="jsonConstants" />
             </node>
             <node concept="liA8E" id="7OJcYqzo0$m" role="2OqNvi">
-              <ref role="37wK5l" to="6peh:7OJcYqxTwQ8" resolve="listClassifiersX" />
+              <ref role="37wK5l" to="6peh:7OJcYqxTwQ8" resolve="listLcClassifiers" />
             </node>
           </node>
           <node concept="3clFbS" id="7OJcYqznIGn" role="2LFqv$">
@@ -4126,7 +4126,7 @@
                       <ref role="2Gs0qQ" node="7OJcYqznIGj" resolve="classifier" />
                     </node>
                     <node concept="liA8E" id="7OJcYqzopKn" role="2OqNvi">
-                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getStaple" />
                     </node>
                   </node>
                   <node concept="liA8E" id="7OJcYqzoyR_" role="2OqNvi">
@@ -6335,14 +6335,14 @@
             </node>
             <node concept="3cpWs8" id="7OJcYqzpU1B" role="3cqZAp">
               <node concept="3cpWsn" id="7OJcYqzpU1C" role="3cpWs9">
-                <property role="TrG5h" value="mapper" />
+                <property role="TrG5h" value="staple" />
                 <node concept="3uibUv" id="7OJcYqzpRQQ" role="1tU5fm">
-                  <ref role="3uigEE" to="6peh:7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+                  <ref role="3uigEE" to="6peh:7OJcYqxQZIZ" resolve="IJsonStaple" />
                   <node concept="3uibUv" id="7OJcYqzpRQV" role="11_B2D">
                     <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
                   </node>
                   <node concept="3uibUv" id="7OJcYqzpRQW" role="11_B2D">
-                    <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+                    <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
                   </node>
                 </node>
                 <node concept="2OqwBi" id="7OJcYqzpU1D" role="33vP2m">
@@ -6351,7 +6351,7 @@
                       <ref role="3cqZAo" node="39$JcGF4Bup" resolve="jsonConstants" />
                     </node>
                     <node concept="liA8E" id="7OJcYqzpU1G" role="2OqNvi">
-                      <ref role="37wK5l" to="6peh:7OJcYqxTsMO" resolve="listPrimitiveTypesX" />
+                      <ref role="37wK5l" to="6peh:7OJcYqxTsMO" resolve="listLcPrimitiveTypes" />
                     </node>
                   </node>
                   <node concept="1z4cxt" id="7OJcYqzpU1H" role="2OqNvi">
@@ -6368,7 +6368,7 @@
                                   <ref role="3cqZAo" node="7OJcYqzpU1S" resolve="it" />
                                 </node>
                                 <node concept="liA8E" id="7OJcYqzpU1Q" role="2OqNvi">
-                                  <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                                  <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getStaple" />
                                 </node>
                               </node>
                               <node concept="liA8E" id="7OJcYqzpU1R" role="2OqNvi">
@@ -6392,7 +6392,7 @@
                 <node concept="3cpWs6" id="39$JcGFU3Sb" role="3cqZAp">
                   <node concept="2OqwBi" id="7OJcYqzqvVy" role="3cqZAk">
                     <node concept="37vLTw" id="7OJcYqzqqYb" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7OJcYqzpU1C" resolve="mapper" />
+                      <ref role="3cqZAo" node="7OJcYqzpU1C" resolve="staple" />
                     </node>
                     <node concept="liA8E" id="7OJcYqzqGrp" role="2OqNvi">
                       <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
@@ -6403,7 +6403,7 @@
               <node concept="3y3z36" id="7OJcYqzqgu0" role="3clFbw">
                 <node concept="10Nm6u" id="7OJcYqzqk4R" role="3uHU7w" />
                 <node concept="37vLTw" id="7OJcYqzqdz3" role="3uHU7B">
-                  <ref role="3cqZAo" node="7OJcYqzpU1C" resolve="mapper" />
+                  <ref role="3cqZAo" node="7OJcYqzpU1C" resolve="staple" />
                 </node>
               </node>
             </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.lioncore.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.lioncore.mps
@@ -33,12 +33,9 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
-      <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
-      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
-        <child id="1076505808688" name="condition" index="2$JKZa" />
-      </concept>
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
@@ -70,7 +67,6 @@
         <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
-      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
@@ -87,6 +83,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -111,9 +108,6 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
-      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
-        <property id="1068580320021" name="value" index="3cmrfH" />
-      </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
@@ -141,6 +135,7 @@
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -160,6 +155,12 @@
     </language>
     <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
       <concept id="2546654756694997551" name="jetbrains.mps.baseLanguage.javadoc.structure.LinkInlineDocTag" flags="ng" index="92FcH">
@@ -258,15 +259,12 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
-      <concept id="1237467461002" name="jetbrains.mps.baseLanguage.collections.structure.GetIteratorOperation" flags="nn" index="uNJiE" />
-      <concept id="1237467705688" name="jetbrains.mps.baseLanguage.collections.structure.IteratorType" flags="in" index="uOF1S">
-        <child id="1237467730343" name="elementType" index="uOL27" />
-      </concept>
-      <concept id="1237470895604" name="jetbrains.mps.baseLanguage.collections.structure.HasNextOperation" flags="nn" index="v0PNk" />
-      <concept id="1237471031357" name="jetbrains.mps.baseLanguage.collections.structure.GetNextOperation" flags="nn" index="v1n4t" />
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -281,10 +279,9 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1237909114519" name="jetbrains.mps.baseLanguage.collections.structure.GetValuesOperation" flags="nn" index="T8wYR" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
-      <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
-      <concept id="1240151247486" name="jetbrains.mps.baseLanguage.collections.structure.ContainerIteratorType" flags="in" index="2YL$Hu" />
       <concept id="1240216724530" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashMapCreator" flags="nn" index="32Fmki" />
       <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
         <child id="1197683466920" name="keyType" index="3rvQeY" />
@@ -294,10 +291,7 @@
         <child id="1197687026896" name="keyType" index="3rHrn6" />
         <child id="1197687035757" name="valueType" index="3rHtpV" />
       </concept>
-      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
-        <child id="1225711182005" name="list" index="1y566C" />
-        <child id="1225711191269" name="index" index="1y58nS" />
-      </concept>
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1240824834947" name="jetbrains.mps.baseLanguage.collections.structure.ValueAccessOperation" flags="nn" index="3AV6Ez" />
       <concept id="1240825616499" name="jetbrains.mps.baseLanguage.collections.structure.KeyAccessOperation" flags="nn" index="3AY5_j" />
       <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
@@ -666,158 +660,85 @@
       <node concept="3Tm6S6" id="5M3rB6BDRk8" role="1B3o_S" />
       <node concept="3cqZAl" id="5M3rB6BDRk9" role="3clF45" />
       <node concept="3clFbS" id="5M3rB6BDRix" role="3clF47">
-        <node concept="3cpWs8" id="5M3rB6BDRiy" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6BDRiz" role="3cpWs9">
-            <property role="TrG5h" value="jsonDataTypeIter" />
-            <node concept="2YL$Hu" id="5M3rB6BDRi$" role="1tU5fm">
-              <node concept="3uibUv" id="5M3rB6BDRi_" role="uOL27">
-                <ref role="3uigEE" to="imb3:~DataType" resolve="DataType" />
-              </node>
+        <node concept="2Gpval" id="7OJcYqzhnDz" role="3cqZAp">
+          <node concept="2GrKxI" id="7OJcYqzhnD_" role="2Gsz3X">
+            <property role="TrG5h" value="dataType" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqzh_b_" role="2GsD0m">
+            <node concept="37vLTw" id="7OJcYqzhyaj" role="2Oq$k0">
+              <ref role="3cqZAo" node="39$JcGF2la_" resolve="jsonConstants" />
             </node>
-            <node concept="2OqwBi" id="5M3rB6BDRiA" role="33vP2m">
-              <node concept="2OqwBi" id="5TNjoy1yAfe" role="2Oq$k0">
-                <node concept="37vLTw" id="5TNjoy1yhm$" role="2Oq$k0">
-                  <ref role="3cqZAo" node="39$JcGF2la_" resolve="jsonConstants" />
-                </node>
-                <node concept="liA8E" id="5TNjoy1yDSW" role="2OqNvi">
-                  <ref role="37wK5l" to="6peh:5JNiskj4Oxk" resolve="listPrimitiveTypes" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6BDRiD" role="2OqNvi" />
+            <node concept="liA8E" id="7OJcYqzhCDv" role="2OqNvi">
+              <ref role="37wK5l" to="6peh:7OJcYqxTsMO" resolve="listPrimitiveTypesX" />
             </node>
           </node>
-        </node>
-        <node concept="3cpWs8" id="5M3rB6BDRiE" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6BDRiF" role="3cpWs9">
-            <property role="TrG5h" value="lcDataTypeIter" />
-            <node concept="uOF1S" id="5M3rB6BDRiG" role="1tU5fm">
-              <node concept="3Tqbb2" id="5M3rB6BDRiH" role="uOL27">
-                <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5M3rB6BDRiI" role="33vP2m">
-              <node concept="2OqwBi" id="5M3rB6BDRiJ" role="2Oq$k0">
-                <node concept="37vLTw" id="5M3rB6BDRk1" role="2Oq$k0">
-                  <ref role="3cqZAo" node="39$JcGF2lax" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="5M3rB6BDRiL" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3k19" resolve="listLcPrimitiveTypes" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6BDRiM" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="2$JKZl" id="5M3rB6BDRiN" role="3cqZAp">
-          <node concept="3clFbS" id="5M3rB6BDRiO" role="2LFqv$">
+          <node concept="3clFbS" id="7OJcYqzhnDD" role="2LFqv$">
             <node concept="3clFbF" id="5M3rB6BDRiP" role="3cqZAp">
               <node concept="1rXfSq" id="5M3rB6BDRiQ" role="3clFbG">
                 <ref role="37wK5l" node="z1IqfG9XJi" resolve="recordDataType" />
-                <node concept="2OqwBi" id="5M3rB6BDRiR" role="37wK5m">
-                  <node concept="37vLTw" id="5M3rB6BDRiS" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5M3rB6BDRiz" resolve="jsonDataTypeIter" />
+                <node concept="2OqwBi" id="7OJcYqzhY_C" role="37wK5m">
+                  <node concept="2GrUjf" id="7OJcYqzhUh7" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="7OJcYqzhnD_" resolve="dataType" />
                   </node>
-                  <node concept="v1n4t" id="5M3rB6BDRiT" role="2OqNvi" />
-                </node>
-                <node concept="2OqwBi" id="5M3rB6BDRiU" role="37wK5m">
-                  <node concept="37vLTw" id="5M3rB6BDRiV" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5M3rB6BDRiF" resolve="lcDataTypeIter" />
+                  <node concept="liA8E" id="7OJcYqzi3UR" role="2OqNvi">
+                    <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
                   </node>
-                  <node concept="v1n4t" id="5M3rB6BDRiW" role="2OqNvi" />
                 </node>
-              </node>
-            </node>
-          </node>
-          <node concept="1Wc70l" id="5M3rB6BDRiX" role="2$JKZa">
-            <node concept="2OqwBi" id="5M3rB6BDRiY" role="3uHU7w">
-              <node concept="37vLTw" id="5M3rB6BDRiZ" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6BDRiF" resolve="lcDataTypeIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6BDRj0" role="2OqNvi" />
-            </node>
-            <node concept="2OqwBi" id="5M3rB6BDRj1" role="3uHU7B">
-              <node concept="37vLTw" id="5M3rB6BDRj2" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6BDRiz" resolve="jsonDataTypeIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6BDRj3" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5M3rB6BDRj4" role="3cqZAp" />
-        <node concept="3cpWs8" id="5M3rB6BDRj5" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6BDRj6" role="3cpWs9">
-            <property role="TrG5h" value="jsonClassifierIter" />
-            <node concept="2YL$Hu" id="5M3rB6BDRj7" role="1tU5fm">
-              <node concept="3uibUv" id="5M3rB6BDRj8" role="uOL27">
-                <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5M3rB6BDRj9" role="33vP2m">
-              <node concept="uNJiE" id="5M3rB6BDRjc" role="2OqNvi" />
-              <node concept="2OqwBi" id="5TNjoy1yHN9" role="2Oq$k0">
-                <node concept="37vLTw" id="5TNjoy1yHNa" role="2Oq$k0">
-                  <ref role="3cqZAo" node="39$JcGF2la_" resolve="jsonConstants" />
-                </node>
-                <node concept="liA8E" id="5TNjoy1yHNb" role="2OqNvi">
-                  <ref role="37wK5l" to="6peh:5JNiskj4Oxz" resolve="listClassifiers" />
+                <node concept="2OqwBi" id="7OJcYqzipnA" role="37wK5m">
+                  <node concept="2OqwBi" id="7OJcYqzifP0" role="2Oq$k0">
+                    <node concept="2GrUjf" id="7OJcYqzicrV" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="7OJcYqzhnD_" resolve="dataType" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqzikPB" role="2OqNvi">
+                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="7OJcYqzitKr" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
+                  </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="5M3rB6BDRjd" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6BDRje" role="3cpWs9">
-            <property role="TrG5h" value="lcClassifierIter" />
-            <node concept="uOF1S" id="5M3rB6BDRjf" role="1tU5fm">
-              <node concept="3Tqbb2" id="5M3rB6BDRjg" role="uOL27">
-                <ref role="ehGHo" to="h3y3:2ju2syjkl4i" resolve="Classifier" />
-              </node>
+        <node concept="2Gpval" id="7OJcYqziAsN" role="3cqZAp">
+          <node concept="2GrKxI" id="7OJcYqziAsP" role="2Gsz3X">
+            <property role="TrG5h" value="classifier" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqziSKn" role="2GsD0m">
+            <node concept="37vLTw" id="7OJcYqziPoY" role="2Oq$k0">
+              <ref role="3cqZAo" node="39$JcGF2la_" resolve="jsonConstants" />
             </node>
-            <node concept="2OqwBi" id="5M3rB6BDRjh" role="33vP2m">
-              <node concept="2OqwBi" id="5M3rB6BDRji" role="2Oq$k0">
-                <node concept="37vLTw" id="5M3rB6BDRjZ" role="2Oq$k0">
-                  <ref role="3cqZAo" node="39$JcGF2lax" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="5M3rB6BDRjk" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jZs" resolve="listLcClassifiers" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6BDRjl" role="2OqNvi" />
+            <node concept="liA8E" id="7OJcYqziXj5" role="2OqNvi">
+              <ref role="37wK5l" to="6peh:7OJcYqxTwQ8" resolve="listClassifiersX" />
             </node>
           </node>
-        </node>
-        <node concept="2$JKZl" id="5M3rB6BDRjm" role="3cqZAp">
-          <node concept="3clFbS" id="5M3rB6BDRjn" role="2LFqv$">
+          <node concept="3clFbS" id="7OJcYqziAsT" role="2LFqv$">
             <node concept="3clFbF" id="5M3rB6BDRjo" role="3cqZAp">
               <node concept="1rXfSq" id="5M3rB6BDRjp" role="3clFbG">
                 <ref role="37wK5l" node="z1IqfG9Xfg" resolve="recordClassifier" />
-                <node concept="2OqwBi" id="5M3rB6BDRjq" role="37wK5m">
-                  <node concept="37vLTw" id="5M3rB6BDRjr" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5M3rB6BDRj6" resolve="jsonClassifierIter" />
+                <node concept="2OqwBi" id="7OJcYqzjiBj" role="37wK5m">
+                  <node concept="2GrUjf" id="7OJcYqzjf9Y" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="7OJcYqziAsP" resolve="classifier" />
                   </node>
-                  <node concept="v1n4t" id="5M3rB6BDRjs" role="2OqNvi" />
-                </node>
-                <node concept="2OqwBi" id="5M3rB6BDRjt" role="37wK5m">
-                  <node concept="37vLTw" id="5M3rB6BDRju" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5M3rB6BDRje" resolve="lcClassifierIter" />
+                  <node concept="liA8E" id="7OJcYqzjlM_" role="2OqNvi">
+                    <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
                   </node>
-                  <node concept="v1n4t" id="5M3rB6BDRjv" role="2OqNvi" />
+                </node>
+                <node concept="2OqwBi" id="7OJcYqzjEd_" role="37wK5m">
+                  <node concept="2OqwBi" id="7OJcYqzjxd6" role="2Oq$k0">
+                    <node concept="2GrUjf" id="7OJcYqzju4c" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="7OJcYqziAsP" resolve="classifier" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqzj_zN" role="2OqNvi">
+                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="7OJcYqzjIz1" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
+                  </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="1Wc70l" id="5M3rB6BDRjw" role="2$JKZa">
-            <node concept="2OqwBi" id="5M3rB6BDRjx" role="3uHU7w">
-              <node concept="37vLTw" id="5M3rB6BDRjy" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6BDRje" resolve="lcClassifierIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6BDRjz" role="2OqNvi" />
-            </node>
-            <node concept="2OqwBi" id="5M3rB6BDRj$" role="3uHU7B">
-              <node concept="37vLTw" id="5M3rB6BDRj_" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6BDRj6" resolve="jsonClassifierIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6BDRjA" role="2OqNvi" />
             </node>
           </node>
         </node>
@@ -2742,22 +2663,50 @@
         </node>
       </node>
       <node concept="3clFbS" id="z1IqfFJAFi" role="3clF47">
-        <node concept="3cpWs8" id="39$JcGFRY0C" role="3cqZAp">
-          <node concept="3cpWsn" id="39$JcGFRY0D" role="3cpWs9">
-            <property role="TrG5h" value="index" />
-            <node concept="10Oyi0" id="39$JcGFRWT2" role="1tU5fm" />
-            <node concept="2OqwBi" id="39$JcGFRY0E" role="33vP2m">
-              <node concept="2WmjW8" id="39$JcGFRY0H" role="2OqNvi">
-                <node concept="37vLTw" id="39$JcGFRY0I" role="25WWJ7">
-                  <ref role="3cqZAo" node="z1IqfFJAFg" resolve="json" />
-                </node>
+        <node concept="3cpWs8" id="7OJcYqzkHtB" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqzkHtC" role="3cpWs9">
+            <property role="TrG5h" value="mapper" />
+            <node concept="3uibUv" id="7OJcYqzkG0N" role="1tU5fm">
+              <ref role="3uigEE" to="6peh:7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+              <node concept="3uibUv" id="7OJcYqzkG0T" role="11_B2D">
+                <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
               </node>
-              <node concept="2OqwBi" id="5TNjoy1yQyz" role="2Oq$k0">
-                <node concept="37vLTw" id="5TNjoy1yQy$" role="2Oq$k0">
+              <node concept="3uibUv" id="7OJcYqzkG0S" role="11_B2D">
+                <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7OJcYqzkHtD" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqzkHtE" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYqzkHtF" role="2Oq$k0">
                   <ref role="3cqZAo" node="39$JcGF2la_" resolve="jsonConstants" />
                 </node>
-                <node concept="liA8E" id="5TNjoy1yQy_" role="2OqNvi">
-                  <ref role="37wK5l" to="6peh:5JNiskj4Oxk" resolve="listPrimitiveTypes" />
+                <node concept="liA8E" id="7OJcYqzkHtG" role="2OqNvi">
+                  <ref role="37wK5l" to="6peh:7OJcYqxTsMO" resolve="listPrimitiveTypesX" />
+                </node>
+              </node>
+              <node concept="1z4cxt" id="7OJcYqzkHtH" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYqzkHtI" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYqzkHtJ" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYqzkHtK" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYqzkHtL" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYqzkHtM" role="3uHU7w">
+                          <ref role="3cqZAo" node="z1IqfFJAFg" resolve="json" />
+                        </node>
+                        <node concept="2OqwBi" id="7OJcYqzkHtN" role="3uHU7B">
+                          <node concept="37vLTw" id="7OJcYqzkHtO" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqzkHtQ" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqzkHtP" role="2OqNvi">
+                            <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYqzkHtQ" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYqzkHtR" role="1tU5fm" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -2767,29 +2716,27 @@
           <node concept="3clFbS" id="39$JcGFS6JV" role="3clFbx">
             <node concept="3cpWs6" id="39$JcGFSj6J" role="3cqZAp">
               <node concept="2OqwBi" id="39$JcGFSKFN" role="3cqZAk">
-                <node concept="1y4W85" id="39$JcGFSETP" role="2Oq$k0">
-                  <node concept="37vLTw" id="39$JcGFSHKa" role="1y58nS">
-                    <ref role="3cqZAo" node="39$JcGFRY0D" resolve="index" />
+                <node concept="2OqwBi" id="7OJcYqzlybn" role="2Oq$k0">
+                  <node concept="2OqwBi" id="7OJcYqzlq1P" role="2Oq$k0">
+                    <node concept="37vLTw" id="7OJcYqzllvn" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYqzkHtC" resolve="mapper" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqzltAw" role="2OqNvi">
+                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                    </node>
                   </node>
-                  <node concept="2OqwBi" id="39$JcGFSr$N" role="1y566C">
-                    <node concept="37vLTw" id="39$JcGFSoH6" role="2Oq$k0">
-                      <ref role="3cqZAo" node="39$JcGF2lax" resolve="constants" />
-                    </node>
-                    <node concept="liA8E" id="39$JcGFSuy6" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3k19" resolve="listLcPrimitiveTypes" />
-                    </node>
+                  <node concept="liA8E" id="7OJcYqzl_OC" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
                   </node>
                 </node>
                 <node concept="1$rogu" id="39$JcGFSMSu" role="2OqNvi" />
               </node>
             </node>
           </node>
-          <node concept="2d3UOw" id="39$JcGFSdo7" role="3clFbw">
-            <node concept="3cmrfG" id="39$JcGFSgar" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="37vLTw" id="39$JcGFS9LT" role="3uHU7B">
-              <ref role="3cqZAo" node="39$JcGFRY0D" resolve="index" />
+          <node concept="3y3z36" id="7OJcYqzkW9Y" role="3clFbw">
+            <node concept="10Nm6u" id="7OJcYqzkZf3" role="3uHU7w" />
+            <node concept="37vLTw" id="7OJcYqzkTJt" role="3uHU7B">
+              <ref role="3cqZAo" node="7OJcYqzkHtC" resolve="mapper" />
             </node>
           </node>
         </node>
@@ -4116,158 +4063,85 @@
       <node concept="3Tm6S6" id="5M3rB6BJsKv" role="1B3o_S" />
       <node concept="3cqZAl" id="5M3rB6BJsKw" role="3clF45" />
       <node concept="3clFbS" id="5M3rB6BJsJe" role="3clF47">
-        <node concept="3cpWs8" id="5M3rB6BJsJf" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6BJsJg" role="3cpWs9">
-            <property role="TrG5h" value="lcDataTypeIter" />
-            <node concept="uOF1S" id="5M3rB6BJsJh" role="1tU5fm">
-              <node concept="3Tqbb2" id="5M3rB6BJsJi" role="uOL27">
-                <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-              </node>
+        <node concept="2Gpval" id="7OJcYqzlRYf" role="3cqZAp">
+          <node concept="2GrKxI" id="7OJcYqzlRYh" role="2Gsz3X">
+            <property role="TrG5h" value="dataType" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqzm5Oq" role="2GsD0m">
+            <node concept="37vLTw" id="7OJcYqzm32B" role="2Oq$k0">
+              <ref role="3cqZAo" node="39$JcGF4Bup" resolve="jsonConstants" />
             </node>
-            <node concept="2OqwBi" id="5M3rB6BJsJj" role="33vP2m">
-              <node concept="2OqwBi" id="5M3rB6BJsJk" role="2Oq$k0">
-                <node concept="37vLTw" id="5M3rB6BJsKo" role="2Oq$k0">
-                  <ref role="3cqZAo" node="39$JcGF4Bul" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="5M3rB6BJsJm" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3k19" resolve="listLcPrimitiveTypes" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6BJsJn" role="2OqNvi" />
+            <node concept="liA8E" id="7OJcYqzm9O3" role="2OqNvi">
+              <ref role="37wK5l" to="6peh:7OJcYqxTsMO" resolve="listPrimitiveTypesX" />
             </node>
           </node>
-        </node>
-        <node concept="3cpWs8" id="5M3rB6BJsJo" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6BJsJp" role="3cpWs9">
-            <property role="TrG5h" value="jsonDataTypeIter" />
-            <node concept="2YL$Hu" id="5M3rB6BJsJq" role="1tU5fm">
-              <node concept="3uibUv" id="5M3rB6BJsJr" role="uOL27">
-                <ref role="3uigEE" to="imb3:~DataType" resolve="DataType" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5M3rB6BJsJs" role="33vP2m">
-              <node concept="2OqwBi" id="5TNjoy1xvN7" role="2Oq$k0">
-                <node concept="37vLTw" id="5TNjoy1xqB5" role="2Oq$k0">
-                  <ref role="3cqZAo" node="39$JcGF4Bup" resolve="jsonConstants" />
-                </node>
-                <node concept="liA8E" id="5TNjoy1xz4p" role="2OqNvi">
-                  <ref role="37wK5l" to="6peh:5JNiskj4Oxk" resolve="listPrimitiveTypes" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6BJsJv" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="2$JKZl" id="5M3rB6BJsJw" role="3cqZAp">
-          <node concept="3clFbS" id="5M3rB6BJsJx" role="2LFqv$">
+          <node concept="3clFbS" id="7OJcYqzlRYl" role="2LFqv$">
             <node concept="3clFbF" id="5M3rB6BJsJy" role="3cqZAp">
               <node concept="1rXfSq" id="5M3rB6BJsJz" role="3clFbG">
                 <ref role="37wK5l" node="5sACIIsA0Gm" resolve="recordDataType" />
-                <node concept="2OqwBi" id="5M3rB6BJsJ$" role="37wK5m">
-                  <node concept="37vLTw" id="5M3rB6BJsJ_" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5M3rB6BJsJg" resolve="lcDataTypeIter" />
+                <node concept="2OqwBi" id="7OJcYqzncbx" role="37wK5m">
+                  <node concept="2OqwBi" id="7OJcYqzmvBd" role="2Oq$k0">
+                    <node concept="2GrUjf" id="7OJcYqzms7m" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="7OJcYqzlRYh" resolve="dataType" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqzn9ph" role="2OqNvi">
+                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                    </node>
                   </node>
-                  <node concept="v1n4t" id="5M3rB6BJsJA" role="2OqNvi" />
-                </node>
-                <node concept="2OqwBi" id="5M3rB6BJsJB" role="37wK5m">
-                  <node concept="37vLTw" id="5M3rB6BJsJC" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5M3rB6BJsJp" resolve="jsonDataTypeIter" />
+                  <node concept="liA8E" id="7OJcYqznfFh" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
                   </node>
-                  <node concept="v1n4t" id="5M3rB6BJsJD" role="2OqNvi" />
                 </node>
-              </node>
-            </node>
-          </node>
-          <node concept="1Wc70l" id="5M3rB6BJsJE" role="2$JKZa">
-            <node concept="2OqwBi" id="5M3rB6BJsJF" role="3uHU7B">
-              <node concept="37vLTw" id="5M3rB6BJsJG" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6BJsJg" resolve="lcDataTypeIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6BJsJH" role="2OqNvi" />
-            </node>
-            <node concept="2OqwBi" id="5M3rB6BJsJI" role="3uHU7w">
-              <node concept="37vLTw" id="5M3rB6BJsJJ" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6BJsJp" resolve="jsonDataTypeIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6BJsJK" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5M3rB6BJsJL" role="3cqZAp" />
-        <node concept="3cpWs8" id="5M3rB6BJsJM" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6BJsJN" role="3cpWs9">
-            <property role="TrG5h" value="lcClassifierIter" />
-            <node concept="uOF1S" id="5M3rB6BJsJO" role="1tU5fm">
-              <node concept="3Tqbb2" id="5M3rB6BJsJP" role="uOL27">
-                <ref role="ehGHo" to="h3y3:2ju2syjkl4i" resolve="Classifier" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5M3rB6BJsJQ" role="33vP2m">
-              <node concept="2OqwBi" id="5M3rB6BJsJR" role="2Oq$k0">
-                <node concept="37vLTw" id="5M3rB6BJsKq" role="2Oq$k0">
-                  <ref role="3cqZAo" node="39$JcGF4Bul" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="5M3rB6BJsJT" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:5JNiski3jZs" resolve="listLcClassifiers" />
-                </node>
-              </node>
-              <node concept="uNJiE" id="5M3rB6BJsJU" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="5M3rB6BJsJV" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6BJsJW" role="3cpWs9">
-            <property role="TrG5h" value="jsonClassifierIter" />
-            <node concept="2YL$Hu" id="5M3rB6BJsJX" role="1tU5fm">
-              <node concept="3uibUv" id="5M3rB6BJsJY" role="uOL27">
-                <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5M3rB6BJsJZ" role="33vP2m">
-              <node concept="uNJiE" id="5M3rB6BJsK2" role="2OqNvi" />
-              <node concept="2OqwBi" id="5TNjoy1xC1v" role="2Oq$k0">
-                <node concept="37vLTw" id="5TNjoy1xC1w" role="2Oq$k0">
-                  <ref role="3cqZAo" node="39$JcGF4Bup" resolve="jsonConstants" />
-                </node>
-                <node concept="liA8E" id="5TNjoy1xC1x" role="2OqNvi">
-                  <ref role="37wK5l" to="6peh:5JNiskj4Oxz" resolve="listClassifiers" />
+                <node concept="2OqwBi" id="7OJcYqznrvk" role="37wK5m">
+                  <node concept="2GrUjf" id="7OJcYqznouc" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="7OJcYqzlRYh" resolve="dataType" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqznwNd" role="2OqNvi">
+                    <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
+                  </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="2$JKZl" id="5M3rB6BJsK3" role="3cqZAp">
-          <node concept="3clFbS" id="5M3rB6BJsK4" role="2LFqv$">
+        <node concept="2Gpval" id="7OJcYqznIGh" role="3cqZAp">
+          <node concept="2GrKxI" id="7OJcYqznIGj" role="2Gsz3X">
+            <property role="TrG5h" value="classifier" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqznWcN" role="2GsD0m">
+            <node concept="37vLTw" id="7OJcYqznRkP" role="2Oq$k0">
+              <ref role="3cqZAo" node="39$JcGF4Bup" resolve="jsonConstants" />
+            </node>
+            <node concept="liA8E" id="7OJcYqzo0$m" role="2OqNvi">
+              <ref role="37wK5l" to="6peh:7OJcYqxTwQ8" resolve="listClassifiersX" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="7OJcYqznIGn" role="2LFqv$">
             <node concept="3clFbF" id="5M3rB6BJsK5" role="3cqZAp">
               <node concept="1rXfSq" id="5M3rB6BJsK6" role="3clFbG">
                 <ref role="37wK5l" node="5sACIIsA0Fa" resolve="recordClassifier" />
-                <node concept="2OqwBi" id="5M3rB6BJsK7" role="37wK5m">
-                  <node concept="37vLTw" id="5M3rB6BJsK8" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5M3rB6BJsJN" resolve="lcClassifierIter" />
+                <node concept="2OqwBi" id="7OJcYqzouOg" role="37wK5m">
+                  <node concept="2OqwBi" id="7OJcYqzolQm" role="2Oq$k0">
+                    <node concept="2GrUjf" id="7OJcYqzoho2" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="7OJcYqznIGj" resolve="classifier" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqzopKn" role="2OqNvi">
+                      <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                    </node>
                   </node>
-                  <node concept="v1n4t" id="5M3rB6BJsK9" role="2OqNvi" />
-                </node>
-                <node concept="2OqwBi" id="5M3rB6BJsKa" role="37wK5m">
-                  <node concept="37vLTw" id="5M3rB6BJsKb" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5M3rB6BJsJW" resolve="jsonClassifierIter" />
+                  <node concept="liA8E" id="7OJcYqzoyR_" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
                   </node>
-                  <node concept="v1n4t" id="5M3rB6BJsKc" role="2OqNvi" />
+                </node>
+                <node concept="2OqwBi" id="7OJcYqzoKWX" role="37wK5m">
+                  <node concept="2GrUjf" id="7OJcYqzoGHl" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="7OJcYqznIGj" resolve="classifier" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqzoOTh" role="2OqNvi">
+                    <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
+                  </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="1Wc70l" id="5M3rB6BJsKd" role="2$JKZa">
-            <node concept="2OqwBi" id="5M3rB6BJsKe" role="3uHU7B">
-              <node concept="37vLTw" id="5M3rB6BJsKf" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6BJsJN" resolve="lcClassifierIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6BJsKg" role="2OqNvi" />
-            </node>
-            <node concept="2OqwBi" id="5M3rB6BJsKh" role="3uHU7w">
-              <node concept="37vLTw" id="5M3rB6BJsKi" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6BJsJW" resolve="jsonClassifierIter" />
-              </node>
-              <node concept="v0PNk" id="5M3rB6BJsKj" role="2OqNvi" />
             </node>
           </node>
         </node>
@@ -6459,22 +6333,55 @@
                 </node>
               </node>
             </node>
-            <node concept="3cpWs8" id="39$JcGFT_BD" role="3cqZAp">
-              <node concept="3cpWsn" id="39$JcGFT_BE" role="3cpWs9">
-                <property role="TrG5h" value="index" />
-                <node concept="10Oyi0" id="39$JcGFT$xl" role="1tU5fm" />
-                <node concept="2OqwBi" id="39$JcGFT_BF" role="33vP2m">
-                  <node concept="2OqwBi" id="39$JcGFT_BG" role="2Oq$k0">
-                    <node concept="37vLTw" id="39$JcGFT_BH" role="2Oq$k0">
-                      <ref role="3cqZAo" node="39$JcGF4Bul" resolve="constants" />
+            <node concept="3cpWs8" id="7OJcYqzpU1B" role="3cqZAp">
+              <node concept="3cpWsn" id="7OJcYqzpU1C" role="3cpWs9">
+                <property role="TrG5h" value="mapper" />
+                <node concept="3uibUv" id="7OJcYqzpRQQ" role="1tU5fm">
+                  <ref role="3uigEE" to="6peh:7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+                  <node concept="3uibUv" id="7OJcYqzpRQV" role="11_B2D">
+                    <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+                  </node>
+                  <node concept="3uibUv" id="7OJcYqzpRQW" role="11_B2D">
+                    <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqzpU1D" role="33vP2m">
+                  <node concept="2OqwBi" id="7OJcYqzpU1E" role="2Oq$k0">
+                    <node concept="37vLTw" id="7OJcYqzpU1F" role="2Oq$k0">
+                      <ref role="3cqZAo" node="39$JcGF4Bup" resolve="jsonConstants" />
                     </node>
-                    <node concept="liA8E" id="39$JcGFT_BI" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:5JNiski3k19" resolve="listLcPrimitiveTypes" />
+                    <node concept="liA8E" id="7OJcYqzpU1G" role="2OqNvi">
+                      <ref role="37wK5l" to="6peh:7OJcYqxTsMO" resolve="listPrimitiveTypesX" />
                     </node>
                   </node>
-                  <node concept="2WmjW8" id="39$JcGFT_BJ" role="2OqNvi">
-                    <node concept="37vLTw" id="39$JcGFT_BK" role="25WWJ7">
-                      <ref role="3cqZAo" node="5sACIIsVkso" resolve="ptLc" />
+                  <node concept="1z4cxt" id="7OJcYqzpU1H" role="2OqNvi">
+                    <node concept="1bVj0M" id="7OJcYqzpU1I" role="23t8la">
+                      <node concept="3clFbS" id="7OJcYqzpU1J" role="1bW5cS">
+                        <node concept="3clFbF" id="7OJcYqzpU1K" role="3cqZAp">
+                          <node concept="17R0WA" id="7OJcYqzpU1L" role="3clFbG">
+                            <node concept="37vLTw" id="7OJcYqzpU1M" role="3uHU7w">
+                              <ref role="3cqZAo" node="5sACIIsA0Cn" resolve="lc" />
+                            </node>
+                            <node concept="2OqwBi" id="7OJcYqzpU1N" role="3uHU7B">
+                              <node concept="2OqwBi" id="7OJcYqzpU1O" role="2Oq$k0">
+                                <node concept="37vLTw" id="7OJcYqzpU1P" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7OJcYqzpU1S" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="7OJcYqzpU1Q" role="2OqNvi">
+                                  <ref role="37wK5l" to="6peh:7OJcYqxR0T3" resolve="getMapping" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="7OJcYqzpU1R" role="2OqNvi">
+                                <ref role="37wK5l" to="y7p:7OJcYqvKhKf" resolve="getLc" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="7OJcYqzpU1S" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7OJcYqzpU1T" role="1tU5fm" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -6483,27 +6390,20 @@
             <node concept="3clFbJ" id="39$JcGFTHSK" role="3cqZAp">
               <node concept="3clFbS" id="39$JcGFTHSM" role="3clFbx">
                 <node concept="3cpWs6" id="39$JcGFU3Sb" role="3cqZAp">
-                  <node concept="1y4W85" id="39$JcGFU3Sd" role="3cqZAk">
-                    <node concept="37vLTw" id="39$JcGFU3Se" role="1y58nS">
-                      <ref role="3cqZAo" node="39$JcGFT_BE" resolve="index" />
+                  <node concept="2OqwBi" id="7OJcYqzqvVy" role="3cqZAk">
+                    <node concept="37vLTw" id="7OJcYqzqqYb" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYqzpU1C" resolve="mapper" />
                     </node>
-                    <node concept="2OqwBi" id="5TNjoy1xRMN" role="1y566C">
-                      <node concept="37vLTw" id="5TNjoy1xRMO" role="2Oq$k0">
-                        <ref role="3cqZAo" node="39$JcGF4Bup" resolve="jsonConstants" />
-                      </node>
-                      <node concept="liA8E" id="5TNjoy1xRMP" role="2OqNvi">
-                        <ref role="37wK5l" to="6peh:5JNiskj4Oxk" resolve="listPrimitiveTypes" />
-                      </node>
+                    <node concept="liA8E" id="7OJcYqzqGrp" role="2OqNvi">
+                      <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="2d3UOw" id="39$JcGFTNpP" role="3clFbw">
-                <node concept="3cmrfG" id="39$JcGFTPBd" role="3uHU7w">
-                  <property role="3cmrfH" value="0" />
-                </node>
-                <node concept="37vLTw" id="39$JcGFTKqp" role="3uHU7B">
-                  <ref role="3cqZAo" node="39$JcGFT_BE" resolve="index" />
+              <node concept="3y3z36" id="7OJcYqzqgu0" role="3clFbw">
+                <node concept="10Nm6u" id="7OJcYqzqk4R" role="3uHU7w" />
+                <node concept="37vLTw" id="7OJcYqzqdz3" role="3uHU7B">
+                  <ref role="3cqZAo" node="7OJcYqzpU1C" resolve="mapper" />
                 </node>
               </node>
             </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
@@ -6566,6 +6566,9 @@
               <node concept="1rXfSq" id="5M8g5cSAPIi" role="HW$Y0">
                 <ref role="37wK5l" node="7weWCFlwuK9" resolve="getInterfaceConcept" />
               </node>
+              <node concept="1rXfSq" id="6Z_tmAeidwg" role="HW$Y0">
+                <ref role="37wK5l" node="5TNjoy1vudm" resolve="getINamed" />
+              </node>
             </node>
           </node>
         </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
@@ -117,6 +117,15 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ">
+        <child id="1214996921760" name="bound" index="3ztrMU" />
+      </concept>
+      <concept id="1109279851642" name="jetbrains.mps.baseLanguage.structure.GenericDeclaration" flags="ng" index="16eOlS">
+        <child id="1109279881614" name="typeVariableDeclaration" index="16eVyc" />
+      </concept>
+      <concept id="1109283449304" name="jetbrains.mps.baseLanguage.structure.TypeVariableReference" flags="in" index="16syzq">
+        <reference id="1109283546497" name="typeVariableDeclaration" index="16sUi3" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -174,12 +183,17 @@
         <child id="4972241301747169160" name="typeArgument" index="3PaCim" />
       </concept>
       <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="nn" index="3nyPlj" />
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
+        <child id="1212687122400" name="typeParameter" index="1pMfVU" />
+      </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="1171903607971" name="jetbrains.mps.baseLanguage.structure.WildCardType" flags="in" index="3qTvmN" />
+      <concept id="1171903916106" name="jetbrains.mps.baseLanguage.structure.UpperBoundType" flags="in" index="3qUE_q">
+        <child id="1171903916107" name="bound" index="3qUE_r" />
+      </concept>
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
@@ -1106,14 +1120,105 @@
   <node concept="312cEu" id="39$JcGFQll9">
     <property role="TrG5h" value="JsonConstants_2023_1" />
     <property role="3GE5qa" value="jsonConstants" />
-    <node concept="312cEg" id="5TNjoy1vf5J" role="jymVt">
-      <property role="TrG5h" value="builtins" />
+    <node concept="312cEg" id="7OJcYqy7LqN" role="jymVt">
+      <property role="TrG5h" value="BUILTINS" />
       <property role="3TUv4t" value="true" />
-      <node concept="3Tm6S6" id="5TNjoy1vf5K" role="1B3o_S" />
-      <node concept="3uibUv" id="5TNjoy1vf5M" role="1tU5fm">
-        <ref role="3uigEE" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+      <node concept="3Tm6S6" id="7OJcYqy7LqL" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqy8pi6" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqy8pi7" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqy8pi8" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        </node>
       </node>
     </node>
+    <node concept="312cEg" id="7OJcYqy7P4y" role="jymVt">
+      <property role="TrG5h" value="STRING" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqy7P4w" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqy8PmV" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqy8PmW" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqy8PmX" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqy7SKo" role="jymVt">
+      <property role="TrG5h" value="INTEGER" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqy7SKm" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqy9iNB" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqy9iNC" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqy9iND" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqy7Wt4" role="jymVt">
+      <property role="TrG5h" value="BOOLEAN" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqy7Wt2" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqy9mWH" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqy9mWI" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqy9mWJ" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqy80aA" role="jymVt">
+      <property role="TrG5h" value="JSON" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqy80a$" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqy9qdT" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqy9qdU" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqy9qdV" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqy83SY" role="jymVt">
+      <property role="TrG5h" value="INAMED" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqy83SW" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqy9C$D" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqy9C$E" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Interface" resolve="Interface" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqy9C$F" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvXZ8V" resolve="InterfaceKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqy87Cc" role="jymVt">
+      <property role="TrG5h" value="NODE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqy87Ca" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqy9K3u" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqy9K3v" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqy9K3w" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqyaF5s" role="jymVt" />
     <node concept="3clFbW" id="5TNjoy1vf0o" role="jymVt">
       <node concept="37vLTG" id="5TNjoy1vedD" role="3clF46">
         <property role="TrG5h" value="builtins" />
@@ -1124,25 +1229,327 @@
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
+      <node concept="37vLTG" id="7OJcYqxTzQb" role="3clF46">
+        <property role="TrG5h" value="constants" />
+        <node concept="3uibUv" id="7OJcYqxT$cT" role="1tU5fm">
+          <ref role="3uigEE" to="y7p:5JNiski3jVc" resolve="ILionCoreConstants_2023_1" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqxT$hg" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
       <node concept="3cqZAl" id="5TNjoy1vf0q" role="3clF45" />
       <node concept="3Tm1VV" id="5TNjoy1vf0r" role="1B3o_S" />
       <node concept="3clFbS" id="5TNjoy1vf0s" role="3clF47">
-        <node concept="3clFbF" id="5TNjoy1vf5N" role="3cqZAp">
-          <node concept="37vLTI" id="5TNjoy1vf5P" role="3clFbG">
-            <node concept="2OqwBi" id="5TNjoy1vfed" role="37vLTJ">
-              <node concept="Xjq3P" id="5TNjoy1vfeA" role="2Oq$k0" />
-              <node concept="2OwXpG" id="5TNjoy1vfeg" role="2OqNvi">
-                <ref role="2Oxat5" node="5TNjoy1vf5J" resolve="builtins" />
+        <node concept="3clFbF" id="7OJcYqy7LqZ" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqy7Lr0" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqy7Lr1" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqy7Lr2" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqy7Lr3" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqy7LqN" resolve="BUILTINS" />
               </node>
             </node>
-            <node concept="37vLTw" id="5TNjoy1vf5T" role="37vLTx">
-              <ref role="3cqZAo" node="5TNjoy1vedD" resolve="builtins" />
+            <node concept="2ShNRf" id="7OJcYqy7Lr4" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqy7Lr5" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="10QFUN" id="7OJcYqy8A9g" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqy8A9f" role="10QFUP">
+                    <ref role="3cqZAo" node="5TNjoy1vedD" resolve="builtins" />
+                  </node>
+                  <node concept="3uibUv" id="7OJcYqy8A9e" role="10QFUM">
+                    <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqy7Lr7" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqy7Lr8" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxTzQb" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqy7Lr9" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQm1b" resolve="getLioncoreBuiltins" />
+                  </node>
+                </node>
+                <node concept="3uibUv" id="7OJcYqy8FMH" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+                </node>
+                <node concept="3uibUv" id="7OJcYqy8GQR" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqy7P4K" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqy7P4L" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqy7P4M" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqy7P4N" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqy7P4O" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqy7P4y" resolve="STRING" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqy7P4P" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqy7P4Q" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="2OqwBi" id="7OJcYqy7P4R" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqy7P4S" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5TNjoy1vedD" resolve="builtins" />
+                  </node>
+                  <node concept="2PDubS" id="7OJcYqy7P4T" role="2OqNvi">
+                    <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getString()" resolve="getString" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqy7P4U" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqy7P4V" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxTzQb" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqy7P4W" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQm1k" resolve="getString" />
+                  </node>
+                </node>
+                <node concept="3uibUv" id="7OJcYqy8V9m" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+                </node>
+                <node concept="3uibUv" id="7OJcYqy8XsK" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqy7SKA" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqy7SKB" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqy7SKC" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqy7SKD" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqy7SKE" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqy7SKo" resolve="INTEGER" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqy7SKF" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqy7SKG" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="2OqwBi" id="7OJcYqy7SKH" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqy7SKI" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5TNjoy1vedD" resolve="builtins" />
+                  </node>
+                  <node concept="2PDubS" id="7OJcYqy7SKJ" role="2OqNvi">
+                    <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInteger()" resolve="getInteger" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqy7SKK" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqy7SKL" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxTzQb" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqy7SKM" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQm1A" resolve="getInteger" />
+                  </node>
+                </node>
+                <node concept="3uibUv" id="7OJcYqy91zn" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+                </node>
+                <node concept="3uibUv" id="7OJcYqy91zo" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqy7Wti" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqy7Wtj" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqy7Wtk" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqy7Wtl" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqy7Wtm" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqy7Wt4" resolve="BOOLEAN" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqy7Wtn" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqy7Wto" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="2OqwBi" id="7OJcYqy7Wtp" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqy7Wtq" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5TNjoy1vedD" resolve="builtins" />
+                  </node>
+                  <node concept="2PDubS" id="7OJcYqy7Wtr" role="2OqNvi">
+                    <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getBoolean()" resolve="getBoolean" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqy7Wts" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqy7Wtt" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxTzQb" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqy7Wtu" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQm1t" resolve="getBoolean" />
+                  </node>
+                </node>
+                <node concept="3uibUv" id="7OJcYqy93G9" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+                </node>
+                <node concept="3uibUv" id="7OJcYqy93Ga" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqy80aO" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqy80aP" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqy80aQ" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqy80aR" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqy80aS" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqy80aA" resolve="JSON" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqy80aT" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqy80aU" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="2OqwBi" id="7OJcYqy80aV" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqy80aW" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5TNjoy1vedD" resolve="builtins" />
+                  </node>
+                  <node concept="2PDubS" id="7OJcYqy80aX" role="2OqNvi">
+                    <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getJSON()" resolve="getJSON" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqy80aY" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqy80aZ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxTzQb" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqy80b0" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQm1J" resolve="getJson" />
+                  </node>
+                </node>
+                <node concept="3uibUv" id="7OJcYqy96Mr" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+                </node>
+                <node concept="3uibUv" id="7OJcYqy96Ms" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqy83Tc" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqy83Td" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqy83Te" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqy83Tf" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqy83Tg" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqy83SY" resolve="INAMED" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqy83Th" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqy83Ti" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="2OqwBi" id="7OJcYqy83Tj" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqy83Tk" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5TNjoy1vedD" resolve="builtins" />
+                  </node>
+                  <node concept="2PDubS" id="7OJcYqy83Tl" role="2OqNvi">
+                    <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getINamed()" resolve="getINamed" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqy83Tm" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqy83Tn" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxTzQb" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqy83To" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQm2j" resolve="getINamed" />
+                  </node>
+                </node>
+                <node concept="3uibUv" id="7OJcYqy9IIh" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~Interface" resolve="Interface" />
+                </node>
+                <node concept="3uibUv" id="7OJcYqy9IIi" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqvXZ8V" resolve="InterfaceKeyedMapping" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqy87Cq" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqy87Cr" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqy87Cs" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqy87Ct" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqy87Cu" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqy87Cc" resolve="NODE" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqy87Cv" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqy87Cw" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="2OqwBi" id="7OJcYqy87Cx" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqy87Cy" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5TNjoy1vedD" resolve="builtins" />
+                  </node>
+                  <node concept="2PDubS" id="7OJcYqy87Cz" role="2OqNvi">
+                    <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getNode()" resolve="getNode" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqy87C$" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqy87C_" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxTzQb" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqy87CA" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQm1S" resolve="getNode" />
+                  </node>
+                </node>
+                <node concept="3uibUv" id="7OJcYqy9XnK" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+                </node>
+                <node concept="3uibUv" id="7OJcYqy9XnL" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+                </node>
+              </node>
             </node>
           </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="5TNjoy1vfuc" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxTKjk" role="jymVt">
+      <property role="TrG5h" value="listPrimitiveTypesX" />
+      <node concept="3Tm1VV" id="7OJcYqxTKjm" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqxTKjn" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqxTKjo" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <node concept="3uibUv" id="7OJcYqxTKjp" role="11_B2D">
+            <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+          </node>
+          <node concept="3uibUv" id="7OJcYqxTKjq" role="11_B2D">
+            <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqxTKjr" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqxUBUO" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqxUBUM" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqxUFnC" role="2ShVmc">
+              <node concept="3uibUv" id="7OJcYqxUJEz" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+                <node concept="3uibUv" id="7OJcYqxUJE$" role="11_B2D">
+                  <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+                </node>
+                <node concept="3uibUv" id="7OJcYqxUJE_" role="11_B2D">
+                  <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+                </node>
+              </node>
+              <node concept="1rXfSq" id="7OJcYqxUPiH" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqxTCCR" resolve="getBooleanX" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqxUTfm" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqxTAF2" resolve="getIntegerX" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqxUVx$" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getStringX" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqxUZyX" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqxTERH" resolve="getJsonX" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxTKjs" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="5TNjoy1vedB" role="jymVt">
       <property role="TrG5h" value="listPrimitiveTypes" />
       <node concept="3clFbS" id="5TNjoy1vedG" role="3clF47">
@@ -1179,6 +1586,55 @@
       </node>
     </node>
     <node concept="2tJIrI" id="39$JcGGbiRJ" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxTMvG" role="jymVt">
+      <property role="TrG5h" value="listClassifiersX" />
+      <node concept="3Tm1VV" id="7OJcYqxTMvI" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqxTMvJ" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqxTMvK" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <node concept="3qUE_q" id="7OJcYqxVE1n" role="11_B2D">
+            <node concept="3uibUv" id="7OJcYqxVHHa" role="3qUE_r">
+              <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
+            </node>
+          </node>
+          <node concept="3qUE_q" id="7OJcYqxVLqQ" role="11_B2D">
+            <node concept="3uibUv" id="7OJcYqxVP8t" role="3qUE_r">
+              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqxTMvN" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqxV0jb" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqxV0j9" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqxV3Pt" role="2ShVmc">
+              <node concept="3uibUv" id="7OJcYqxV8Fc" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+                <node concept="3qUE_q" id="7OJcYqxVQg6" role="11_B2D">
+                  <node concept="3uibUv" id="7OJcYqxVQg7" role="3qUE_r">
+                    <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
+                  </node>
+                </node>
+                <node concept="3qUE_q" id="7OJcYqxVQg8" role="11_B2D">
+                  <node concept="3uibUv" id="7OJcYqxVQg9" role="3qUE_r">
+                    <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1rXfSq" id="7OJcYqxVmbT" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqxTIfx" resolve="getNodeX" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqxVuG3" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamedX" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxTMvO" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="5TNjoy1vfyI" role="jymVt">
       <property role="TrG5h" value="listClassifiers" />
       <node concept="3clFbS" id="5TNjoy1vfyN" role="3clF47">
@@ -1209,6 +1665,32 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5TNjoy1vtg4" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxT$o7" role="jymVt">
+      <property role="TrG5h" value="getBuiltinsX" />
+      <node concept="3Tm1VV" id="7OJcYqxT$o9" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqxT$oa" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqxT$ob" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqxT$oc" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqxT$od" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqxT$og" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqy7Lra" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqy7Lrb" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqy7Lrc" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqy7LqN" resolve="BUILTINS" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxT$oe" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="4Yo3buYJQ9P" role="jymVt">
       <property role="TrG5h" value="getBuiltins" />
       <node concept="3Tm1VV" id="4Yo3buYJQ9R" role="1B3o_S" />
@@ -1216,9 +1698,14 @@
         <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
       </node>
       <node concept="3clFbS" id="4Yo3buYJQ9T" role="3clF47">
-        <node concept="3clFbF" id="4Yo3buYJQ9W" role="3cqZAp">
-          <node concept="37vLTw" id="4Yo3buYJQOP" role="3clFbG">
-            <ref role="3cqZAo" node="5TNjoy1vf5J" resolve="builtins" />
+        <node concept="3clFbF" id="7OJcYqy8KB0" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqy8MQc" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqy8KAX" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqxT$o7" resolve="getBuiltinsX" />
+            </node>
+            <node concept="liA8E" id="7OJcYqy8NZ2" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+            </node>
           </node>
         </node>
       </node>
@@ -1227,6 +1714,32 @@
       </node>
     </node>
     <node concept="2tJIrI" id="4Yo3buYJQ$9" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxT_$X" role="jymVt">
+      <property role="TrG5h" value="getStringX" />
+      <node concept="3Tm1VV" id="7OJcYqxT_$Z" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqxT__0" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqxT__1" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqxT__2" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqxT__3" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqxU5jl" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqy7P4X" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqy7P4Y" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqy7P4Z" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqy7P4y" resolve="STRING" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxT__4" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="5TNjoy1vtGO" role="jymVt">
       <property role="TrG5h" value="getString" />
       <node concept="3uibUv" id="5TNjoy1vtGS" role="3clF45">
@@ -1235,12 +1748,12 @@
       <node concept="3Tm1VV" id="5TNjoy1vtGQ" role="1B3o_S" />
       <node concept="3clFbS" id="5TNjoy1vupI" role="3clF47">
         <node concept="3clFbF" id="5TNjoy1vuCp" role="3cqZAp">
-          <node concept="2OqwBi" id="5TNjoy1vvas" role="3clFbG">
-            <node concept="37vLTw" id="5TNjoy1vuCo" role="2Oq$k0">
-              <ref role="3cqZAo" node="5TNjoy1vf5J" resolve="builtins" />
+          <node concept="2OqwBi" id="7OJcYqyacrB" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqyaa0e" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getStringX" />
             </node>
-            <node concept="2PDubS" id="5TNjoy1vwal" role="2OqNvi">
-              <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getString()" resolve="getString" />
+            <node concept="liA8E" id="7OJcYqyafhm" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
             </node>
           </node>
         </node>
@@ -1250,6 +1763,32 @@
       </node>
     </node>
     <node concept="2tJIrI" id="4Yo3buYJT1B" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxTAF2" role="jymVt">
+      <property role="TrG5h" value="getIntegerX" />
+      <node concept="3Tm1VV" id="7OJcYqxTAF4" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqxTAF5" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqxTAF6" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqxTAF7" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqxTAF8" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqxUbHO" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqy7SKN" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqy7SKO" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqy7SKP" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqy7SKo" resolve="INTEGER" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxTAF9" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="5TNjoy1vtVU" role="jymVt">
       <property role="TrG5h" value="getInteger" />
       <node concept="3uibUv" id="5TNjoy1vtVY" role="3clF45">
@@ -1258,12 +1797,12 @@
       <node concept="3Tm1VV" id="5TNjoy1vtVW" role="1B3o_S" />
       <node concept="3clFbS" id="5TNjoy1vwD5" role="3clF47">
         <node concept="3clFbF" id="5TNjoy1vwgQ" role="3cqZAp">
-          <node concept="2OqwBi" id="5TNjoy1vwgR" role="3clFbG">
-            <node concept="37vLTw" id="5TNjoy1vwgS" role="2Oq$k0">
-              <ref role="3cqZAo" node="5TNjoy1vf5J" resolve="builtins" />
+          <node concept="2OqwBi" id="7OJcYqyahMk" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqyahMl" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqxTAF2" resolve="getIntegerX" />
             </node>
-            <node concept="2PDubS" id="5TNjoy1vwgT" role="2OqNvi">
-              <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInteger()" resolve="getInteger" />
+            <node concept="liA8E" id="7OJcYqyahMm" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
             </node>
           </node>
         </node>
@@ -1273,6 +1812,32 @@
       </node>
     </node>
     <node concept="2tJIrI" id="4Yo3buYJTGT" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxTCCR" role="jymVt">
+      <property role="TrG5h" value="getBooleanX" />
+      <node concept="3Tm1VV" id="7OJcYqxTCCT" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqxTCCU" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqxTCCV" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqxTCCW" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqxTCCX" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqxUgkp" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqy7Wtv" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqy7Wtw" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqy7Wtx" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqy7Wt4" resolve="BOOLEAN" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxTCCY" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="5TNjoy1vu1A" role="jymVt">
       <property role="TrG5h" value="getBoolean" />
       <node concept="3uibUv" id="5TNjoy1vu1E" role="3clF45">
@@ -1281,12 +1846,12 @@
       <node concept="3Tm1VV" id="5TNjoy1vu1C" role="1B3o_S" />
       <node concept="3clFbS" id="5TNjoy1vwPp" role="3clF47">
         <node concept="3clFbF" id="5TNjoy1vwV9" role="3cqZAp">
-          <node concept="2OqwBi" id="5TNjoy1vwVa" role="3clFbG">
-            <node concept="37vLTw" id="5TNjoy1vwVb" role="2Oq$k0">
-              <ref role="3cqZAo" node="5TNjoy1vf5J" resolve="builtins" />
+          <node concept="2OqwBi" id="7OJcYqyamXY" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqyamXZ" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqxTCCR" resolve="getBooleanX" />
             </node>
-            <node concept="2PDubS" id="5TNjoy1vwVc" role="2OqNvi">
-              <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getBoolean()" resolve="getBoolean" />
+            <node concept="liA8E" id="7OJcYqyamY0" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
             </node>
           </node>
         </node>
@@ -1296,6 +1861,32 @@
       </node>
     </node>
     <node concept="2tJIrI" id="4Yo3buYJUog" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxTERH" role="jymVt">
+      <property role="TrG5h" value="getJsonX" />
+      <node concept="3Tm1VV" id="7OJcYqxTERJ" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqxTERK" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqxTERL" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqxTERM" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqxTERN" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqxUl2s" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqy80b1" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqy80b2" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqy80b3" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqy80aA" resolve="JSON" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxTERO" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="5TNjoy1vu7q" role="jymVt">
       <property role="TrG5h" value="getJSON" />
       <node concept="3uibUv" id="5TNjoy1vu7u" role="3clF45">
@@ -1304,12 +1895,12 @@
       <node concept="3Tm1VV" id="5TNjoy1vu7s" role="1B3o_S" />
       <node concept="3clFbS" id="5TNjoy1vx2D" role="3clF47">
         <node concept="3clFbF" id="5TNjoy1vxin" role="3cqZAp">
-          <node concept="2OqwBi" id="5TNjoy1vxio" role="3clFbG">
-            <node concept="37vLTw" id="5TNjoy1vxip" role="2Oq$k0">
-              <ref role="3cqZAo" node="5TNjoy1vf5J" resolve="builtins" />
+          <node concept="2OqwBi" id="7OJcYqyasc2" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqyasc3" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqxTERH" resolve="getJsonX" />
             </node>
-            <node concept="2PDubS" id="5TNjoy1vxiq" role="2OqNvi">
-              <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getJSON()" resolve="getJSON" />
+            <node concept="liA8E" id="7OJcYqyasc4" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
             </node>
           </node>
         </node>
@@ -1319,6 +1910,32 @@
       </node>
     </node>
     <node concept="2tJIrI" id="4Yo3buYJV3G" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxTGtE" role="jymVt">
+      <property role="TrG5h" value="getINamedX" />
+      <node concept="3Tm1VV" id="7OJcYqxTGtG" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqxTGtH" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqxTGtI" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Interface" resolve="Interface" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqxTGtJ" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvXZ8V" resolve="InterfaceKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqxTGtK" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqxUq1t" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqy83Tp" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqy83Tq" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqy83Tr" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqy83SY" resolve="INAMED" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxTGtL" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="5TNjoy1vudm" role="jymVt">
       <property role="TrG5h" value="getINamed" />
       <node concept="3uibUv" id="5TNjoy1vudq" role="3clF45">
@@ -1327,12 +1944,12 @@
       <node concept="3Tm1VV" id="5TNjoy1vudo" role="1B3o_S" />
       <node concept="3clFbS" id="5TNjoy1vxqj" role="3clF47">
         <node concept="3clFbF" id="5TNjoy1vxql" role="3cqZAp">
-          <node concept="2OqwBi" id="5TNjoy1vxqm" role="3clFbG">
-            <node concept="37vLTw" id="5TNjoy1vxqn" role="2Oq$k0">
-              <ref role="3cqZAo" node="5TNjoy1vf5J" resolve="builtins" />
+          <node concept="2OqwBi" id="7OJcYqyaxsw" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqyaxsx" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamedX" />
             </node>
-            <node concept="2PDubS" id="5TNjoy1vxqo" role="2OqNvi">
-              <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getINamed()" resolve="getINamed" />
+            <node concept="liA8E" id="7OJcYqyaxsy" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
             </node>
           </node>
         </node>
@@ -1342,6 +1959,32 @@
       </node>
     </node>
     <node concept="2tJIrI" id="4Yo3buYJVJd" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxTIfx" role="jymVt">
+      <property role="TrG5h" value="getNodeX" />
+      <node concept="3Tm1VV" id="7OJcYqxTIfz" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqxTIf$" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqxTIf_" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqxTIfA" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqxTIfB" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqxUwGw" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqy87CB" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqy87CC" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqy87CD" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqy87Cc" resolve="NODE" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxTIfC" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="5TNjoy1vujq" role="jymVt">
       <property role="TrG5h" value="getNode" />
       <node concept="3uibUv" id="5TNjoy1vuju" role="3clF45">
@@ -1350,12 +1993,12 @@
       <node concept="3Tm1VV" id="5TNjoy1vujs" role="1B3o_S" />
       <node concept="3clFbS" id="5TNjoy1vxyH" role="3clF47">
         <node concept="3clFbF" id="5TNjoy1vxyJ" role="3cqZAp">
-          <node concept="2OqwBi" id="5TNjoy1vxyK" role="3clFbG">
-            <node concept="37vLTw" id="5TNjoy1vxyL" role="2Oq$k0">
-              <ref role="3cqZAo" node="5TNjoy1vf5J" resolve="builtins" />
+          <node concept="2OqwBi" id="7OJcYqyaAm6" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqyaAm7" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqxTIfx" resolve="getNodeX" />
             </node>
-            <node concept="2PDubS" id="5TNjoy1vxyM" role="2OqNvi">
-              <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getNode()" resolve="getNode" />
+            <node concept="liA8E" id="7OJcYqyaAm8" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
             </node>
           </node>
         </node>
@@ -3731,6 +4374,9 @@
                         <ref role="HV5vE" node="7weWCFlyxlE" resolve="LionCoreAdapter" />
                       </node>
                     </node>
+                    <node concept="37vLTw" id="7OJcYqxWRw6" role="37wK5m">
+                      <ref role="3cqZAo" node="4WflrVaq3Zc" resolve="constants" />
+                    </node>
                   </node>
                 </node>
                 <node concept="37vLTw" id="5wsogBcrRgJ" role="37wK5m">
@@ -3831,6 +4477,9 @@
                       <node concept="HV5vD" id="7weWCFlyURy" role="2ShVmc">
                         <ref role="HV5vE" node="7weWCFlyxlE" resolve="LionCoreAdapter" />
                       </node>
+                    </node>
+                    <node concept="37vLTw" id="7OJcYqxWROm" role="37wK5m">
+                      <ref role="3cqZAo" node="4WflrVaq3Zc" resolve="constants" />
                     </node>
                   </node>
                 </node>
@@ -4710,6 +5359,9 @@
                     <ref role="HV5vE" node="7weWCFlyxlE" resolve="LionCoreAdapter" />
                   </node>
                 </node>
+                <node concept="37vLTw" id="7OJcYqxWAhp" role="37wK5m">
+                  <ref role="3cqZAo" node="5TNjoy1Aj0O" resolve="constants" />
+                </node>
               </node>
             </node>
             <node concept="37vLTw" id="5TNjoy1Ae_g" role="37vLTJ">
@@ -4735,6 +5387,24 @@
   <node concept="3HP615" id="5JNiskj4NAJ">
     <property role="3GE5qa" value="jsonConstants" />
     <property role="TrG5h" value="IJsonConstants_2023_1" />
+    <node concept="3clFb_" id="7OJcYqxTsMO" role="jymVt">
+      <property role="TrG5h" value="listPrimitiveTypesX" />
+      <node concept="3clFbS" id="7OJcYqxTsMP" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqxTsMQ" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqxTv7t" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqxTsMR" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <node concept="3uibUv" id="7OJcYqxTwtc" role="11_B2D">
+            <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+          </node>
+          <node concept="3uibUv" id="7OJcYqxTwtd" role="11_B2D">
+            <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqxTsMU" role="jymVt" />
+    <node concept="2tJIrI" id="7OJcYqxTsIs" role="jymVt" />
     <node concept="3clFb_" id="5JNiskj4Oxk" role="jymVt">
       <property role="TrG5h" value="listPrimitiveTypes" />
       <node concept="3clFbS" id="5JNiskj4Oxl" role="3clF47" />
@@ -4758,6 +5428,27 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskj4Oxy" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxTwQ8" role="jymVt">
+      <property role="TrG5h" value="listClassifiersX" />
+      <node concept="3clFbS" id="7OJcYqxTwQ9" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqxTwQa" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqxTwQb" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqxTwQc" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <node concept="3qUE_q" id="7OJcYqxVZMX" role="11_B2D">
+            <node concept="3uibUv" id="7OJcYqxVZMY" role="3qUE_r">
+              <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
+            </node>
+          </node>
+          <node concept="3qUE_q" id="7OJcYqxVZMZ" role="11_B2D">
+            <node concept="3uibUv" id="7OJcYqxVZN0" role="3qUE_r">
+              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqxTwLu" role="jymVt" />
     <node concept="3clFb_" id="5JNiskj4Oxz" role="jymVt">
       <property role="TrG5h" value="listClassifiers" />
       <node concept="3clFbS" id="5JNiskj4Ox$" role="3clF47" />
@@ -4781,6 +5472,21 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskj4OxJ" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxR6CI" role="jymVt">
+      <property role="TrG5h" value="getBuiltinsX" />
+      <node concept="3clFbS" id="7OJcYqxR6CJ" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqxR6CK" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqxR6CL" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqxR6CM" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqxR6CN" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqxR6_Q" role="jymVt" />
     <node concept="3clFb_" id="4Yo3buYJP_4" role="jymVt">
       <property role="TrG5h" value="getBuiltins" />
       <node concept="3clFbS" id="4Yo3buYJP_7" role="3clF47" />
@@ -4808,6 +5514,20 @@
       </node>
     </node>
     <node concept="2tJIrI" id="4Yo3buYJPxh" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxR63A" role="jymVt">
+      <property role="TrG5h" value="getStringX" />
+      <node concept="3clFbS" id="7OJcYqxR63D" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqxR63E" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqxR5F2" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqxR5HM" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqxR5NE" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+        </node>
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiskj4OxK" role="jymVt">
       <property role="TrG5h" value="getString" />
       <node concept="3uibUv" id="5JNiskj4OxL" role="3clF45">
@@ -4823,6 +5543,21 @@
         </node>
       </node>
     </node>
+    <node concept="3clFb_" id="7OJcYqxTgBk" role="jymVt">
+      <property role="TrG5h" value="getIntegerX" />
+      <node concept="3clFbS" id="7OJcYqxTgBl" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqxTgBm" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqxTgBn" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqxThfp" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqxThfq" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqxTg$c" role="jymVt" />
     <node concept="3clFb_" id="5JNiskj4OxT" role="jymVt">
       <property role="TrG5h" value="getInteger" />
       <node concept="3uibUv" id="5JNiskj4OxU" role="3clF45">
@@ -4838,6 +5573,21 @@
         </node>
       </node>
     </node>
+    <node concept="3clFb_" id="7OJcYqxThz6" role="jymVt">
+      <property role="TrG5h" value="getBooleanX" />
+      <node concept="3clFbS" id="7OJcYqxThz7" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqxThz8" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqxThz9" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqxThza" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqxThzb" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqxThvI" role="jymVt" />
     <node concept="3clFb_" id="5JNiskj4Oy2" role="jymVt">
       <property role="TrG5h" value="getBoolean" />
       <node concept="3uibUv" id="5JNiskj4Oy3" role="3clF45">
@@ -4853,6 +5603,21 @@
         </node>
       </node>
     </node>
+    <node concept="3clFb_" id="7OJcYqxTinV" role="jymVt">
+      <property role="TrG5h" value="getJsonX" />
+      <node concept="3clFbS" id="7OJcYqxTinW" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqxTinX" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqxTinY" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqxTinZ" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqxTio0" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqxTimg" role="jymVt" />
     <node concept="3clFb_" id="5JNiskj4Oyb" role="jymVt">
       <property role="TrG5h" value="getJSON" />
       <node concept="3uibUv" id="5JNiskj4Oyc" role="3clF45">
@@ -4868,6 +5633,21 @@
         </node>
       </node>
     </node>
+    <node concept="3clFb_" id="7OJcYqxTjiV" role="jymVt">
+      <property role="TrG5h" value="getINamedX" />
+      <node concept="3clFbS" id="7OJcYqxTjiW" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqxTjiX" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqxTjiY" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqxTjiZ" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Interface" resolve="Interface" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqxTjj0" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvXZ8V" resolve="InterfaceKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqxTjh9" role="jymVt" />
     <node concept="3clFb_" id="5JNiskj4Oyk" role="jymVt">
       <property role="TrG5h" value="getINamed" />
       <node concept="3uibUv" id="5JNiskj4Oyl" role="3clF45">
@@ -4883,6 +5663,21 @@
         </node>
       </node>
     </node>
+    <node concept="3clFb_" id="7OJcYqxTras" role="jymVt">
+      <property role="TrG5h" value="getNodeX" />
+      <node concept="3clFbS" id="7OJcYqxTrat" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqxTrau" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqxTrav" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqxTraw" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqxTrax" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqxTray" role="jymVt" />
     <node concept="3clFb_" id="5JNiskj4Oyt" role="jymVt">
       <property role="TrG5h" value="getNode" />
       <node concept="3uibUv" id="5JNiskj4Oyu" role="3clF45">
@@ -4909,6 +5704,20 @@
   <node concept="3HP615" id="5JNiskj4R_R">
     <property role="3GE5qa" value="jsonConstants" />
     <property role="TrG5h" value="IJsonConstants" />
+    <node concept="3clFb_" id="7OJcYqyaYLW" role="jymVt">
+      <property role="TrG5h" value="getSpecificLanguageX" />
+      <node concept="3clFbS" id="7OJcYqyaYLX" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqyaYLY" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyaYLZ" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyaYM0" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyaYM1" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        </node>
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiskj6wTk" role="jymVt">
       <property role="TrG5h" value="getSpecificLanguage" />
       <node concept="3clFbS" id="5JNiskj6wTn" role="3clF47" />
@@ -4936,6 +5745,20 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskj6wPP" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqyb0Gn" role="jymVt">
+      <property role="TrG5h" value="getVirtualPackageX" />
+      <node concept="3clFbS" id="7OJcYqyb0Go" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqyb0Gp" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyb0Gq" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyb0Gr" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyb0Gs" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+        </node>
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiskj67eE" role="jymVt">
       <property role="TrG5h" value="getVirtualPackage" />
       <node concept="3clFbS" id="5JNiskj67eH" role="3clF47" />
@@ -4967,6 +5790,22 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="7OJcYqyb4hc" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqyb2JF" role="jymVt">
+      <property role="TrG5h" value="getVirtualPackage_NameX" />
+      <node concept="3clFbS" id="7OJcYqyb2JG" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqyb2JH" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyb2JI" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyb2JJ" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyb2JK" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqyb2Cw" role="jymVt" />
     <node concept="3clFb_" id="5JNiskj67nR" role="jymVt">
       <property role="TrG5h" value="getVirtualPackage_Name" />
       <node concept="3clFbS" id="5JNiskj67nU" role="3clF47" />
@@ -4999,6 +5838,21 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskj67qn" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqyb4U4" role="jymVt">
+      <property role="TrG5h" value="getShortDescriptionX" />
+      <node concept="3clFbS" id="7OJcYqyb4U5" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqyb4U6" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyb4U7" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyb4U8" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyb4U9" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqyb4PP" role="jymVt" />
     <node concept="3clFb_" id="5JNiskj67iX" role="jymVt">
       <property role="TrG5h" value="getShortDescription" />
       <node concept="3clFbS" id="5JNiskj67j0" role="3clF47" />
@@ -5030,6 +5884,22 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="7OJcYqyb6Jl" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqyb6S2" role="jymVt">
+      <property role="TrG5h" value="getShortDescription_DescriptionX" />
+      <node concept="3clFbS" id="7OJcYqyb6S3" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqyb6S4" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyb6S5" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyb6S6" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyb6S7" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqyb6NF" role="jymVt" />
     <node concept="3clFb_" id="5JNiskj67rQ" role="jymVt">
       <property role="TrG5h" value="getShortDescription_Description" />
       <node concept="3clFbS" id="5JNiskj67rR" role="3clF47" />
@@ -5224,6 +6094,21 @@
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zN_wDu" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqyb96D" role="jymVt">
+      <property role="TrG5h" value="getConceptDescriptionAnnotationX" />
+      <node concept="3clFbS" id="7OJcYqyb96E" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqyb96F" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyb96G" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyb96H" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyb96I" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqyb8YG" role="jymVt" />
     <node concept="3clFb_" id="34Q84zNB8uo" role="jymVt">
       <property role="TrG5h" value="getConceptDescriptionAnnotation" />
       <node concept="3clFbS" id="34Q84zNB8ur" role="3clF47" />
@@ -5244,6 +6129,22 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="7OJcYqybbIQ" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqybbS1" role="jymVt">
+      <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptAliasX" />
+      <node concept="3clFbS" id="7OJcYqybbS2" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqybbS3" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqybbS4" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqybbS5" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqybbS6" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqybbNr" role="jymVt" />
     <node concept="3clFb_" id="34Q84zNToVR" role="jymVt">
       <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptAlias" />
       <node concept="3clFbS" id="34Q84zNToVS" role="3clF47" />
@@ -5278,6 +6179,22 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="7OJcYqybeuo" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqybeup" role="jymVt">
+      <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptShortDescriptionX" />
+      <node concept="3clFbS" id="7OJcYqybeuq" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqybeur" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqybeus" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqybeut" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqybeuu" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqybelU" role="jymVt" />
     <node concept="3clFb_" id="34Q84zNTp5n" role="jymVt">
       <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptShortDescription" />
       <node concept="3clFbS" id="34Q84zNTp5o" role="3clF47" />
@@ -5336,6 +6253,20 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7weWCFlvJ3J" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqybgVi" role="jymVt">
+      <property role="TrG5h" value="getAnnotationConceptX" />
+      <node concept="3clFbS" id="7OJcYqybgVj" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqybgVk" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqybgVl" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqybgVm" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqybgVn" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        </node>
+      </node>
+    </node>
     <node concept="3clFb_" id="7weWCFlwidJ" role="jymVt">
       <property role="TrG5h" value="getAnnotationConcept" />
       <node concept="3clFbS" id="7weWCFlwidM" role="3clF47" />
@@ -5362,6 +6293,22 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="7OJcYqybjHa" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqybjR1" role="jymVt">
+      <property role="TrG5h" value="getClassifierConceptX" />
+      <node concept="3clFbS" id="7OJcYqybjR2" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqybjR3" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqybjR4" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqybjR5" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqybjR6" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqybjM5" role="jymVt" />
     <node concept="3clFb_" id="7weWCFlwin$" role="jymVt">
       <property role="TrG5h" value="getClassifierConcept" />
       <node concept="3clFbS" id="7weWCFlwin_" role="3clF47" />
@@ -5388,6 +6335,22 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="7OJcYqybmkw" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqybmuB" role="jymVt">
+      <property role="TrG5h" value="getConceptConceptX" />
+      <node concept="3clFbS" id="7OJcYqybmuC" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqybmuD" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqybmuE" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqybmuF" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqybmuG" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqybmpz" role="jymVt" />
     <node concept="3clFb_" id="7weWCFlwj$H" role="jymVt">
       <property role="TrG5h" value="getConceptConcept" />
       <node concept="3clFbS" id="7weWCFlwj$I" role="3clF47" />
@@ -5414,6 +6377,22 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="7OJcYqybp5S" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqybpgf" role="jymVt">
+      <property role="TrG5h" value="getInterfaceConceptX" />
+      <node concept="3clFbS" id="7OJcYqybpgg" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqybpgh" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqybpgi" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqybpgj" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqybpgk" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqybpb3" role="jymVt" />
     <node concept="3clFb_" id="7weWCFlwk05" role="jymVt">
       <property role="TrG5h" value="getInterfaceConcept" />
       <node concept="3clFbS" id="7weWCFlwk06" role="3clF47" />
@@ -5474,14 +6453,175 @@
     <node concept="3uibUv" id="5JNiskj4S_T" role="EKbjA">
       <ref role="3uigEE" node="5JNiskj4R_R" resolve="IJsonConstants" />
     </node>
-    <node concept="312cEg" id="7weWCFlwCp6" role="jymVt">
-      <property role="TrG5h" value="m3" />
+    <node concept="312cEg" id="7OJcYqyctMv" role="jymVt">
+      <property role="TrG5h" value="SPECIFIC_LANGUAGE" />
       <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="7weWCFlwNpW" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlwCp9" role="1tU5fm">
-        <ref role="3uigEE" node="7weWCFlywjb" resolve="ILionCoreAdapter" />
+      <node concept="3Tm6S6" id="7OJcYqyctMr" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyctMs" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyctMt" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyctMu" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        </node>
       </node>
     </node>
+    <node concept="312cEg" id="7OJcYqyd5wz" role="jymVt">
+      <property role="TrG5h" value="VIRTUAL_PACKAGE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqyd5wx" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyd5wy" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqygH8i" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqygH8j" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqydvJX" role="jymVt">
+      <property role="TrG5h" value="SHORT_DESCRIPTION" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqydvJV" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqydvJW" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyh4JR" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyh4JS" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqydNSU" role="jymVt">
+      <property role="TrG5h" value="ANNOTATION" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqydNSS" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqydNST" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyjm$8" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyjm$9" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqyeaqZ" role="jymVt">
+      <property role="TrG5h" value="CLASSIFIER" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqyeaqX" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyeaqY" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyjsr2" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyjsr3" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqyexdn" role="jymVt">
+      <property role="TrG5h" value="CONCEPT" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqyexdl" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyexdm" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyjub8" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyjub9" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqyeRGY" role="jymVt">
+      <property role="TrG5h" value="INTERFACE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqyeRGW" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyeRGX" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyjzkQ" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyjzkR" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqyfkgL" role="jymVt">
+      <property role="TrG5h" value="CONCEPT_DESCRIPTION" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqyfkgJ" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyfkgK" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyhA1D" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyhA1E" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqyfGaR" role="jymVt">
+      <property role="TrG5h" value="CONCEPT_ALIAS" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqyfGaP" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyfGaQ" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyi6YV" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyi6YW" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqygecs" role="jymVt">
+      <property role="TrG5h" value="CONCEPT_SHORT_DESCRIPTION" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqygecq" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqygecr" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyiRxW" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyiRxX" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqylZ6o" role="jymVt">
+      <property role="TrG5h" value="VIRTUAL_PACKAGE_NAME" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqylZ6m" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqylZ6n" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqymltJ" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqymltK" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqymLc_" role="jymVt">
+      <property role="TrG5h" value="SHORT_DESCRIPTION_DESCRIPTION" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqymLcz" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqymLc$" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyn2$k" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyn2$l" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqywJzl" role="jymVt" />
     <node concept="3clFbW" id="5JNiskj4SJa" role="jymVt">
       <node concept="37vLTG" id="5JNiskj4SJb" role="3clF46">
         <property role="TrG5h" value="builtins" />
@@ -5500,135 +6640,223 @@
           <node concept="37vLTw" id="5JNiskj4SJp" role="37wK5m">
             <ref role="3cqZAo" node="5JNiskj4SJb" resolve="builtins" />
           </node>
+          <node concept="37vLTw" id="7OJcYqxWuKn" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+          </node>
         </node>
-        <node concept="3clFbF" id="7weWCFlwCpa" role="3cqZAp">
-          <node concept="37vLTI" id="7weWCFlwCpc" role="3clFbG">
-            <node concept="2OqwBi" id="7weWCFlwEBF" role="37vLTJ">
-              <node concept="Xjq3P" id="7weWCFlwFFX" role="2Oq$k0" />
-              <node concept="2OwXpG" id="7weWCFlwEBI" role="2OqNvi">
-                <ref role="2Oxat5" node="7weWCFlwCp6" resolve="m3" />
+        <node concept="3clFbF" id="7OJcYqydNT6" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqydNT7" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqydNT8" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqydNT9" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqydNTa" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqydNSU" resolve="ANNOTATION" />
               </node>
             </node>
-            <node concept="37vLTw" id="7weWCFlwCpg" role="37vLTx">
-              <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
+            <node concept="2ShNRf" id="7OJcYqydNTb" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqydNTc" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="2OqwBi" id="7weWCFlxmzL" role="37wK5m">
+                  <node concept="37vLTw" id="7weWCFlxmke" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
+                  </node>
+                  <node concept="liA8E" id="7weWCFlyC9C" role="2OqNvi">
+                    <ref role="37wK5l" node="7weWCFlye1e" resolve="getAnnotation" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqydNTe" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqydNTf" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqydNTg" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQm21" resolve="getAnnotation" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="5JNiskj6ryJ" role="3cqZAp" />
-        <node concept="3clFbF" id="7weWCFlxjeu" role="3cqZAp">
-          <node concept="37vLTI" id="7weWCFlxkxc" role="3clFbG">
-            <node concept="2OqwBi" id="7weWCFlxmzL" role="37vLTx">
-              <node concept="37vLTw" id="7weWCFlxmke" role="2Oq$k0">
-                <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
-              </node>
-              <node concept="liA8E" id="7weWCFlyC9C" role="2OqNvi">
-                <ref role="37wK5l" node="7weWCFlye1e" resolve="getAnnotation" />
+        <node concept="3clFbF" id="7OJcYqyearb" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqyearc" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqyeard" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqyeare" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqyearf" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqyeaqZ" resolve="CLASSIFIER" />
               </node>
             </node>
-            <node concept="37vLTw" id="7weWCFlxjes" role="37vLTJ">
-              <ref role="3cqZAo" node="7weWCFlwRoH" resolve="ANNOTATION_CONCEPT" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7weWCFlxpN1" role="3cqZAp">
-          <node concept="37vLTI" id="7weWCFlxr6p" role="3clFbG">
-            <node concept="2OqwBi" id="7weWCFlxsjJ" role="37vLTx">
-              <node concept="37vLTw" id="7weWCFlxs3F" role="2Oq$k0">
-                <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
+            <node concept="2ShNRf" id="7OJcYqyearg" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqyearh" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="2OqwBi" id="7weWCFlxsjJ" role="37wK5m">
+                  <node concept="37vLTw" id="7weWCFlxs3F" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
+                  </node>
+                  <node concept="liA8E" id="7weWCFlyCYt" role="2OqNvi">
+                    <ref role="37wK5l" node="7weWCFlyegi" resolve="getClassifier" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqyearj" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqyeark" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqyearl" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQy$m" resolve="getClassifier" />
+                  </node>
+                </node>
               </node>
-              <node concept="liA8E" id="7weWCFlyCYt" role="2OqNvi">
-                <ref role="37wK5l" node="7weWCFlyegi" resolve="getClassifier" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="7weWCFlxpMZ" role="37vLTJ">
-              <ref role="3cqZAo" node="7weWCFlwYLn" resolve="CLASSIFIER_CONCEPT" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7weWCFlxvC8" role="3cqZAp">
-          <node concept="37vLTI" id="7weWCFlxxae" role="3clFbG">
-            <node concept="2OqwBi" id="7weWCFlxyXS" role="37vLTx">
-              <node concept="37vLTw" id="7weWCFlxyHj" role="2Oq$k0">
-                <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
-              </node>
-              <node concept="liA8E" id="7weWCFlyDSA" role="2OqNvi">
-                <ref role="37wK5l" node="7weWCFlye2B" resolve="getConcept" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="7weWCFlxvC6" role="37vLTJ">
-              <ref role="3cqZAo" node="7weWCFlx57a" resolve="CONCEPT_CONCEPT" />
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="7weWCFlxAgR" role="3cqZAp">
-          <node concept="37vLTI" id="7weWCFlxB_t" role="3clFbG">
-            <node concept="2OqwBi" id="7weWCFlxDsZ" role="37vLTx">
-              <node concept="37vLTw" id="7weWCFlxDbT" role="2Oq$k0">
-                <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
-              </node>
-              <node concept="liA8E" id="7weWCFlyEZu" role="2OqNvi">
-                <ref role="37wK5l" node="7weWCFlye49" resolve="getInterface" />
+        <node concept="3clFbF" id="7OJcYqyexdz" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqyexd$" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqyexd_" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqyexdA" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqyexdB" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqyexdn" resolve="CONCEPT" />
               </node>
             </node>
-            <node concept="37vLTw" id="7weWCFlxAgP" role="37vLTJ">
-              <ref role="3cqZAo" node="7weWCFlxbqI" resolve="INTERFACE_CONCEPT" />
+            <node concept="2ShNRf" id="7OJcYqyexdC" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqyexdD" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="2OqwBi" id="7weWCFlxyXS" role="37wK5m">
+                  <node concept="37vLTw" id="7weWCFlxyHj" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
+                  </node>
+                  <node concept="liA8E" id="7weWCFlyDSA" role="2OqNvi">
+                    <ref role="37wK5l" node="7weWCFlye2B" resolve="getConcept" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqyexdF" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqyexdG" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqyexdH" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQy$v" resolve="getConcept" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqyeRHa" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqyeRHb" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqyeRHc" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqyeRHd" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqyeRHe" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqyeRGY" resolve="INTERFACE" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqyeRHf" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqyeRHg" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="2OqwBi" id="7weWCFlxDsZ" role="37wK5m">
+                  <node concept="37vLTw" id="7weWCFlxDbT" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
+                  </node>
+                  <node concept="liA8E" id="7weWCFlyEZu" role="2OqNvi">
+                    <ref role="37wK5l" node="7weWCFlye49" resolve="getInterface" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqyeRHi" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqyeRHj" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqyeRHk" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQy$C" resolve="getInterface" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="7weWCFlxi6m" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiskj6AAg" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskj6B66" role="3clFbG">
-            <node concept="2ShNRf" id="5JNiskj6BrP" role="37vLTx">
-              <node concept="1pGfFk" id="5JNiskj6BT0" role="2ShVmc">
+        <node concept="3cpWs8" id="7OJcYqypXxk" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqypXxl" role="3cpWs9">
+            <property role="TrG5h" value="specificLanguage" />
+            <node concept="3uibUv" id="7OJcYqypWup" role="1tU5fm">
+              <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+            </node>
+            <node concept="2ShNRf" id="7OJcYqypXxm" role="33vP2m">
+              <node concept="1pGfFk" id="7OJcYqypXxn" role="2ShVmc">
                 <ref role="37wK5l" to="imb3:~Language.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,java.lang.String)" resolve="Language" />
-                <node concept="Xl_RD" id="5JNiskj6CET" role="37wK5m">
+                <node concept="Xl_RD" id="7OJcYqypXxo" role="37wK5m">
                   <property role="Xl_RC" value="MPS-specific annotations" />
                 </node>
-                <node concept="Xl_RD" id="5JNiskj6D5M" role="37wK5m">
+                <node concept="Xl_RD" id="7OJcYqypXxp" role="37wK5m">
                   <property role="Xl_RC" value="io-lionweb-mps-specific" />
                 </node>
-                <node concept="Xl_RD" id="5JNiskj6DQE" role="37wK5m">
+                <node concept="Xl_RD" id="7OJcYqypXxq" role="37wK5m">
                   <property role="Xl_RC" value="io-lionweb-mps-specific" />
                 </node>
-                <node concept="Xl_RD" id="5JNiskj6Fel" role="37wK5m">
+                <node concept="Xl_RD" id="7OJcYqypXxr" role="37wK5m">
                   <property role="Xl_RC" value="0" />
                 </node>
               </node>
             </node>
-            <node concept="37vLTw" id="5JNiskj6AAe" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskj6vKU" resolve="SPECIFIC_LANGUAGE" />
-            </node>
           </node>
         </node>
         <node concept="3clFbH" id="5JNiskj6Ato" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiskj6rEg" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskj6spw" role="3clFbG">
-            <node concept="2ShNRf" id="5JNiskj6sDH" role="37vLTx">
-              <node concept="1pGfFk" id="5JNiskj6sDz" role="2ShVmc">
-                <ref role="37wK5l" to="imb3:~Annotation.&lt;init&gt;(io.lionweb.lioncore.java.language.Language,java.lang.String,java.lang.String,java.lang.String)" resolve="Annotation" />
-                <node concept="37vLTw" id="5JNiskj6FHO" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiskj6vKU" resolve="SPECIFIC_LANGUAGE" />
+        <node concept="3clFbF" id="7OJcYqyctMH" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqyctMI" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqyctMJ" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqyctMK" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqyctML" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqyctMv" resolve="SPECIFIC_LANGUAGE" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqyctMM" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqyctMN" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="3uibUv" id="7OJcYqyctMO" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
                 </node>
-                <node concept="Xl_RD" id="5JNiskj6GeV" role="37wK5m">
-                  <property role="Xl_RC" value="VirtualPackage" />
+                <node concept="3uibUv" id="7OJcYqyctMP" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
                 </node>
-                <node concept="Xl_RD" id="5JNiskj6HF3" role="37wK5m">
-                  <property role="Xl_RC" value="VirtualPackage" />
+                <node concept="37vLTw" id="7OJcYqyctMQ" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqypXxl" resolve="specificLanguage" />
                 </node>
-                <node concept="Xl_RD" id="5JNiskj6Iqn" role="37wK5m">
-                  <property role="Xl_RC" value="VirtualPackage" />
+                <node concept="2OqwBi" id="7OJcYqyctMR" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqyctMS" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqyctMT" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwUzr1" resolve="getSpecificLanguage" />
+                  </node>
                 </node>
               </node>
             </node>
-            <node concept="37vLTw" id="5JNiskj6rEe" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskj69hx" resolve="VIRTUAL_PACKAGE" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqyca$O" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYqyqduq" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqyqdur" role="3cpWs9">
+            <property role="TrG5h" value="virtualPackage" />
+            <node concept="3uibUv" id="7OJcYqyqcsJ" role="1tU5fm">
+              <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+            </node>
+            <node concept="2ShNRf" id="7OJcYqyqdus" role="33vP2m">
+              <node concept="1pGfFk" id="7OJcYqyqdut" role="2ShVmc">
+                <ref role="37wK5l" to="imb3:~Annotation.&lt;init&gt;(io.lionweb.lioncore.java.language.Language,java.lang.String,java.lang.String,java.lang.String)" resolve="Annotation" />
+                <node concept="37vLTw" id="7OJcYqyqduu" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqypXxl" resolve="specificLanguage" />
+                </node>
+                <node concept="Xl_RD" id="7OJcYqyqduv" role="37wK5m">
+                  <property role="Xl_RC" value="VirtualPackage" />
+                </node>
+                <node concept="Xl_RD" id="7OJcYqyqduw" role="37wK5m">
+                  <property role="Xl_RC" value="VirtualPackage" />
+                </node>
+                <node concept="Xl_RD" id="7OJcYqyqdux" role="37wK5m">
+                  <property role="Xl_RC" value="VirtualPackage" />
+                </node>
+              </node>
             </node>
           </node>
         </node>
         <node concept="3clFbF" id="5JNiskj6IWo" role="3cqZAp">
           <node concept="2OqwBi" id="5JNiskj6OSl" role="3clFbG">
             <node concept="37vLTw" id="5JNiskj6Oel" role="2Oq$k0">
-              <ref role="3cqZAo" node="5JNiskj69hx" resolve="VIRTUAL_PACKAGE" />
+              <ref role="3cqZAo" node="7OJcYqyqdur" resolve="virtualPackage" />
             </node>
             <node concept="liA8E" id="5JNiskj6PtP" role="2OqNvi">
               <ref role="37wK5l" to="imb3:~Annotation.addImplementedInterface(io.lionweb.lioncore.java.language.Interface)" resolve="addImplementedInterface" />
@@ -5639,24 +6867,93 @@
           </node>
         </node>
         <node concept="3clFbH" id="5JNiskj6Qe2" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiskj6Qvu" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskj6RjS" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskj6Qvs" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskj6eEd" resolve="SHORT_DESCRIPTION" />
+        <node concept="3clFbF" id="7OJcYqyd5wJ" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqyd5wK" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqyd5wL" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqyd5wM" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqyd5wN" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqyd5wz" resolve="VIRTUAL_PACKAGE" />
+              </node>
             </node>
-            <node concept="2ShNRf" id="5JNiskj6Rws" role="37vLTx">
-              <node concept="1pGfFk" id="5JNiskj6Rwt" role="2ShVmc">
+            <node concept="2ShNRf" id="7OJcYqyd5wO" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqyd5wP" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="37vLTw" id="7OJcYqyd5wQ" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqyqdur" resolve="virtualPackage" />
+                </node>
+                <node concept="2OqwBi" id="7OJcYqyd5wR" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqyd5wS" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqyd5wT" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQyzV" resolve="getVirtualPackage" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqylZ6E" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqylZ6F" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqylZ6G" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqylZ6H" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqylZ6I" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqylZ6o" resolve="VIRTUAL_PACKAGE_NAME" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqylZ6J" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqylZ6K" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="2OqwBi" id="7OJcYqylZ6L" role="37wK5m">
+                  <node concept="2OqwBi" id="7OJcYqylZ6M" role="2Oq$k0">
+                    <node concept="2OqwBi" id="7OJcYqylZ6N" role="2Oq$k0">
+                      <node concept="1rXfSq" id="7OJcYqylZ6O" role="2Oq$k0">
+                        <ref role="37wK5l" node="5TNjoy1vudm" resolve="getINamed" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYqylZ6P" role="2OqNvi">
+                        <ref role="37wK5l" to="imb3:~Classifier.allProperties()" resolve="allProperties" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="7OJcYqylZ6Q" role="2OqNvi">
+                      <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="7OJcYqylZ6R" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqylZ6S" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqylZ6T" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqylZ6U" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQm2s" resolve="getINamedName" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqycDuQ" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYqyqtIM" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqyqtIN" role="3cpWs9">
+            <property role="TrG5h" value="shortDescription" />
+            <node concept="3uibUv" id="7OJcYqyqsCA" role="1tU5fm">
+              <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+            </node>
+            <node concept="2ShNRf" id="7OJcYqyqtIO" role="33vP2m">
+              <node concept="1pGfFk" id="7OJcYqyqtIP" role="2ShVmc">
                 <ref role="37wK5l" to="imb3:~Annotation.&lt;init&gt;(io.lionweb.lioncore.java.language.Language,java.lang.String,java.lang.String,java.lang.String)" resolve="Annotation" />
-                <node concept="37vLTw" id="5JNiskj6Rwu" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiskj6vKU" resolve="SPECIFIC_LANGUAGE" />
+                <node concept="37vLTw" id="7OJcYqyqtIQ" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqypXxl" resolve="specificLanguage" />
                 </node>
-                <node concept="Xl_RD" id="5JNiskj6Rwv" role="37wK5m">
+                <node concept="Xl_RD" id="7OJcYqyqtIR" role="37wK5m">
                   <property role="Xl_RC" value="ShortDescription" />
                 </node>
-                <node concept="Xl_RD" id="5JNiskj6Rww" role="37wK5m">
+                <node concept="Xl_RD" id="7OJcYqyqtIS" role="37wK5m">
                   <property role="Xl_RC" value="ShortDescription" />
                 </node>
-                <node concept="Xl_RD" id="5JNiskj6Rwx" role="37wK5m">
+                <node concept="Xl_RD" id="7OJcYqyqtIT" role="37wK5m">
                   <property role="Xl_RC" value="ShortDescription" />
                 </node>
               </node>
@@ -5666,7 +6963,7 @@
         <node concept="3clFbF" id="5JNiskj6SFB" role="3cqZAp">
           <node concept="2OqwBi" id="5JNiskj6TwW" role="3clFbG">
             <node concept="37vLTw" id="5JNiskj6SF_" role="2Oq$k0">
-              <ref role="3cqZAo" node="5JNiskj6eEd" resolve="SHORT_DESCRIPTION" />
+              <ref role="3cqZAo" node="7OJcYqyqtIN" resolve="shortDescription" />
             </node>
             <node concept="liA8E" id="5JNiskj6UtL" role="2OqNvi">
               <ref role="37wK5l" to="imb3:~Classifier.addFeature(io.lionweb.lioncore.java.language.Feature)" resolve="addFeature" />
@@ -5695,7 +6992,7 @@
                 <node concept="liA8E" id="5JNiskjoB4o" role="2OqNvi">
                   <ref role="37wK5l" to="tzx8:~M3Node.setParent(io.lionweb.lioncore.java.model.Node)" resolve="setParent" />
                   <node concept="37vLTw" id="5JNiskjoB_g" role="37wK5m">
-                    <ref role="3cqZAo" node="5JNiskj6eEd" resolve="SHORT_DESCRIPTION" />
+                    <ref role="3cqZAo" node="7OJcYqyqtIN" resolve="shortDescription" />
                   </node>
                 </node>
               </node>
@@ -5703,61 +7000,132 @@
           </node>
         </node>
         <node concept="3clFbH" id="34Q84zNSU$E" role="3cqZAp" />
-        <node concept="3clFbF" id="34Q84zNSV6_" role="3cqZAp">
-          <node concept="37vLTI" id="34Q84zNSWws" role="3clFbG">
-            <node concept="2ShNRf" id="34Q84zNSWU0" role="37vLTx">
-              <node concept="1pGfFk" id="34Q84zNSXM9" role="2ShVmc">
+        <node concept="3clFbF" id="7OJcYqydvK9" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqydvKa" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqydvKb" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqydvKc" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqydvKd" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqydvJX" resolve="SHORT_DESCRIPTION" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqydvKe" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqydvKf" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="37vLTw" id="7OJcYqydvKg" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqyqtIN" resolve="shortDescription" />
+                </node>
+                <node concept="2OqwBi" id="7OJcYqydvKh" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqydvKi" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqydvKj" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQy$4" resolve="getShortDescription" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqymLcR" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqymLcS" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqymLcT" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqymLcU" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqymLcV" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqymLc_" resolve="SHORT_DESCRIPTION_DESCRIPTION" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqymLcW" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqymLcX" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="2OqwBi" id="7OJcYqymLcY" role="37wK5m">
+                  <node concept="2OqwBi" id="7OJcYqymLcZ" role="2Oq$k0">
+                    <node concept="2OqwBi" id="7OJcYqymLd0" role="2Oq$k0">
+                      <node concept="1rXfSq" id="7OJcYqymLd1" role="2Oq$k0">
+                        <ref role="37wK5l" node="5JNiskj67Oa" resolve="getShortDescription" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYqymLd2" role="2OqNvi">
+                        <ref role="37wK5l" to="imb3:~Classifier.allProperties()" resolve="allProperties" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="7OJcYqymLd3" role="2OqNvi">
+                      <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="7OJcYqymLd4" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqymLd5" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqymLd6" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqymLd7" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQy$4" resolve="getShortDescription" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqydf4D" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYqyqMhq" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqyqMhr" role="3cpWs9">
+            <property role="TrG5h" value="conceptDescription" />
+            <node concept="3uibUv" id="7OJcYqyqLcX" role="1tU5fm">
+              <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+            </node>
+            <node concept="2ShNRf" id="7OJcYqyqMhs" role="33vP2m">
+              <node concept="1pGfFk" id="7OJcYqyqMht" role="2ShVmc">
                 <ref role="37wK5l" to="imb3:~Annotation.&lt;init&gt;(io.lionweb.lioncore.java.language.Language,java.lang.String,java.lang.String,java.lang.String)" resolve="Annotation" />
-                <node concept="37vLTw" id="34Q84zNSYdw" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiskj6vKU" resolve="SPECIFIC_LANGUAGE" />
+                <node concept="37vLTw" id="7OJcYqyqMhu" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqypXxl" resolve="specificLanguage" />
                 </node>
-                <node concept="Xl_RD" id="34Q84zNSZmk" role="37wK5m">
+                <node concept="Xl_RD" id="7OJcYqyqMhv" role="37wK5m">
                   <property role="Xl_RC" value="ConceptDescription" />
                 </node>
-                <node concept="Xl_RD" id="34Q84zNT0_z" role="37wK5m">
+                <node concept="Xl_RD" id="7OJcYqyqMhw" role="37wK5m">
                   <property role="Xl_RC" value="ConceptDescription" />
                 </node>
-                <node concept="Xl_RD" id="34Q84zNT1W8" role="37wK5m">
+                <node concept="Xl_RD" id="7OJcYqyqMhx" role="37wK5m">
                   <property role="Xl_RC" value="ConceptDescription" />
                 </node>
               </node>
             </node>
-            <node concept="37vLTw" id="34Q84zNSV6z" role="37vLTJ">
-              <ref role="3cqZAo" node="34Q84zNSMRU" resolve="CONCEPT_DESCRIPTION" />
-            </node>
           </node>
         </node>
-        <node concept="3clFbF" id="34Q84zNUa_v" role="3cqZAp">
-          <node concept="37vLTI" id="34Q84zNUbCK" role="3clFbG">
-            <node concept="37vLTw" id="34Q84zNUa_t" role="37vLTJ">
-              <ref role="3cqZAo" node="34Q84zNTU6H" resolve="CONCEPT_ALIAS" />
+        <node concept="3clFbH" id="7OJcYqyfSFs" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYqyr1o1" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqyr1o2" role="3cpWs9">
+            <property role="TrG5h" value="conceptAlias" />
+            <node concept="3uibUv" id="7OJcYqyr0dB" role="1tU5fm">
+              <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
             </node>
-            <node concept="2OqwBi" id="34Q84zNThN3" role="37vLTx">
-              <node concept="2OqwBi" id="34Q84zNTenW" role="2Oq$k0">
-                <node concept="2YIFZM" id="34Q84zNT772" role="2Oq$k0">
+            <node concept="2OqwBi" id="7OJcYqyr1o3" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqyr1o4" role="2Oq$k0">
+                <node concept="2YIFZM" id="7OJcYqyr1o5" role="2Oq$k0">
                   <ref role="1Pybhc" to="imb3:~Property" resolve="Property" />
                   <ref role="37wK5l" to="imb3:~Property.createOptional(java.lang.String,io.lionweb.lioncore.java.language.DataType,java.lang.String)" resolve="createOptional" />
-                  <node concept="Xl_RD" id="34Q84zNT7Ln" role="37wK5m">
+                  <node concept="Xl_RD" id="7OJcYqyr1o6" role="37wK5m">
                     <property role="Xl_RC" value="conceptAlias" />
                   </node>
-                  <node concept="1rXfSq" id="34Q84zNT9MR" role="37wK5m">
+                  <node concept="1rXfSq" id="7OJcYqyr1o7" role="37wK5m">
                     <ref role="37wK5l" node="5TNjoy1vtGO" resolve="getString" />
                   </node>
-                  <node concept="Xl_RD" id="34Q84zNTcIK" role="37wK5m">
+                  <node concept="Xl_RD" id="7OJcYqyr1o8" role="37wK5m">
                     <property role="Xl_RC" value="conceptAlias" />
                   </node>
                 </node>
-                <node concept="liA8E" id="34Q84zNTfRC" role="2OqNvi">
+                <node concept="liA8E" id="7OJcYqyr1o9" role="2OqNvi">
                   <ref role="37wK5l" to="imb3:~Feature.setKey(java.lang.String)" resolve="setKey" />
-                  <node concept="Xl_RD" id="34Q84zNTgvq" role="37wK5m">
+                  <node concept="Xl_RD" id="7OJcYqyr1oa" role="37wK5m">
                     <property role="Xl_RC" value="ConceptDescription-conceptAlias" />
                   </node>
                 </node>
               </node>
-              <node concept="liA8E" id="34Q84zNTjau" role="2OqNvi">
+              <node concept="liA8E" id="7OJcYqyr1ob" role="2OqNvi">
                 <ref role="37wK5l" to="tzx8:~M3Node.setParent(io.lionweb.lioncore.java.model.Node)" resolve="setParent" />
-                <node concept="37vLTw" id="34Q84zNTk3b" role="37wK5m">
-                  <ref role="3cqZAo" node="34Q84zNSMRU" resolve="CONCEPT_DESCRIPTION" />
+                <node concept="37vLTw" id="7OJcYqyr1oc" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqyqMhr" resolve="conceptDescription" />
                 </node>
               </node>
             </node>
@@ -5766,47 +7134,75 @@
         <node concept="3clFbF" id="34Q84zNT3bb" role="3cqZAp">
           <node concept="2OqwBi" id="34Q84zNT48F" role="3clFbG">
             <node concept="37vLTw" id="34Q84zNT3b9" role="2Oq$k0">
-              <ref role="3cqZAo" node="34Q84zNSMRU" resolve="CONCEPT_DESCRIPTION" />
+              <ref role="3cqZAo" node="7OJcYqyqMhr" resolve="conceptDescription" />
             </node>
             <node concept="liA8E" id="34Q84zNT56X" role="2OqNvi">
               <ref role="37wK5l" to="imb3:~Classifier.addFeature(io.lionweb.lioncore.java.language.Feature)" resolve="addFeature" />
               <node concept="37vLTw" id="34Q84zNUdpg" role="37wK5m">
-                <ref role="3cqZAo" node="34Q84zNTU6H" resolve="CONCEPT_ALIAS" />
+                <ref role="3cqZAo" node="7OJcYqyr1o2" resolve="conceptAlias" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="34Q84zNUgBX" role="3cqZAp">
-          <node concept="37vLTI" id="34Q84zNUiC5" role="3clFbG">
-            <node concept="37vLTw" id="34Q84zNUgBV" role="37vLTJ">
-              <ref role="3cqZAo" node="34Q84zNTWWd" resolve="CONCEPT_SHORT_DESCRIPTION" />
+        <node concept="3clFbF" id="7OJcYqyfGb3" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqyfGb4" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqyfGb5" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqyfGb6" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqyfGb7" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqyfGaR" resolve="CONCEPT_ALIAS" />
+              </node>
             </node>
-            <node concept="2OqwBi" id="34Q84zNUjMQ" role="37vLTx">
-              <node concept="2OqwBi" id="34Q84zNUjMR" role="2Oq$k0">
-                <node concept="2YIFZM" id="34Q84zNUjMS" role="2Oq$k0">
+            <node concept="2ShNRf" id="7OJcYqyfGb8" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqyfGb9" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="37vLTw" id="7OJcYqyfGba" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqyr1o2" resolve="conceptAlias" />
+                </node>
+                <node concept="2OqwBi" id="7OJcYqyfGbb" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqyfGbc" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqyfGbd" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQy$L" resolve="getConceptAlias" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqyfoRz" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYqyrmf$" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqyrmf_" role="3cpWs9">
+            <property role="TrG5h" value="conceptShortDescription" />
+            <node concept="3uibUv" id="7OJcYqyrl6c" role="1tU5fm">
+              <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqyrmfA" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqyrmfB" role="2Oq$k0">
+                <node concept="2YIFZM" id="7OJcYqyrmfC" role="2Oq$k0">
                   <ref role="37wK5l" to="imb3:~Property.createOptional(java.lang.String,io.lionweb.lioncore.java.language.DataType,java.lang.String)" resolve="createOptional" />
                   <ref role="1Pybhc" to="imb3:~Property" resolve="Property" />
-                  <node concept="Xl_RD" id="34Q84zNUjMT" role="37wK5m">
+                  <node concept="Xl_RD" id="7OJcYqyrmfD" role="37wK5m">
                     <property role="Xl_RC" value="conceptShortDescription" />
                   </node>
-                  <node concept="1rXfSq" id="34Q84zNUjMU" role="37wK5m">
+                  <node concept="1rXfSq" id="7OJcYqyrmfE" role="37wK5m">
                     <ref role="37wK5l" node="5TNjoy1vtGO" resolve="getString" />
                   </node>
-                  <node concept="Xl_RD" id="34Q84zNUjMV" role="37wK5m">
+                  <node concept="Xl_RD" id="7OJcYqyrmfF" role="37wK5m">
                     <property role="Xl_RC" value="conceptShortDescription" />
                   </node>
                 </node>
-                <node concept="liA8E" id="34Q84zNUjMW" role="2OqNvi">
+                <node concept="liA8E" id="7OJcYqyrmfG" role="2OqNvi">
                   <ref role="37wK5l" to="imb3:~Feature.setKey(java.lang.String)" resolve="setKey" />
-                  <node concept="Xl_RD" id="34Q84zNUjMX" role="37wK5m">
+                  <node concept="Xl_RD" id="7OJcYqyrmfH" role="37wK5m">
                     <property role="Xl_RC" value="ConceptDescription-conceptShortDescription" />
                   </node>
                 </node>
               </node>
-              <node concept="liA8E" id="34Q84zNUjMY" role="2OqNvi">
+              <node concept="liA8E" id="7OJcYqyrmfI" role="2OqNvi">
                 <ref role="37wK5l" to="tzx8:~M3Node.setParent(io.lionweb.lioncore.java.model.Node)" resolve="setParent" />
-                <node concept="37vLTw" id="34Q84zNUjMZ" role="37wK5m">
-                  <ref role="3cqZAo" node="34Q84zNSMRU" resolve="CONCEPT_DESCRIPTION" />
+                <node concept="37vLTw" id="7OJcYqyrmfJ" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqyqMhr" resolve="conceptDescription" />
                 </node>
               </node>
             </node>
@@ -5815,12 +7211,65 @@
         <node concept="3clFbF" id="34Q84zNTkBR" role="3cqZAp">
           <node concept="2OqwBi" id="34Q84zNTkBS" role="3clFbG">
             <node concept="37vLTw" id="34Q84zNTkBT" role="2Oq$k0">
-              <ref role="3cqZAo" node="34Q84zNSMRU" resolve="CONCEPT_DESCRIPTION" />
+              <ref role="3cqZAo" node="7OJcYqyqMhr" resolve="conceptDescription" />
             </node>
             <node concept="liA8E" id="34Q84zNTkBU" role="2OqNvi">
               <ref role="37wK5l" to="imb3:~Classifier.addFeature(io.lionweb.lioncore.java.language.Feature)" resolve="addFeature" />
               <node concept="37vLTw" id="34Q84zNUeNX" role="37wK5m">
-                <ref role="3cqZAo" node="34Q84zNTWWd" resolve="CONCEPT_SHORT_DESCRIPTION" />
+                <ref role="3cqZAo" node="7OJcYqyrmf_" resolve="conceptShortDescription" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqygecC" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqygecD" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqygecE" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqygecF" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqygecG" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqygecs" resolve="CONCEPT_SHORT_DESCRIPTION" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqygecH" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqygecI" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="37vLTw" id="7OJcYqygecJ" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqyrmf_" resolve="conceptShortDescription" />
+                </node>
+                <node concept="2OqwBi" id="7OJcYqygecK" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqygecL" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqygecM" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQy$U" resolve="getConceptShortDescription" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqyf4C4" role="3cqZAp" />
+        <node concept="3clFbF" id="7OJcYqyfkgX" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqyfkgY" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqyfkgZ" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqyfkh0" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqyfkh1" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqyfkgL" resolve="CONCEPT_DESCRIPTION" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqyfkh2" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqyfkh3" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <node concept="37vLTw" id="7OJcYqyfkh4" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqyqMhr" resolve="conceptDescription" />
+                </node>
+                <node concept="2OqwBi" id="7OJcYqyfkh5" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqyfkh6" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqyrCcO" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwUzr1" resolve="getSpecificLanguage" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -5835,14 +7284,38 @@
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
+      <node concept="37vLTG" id="7OJcYqxWqYT" role="3clF46">
+        <property role="TrG5h" value="constants" />
+        <node concept="3uibUv" id="7OJcYqxWqYU" role="1tU5fm">
+          <ref role="3uigEE" to="y7p:5JNiskhxHcX" resolve="ILionCoreConstants" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqxWqYV" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="5JNiskj6tqO" role="jymVt" />
-    <node concept="312cEg" id="5JNiskj6vKU" role="jymVt">
-      <property role="TrG5h" value="SPECIFIC_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskj6uR4" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskj6w$4" role="1tU5fm">
-        <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+    <node concept="3clFb_" id="7OJcYqybDcU" role="jymVt">
+      <property role="TrG5h" value="getSpecificLanguageX" />
+      <node concept="3Tm1VV" id="7OJcYqybDcW" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqybDcX" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqybDcY" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqybDcZ" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqybDd1" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqybZay" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqycAcP" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqyctMv" resolve="SPECIFIC_LANGUAGE" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqybDd2" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskj6yKO" role="jymVt">
@@ -5853,8 +7326,13 @@
       </node>
       <node concept="3clFbS" id="5JNiskj6yKT" role="3clF47">
         <node concept="3clFbF" id="5JNiskj6$VA" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskj6$Vz" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskj6vKU" resolve="SPECIFIC_LANGUAGE" />
+          <node concept="2OqwBi" id="7OJcYqypjRB" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqypjRC" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqybDcU" resolve="getSpecificLanguageX" />
+            </node>
+            <node concept="liA8E" id="7OJcYqypjRD" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+            </node>
           </node>
         </node>
       </node>
@@ -5863,12 +7341,27 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskj64xG" role="jymVt" />
-    <node concept="312cEg" id="5JNiskj69hx" role="jymVt">
-      <property role="TrG5h" value="VIRTUAL_PACKAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskj68QS" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskj69b5" role="1tU5fm">
-        <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+    <node concept="3clFb_" id="7OJcYqygnxo" role="jymVt">
+      <property role="TrG5h" value="getVirtualPackageX" />
+      <node concept="3Tm1VV" id="7OJcYqygnxq" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqygnxr" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqygnxs" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqygnxt" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqygnxv" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqyg_CB" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqyg_C$" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqyd5wz" resolve="VIRTUAL_PACKAGE" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqygnxw" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskj67NS" role="jymVt">
@@ -5879,12 +7372,41 @@
       </node>
       <node concept="3clFbS" id="5JNiskj67NX" role="3clF47">
         <node concept="3clFbF" id="5JNiskj67O0" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskj69vv" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskj69hx" resolve="VIRTUAL_PACKAGE" />
+          <node concept="2OqwBi" id="7OJcYqyp5I_" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqyp5IA" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqygnxo" resolve="getVirtualPackageX" />
+            </node>
+            <node concept="liA8E" id="7OJcYqyp5IB" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="2AHcQZ" id="5JNiskj67NY" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqyliQo" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqylp3c" role="jymVt">
+      <property role="TrG5h" value="getVirtualPackage_NameX" />
+      <node concept="3Tm1VV" id="7OJcYqylp3e" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqylp3f" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqylp3g" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqylp3h" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqylp3j" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqymcry" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqymcrv" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqylZ6o" resolve="VIRTUAL_PACKAGE_NAME" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqylp3k" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -5921,12 +7443,27 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskj6e2B" role="jymVt" />
-    <node concept="312cEg" id="5JNiskj6eEd" role="jymVt">
-      <property role="TrG5h" value="SHORT_DESCRIPTION" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskj6eEe" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskj6eEf" role="1tU5fm">
-        <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+    <node concept="3clFb_" id="7OJcYqygOBN" role="jymVt">
+      <property role="TrG5h" value="getShortDescriptionX" />
+      <node concept="3Tm1VV" id="7OJcYqygOBP" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqygOBQ" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqygOBR" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqygOBS" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqygOBU" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqygOBX" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqygUiR" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqydvJX" resolve="SHORT_DESCRIPTION" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqygOBV" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskj67Oa" role="jymVt">
@@ -5936,13 +7473,42 @@
         <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
       </node>
       <node concept="3clFbS" id="5JNiskj67Of" role="3clF47">
-        <node concept="3clFbF" id="5JNiskj67Oi" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskj6f_C" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskj6eEd" resolve="SHORT_DESCRIPTION" />
+        <node concept="3clFbF" id="7OJcYqyoRHv" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqyoRHw" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqyoRHx" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqygOBN" resolve="getShortDescriptionX" />
+            </node>
+            <node concept="liA8E" id="7OJcYqyoRHy" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="2AHcQZ" id="5JNiskj67Og" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqykZXv" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqyl4JA" role="jymVt">
+      <property role="TrG5h" value="getShortDescription_DescriptionX" />
+      <node concept="3Tm1VV" id="7OJcYqyl4JC" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyl4JD" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyl4JE" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyl4JF" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqyl4JH" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqyl4JK" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqymUxQ" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqymLc_" resolve="SHORT_DESCRIPTION_DESCRIPTION" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqyl4JI" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -5979,12 +7545,27 @@
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNSLh9" role="jymVt" />
-    <node concept="312cEg" id="34Q84zNSMRU" role="jymVt">
-      <property role="TrG5h" value="CONCEPT_DESCRIPTION" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="34Q84zNSMRV" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNSMRW" role="1tU5fm">
-        <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+    <node concept="3clFb_" id="7OJcYqyhdSU" role="jymVt">
+      <property role="TrG5h" value="getConceptDescriptionAnnotationX" />
+      <node concept="3Tm1VV" id="7OJcYqyhdSW" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyhdSX" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyhdSY" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyhdSZ" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqyhdT1" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqyhunt" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqyhunq" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqyfkgL" resolve="CONCEPT_DESCRIPTION" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqyhdT2" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNSFdn" role="jymVt">
@@ -5994,9 +7575,14 @@
         <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
       </node>
       <node concept="3clFbS" id="34Q84zNSFds" role="3clF47">
-        <node concept="3clFbF" id="34Q84zNSFdv" role="3cqZAp">
-          <node concept="37vLTw" id="34Q84zNTJEX" role="3clFbG">
-            <ref role="3cqZAo" node="34Q84zNSMRU" resolve="CONCEPT_DESCRIPTION" />
+        <node concept="3clFbF" id="7OJcYqyoDlY" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqyoDlZ" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqyoDm0" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqyhdSU" resolve="getConceptDescriptionAnnotationX" />
+            </node>
+            <node concept="liA8E" id="7OJcYqyoDm1" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+            </node>
           </node>
         </node>
       </node>
@@ -6004,12 +7590,28 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="312cEg" id="34Q84zNTU6H" role="jymVt">
-      <property role="TrG5h" value="CONCEPT_ALIAS" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="34Q84zNTU6I" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNTU6J" role="1tU5fm">
-        <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+    <node concept="2tJIrI" id="7OJcYqyijIi" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqyhHPP" role="jymVt">
+      <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptAliasX" />
+      <node concept="3Tm1VV" id="7OJcYqyhHPR" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyhHPS" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyhHPT" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyhHPU" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqyhHPW" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqyhYYY" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqyhYYV" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqyfGaR" resolve="CONCEPT_ALIAS" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqyhHPX" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNTspf" role="jymVt">
@@ -6019,9 +7621,14 @@
         <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
       </node>
       <node concept="3clFbS" id="34Q84zNTspk" role="3clF47">
-        <node concept="3clFbF" id="34Q84zNTspn" role="3cqZAp">
-          <node concept="37vLTw" id="34Q84zNU3Qx" role="3clFbG">
-            <ref role="3cqZAo" node="34Q84zNTU6H" resolve="CONCEPT_ALIAS" />
+        <node concept="3clFbF" id="7OJcYqyoqLw" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqyoqLx" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqyoqLy" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqyhHPP" resolve="getConceptDescriptionAnnotation_ConceptAliasX" />
+            </node>
+            <node concept="liA8E" id="7OJcYqyoqLz" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+            </node>
           </node>
         </node>
       </node>
@@ -6029,12 +7636,28 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="312cEg" id="34Q84zNTWWd" role="jymVt">
-      <property role="TrG5h" value="CONCEPT_SHORT_DESCRIPTION" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="34Q84zNTWWe" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNTWWf" role="1tU5fm">
-        <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+    <node concept="2tJIrI" id="7OJcYqyiatN" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqyisuh" role="jymVt">
+      <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptShortDescriptionX" />
+      <node concept="3Tm1VV" id="7OJcYqyisuj" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyisuk" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyisul" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyisum" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqyisuo" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqyiIpI" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqyiIpF" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqygecs" resolve="CONCEPT_SHORT_DESCRIPTION" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqyisup" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNTspo" role="jymVt">
@@ -6044,9 +7667,14 @@
         <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
       </node>
       <node concept="3clFbS" id="34Q84zNTspt" role="3clF47">
-        <node concept="3clFbF" id="34Q84zNTspw" role="3cqZAp">
-          <node concept="37vLTw" id="34Q84zNU7iV" role="3clFbG">
-            <ref role="3cqZAo" node="34Q84zNTWWd" resolve="CONCEPT_SHORT_DESCRIPTION" />
+        <node concept="3clFbF" id="7OJcYqyobY0" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqyobY1" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqyobY2" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqyisuh" resolve="getConceptDescriptionAnnotation_ConceptShortDescriptionX" />
+            </node>
+            <node concept="liA8E" id="7OJcYqyobY3" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+            </node>
           </node>
         </node>
       </node>
@@ -6435,12 +8063,27 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7weWCFlwstm" role="jymVt" />
-    <node concept="312cEg" id="7weWCFlwRoH" role="jymVt">
-      <property role="TrG5h" value="ANNOTATION_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="7weWCFlwRoI" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlwRoJ" role="1tU5fm">
-        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+    <node concept="3clFb_" id="7OJcYqyiZMB" role="jymVt">
+      <property role="TrG5h" value="getAnnotationConceptX" />
+      <node concept="3Tm1VV" id="7OJcYqyiZMD" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyiZME" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyiZMF" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyiZMG" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqyiZMI" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqyjgNS" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqyjgNP" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqydNSU" resolve="ANNOTATION" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqyiZMJ" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="7weWCFlwuJI" role="jymVt">
@@ -6450,9 +8093,14 @@
         <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
       </node>
       <node concept="3clFbS" id="7weWCFlwuJN" role="3clF47">
-        <node concept="3clFbF" id="7weWCFlxHfg" role="3cqZAp">
-          <node concept="37vLTw" id="7weWCFlxHfd" role="3clFbG">
-            <ref role="3cqZAo" node="7weWCFlwRoH" resolve="ANNOTATION_CONCEPT" />
+        <node concept="3clFbF" id="7OJcYqynXem" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqynXen" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqynXeo" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqyiZMB" resolve="getAnnotationConceptX" />
+            </node>
+            <node concept="liA8E" id="7OJcYqynXep" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+            </node>
           </node>
         </node>
       </node>
@@ -6460,12 +8108,28 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="312cEg" id="7weWCFlwYLn" role="jymVt">
-      <property role="TrG5h" value="CLASSIFIER_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="7weWCFlwYLo" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlwYLp" role="1tU5fm">
-        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+    <node concept="2tJIrI" id="7OJcYqyjDll" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqyjHUZ" role="jymVt">
+      <property role="TrG5h" value="getClassifierConceptX" />
+      <node concept="3Tm1VV" id="7OJcYqyjHV1" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqyjHV2" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqyjHV3" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqyjHV4" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqyjHV6" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqyjYbT" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqyjYbQ" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqyeaqZ" resolve="CLASSIFIER" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqyjHV7" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="7weWCFlwuJR" role="jymVt">
@@ -6475,9 +8139,14 @@
         <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
       </node>
       <node concept="3clFbS" id="7weWCFlwuJW" role="3clF47">
-        <node concept="3clFbF" id="7weWCFlxL18" role="3cqZAp">
-          <node concept="37vLTw" id="7weWCFlxL15" role="3clFbG">
-            <ref role="3cqZAo" node="7weWCFlwYLn" resolve="CLASSIFIER_CONCEPT" />
+        <node concept="3clFbF" id="7OJcYqynIah" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqynIai" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqynIaj" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqyjHUZ" resolve="getClassifierConceptX" />
+            </node>
+            <node concept="liA8E" id="7OJcYqynIak" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+            </node>
           </node>
         </node>
       </node>
@@ -6485,12 +8154,28 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="312cEg" id="7weWCFlx57a" role="jymVt">
-      <property role="TrG5h" value="CONCEPT_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="7weWCFlx57b" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlx57c" role="1tU5fm">
-        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+    <node concept="2tJIrI" id="7OJcYqyk8yX" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqykdbt" role="jymVt">
+      <property role="TrG5h" value="getConceptConceptX" />
+      <node concept="3Tm1VV" id="7OJcYqykdbv" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqykdbw" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqykdbx" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqykdby" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqykdb$" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqykwgt" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqykwgq" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqyexdn" resolve="CONCEPT" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqykdb_" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="7weWCFlwuK0" role="jymVt">
@@ -6500,9 +8185,14 @@
         <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
       </node>
       <node concept="3clFbS" id="7weWCFlwuK5" role="3clF47">
-        <node concept="3clFbF" id="7weWCFlxUg4" role="3cqZAp">
-          <node concept="37vLTw" id="7weWCFlxUg1" role="3clFbG">
-            <ref role="3cqZAo" node="7weWCFlx57a" resolve="CONCEPT_CONCEPT" />
+        <node concept="3clFbF" id="7OJcYqynvKt" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqynvKu" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqynvKv" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqykdbt" resolve="getConceptConceptX" />
+            </node>
+            <node concept="liA8E" id="7OJcYqynvKw" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+            </node>
           </node>
         </node>
       </node>
@@ -6510,12 +8200,28 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="312cEg" id="7weWCFlxbqI" role="jymVt">
-      <property role="TrG5h" value="INTERFACE_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="7weWCFlxbqJ" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlxbqK" role="1tU5fm">
-        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+    <node concept="2tJIrI" id="7OJcYqyk$0J" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqykHtf" role="jymVt">
+      <property role="TrG5h" value="getInterfaceConceptX" />
+      <node concept="3Tm1VV" id="7OJcYqykHth" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqykHti" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <node concept="3uibUv" id="7OJcYqykHtj" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+        </node>
+        <node concept="3uibUv" id="7OJcYqykHtk" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqykHtm" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqykVr6" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqykVr3" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqyeRGY" resolve="INTERFACE" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqykHtn" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="7weWCFlwuK9" role="jymVt">
@@ -6525,9 +8231,14 @@
         <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
       </node>
       <node concept="3clFbS" id="7weWCFlwuKe" role="3clF47">
-        <node concept="3clFbF" id="7weWCFlxY0V" role="3cqZAp">
-          <node concept="37vLTw" id="7weWCFlxY0S" role="3clFbG">
-            <ref role="3cqZAo" node="7weWCFlxbqI" resolve="INTERFACE_CONCEPT" />
+        <node concept="3clFbF" id="7OJcYqynb_W" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqynf4J" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqynb_T" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqykHtf" resolve="getInterfaceConceptX" />
+            </node>
+            <node concept="liA8E" id="7OJcYqynkbH" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+            </node>
           </node>
         </node>
       </node>
@@ -7014,6 +8725,165 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7weWCFlyeL3" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+  </node>
+  <node concept="3HP615" id="7OJcYqxQZIZ">
+    <property role="3GE5qa" value="jsonConstants" />
+    <property role="TrG5h" value="IJsonKeyedMapper" />
+    <node concept="3clFb_" id="7OJcYqxR0RG" role="jymVt">
+      <property role="TrG5h" value="getJson" />
+      <node concept="3clFbS" id="7OJcYqxR0RJ" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqxR0RK" role="1B3o_S" />
+      <node concept="16syzq" id="7OJcYqxR0Rr" role="3clF45">
+        <ref role="16sUi3" node="7OJcYqxQZLr" resolve="JSON" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqxR0T3" role="jymVt">
+      <property role="TrG5h" value="getMapping" />
+      <node concept="3clFbS" id="7OJcYqxR0T6" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqxR0T7" role="1B3o_S" />
+      <node concept="16syzq" id="7OJcYqxR0S_" role="3clF45">
+        <ref role="16sUi3" node="7OJcYqxQZJU" resolve="MAPPING" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="7OJcYqxQZJ0" role="1B3o_S" />
+    <node concept="16euLQ" id="7OJcYqxQZLr" role="16eVyc">
+      <property role="TrG5h" value="JSON" />
+      <node concept="3uibUv" id="7OJcYqvF2lx" role="3ztrMU">
+        <ref role="3uigEE" to="imb3:~IKeyed" resolve="IKeyed" />
+      </node>
+    </node>
+    <node concept="16euLQ" id="7OJcYqxQZJU" role="16eVyc">
+      <property role="TrG5h" value="MAPPING" />
+      <node concept="3uibUv" id="7OJcYqxQZL0" role="3ztrMU">
+        <ref role="3uigEE" to="y7p:7OJcYqvKf0O" resolve="IKeyedMapping" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="7OJcYqxTPY1">
+    <property role="3GE5qa" value="jsonConstants" />
+    <property role="TrG5h" value="JsonKeyedMapper" />
+    <node concept="3Tm1VV" id="7OJcYqxTPY2" role="1B3o_S" />
+    <node concept="3uibUv" id="7OJcYqxTPYR" role="EKbjA">
+      <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+      <node concept="16syzq" id="7OJcYqxTQ0M" role="11_B2D">
+        <ref role="16sUi3" node="7OJcYqxTPZF" resolve="JSON" />
+      </node>
+      <node concept="16syzq" id="7OJcYqxTQ1D" role="11_B2D">
+        <ref role="16sUi3" node="7OJcYqxTPZH" resolve="MAPPING" />
+      </node>
+    </node>
+    <node concept="16euLQ" id="7OJcYqxTPZF" role="16eVyc">
+      <property role="TrG5h" value="JSON" />
+      <node concept="3uibUv" id="7OJcYqxTPZG" role="3ztrMU">
+        <ref role="3uigEE" to="imb3:~IKeyed" resolve="IKeyed" />
+      </node>
+    </node>
+    <node concept="16euLQ" id="7OJcYqxTPZH" role="16eVyc">
+      <property role="TrG5h" value="MAPPING" />
+      <node concept="3uibUv" id="7OJcYqxTPZI" role="3ztrMU">
+        <ref role="3uigEE" to="y7p:7OJcYqvKf0O" resolve="IKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqxTQrm" role="jymVt">
+      <property role="TrG5h" value="json" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqxTQrn" role="1B3o_S" />
+      <node concept="16syzq" id="7OJcYqxTQrp" role="1tU5fm">
+        <ref role="16sUi3" node="7OJcYqxTPZF" resolve="JSON" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqxTQEC" role="jymVt">
+      <property role="TrG5h" value="mapping" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqxTQED" role="1B3o_S" />
+      <node concept="16syzq" id="7OJcYqxTQEF" role="1tU5fm">
+        <ref role="16sUi3" node="7OJcYqxTPZH" resolve="MAPPING" />
+      </node>
+    </node>
+    <node concept="3clFbW" id="7OJcYqxTQa5" role="jymVt">
+      <node concept="3cqZAl" id="7OJcYqxTQa6" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqxTQa7" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqxTQa9" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqxTQrq" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqxTQrs" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqxTQyp" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqxTQyV" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqxTQys" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqxTQrm" resolve="json" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7OJcYqxTQrw" role="37vLTx">
+              <ref role="3cqZAo" node="7OJcYqxTQe_" resolve="json" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqxTQEG" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqxTQEI" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqxTQKz" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqxTQOl" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqxTQKA" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqxTQEC" resolve="mapping" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7OJcYqxTQEM" role="37vLTx">
+              <ref role="3cqZAo" node="7OJcYqxTQhv" resolve="mapping" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqxTQe_" role="3clF46">
+        <property role="TrG5h" value="json" />
+        <node concept="16syzq" id="7OJcYqxTQe$" role="1tU5fm">
+          <ref role="16sUi3" node="7OJcYqxTPZF" resolve="JSON" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqxTQpV" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqxTQhv" role="3clF46">
+        <property role="TrG5h" value="mapping" />
+        <node concept="16syzq" id="7OJcYqxTQlC" role="1tU5fm">
+          <ref role="16sUi3" node="7OJcYqxTPZH" resolve="MAPPING" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqxTQoB" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqxTQ2j" role="jymVt">
+      <property role="TrG5h" value="getJson" />
+      <node concept="3Tm1VV" id="7OJcYqxTQ2l" role="1B3o_S" />
+      <node concept="16syzq" id="7OJcYqxTQ2n" role="3clF45">
+        <ref role="16sUi3" node="7OJcYqxTPZF" resolve="JSON" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqxTQ2o" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqxTRgY" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqxTRgX" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqxTQrm" resolve="json" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxTQ2p" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqxTQ2q" role="jymVt">
+      <property role="TrG5h" value="getMapping" />
+      <node concept="3Tm1VV" id="7OJcYqxTQ2s" role="1B3o_S" />
+      <node concept="16syzq" id="7OJcYqxTQ2u" role="3clF45">
+        <ref role="16sUi3" node="7OJcYqxTPZH" resolve="MAPPING" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqxTQ2v" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqxTRpx" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqxTRpw" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqxTQEC" resolve="mapping" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxTQ2w" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
@@ -267,9 +267,6 @@
       <concept id="8465538089690331492" name="jetbrains.mps.baseLanguage.javadoc.structure.DeprecatedBlockDocTag" flags="ng" index="TZ5HI">
         <child id="2667874559098216723" name="text" index="3HnX3l" />
       </concept>
-      <concept id="2217234381367190443" name="jetbrains.mps.baseLanguage.javadoc.structure.SeeBlockDocTag" flags="ng" index="VUp57">
-        <child id="2217234381367190458" name="reference" index="VUp5m" />
-      </concept>
       <concept id="2217234381367530212" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocReference" flags="ng" index="VXe08">
         <reference id="2217234381367530213" name="classifier" index="VXe09" />
       </concept>
@@ -594,12 +591,17 @@
             </node>
             <node concept="liA8E" id="5hsSXrmCrqo" role="2OqNvi">
               <ref role="37wK5l" to="jxh5:~JsonSerialization.registerLanguage(io.lionweb.lioncore.java.language.Language)" resolve="registerLanguage" />
-              <node concept="2OqwBi" id="5hsSXrmCC1Y" role="37wK5m">
-                <node concept="37vLTw" id="5hsSXrmCBHp" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5hsSXrmC_NE" resolve="jsonConstants" />
+              <node concept="2OqwBi" id="7OJcYqz_25l" role="37wK5m">
+                <node concept="2OqwBi" id="5hsSXrmCC1Y" role="2Oq$k0">
+                  <node concept="37vLTw" id="5hsSXrmCBHp" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5hsSXrmC_NE" resolve="jsonConstants" />
+                  </node>
+                  <node concept="liA8E" id="5hsSXrmCCfP" role="2OqNvi">
+                    <ref role="37wK5l" node="7OJcYqyaYLW" resolve="getSpecificLanguageX" />
+                  </node>
                 </node>
-                <node concept="liA8E" id="5hsSXrmCCfP" role="2OqNvi">
-                  <ref role="37wK5l" node="5JNiskj6wTk" resolve="getSpecificLanguage" />
+                <node concept="liA8E" id="7OJcYqz_2uH" role="2OqNvi">
+                  <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
                 </node>
               </node>
             </node>
@@ -1550,41 +1552,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="5TNjoy1vedB" role="jymVt">
-      <property role="TrG5h" value="listPrimitiveTypes" />
-      <node concept="3clFbS" id="5TNjoy1vedG" role="3clF47">
-        <node concept="3clFbF" id="5TNjoy1vedH" role="3cqZAp">
-          <node concept="2ShNRf" id="5TNjoy1vedI" role="3clFbG">
-            <node concept="Tc6Ow" id="5TNjoy1vedJ" role="2ShVmc">
-              <node concept="3uibUv" id="5TNjoy1vedK" role="HW$YZ">
-                <ref role="3uigEE" to="imb3:~DataType" resolve="DataType" />
-              </node>
-              <node concept="1rXfSq" id="5TNjoy1vBa6" role="HW$Y0">
-                <ref role="37wK5l" node="5TNjoy1vu1A" resolve="getBoolean" />
-              </node>
-              <node concept="1rXfSq" id="5TNjoy1vByB" role="HW$Y0">
-                <ref role="37wK5l" node="5TNjoy1vtVU" resolve="getInteger" />
-              </node>
-              <node concept="1rXfSq" id="5TNjoy1vBLq" role="HW$Y0">
-                <ref role="37wK5l" node="5TNjoy1vtGO" resolve="getString" />
-              </node>
-              <node concept="1rXfSq" id="5TNjoy1vC9z" role="HW$Y0">
-                <ref role="37wK5l" node="5TNjoy1vu7q" resolve="getJSON" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="_YKpA" id="5TNjoy1vedY" role="3clF45">
-        <node concept="3uibUv" id="5TNjoy1vedZ" role="_ZDj9">
-          <ref role="3uigEE" to="imb3:~DataType" resolve="DataType" />
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5TNjoy1vedX" role="1B3o_S" />
-      <node concept="2AHcQZ" id="4Yo3buYJWHF" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="39$JcGGbiRJ" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTMvG" role="jymVt">
       <property role="TrG5h" value="listClassifiersX" />
@@ -1635,35 +1602,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="5TNjoy1vfyI" role="jymVt">
-      <property role="TrG5h" value="listClassifiers" />
-      <node concept="3clFbS" id="5TNjoy1vfyN" role="3clF47">
-        <node concept="3clFbF" id="5TNjoy1vfyO" role="3cqZAp">
-          <node concept="2ShNRf" id="5TNjoy1vfyP" role="3clFbG">
-            <node concept="Tc6Ow" id="5TNjoy1vfyQ" role="2ShVmc">
-              <node concept="3uibUv" id="5TNjoy1vfyR" role="HW$YZ">
-                <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
-              </node>
-              <node concept="1rXfSq" id="5TNjoy1vCmp" role="HW$Y0">
-                <ref role="37wK5l" node="5TNjoy1vujq" resolve="getNode" />
-              </node>
-              <node concept="1rXfSq" id="5TNjoy1vC$d" role="HW$Y0">
-                <ref role="37wK5l" node="5TNjoy1vudm" resolve="getINamed" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="_YKpA" id="5TNjoy1vfyZ" role="3clF45">
-        <node concept="3uibUv" id="5TNjoy1vfz0" role="_ZDj9">
-          <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5TNjoy1vfyY" role="1B3o_S" />
-      <node concept="2AHcQZ" id="4Yo3buYJX8y" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5TNjoy1vtg4" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxT$o7" role="jymVt">
       <property role="TrG5h" value="getBuiltinsX" />
@@ -1688,28 +1626,6 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqxT$oe" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="4Yo3buYJQ9P" role="jymVt">
-      <property role="TrG5h" value="getBuiltins" />
-      <node concept="3Tm1VV" id="4Yo3buYJQ9R" role="1B3o_S" />
-      <node concept="3uibUv" id="4Yo3buYJQ9S" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
-      </node>
-      <node concept="3clFbS" id="4Yo3buYJQ9T" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqy8KB0" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqy8MQc" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqy8KAX" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqxT$o7" resolve="getBuiltinsX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqy8NZ2" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="4Yo3buYJQ9U" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -1740,28 +1656,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="5TNjoy1vtGO" role="jymVt">
-      <property role="TrG5h" value="getString" />
-      <node concept="3uibUv" id="5TNjoy1vtGS" role="3clF45">
-        <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
-      </node>
-      <node concept="3Tm1VV" id="5TNjoy1vtGQ" role="1B3o_S" />
-      <node concept="3clFbS" id="5TNjoy1vupI" role="3clF47">
-        <node concept="3clFbF" id="5TNjoy1vuCp" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqyacrB" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqyaa0e" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getStringX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqyafhm" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="4Yo3buYJSCl" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="4Yo3buYJT1B" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTAF2" role="jymVt">
       <property role="TrG5h" value="getIntegerX" />
@@ -1786,28 +1680,6 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqxTAF9" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5TNjoy1vtVU" role="jymVt">
-      <property role="TrG5h" value="getInteger" />
-      <node concept="3uibUv" id="5TNjoy1vtVY" role="3clF45">
-        <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
-      </node>
-      <node concept="3Tm1VV" id="5TNjoy1vtVW" role="1B3o_S" />
-      <node concept="3clFbS" id="5TNjoy1vwD5" role="3clF47">
-        <node concept="3clFbF" id="5TNjoy1vwgQ" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqyahMk" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqyahMl" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqxTAF2" resolve="getIntegerX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqyahMm" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="4Yo3buYJTjA" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -1838,28 +1710,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="5TNjoy1vu1A" role="jymVt">
-      <property role="TrG5h" value="getBoolean" />
-      <node concept="3uibUv" id="5TNjoy1vu1E" role="3clF45">
-        <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
-      </node>
-      <node concept="3Tm1VV" id="5TNjoy1vu1C" role="1B3o_S" />
-      <node concept="3clFbS" id="5TNjoy1vwPp" role="3clF47">
-        <node concept="3clFbF" id="5TNjoy1vwV9" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqyamXY" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqyamXZ" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqxTCCR" resolve="getBooleanX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqyamY0" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="4Yo3buYJTYW" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="4Yo3buYJUog" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTERH" role="jymVt">
       <property role="TrG5h" value="getJsonX" />
@@ -1884,28 +1734,6 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqxTERO" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5TNjoy1vu7q" role="jymVt">
-      <property role="TrG5h" value="getJSON" />
-      <node concept="3uibUv" id="5TNjoy1vu7u" role="3clF45">
-        <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
-      </node>
-      <node concept="3Tm1VV" id="5TNjoy1vu7s" role="1B3o_S" />
-      <node concept="3clFbS" id="5TNjoy1vx2D" role="3clF47">
-        <node concept="3clFbF" id="5TNjoy1vxin" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqyasc2" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqyasc3" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqxTERH" resolve="getJsonX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqyasc4" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="4Yo3buYJUEn" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -1936,28 +1764,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="5TNjoy1vudm" role="jymVt">
-      <property role="TrG5h" value="getINamed" />
-      <node concept="3uibUv" id="5TNjoy1vudq" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Interface" resolve="Interface" />
-      </node>
-      <node concept="3Tm1VV" id="5TNjoy1vudo" role="1B3o_S" />
-      <node concept="3clFbS" id="5TNjoy1vxqj" role="3clF47">
-        <node concept="3clFbF" id="5TNjoy1vxql" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqyaxsw" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqyaxsx" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamedX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqyaxsy" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="4Yo3buYJVlR" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="4Yo3buYJVJd" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTIfx" role="jymVt">
       <property role="TrG5h" value="getNodeX" />
@@ -1982,28 +1788,6 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqxTIfC" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5TNjoy1vujq" role="jymVt">
-      <property role="TrG5h" value="getNode" />
-      <node concept="3uibUv" id="5TNjoy1vuju" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
-      </node>
-      <node concept="3Tm1VV" id="5TNjoy1vujs" role="1B3o_S" />
-      <node concept="3clFbS" id="5TNjoy1vxyH" role="3clF47">
-        <node concept="3clFbF" id="5TNjoy1vxyJ" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqyaAm6" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqyaAm7" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqxTIfx" resolve="getNodeX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqyaAm8" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="4Yo3buYJW1s" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -5404,30 +5188,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqxTsMU" role="jymVt" />
-    <node concept="2tJIrI" id="7OJcYqxTsIs" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskj4Oxk" role="jymVt">
-      <property role="TrG5h" value="listPrimitiveTypes" />
-      <node concept="3clFbS" id="5JNiskj4Oxl" role="3clF47" />
-      <node concept="_YKpA" id="5JNiskj4Oxu" role="3clF45">
-        <node concept="3uibUv" id="5JNiskj4Oxv" role="_ZDj9">
-          <ref role="3uigEE" to="imb3:~DataType" resolve="DataType" />
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskj4Oxw" role="1B3o_S" />
-      <node concept="P$JXv" id="5M8g5cS_YzB" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_YA_" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_YAA" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin primitive types as JSON DataType." />
-          </node>
-        </node>
-        <node concept="VUp57" id="5M8g5cS_YEV" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cS_YMV" role="VUp5m">
-            <ref role="VXe0S" to="y7p:5JNiski3k19" resolve="listLcPrimitiveTypes" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiskj4Oxy" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTwQ8" role="jymVt">
       <property role="TrG5h" value="listClassifiersX" />
       <node concept="3clFbS" id="7OJcYqxTwQ9" role="3clF47" />
@@ -5449,29 +5209,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqxTwLu" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskj4Oxz" role="jymVt">
-      <property role="TrG5h" value="listClassifiers" />
-      <node concept="3clFbS" id="5JNiskj4Ox$" role="3clF47" />
-      <node concept="_YKpA" id="5JNiskj4OxF" role="3clF45">
-        <node concept="3uibUv" id="5JNiskj4OxG" role="_ZDj9">
-          <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskj4OxH" role="1B3o_S" />
-      <node concept="P$JXv" id="5M8g5cS_YN8" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cSA8Ky" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cSA8Kz" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin classifiers as JSON Classifier." />
-          </node>
-        </node>
-        <node concept="VUp57" id="5M8g5cSA8M1" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cSA8Nv" role="VUp5m">
-            <ref role="VXe0S" to="y7p:5JNiski3jZs" resolve="listLcClassifiers" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiskj4OxJ" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxR6CI" role="jymVt">
       <property role="TrG5h" value="getBuiltinsX" />
       <node concept="3clFbS" id="7OJcYqxR6CJ" role="3clF47" />
@@ -5487,33 +5224,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqxR6_Q" role="jymVt" />
-    <node concept="3clFb_" id="4Yo3buYJP_4" role="jymVt">
-      <property role="TrG5h" value="getBuiltins" />
-      <node concept="3clFbS" id="4Yo3buYJP_7" role="3clF47" />
-      <node concept="3Tm1VV" id="4Yo3buYJP_8" role="1B3o_S" />
-      <node concept="3uibUv" id="4Yo3buYJPz9" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cSA8QE" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cSA8QF" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cSA8QG" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cSA9EQ" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cSA9F4" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cSA9F6" role="2XjZqd" />
-              <node concept="VXe08" id="5M8g5cSA9Fl" role="92FcQ">
-                <ref role="VXe09" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cSA9EP" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="4Yo3buYJPxh" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxR63A" role="jymVt">
       <property role="TrG5h" value="getStringX" />
       <node concept="3clFbS" id="7OJcYqxR63D" role="3clF47" />
@@ -5528,21 +5238,7 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiskj4OxK" role="jymVt">
-      <property role="TrG5h" value="getString" />
-      <node concept="3uibUv" id="5JNiskj4OxL" role="3clF45">
-        <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
-      </node>
-      <node concept="3Tm1VV" id="5JNiskj4OxM" role="1B3o_S" />
-      <node concept="3clFbS" id="5JNiskj4OxN" role="3clF47" />
-      <node concept="P$JXv" id="5M8g5cSA9HN" role="lGtFl">
-        <node concept="VUp57" id="5M8g5cSA9KL" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cSA9NB" role="VUp5m">
-            <ref role="VXe0S" to="y7p:5JNiski3jVi" resolve="lcStringType" />
-          </node>
-        </node>
-      </node>
-    </node>
+    <node concept="2tJIrI" id="7OJcYqz_0mW" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTgBk" role="jymVt">
       <property role="TrG5h" value="getIntegerX" />
       <node concept="3clFbS" id="7OJcYqxTgBl" role="3clF47" />
@@ -5558,21 +5254,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqxTg$c" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskj4OxT" role="jymVt">
-      <property role="TrG5h" value="getInteger" />
-      <node concept="3uibUv" id="5JNiskj4OxU" role="3clF45">
-        <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
-      </node>
-      <node concept="3Tm1VV" id="5JNiskj4OxV" role="1B3o_S" />
-      <node concept="3clFbS" id="5JNiskj4OxW" role="3clF47" />
-      <node concept="P$JXv" id="5M8g5cSA9NO" role="lGtFl">
-        <node concept="VUp57" id="5M8g5cSA9Pp" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cSA9TF" role="VUp5m">
-            <ref role="VXe0S" to="y7p:5JNiski3jVW" resolve="lcIntegerType" />
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="7OJcYqxThz6" role="jymVt">
       <property role="TrG5h" value="getBooleanX" />
       <node concept="3clFbS" id="7OJcYqxThz7" role="3clF47" />
@@ -5588,21 +5269,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqxThvI" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskj4Oy2" role="jymVt">
-      <property role="TrG5h" value="getBoolean" />
-      <node concept="3uibUv" id="5JNiskj4Oy3" role="3clF45">
-        <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
-      </node>
-      <node concept="3Tm1VV" id="5JNiskj4Oy4" role="1B3o_S" />
-      <node concept="3clFbS" id="5JNiskj4Oy5" role="3clF47" />
-      <node concept="P$JXv" id="5M8g5cSA9TS" role="lGtFl">
-        <node concept="VUp57" id="5M8g5cSA9Vt" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cSA9ZJ" role="VUp5m">
-            <ref role="VXe0S" to="y7p:5JNiski3jVB" resolve="lcBooleanType" />
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="7OJcYqxTinV" role="jymVt">
       <property role="TrG5h" value="getJsonX" />
       <node concept="3clFbS" id="7OJcYqxTinW" role="3clF47" />
@@ -5618,21 +5284,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqxTimg" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskj4Oyb" role="jymVt">
-      <property role="TrG5h" value="getJSON" />
-      <node concept="3uibUv" id="5JNiskj4Oyc" role="3clF45">
-        <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
-      </node>
-      <node concept="3Tm1VV" id="5JNiskj4Oyd" role="1B3o_S" />
-      <node concept="3clFbS" id="5JNiskj4Oye" role="3clF47" />
-      <node concept="P$JXv" id="5M8g5cSA9ZW" role="lGtFl">
-        <node concept="VUp57" id="5M8g5cSAa1x" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cSAa5N" role="VUp5m">
-            <ref role="VXe0S" to="y7p:5JNiski3jWh" resolve="lcJsonType" />
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="7OJcYqxTjiV" role="jymVt">
       <property role="TrG5h" value="getINamedX" />
       <node concept="3clFbS" id="7OJcYqxTjiW" role="3clF47" />
@@ -5648,21 +5299,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqxTjh9" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskj4Oyk" role="jymVt">
-      <property role="TrG5h" value="getINamed" />
-      <node concept="3uibUv" id="5JNiskj4Oyl" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Interface" resolve="Interface" />
-      </node>
-      <node concept="3Tm1VV" id="5JNiskj4Oym" role="1B3o_S" />
-      <node concept="3clFbS" id="5JNiskj4Oyn" role="3clF47" />
-      <node concept="P$JXv" id="5M8g5cSAa60" role="lGtFl">
-        <node concept="VUp57" id="5M8g5cSAa7_" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cSAabR" role="VUp5m">
-            <ref role="VXe0S" to="y7p:5JNiski3jXc" resolve="lcINamedInterface" />
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="7OJcYqxTras" role="jymVt">
       <property role="TrG5h" value="getNodeX" />
       <node concept="3clFbS" id="7OJcYqxTrat" role="3clF47" />
@@ -5677,23 +5313,6 @@
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="7OJcYqxTray" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskj4Oyt" role="jymVt">
-      <property role="TrG5h" value="getNode" />
-      <node concept="3uibUv" id="5JNiskj4Oyu" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
-      </node>
-      <node concept="3Tm1VV" id="5JNiskj4Oyv" role="1B3o_S" />
-      <node concept="3clFbS" id="5JNiskj4Oyw" role="3clF47" />
-      <node concept="P$JXv" id="5M8g5cSAac4" role="lGtFl">
-        <node concept="VUp57" id="5M8g5cSAagw" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cSAajm" role="VUp5m">
-            <ref role="VXe0S" to="y7p:5JNiski3jWA" resolve="lcNodeConcept" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiskj4Oxi" role="jymVt" />
     <node concept="3Tm1VV" id="5JNiskj4NAK" role="1B3o_S" />
     <node concept="3UR2Jj" id="RuBGkvsmYJ" role="lGtFl">
       <node concept="TZ5HA" id="RuBGkvsmYK" role="TZ5H$">
@@ -5718,32 +5337,6 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiskj6wTk" role="jymVt">
-      <property role="TrG5h" value="getSpecificLanguage" />
-      <node concept="3clFbS" id="5JNiskj6wTn" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskj6wTo" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskj6wRz" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_oz4" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_shD" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_shE" role="1dT_Ay">
-            <property role="1dT_AB" value="io.lionweb.mps.specific as JSON " />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS_som" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS_so$" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS_soA" role="2XjZqd" />
-              <node concept="VXe08" id="5M8g5cS_t4J" role="92FcQ">
-                <ref role="VXe09" to="imb3:~Language" resolve="Language" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS_sol" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="2tJIrI" id="5JNiskj6wPP" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyb0Gn" role="jymVt">
       <property role="TrG5h" value="getVirtualPackageX" />
@@ -5756,37 +5349,6 @@
         </node>
         <node concept="3uibUv" id="7OJcYqyb0Gs" role="11_B2D">
           <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskj67eE" role="jymVt">
-      <property role="TrG5h" value="getVirtualPackage" />
-      <node concept="3clFbS" id="5JNiskj67eH" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskj67eI" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskj67dJ" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_sln" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_uJN" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_uJO" role="1dT_Ay">
-            <property role="1dT_AB" value="io.lionweb.mps.specific.lang.MPS-specific annotations.VirtualPackage as JSON " />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS_uMF" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS_uMT" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS_uMV" role="2XjZqd" />
-              <node concept="VXe08" id="5M8g5cS_uNa" role="92FcQ">
-                <ref role="VXe09" to="imb3:~Annotation" resolve="Annotation" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS_uME" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-        <node concept="VUp57" id="5M8g5cS_uQi" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cS_uTj" role="VUp5m">
-            <ref role="VXe0S" to="y7p:5JNiskipPo2" resolve="lcVirtualPackageAnnotation" />
-          </node>
         </node>
       </node>
     </node>
@@ -5806,38 +5368,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqyb2Cw" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskj67nR" role="jymVt">
-      <property role="TrG5h" value="getVirtualPackage_Name" />
-      <node concept="3clFbS" id="5JNiskj67nU" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskj67nV" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskj67my" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_uWr" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_uWs" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_xnS" role="1dT_Ay">
-            <property role="1dT_AB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.INamed.name as JSON " />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS_xnT" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS_xnU" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS_xnV" role="2XjZqd" />
-              <node concept="VXe08" id="5M8g5cS_xnW" role="92FcQ">
-                <ref role="VXe09" to="imb3:~Annotation" resolve="Annotation" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS_uWt" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-        <node concept="VUp57" id="5M8g5cS_zkL" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cS_zqw" role="VUp5m">
-            <ref role="VXe0S" to="y7p:5JNiskir74n" resolve="lcVirtualPackage_NameProperty" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiskj67qn" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyb4U4" role="jymVt">
       <property role="TrG5h" value="getShortDescriptionX" />
       <node concept="3clFbS" id="7OJcYqyb4U5" role="3clF47" />
@@ -5853,38 +5383,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqyb4PP" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskj67iX" role="jymVt">
-      <property role="TrG5h" value="getShortDescription" />
-      <node concept="3clFbS" id="5JNiskj67j0" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskj67j1" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskj67hP" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_xqw" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_zqN" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_zqO" role="1dT_Ay">
-            <property role="1dT_AB" value="io.lionweb.mps.specific.lang.MPS-specific annotations.ShortDescription as JSON " />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS_zqP" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS_zqQ" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS_zqR" role="2XjZqd" />
-              <node concept="VXe08" id="5M8g5cS_zqS" role="92FcQ">
-                <ref role="VXe09" to="imb3:~Annotation" resolve="Annotation" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS_zqT" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-        <node concept="VUp57" id="5M8g5cS_zzF" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cS_zDq" role="VUp5m">
-            <ref role="VXe0S" to="y7p:5JNiskipPPY" resolve="lcShortDescriptionAnnotation" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="7OJcYqyb6Jl" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyb6S2" role="jymVt">
       <property role="TrG5h" value="getShortDescription_DescriptionX" />
       <node concept="3clFbS" id="7OJcYqyb6S3" role="3clF47" />
@@ -5900,38 +5398,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqyb6NF" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskj67rQ" role="jymVt">
-      <property role="TrG5h" value="getShortDescription_Description" />
-      <node concept="3clFbS" id="5JNiskj67rR" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskj67rS" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskj67rT" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_zDL" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_zGJ" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_zGK" role="1dT_Ay">
-            <property role="1dT_AB" value="io.lionweb.mps.specific.lang.MPS-specific annotations.ShortDescription.description as JSON " />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS_zGL" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS_zGM" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS_zGN" role="2XjZqd" />
-              <node concept="VXe08" id="5M8g5cS_zGO" role="92FcQ">
-                <ref role="VXe09" to="imb3:~Property" resolve="Property" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS_zGP" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-        <node concept="VUp57" id="5M8g5cS_zPJ" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cS_zYj" role="VUp5m">
-            <ref role="VXe0S" to="y7p:5JNiskir8mM" resolve="lcShortDescription_DescriptionProperty" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiskj67cR" role="jymVt" />
     <node concept="3clFb_" id="5JNiskiswUo" role="jymVt">
       <property role="TrG5h" value="isMpsInternalConcept" />
       <node concept="3clFbS" id="5JNiskiswUp" role="3clF47" />
@@ -6001,19 +5467,20 @@
       <node concept="3clFbS" id="5JNiskjpjPQ" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiskjpjPR" role="1B3o_S" />
       <node concept="_YKpA" id="5JNiskjpjNC" role="3clF45">
-        <node concept="3uibUv" id="5JNiskjpjPD" role="_ZDj9">
-          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+        <node concept="3uibUv" id="7OJcYqzLjhJ" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <node concept="3uibUv" id="7OJcYqzLjhK" role="11_B2D">
+            <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+          </node>
+          <node concept="3uibUv" id="7OJcYqzLjhL" role="11_B2D">
+            <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+          </node>
         </node>
       </node>
       <node concept="P$JXv" id="5M8g5cS_zYE" role="lGtFl">
         <node concept="TZ5HA" id="5M8g5cS_zYF" role="TZ5H$">
           <node concept="1dT_AC" id="5M8g5cS_zYG" role="1dT_Ay">
             <property role="1dT_AB" value="All M1 JSON annotations that are converted from MPS node properties." />
-          </node>
-        </node>
-        <node concept="VUp57" id="5M8g5cS_$ak" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cS_$fY" role="VUp5m">
-            <ref role="VXe0S" to="y7p:5JNiskjpaH9" resolve="listSpecificAnnotationProperties" />
           </node>
         </node>
       </node>
@@ -6023,19 +5490,20 @@
       <node concept="3clFbS" id="5JNiskjpjYT" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiskjpjYU" role="1B3o_S" />
       <node concept="_YKpA" id="5JNiskjpjW$" role="3clF45">
-        <node concept="3uibUv" id="5JNiskjpjYN" role="_ZDj9">
-          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        <node concept="3uibUv" id="7OJcYqzLld7" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <node concept="3uibUv" id="7OJcYqzLld8" role="11_B2D">
+            <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+          </node>
+          <node concept="3uibUv" id="7OJcYqzLld9" role="11_B2D">
+            <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          </node>
         </node>
       </node>
       <node concept="P$JXv" id="5M8g5cS_$4u" role="lGtFl">
         <node concept="TZ5HA" id="5M8g5cS_$4v" role="TZ5H$">
           <node concept="1dT_AC" id="5M8g5cS_$4w" role="1dT_Ay">
             <property role="1dT_AB" value="All M1 JSON annotation properties that are converted from MPS node properties." />
-          </node>
-        </node>
-        <node concept="VUp57" id="5M8g5cS_A9h" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cS_A9i" role="VUp5m">
-            <ref role="VXe0S" to="y7p:5JNiskjpaH9" resolve="listSpecificAnnotationProperties" />
           </node>
         </node>
       </node>
@@ -6107,29 +5575,15 @@
           <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
         </node>
       </node>
-    </node>
-    <node concept="2tJIrI" id="7OJcYqyb8YG" role="jymVt" />
-    <node concept="3clFb_" id="34Q84zNB8uo" role="jymVt">
-      <property role="TrG5h" value="getConceptDescriptionAnnotation" />
-      <node concept="3clFbS" id="34Q84zNB8ur" role="3clF47" />
-      <node concept="3Tm1VV" id="34Q84zNB8us" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNB8rv" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_BxF" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_BxG" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_BxH" role="1dT_Ay">
+      <node concept="P$JXv" id="7OJcYqzAThC" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqzAThD" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqzAThE" role="1dT_Ay">
             <property role="1dT_AB" value="All M2 JSON annotations that are converted from MPS concept properties." />
           </node>
         </node>
-        <node concept="VUp57" id="5M8g5cS_BBx" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cS_BK0" role="VUp5m">
-            <ref role="VXe0S" to="y7p:34Q84zNtsh8" resolve="listConceptDescriptionProperties" />
-          </node>
-        </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="7OJcYqybbIQ" role="jymVt" />
+    <node concept="2tJIrI" id="7OJcYqyb8YG" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqybbS1" role="jymVt">
       <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptAliasX" />
       <node concept="3clFbS" id="7OJcYqybbS2" role="3clF47" />
@@ -6145,41 +5599,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqybbNr" role="jymVt" />
-    <node concept="3clFb_" id="34Q84zNToVR" role="jymVt">
-      <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptAlias" />
-      <node concept="3clFbS" id="34Q84zNToVS" role="3clF47" />
-      <node concept="3Tm1VV" id="34Q84zNToVT" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNToVU" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_BKf" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_BKg" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_BT5" role="1dT_Ay">
-            <property role="1dT_AB" value="io.lionweb.mps.specific.lang.MPS-specific annotations.ConceptDescription.conceptAlias as JSON " />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS_BT6" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS_BT7" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS_BT8" role="2XjZqd" />
-              <node concept="VXe08" id="5M8g5cS_BT9" role="92FcQ">
-                <ref role="VXe09" to="imb3:~Property" resolve="Property" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS_BTa" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS_BKh" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-        <node concept="VUp57" id="5M8g5cS_DGt" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cS_DMd" role="VUp5m">
-            <ref role="VXe0S" to="y7p:34Q84zNQVqH" resolve="mpsConceptAliasProperty" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="7OJcYqybeuo" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqybeup" role="jymVt">
       <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptShortDescriptionX" />
       <node concept="3clFbS" id="7OJcYqybeuq" role="3clF47" />
@@ -6195,59 +5614,26 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqybelU" role="jymVt" />
-    <node concept="3clFb_" id="34Q84zNTp5n" role="jymVt">
-      <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptShortDescription" />
-      <node concept="3clFbS" id="34Q84zNTp5o" role="3clF47" />
-      <node concept="3Tm1VV" id="34Q84zNTp5p" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNTp5q" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_DMs" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_DPq" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_DPr" role="1dT_Ay">
-            <property role="1dT_AB" value="io.lionweb.mps.specific.lang.MPS-specific annotations.ConceptDescription.conceptShortDescription as JSON " />
+    <node concept="2tJIrI" id="7OJcYqzAUGl" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqzAV4V" role="jymVt">
+      <property role="TrG5h" value="listConceptDescriptionPropertiesX" />
+      <node concept="3clFbS" id="7OJcYqzAV4Y" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqzAV4Z" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqzAUWE" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqzAVoU" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <node concept="3uibUv" id="7OJcYqzAVoV" role="11_B2D">
+            <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
           </node>
-          <node concept="1dT_AA" id="5M8g5cS_DPs" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS_DPt" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS_DPu" role="2XjZqd" />
-              <node concept="VXe08" id="5M8g5cS_DPv" role="92FcQ">
-                <ref role="VXe09" to="imb3:~Property" resolve="Property" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS_DPw" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS_DPx" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-        <node concept="VUp57" id="5M8g5cS_E5h" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cS_Eb1" role="VUp5m">
-            <ref role="VXe0S" to="y7p:34Q84zNQWR0" resolve="mpsConceptShortDescriptionProperty" />
+          <node concept="3uibUv" id="7OJcYqzAVoW" role="11_B2D">
+            <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
           </node>
         </node>
       </node>
-    </node>
-    <node concept="2tJIrI" id="34Q84zNToUC" role="jymVt" />
-    <node concept="3clFb_" id="34Q84zN__4k" role="jymVt">
-      <property role="TrG5h" value="listConceptDescriptionProperties" />
-      <node concept="3clFbS" id="34Q84zN__4l" role="3clF47" />
-      <node concept="3Tm1VV" id="34Q84zN__4m" role="1B3o_S" />
-      <node concept="_YKpA" id="34Q84zN__4n" role="3clF45">
-        <node concept="3uibUv" id="34Q84zN__4o" role="_ZDj9">
-          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
-        </node>
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_Ebo" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_Eh8" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_Eh9" role="1dT_Ay">
+      <node concept="P$JXv" id="7OJcYqzAXqY" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqzAXqZ" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqzAXr0" role="1dT_Ay">
             <property role="1dT_AB" value="All M2 JSON annotation properties that are converted from MPS concept properties." />
-          </node>
-        </node>
-        <node concept="VUp57" id="5M8g5cS_EpG" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cS_Evm" role="VUp5m">
-            <ref role="VXe0S" to="y7p:34Q84zNtsh8" resolve="listConceptDescriptionProperties" />
           </node>
         </node>
       </node>
@@ -6267,32 +5653,6 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="7weWCFlwidJ" role="jymVt">
-      <property role="TrG5h" value="getAnnotationConcept" />
-      <node concept="3clFbS" id="7weWCFlwidM" role="3clF47" />
-      <node concept="3Tm1VV" id="7weWCFlwidN" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlwi9Z" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_EvH" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_EvI" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_EvJ" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS_H9O" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS_Ha2" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS_Ha4" role="2XjZqd" />
-              <node concept="VXe0Z" id="5M8g5cS_Irm" role="92FcQ">
-                <ref role="VXe0S" to="cz4z:~LionCore.getAnnotation()" resolve="getAnnotation" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS_H9N" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="2tJIrI" id="7OJcYqybjHa" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqybjR1" role="jymVt">
       <property role="TrG5h" value="getClassifierConceptX" />
@@ -6309,33 +5669,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqybjM5" role="jymVt" />
-    <node concept="3clFb_" id="7weWCFlwin$" role="jymVt">
-      <property role="TrG5h" value="getClassifierConcept" />
-      <node concept="3clFbS" id="7weWCFlwin_" role="3clF47" />
-      <node concept="3Tm1VV" id="7weWCFlwinA" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlwinB" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_IBF" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_IED" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_IEE" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS_IEF" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS_IEG" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS_IEH" role="2XjZqd" />
-              <node concept="VXe0Z" id="5M8g5cS_IEI" role="92FcQ">
-                <ref role="VXe0S" to="cz4z:~LionCore.getClassifier()" resolve="getClassifier" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS_IEJ" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="7OJcYqybmkw" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqybmuB" role="jymVt">
       <property role="TrG5h" value="getConceptConceptX" />
       <node concept="3clFbS" id="7OJcYqybmuC" role="3clF47" />
@@ -6351,33 +5684,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqybmpz" role="jymVt" />
-    <node concept="3clFb_" id="7weWCFlwj$H" role="jymVt">
-      <property role="TrG5h" value="getConceptConcept" />
-      <node concept="3clFbS" id="7weWCFlwj$I" role="3clF47" />
-      <node concept="3Tm1VV" id="7weWCFlwj$J" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlwj$K" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_INA" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_IQ$" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_IQ_" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS_IQA" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS_IQB" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS_IQC" role="2XjZqd" />
-              <node concept="VXe0Z" id="5M8g5cS_IQD" role="92FcQ">
-                <ref role="VXe0S" to="cz4z:~LionCore.getConcept()" resolve="getConcept" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS_IQE" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="7OJcYqybp5S" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqybpgf" role="jymVt">
       <property role="TrG5h" value="getInterfaceConceptX" />
       <node concept="3clFbS" id="7OJcYqybpgg" role="3clF47" />
@@ -6393,51 +5699,29 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqybpb3" role="jymVt" />
-    <node concept="3clFb_" id="7weWCFlwk05" role="jymVt">
-      <property role="TrG5h" value="getInterfaceConcept" />
-      <node concept="3clFbS" id="7weWCFlwk06" role="3clF47" />
-      <node concept="3Tm1VV" id="7weWCFlwk07" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlwk08" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_IZt" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_J2r" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_J2s" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS_J2t" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS_J2u" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS_J2v" role="2XjZqd" />
-              <node concept="VXe0Z" id="5M8g5cS_J2w" role="92FcQ">
-                <ref role="VXe0S" to="cz4z:~LionCore.getInterface()" resolve="getInterface" />
-              </node>
+    <node concept="3clFb_" id="7OJcYqyVkp8" role="jymVt">
+      <property role="TrG5h" value="listReplacementMpsSpecificClassifiersX" />
+      <node concept="3clFbS" id="7OJcYqyVkp9" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqyVkpa" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqyVkpb" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqzKD6v" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <node concept="3qUE_q" id="7OJcYqzKVIa" role="11_B2D">
+            <node concept="3uibUv" id="7OJcYqzKVIb" role="3qUE_r">
+              <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
             </node>
           </node>
-          <node concept="1dT_AC" id="5M8g5cS_J2x" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
+          <node concept="3qUE_q" id="7OJcYqzKD6x" role="11_B2D">
+            <node concept="3uibUv" id="7OJcYqzKD6y" role="3qUE_r">
+              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+            </node>
           </node>
         </node>
       </node>
-    </node>
-    <node concept="2tJIrI" id="7weWCFlwedG" role="jymVt" />
-    <node concept="3clFb_" id="7weWCFlvJcc" role="jymVt">
-      <property role="TrG5h" value="listReplacementMpsSpecificClassifiers" />
-      <node concept="3clFbS" id="7weWCFlvJcf" role="3clF47" />
-      <node concept="3Tm1VV" id="7weWCFlvJcg" role="1B3o_S" />
-      <node concept="_YKpA" id="7weWCFlvJ8_" role="3clF45">
-        <node concept="3uibUv" id="7weWCFlvJc9" role="_ZDj9">
-          <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
-        </node>
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_Jrc" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_Jrd" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_Jre" role="1dT_Ay">
+      <node concept="P$JXv" id="7OJcYqyVkpd" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqyVkpe" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqyVkpf" role="1dT_Ay">
             <property role="1dT_AB" value="All JSON classifiers that need special treatment" />
-          </node>
-        </node>
-        <node concept="VUp57" id="5M8g5cS_Vv6" role="3nqlJM">
-          <node concept="VXe0Z" id="5M8g5cS_Y2B" role="VUp5m">
-            <ref role="VXe0S" to="y7p:7weWCFlqTiX" resolve="listSLanguageInternalClassifiers" />
           </node>
         </node>
       </node>
@@ -6860,8 +6144,13 @@
             </node>
             <node concept="liA8E" id="5JNiskj6PtP" role="2OqNvi">
               <ref role="37wK5l" to="imb3:~Annotation.addImplementedInterface(io.lionweb.lioncore.java.language.Interface)" resolve="addImplementedInterface" />
-              <node concept="1rXfSq" id="5JNiskj6PIG" role="37wK5m">
-                <ref role="37wK5l" node="5TNjoy1vudm" resolve="getINamed" />
+              <node concept="2OqwBi" id="7OJcYqzFMTY" role="37wK5m">
+                <node concept="1rXfSq" id="5JNiskj6PIG" role="2Oq$k0">
+                  <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamedX" />
+                </node>
+                <node concept="liA8E" id="7OJcYqzFPqR" role="2OqNvi">
+                  <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+                </node>
               </node>
             </node>
           </node>
@@ -6907,11 +6196,16 @@
                 <node concept="2OqwBi" id="7OJcYqylZ6L" role="37wK5m">
                   <node concept="2OqwBi" id="7OJcYqylZ6M" role="2Oq$k0">
                     <node concept="2OqwBi" id="7OJcYqylZ6N" role="2Oq$k0">
-                      <node concept="1rXfSq" id="7OJcYqylZ6O" role="2Oq$k0">
-                        <ref role="37wK5l" node="5TNjoy1vudm" resolve="getINamed" />
-                      </node>
                       <node concept="liA8E" id="7OJcYqylZ6P" role="2OqNvi">
                         <ref role="37wK5l" to="imb3:~Classifier.allProperties()" resolve="allProperties" />
+                      </node>
+                      <node concept="2OqwBi" id="7OJcYqzFRFN" role="2Oq$k0">
+                        <node concept="1rXfSq" id="7OJcYqzFRFO" role="2Oq$k0">
+                          <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamedX" />
+                        </node>
+                        <node concept="liA8E" id="7OJcYqzFRFP" role="2OqNvi">
+                          <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+                        </node>
                       </node>
                     </node>
                     <node concept="liA8E" id="7OJcYqylZ6Q" role="2OqNvi">
@@ -6975,8 +6269,13 @@
                     <node concept="Xl_RD" id="5JNiskj6VU3" role="37wK5m">
                       <property role="Xl_RC" value="description" />
                     </node>
-                    <node concept="1rXfSq" id="5JNiskj6Xd0" role="37wK5m">
-                      <ref role="37wK5l" node="5TNjoy1vtGO" resolve="getString" />
+                    <node concept="2OqwBi" id="7OJcYqzFVRb" role="37wK5m">
+                      <node concept="1rXfSq" id="5JNiskj6Xd0" role="2Oq$k0">
+                        <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getStringX" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYqzFXGf" role="2OqNvi">
+                        <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+                      </node>
                     </node>
                     <node concept="Xl_RD" id="5JNiskj6Ye5" role="37wK5m">
                       <property role="Xl_RC" value="description" />
@@ -7040,8 +6339,13 @@
                 <node concept="2OqwBi" id="7OJcYqymLcY" role="37wK5m">
                   <node concept="2OqwBi" id="7OJcYqymLcZ" role="2Oq$k0">
                     <node concept="2OqwBi" id="7OJcYqymLd0" role="2Oq$k0">
-                      <node concept="1rXfSq" id="7OJcYqymLd1" role="2Oq$k0">
-                        <ref role="37wK5l" node="5JNiskj67Oa" resolve="getShortDescription" />
+                      <node concept="2OqwBi" id="7OJcYqzNJkr" role="2Oq$k0">
+                        <node concept="1rXfSq" id="7OJcYqymLd1" role="2Oq$k0">
+                          <ref role="37wK5l" node="7OJcYqygOBN" resolve="getShortDescriptionX" />
+                        </node>
+                        <node concept="liA8E" id="7OJcYqzNL_v" role="2OqNvi">
+                          <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+                        </node>
                       </node>
                       <node concept="liA8E" id="7OJcYqymLd2" role="2OqNvi">
                         <ref role="37wK5l" to="imb3:~Classifier.allProperties()" resolve="allProperties" />
@@ -7108,8 +6412,13 @@
                   <node concept="Xl_RD" id="7OJcYqyr1o6" role="37wK5m">
                     <property role="Xl_RC" value="conceptAlias" />
                   </node>
-                  <node concept="1rXfSq" id="7OJcYqyr1o7" role="37wK5m">
-                    <ref role="37wK5l" node="5TNjoy1vtGO" resolve="getString" />
+                  <node concept="2OqwBi" id="7OJcYqzGdXf" role="37wK5m">
+                    <node concept="1rXfSq" id="7OJcYqyr1o7" role="2Oq$k0">
+                      <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getStringX" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqzGgMy" role="2OqNvi">
+                      <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+                    </node>
                   </node>
                   <node concept="Xl_RD" id="7OJcYqyr1o8" role="37wK5m">
                     <property role="Xl_RC" value="conceptAlias" />
@@ -7185,8 +6494,13 @@
                   <node concept="Xl_RD" id="7OJcYqyrmfD" role="37wK5m">
                     <property role="Xl_RC" value="conceptShortDescription" />
                   </node>
-                  <node concept="1rXfSq" id="7OJcYqyrmfE" role="37wK5m">
-                    <ref role="37wK5l" node="5TNjoy1vtGO" resolve="getString" />
+                  <node concept="2OqwBi" id="7OJcYqzGkCa" role="37wK5m">
+                    <node concept="1rXfSq" id="7OJcYqyrmfE" role="2Oq$k0">
+                      <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getStringX" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqzGlZH" role="2OqNvi">
+                      <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+                    </node>
                   </node>
                   <node concept="Xl_RD" id="7OJcYqyrmfF" role="37wK5m">
                     <property role="Xl_RC" value="conceptShortDescription" />
@@ -7318,28 +6632,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiskj6yKO" role="jymVt">
-      <property role="TrG5h" value="getSpecificLanguage" />
-      <node concept="3Tm1VV" id="5JNiskj6yKQ" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskj6yKR" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
-      </node>
-      <node concept="3clFbS" id="5JNiskj6yKT" role="3clF47">
-        <node concept="3clFbF" id="5JNiskj6$VA" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqypjRB" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqypjRC" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqybDcU" resolve="getSpecificLanguageX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqypjRD" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5JNiskj6yKU" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5JNiskj64xG" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqygnxo" role="jymVt">
       <property role="TrG5h" value="getVirtualPackageX" />
@@ -7361,28 +6653,6 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqygnxw" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskj67NS" role="jymVt">
-      <property role="TrG5h" value="getVirtualPackage" />
-      <node concept="3Tm1VV" id="5JNiskj67NU" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskj67NV" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-      </node>
-      <node concept="3clFbS" id="5JNiskj67NX" role="3clF47">
-        <node concept="3clFbF" id="5JNiskj67O0" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqyp5I_" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqyp5IA" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqygnxo" resolve="getVirtualPackageX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqyp5IB" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5JNiskj67NY" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -7410,38 +6680,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiskj67O1" role="jymVt">
-      <property role="TrG5h" value="getVirtualPackage_Name" />
-      <node concept="3Tm1VV" id="5JNiskj67O3" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskj67O4" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
-      </node>
-      <node concept="3clFbS" id="5JNiskj67O6" role="3clF47">
-        <node concept="3clFbF" id="5JNiskj67O9" role="3cqZAp">
-          <node concept="2OqwBi" id="5JNiskj6cP$" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiskj6bDu" role="2Oq$k0">
-              <node concept="2OqwBi" id="5JNiskj6akz" role="2Oq$k0">
-                <node concept="1rXfSq" id="5JNiskj69Gt" role="2Oq$k0">
-                  <ref role="37wK5l" node="5TNjoy1vudm" resolve="getINamed" />
-                </node>
-                <node concept="liA8E" id="5JNiskj6b5e" role="2OqNvi">
-                  <ref role="37wK5l" to="imb3:~Classifier.allProperties()" resolve="allProperties" />
-                </node>
-              </node>
-              <node concept="liA8E" id="5JNiskj6cxX" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
-              </node>
-            </node>
-            <node concept="liA8E" id="5JNiskj6dq0" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5JNiskj67O7" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5JNiskj6e2B" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqygOBN" role="jymVt">
       <property role="TrG5h" value="getShortDescriptionX" />
@@ -7463,28 +6701,6 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqygOBV" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskj67Oa" role="jymVt">
-      <property role="TrG5h" value="getShortDescription" />
-      <node concept="3Tm1VV" id="5JNiskj67Oc" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskj67Od" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-      </node>
-      <node concept="3clFbS" id="5JNiskj67Of" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqyoRHv" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqyoRHw" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqyoRHx" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqygOBN" resolve="getShortDescriptionX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqyoRHy" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5JNiskj67Og" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -7512,38 +6728,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiskj67Oj" role="jymVt">
-      <property role="TrG5h" value="getShortDescription_Description" />
-      <node concept="3Tm1VV" id="5JNiskj67Ol" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskj67Om" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
-      </node>
-      <node concept="3clFbS" id="5JNiskj67Oo" role="3clF47">
-        <node concept="3clFbF" id="5JNiskj6fSt" role="3cqZAp">
-          <node concept="2OqwBi" id="5JNiskj6fSu" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiskj6fSv" role="2Oq$k0">
-              <node concept="2OqwBi" id="5JNiskj6fSw" role="2Oq$k0">
-                <node concept="1rXfSq" id="5JNiskj6fSx" role="2Oq$k0">
-                  <ref role="37wK5l" node="5JNiskj67Oa" resolve="getShortDescription" />
-                </node>
-                <node concept="liA8E" id="5JNiskj6fSy" role="2OqNvi">
-                  <ref role="37wK5l" to="imb3:~Classifier.allProperties()" resolve="allProperties" />
-                </node>
-              </node>
-              <node concept="liA8E" id="5JNiskj6fSz" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
-              </node>
-            </node>
-            <node concept="liA8E" id="5JNiskj6fS$" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5JNiskj67Op" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="34Q84zNSLh9" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyhdSU" role="jymVt">
       <property role="TrG5h" value="getConceptDescriptionAnnotationX" />
@@ -7565,28 +6749,6 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqyhdT2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="34Q84zNSFdn" role="jymVt">
-      <property role="TrG5h" value="getConceptDescriptionAnnotation" />
-      <node concept="3Tm1VV" id="34Q84zNSFdp" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNSFdq" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-      </node>
-      <node concept="3clFbS" id="34Q84zNSFds" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqyoDlY" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqyoDlZ" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqyoDm0" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqyhdSU" resolve="getConceptDescriptionAnnotationX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqyoDm1" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="34Q84zNSFdt" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -7614,28 +6776,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="34Q84zNTspf" role="jymVt">
-      <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptAlias" />
-      <node concept="3Tm1VV" id="34Q84zNTsph" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNTspi" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
-      </node>
-      <node concept="3clFbS" id="34Q84zNTspk" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqyoqLw" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqyoqLx" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqyoqLy" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqyhHPP" resolve="getConceptDescriptionAnnotation_ConceptAliasX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqyoqLz" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="34Q84zNTspl" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="7OJcYqyiatN" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyisuh" role="jymVt">
       <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptShortDescriptionX" />
@@ -7657,28 +6797,6 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqyisup" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="34Q84zNTspo" role="jymVt">
-      <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptShortDescription" />
-      <node concept="3Tm1VV" id="34Q84zNTspq" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNTspr" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
-      </node>
-      <node concept="3clFbS" id="34Q84zNTspt" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqyobY0" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqyobY1" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqyobY2" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqyisuh" resolve="getConceptDescriptionAnnotation_ConceptShortDescriptionX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqyobY3" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="34Q84zNTspu" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -7711,8 +6829,13 @@
                       <node concept="2YIFZM" id="5JNiskj_3ZK" role="3clFbG">
                         <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
                         <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.LanguageEntity)" resolve="from" />
-                        <node concept="37vLTw" id="5JNiskj_5_R" role="37wK5m">
-                          <ref role="3cqZAo" node="5JNiskj_14S" resolve="it" />
+                        <node concept="2OqwBi" id="7OJcYqzMGWa" role="37wK5m">
+                          <node concept="37vLTw" id="5JNiskj_5_R" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5JNiskj_14S" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqzMKKi" role="2OqNvi">
+                            <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -7764,8 +6887,13 @@
                       <node concept="2YIFZM" id="5JNiskj_f6E" role="3clFbG">
                         <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.Feature)" resolve="from" />
                         <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-                        <node concept="37vLTw" id="5JNiskj_gAy" role="37wK5m">
-                          <ref role="3cqZAo" node="5JNiskj_bOF" resolve="it" />
+                        <node concept="2OqwBi" id="7OJcYqzMP4T" role="37wK5m">
+                          <node concept="37vLTw" id="5JNiskj_gAy" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5JNiskj_bOF" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqzMT2L" role="2OqNvi">
+                            <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -7794,8 +6922,14 @@
       <property role="TrG5h" value="listSpecificAnnotations" />
       <node concept="3Tm1VV" id="5JNiskjzWqB" role="1B3o_S" />
       <node concept="_YKpA" id="5JNiskjzWqC" role="3clF45">
-        <node concept="3uibUv" id="5JNiskjzWqD" role="_ZDj9">
-          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+        <node concept="3uibUv" id="7OJcYqzM6gg" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <node concept="3uibUv" id="7OJcYqzM6gh" role="11_B2D">
+            <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+          </node>
+          <node concept="3uibUv" id="7OJcYqzM6gi" role="11_B2D">
+            <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+          </node>
         </node>
       </node>
       <node concept="3clFbS" id="5JNiskjzWqF" role="3clF47">
@@ -7803,13 +6937,19 @@
           <node concept="2ShNRf" id="5JNiskj$yyq" role="3clFbG">
             <node concept="Tc6Ow" id="5JNiskj$yyr" role="2ShVmc">
               <node concept="1rXfSq" id="5JNiskj$yyt" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskj67NS" resolve="getVirtualPackage" />
+                <ref role="37wK5l" node="7OJcYqygnxo" resolve="getVirtualPackageX" />
               </node>
               <node concept="1rXfSq" id="5JNiskj$IW2" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskj67Oa" resolve="getShortDescription" />
+                <ref role="37wK5l" node="7OJcYqygOBN" resolve="getShortDescriptionX" />
               </node>
-              <node concept="3uibUv" id="5JNiskj$yy$" role="HW$YZ">
-                <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+              <node concept="3uibUv" id="7OJcYqzLZrs" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+                <node concept="3uibUv" id="7OJcYqzLZrt" role="11_B2D">
+                  <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+                </node>
+                <node concept="3uibUv" id="7OJcYqzLZru" role="11_B2D">
+                  <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+                </node>
               </node>
             </node>
           </node>
@@ -7824,8 +6964,14 @@
       <property role="TrG5h" value="listSpecificAnnotationMembers" />
       <node concept="3Tm1VV" id="5JNiskjzWqJ" role="1B3o_S" />
       <node concept="_YKpA" id="5JNiskjzWqK" role="3clF45">
-        <node concept="3uibUv" id="5JNiskjzWqL" role="_ZDj9">
-          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        <node concept="3uibUv" id="7OJcYqzMr5s" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <node concept="3uibUv" id="7OJcYqzMr5t" role="11_B2D">
+            <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+          </node>
+          <node concept="3uibUv" id="7OJcYqzMr5u" role="11_B2D">
+            <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          </node>
         </node>
       </node>
       <node concept="3clFbS" id="5JNiskjzWqN" role="3clF47">
@@ -7833,13 +6979,19 @@
           <node concept="2ShNRf" id="5JNiskj$KeJ" role="3clFbG">
             <node concept="Tc6Ow" id="5JNiskj$KeK" role="2ShVmc">
               <node concept="1rXfSq" id="5JNiskj$KeO" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskj67O1" resolve="getVirtualPackage_Name" />
+                <ref role="37wK5l" node="7OJcYqylp3c" resolve="getVirtualPackage_NameX" />
               </node>
               <node concept="1rXfSq" id="5JNiskj$KeS" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskj67Oj" resolve="getShortDescription_Description" />
+                <ref role="37wK5l" node="7OJcYqyl4JA" resolve="getShortDescription_DescriptionX" />
               </node>
-              <node concept="3uibUv" id="5JNiskj$KeT" role="HW$YZ">
-                <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+              <node concept="3uibUv" id="7OJcYqzMkcU" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+                <node concept="3uibUv" id="7OJcYqzMkcV" role="11_B2D">
+                  <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+                </node>
+                <node concept="3uibUv" id="7OJcYqzMkcW" role="11_B2D">
+                  <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+                </node>
               </node>
             </node>
           </node>
@@ -7879,11 +7031,16 @@
                   <node concept="1bVj0M" id="5JNiskjrcbY" role="23t8la">
                     <node concept="3clFbS" id="5JNiskjrcbZ" role="1bW5cS">
                       <node concept="3clFbF" id="5JNiskjrcc0" role="3cqZAp">
-                        <node concept="2YIFZM" id="5JNiskjrcc1" role="3clFbG">
-                          <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.LanguageEntity)" resolve="from" />
+                        <node concept="2YIFZM" id="7OJcYqzQLTz" role="3clFbG">
                           <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-                          <node concept="37vLTw" id="5JNiskjrcc2" role="37wK5m">
-                            <ref role="3cqZAo" node="5JNiskjrcc3" resolve="it" />
+                          <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.LanguageEntity)" resolve="from" />
+                          <node concept="2OqwBi" id="7OJcYqzQLT_" role="37wK5m">
+                            <node concept="37vLTw" id="7OJcYqzQLTA" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5JNiskjrcc3" resolve="it" />
+                            </node>
+                            <node concept="liA8E" id="7OJcYqzQLTB" role="2OqNvi">
+                              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -7965,8 +7122,13 @@
                         <node concept="2YIFZM" id="5JNiskjsbI7" role="3clFbG">
                           <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.Feature)" resolve="from" />
                           <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-                          <node concept="37vLTw" id="5JNiskjsbI8" role="37wK5m">
-                            <ref role="3cqZAo" node="5JNiskjsbI9" resolve="it" />
+                          <node concept="2OqwBi" id="7OJcYqzNkAn" role="37wK5m">
+                            <node concept="37vLTw" id="5JNiskjsbI8" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5JNiskjsbI9" resolve="it" />
+                            </node>
+                            <node concept="liA8E" id="7OJcYqzNpO_" role="2OqNvi">
+                              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -8033,32 +7195,44 @@
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNSIta" role="jymVt" />
-    <node concept="3clFb_" id="34Q84zNSFdw" role="jymVt">
-      <property role="TrG5h" value="listConceptDescriptionProperties" />
-      <node concept="3Tm1VV" id="34Q84zNSFdy" role="1B3o_S" />
-      <node concept="_YKpA" id="34Q84zNSFdz" role="3clF45">
-        <node concept="3uibUv" id="34Q84zNSFd$" role="_ZDj9">
-          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+    <node concept="3clFb_" id="7OJcYqzI5x6" role="jymVt">
+      <property role="TrG5h" value="listConceptDescriptionPropertiesX" />
+      <node concept="3Tm1VV" id="7OJcYqzI5x8" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqzI5x9" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqzI5xa" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <node concept="3uibUv" id="7OJcYqzI5xb" role="11_B2D">
+            <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+          </node>
+          <node concept="3uibUv" id="7OJcYqzI5xc" role="11_B2D">
+            <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          </node>
         </node>
       </node>
-      <node concept="3clFbS" id="34Q84zNSFdA" role="3clF47">
-        <node concept="3clFbF" id="34Q84zNUneT" role="3cqZAp">
-          <node concept="2ShNRf" id="34Q84zNUneR" role="3clFbG">
-            <node concept="Tc6Ow" id="34Q84zNUpry" role="2ShVmc">
-              <node concept="3uibUv" id="34Q84zNUt$f" role="HW$YZ">
-                <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+      <node concept="3clFbS" id="7OJcYqzI5xh" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqzIIat" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqzIIar" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqzILpB" role="2ShVmc">
+              <node concept="1rXfSq" id="7OJcYqzISSx" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqyhHPP" resolve="getConceptDescriptionAnnotation_ConceptAliasX" />
               </node>
-              <node concept="1rXfSq" id="34Q84zNUwG$" role="HW$Y0">
-                <ref role="37wK5l" node="34Q84zNTspf" resolve="getConceptDescriptionAnnotation_ConceptAlias" />
+              <node concept="1rXfSq" id="7OJcYqzJ07G" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqyisuh" resolve="getConceptDescriptionAnnotation_ConceptShortDescriptionX" />
               </node>
-              <node concept="1rXfSq" id="34Q84zNU$2I" role="HW$Y0">
-                <ref role="37wK5l" node="34Q84zNTspo" resolve="getConceptDescriptionAnnotation_ConceptShortDescription" />
+              <node concept="3uibUv" id="7OJcYqzJ5xC" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+                <node concept="3uibUv" id="7OJcYqzJ5xD" role="11_B2D">
+                  <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+                </node>
+                <node concept="3uibUv" id="7OJcYqzJ5xE" role="11_B2D">
+                  <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+                </node>
               </node>
             </node>
           </node>
         </node>
       </node>
-      <node concept="2AHcQZ" id="34Q84zNSFdB" role="2AJF6D">
+      <node concept="2AHcQZ" id="7OJcYqzI5xi" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -8086,28 +7260,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="7weWCFlwuJI" role="jymVt">
-      <property role="TrG5h" value="getAnnotationConcept" />
-      <node concept="3Tm1VV" id="7weWCFlwuJK" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlwuJL" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
-      </node>
-      <node concept="3clFbS" id="7weWCFlwuJN" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqynXem" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqynXen" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqynXeo" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqyiZMB" resolve="getAnnotationConceptX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqynXep" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7weWCFlwuJO" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="7OJcYqyjDll" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyjHUZ" role="jymVt">
       <property role="TrG5h" value="getClassifierConceptX" />
@@ -8129,28 +7281,6 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqyjHV7" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="7weWCFlwuJR" role="jymVt">
-      <property role="TrG5h" value="getClassifierConcept" />
-      <node concept="3Tm1VV" id="7weWCFlwuJT" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlwuJU" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
-      </node>
-      <node concept="3clFbS" id="7weWCFlwuJW" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqynIah" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqynIai" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqynIaj" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqyjHUZ" resolve="getClassifierConceptX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqynIak" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7weWCFlwuJX" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -8178,28 +7308,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="7weWCFlwuK0" role="jymVt">
-      <property role="TrG5h" value="getConceptConcept" />
-      <node concept="3Tm1VV" id="7weWCFlwuK2" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlwuK3" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
-      </node>
-      <node concept="3clFbS" id="7weWCFlwuK5" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqynvKt" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqynvKu" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqynvKv" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqykdbt" resolve="getConceptConceptX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqynvKw" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7weWCFlwuK6" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="7OJcYqyk$0J" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqykHtf" role="jymVt">
       <property role="TrG5h" value="getInterfaceConceptX" />
@@ -8224,67 +7332,65 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="7weWCFlwuK9" role="jymVt">
-      <property role="TrG5h" value="getInterfaceConcept" />
-      <node concept="3Tm1VV" id="7weWCFlwuKb" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlwuKc" role="3clF45">
-        <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
-      </node>
-      <node concept="3clFbS" id="7weWCFlwuKe" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqynb_W" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqynf4J" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqynb_T" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqykHtf" resolve="getInterfaceConceptX" />
-            </node>
-            <node concept="liA8E" id="7OJcYqynkbH" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7weWCFlwuKf" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="7weWCFlvQOd" role="jymVt" />
-    <node concept="3clFb_" id="7weWCFlvMhM" role="jymVt">
-      <property role="TrG5h" value="listReplacementMpsSpecificClassifiers" />
-      <node concept="3Tm1VV" id="7weWCFlvMhO" role="1B3o_S" />
-      <node concept="_YKpA" id="7weWCFlvMhP" role="3clF45">
-        <node concept="3uibUv" id="7weWCFlvMhQ" role="_ZDj9">
-          <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
+    <node concept="3clFb_" id="7OJcYqzJd1s" role="jymVt">
+      <property role="TrG5h" value="listReplacementMpsSpecificClassifiersX" />
+      <node concept="3Tm1VV" id="7OJcYqzJd1u" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqzJd1v" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqzJd1w" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <node concept="3qUE_q" id="7OJcYqzKLSe" role="11_B2D">
+            <node concept="3uibUv" id="7OJcYqzKOwD" role="3qUE_r">
+              <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
+            </node>
+          </node>
+          <node concept="3qUE_q" id="7OJcYqzKfLg" role="11_B2D">
+            <node concept="3uibUv" id="7OJcYqzKiwU" role="3qUE_r">
+              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+            </node>
+          </node>
         </node>
       </node>
-      <node concept="3clFbS" id="7weWCFlvMhS" role="3clF47">
-        <node concept="3clFbF" id="7weWCFlvSqS" role="3cqZAp">
-          <node concept="2ShNRf" id="7weWCFlvSqQ" role="3clFbG">
-            <node concept="Tc6Ow" id="7weWCFlvUWA" role="2ShVmc">
-              <node concept="3uibUv" id="7weWCFlvYZn" role="HW$YZ">
-                <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
+      <node concept="3clFbS" id="7OJcYqzJd1B" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqzJmaO" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqzJmaM" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqzJpGh" role="2ShVmc">
+              <node concept="1rXfSq" id="7OJcYqzJwgX" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqxTIfx" resolve="getNodeX" />
               </node>
-              <node concept="1rXfSq" id="7weWCFlw6kx" role="HW$Y0">
-                <ref role="37wK5l" node="5TNjoy1vujq" resolve="getNode" />
+              <node concept="1rXfSq" id="7OJcYqzJAGU" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqyiZMB" resolve="getAnnotationConceptX" />
               </node>
-              <node concept="1rXfSq" id="7weWCFlwa3U" role="HW$Y0">
-                <ref role="37wK5l" node="7weWCFlwuJI" resolve="getAnnotationConcept" />
+              <node concept="1rXfSq" id="7OJcYqzJGB1" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqyjHUZ" resolve="getClassifierConceptX" />
               </node>
-              <node concept="1rXfSq" id="7weWCFlwqSd" role="HW$Y0">
-                <ref role="37wK5l" node="7weWCFlwuJR" resolve="getClassifierConcept" />
+              <node concept="1rXfSq" id="7OJcYqzJNX_" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqykdbt" resolve="getConceptConceptX" />
               </node>
-              <node concept="1rXfSq" id="5M8g5cSALiW" role="HW$Y0">
-                <ref role="37wK5l" node="7weWCFlwuK0" resolve="getConceptConcept" />
+              <node concept="1rXfSq" id="7OJcYqzJUtB" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqykHtf" resolve="getInterfaceConceptX" />
               </node>
-              <node concept="1rXfSq" id="5M8g5cSAPIi" role="HW$Y0">
-                <ref role="37wK5l" node="7weWCFlwuK9" resolve="getInterfaceConcept" />
+              <node concept="1rXfSq" id="7OJcYqzJZXA" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamedX" />
               </node>
-              <node concept="1rXfSq" id="6Z_tmAeidwg" role="HW$Y0">
-                <ref role="37wK5l" node="5TNjoy1vudm" resolve="getINamed" />
+              <node concept="3uibUv" id="7OJcYqzK6CI" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+                <node concept="3qUE_q" id="7OJcYqzKS81" role="11_B2D">
+                  <node concept="3uibUv" id="7OJcYqzKS82" role="3qUE_r">
+                    <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
+                  </node>
+                </node>
+                <node concept="3qUE_q" id="7OJcYqzKm22" role="11_B2D">
+                  <node concept="3uibUv" id="7OJcYqzKm23" role="3qUE_r">
+                    <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
         </node>
       </node>
-      <node concept="2AHcQZ" id="7weWCFlvMhT" role="2AJF6D">
+      <node concept="2AHcQZ" id="7OJcYqzJd1C" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
@@ -245,6 +245,7 @@
       </concept>
       <concept id="6832197706140896242" name="jetbrains.mps.baseLanguage.javadoc.structure.FieldDocComment" flags="ng" index="z59LJ" />
       <concept id="6832197706140518104" name="jetbrains.mps.baseLanguage.javadoc.structure.DocMethodParameterReference" flags="ng" index="zr_55" />
+      <concept id="6832197706140518107" name="jetbrains.mps.baseLanguage.javadoc.structure.DocTypeParameterReference" flags="ng" index="zr_56" />
       <concept id="6832197706140518103" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseParameterReference" flags="ng" index="zr_5a">
         <reference id="6832197706140518108" name="param" index="zr_51" />
       </concept>
@@ -7671,6 +7672,40 @@
       <property role="TrG5h" value="STAPLE" />
       <node concept="3uibUv" id="7OJcYqxQZL0" role="3ztrMU">
         <ref role="3uigEE" to="y7p:7OJcYqvKf0O" resolve="IKeyedStaple" />
+      </node>
+    </node>
+    <node concept="3UR2Jj" id="alE3w2ldUw" role="lGtFl">
+      <node concept="TZ5HA" id="alE3w2ldo1" role="TZ5H$">
+        <node concept="1dT_AC" id="alE3w2ldo2" role="1dT_Ay">
+          <property role="1dT_AB" value="Staples[1] together representations of the same thing in different representations." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="alE3w2ldq1" role="TZ5H$">
+        <node concept="1dT_AC" id="alE3w2ldq2" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="alE3w2ldMn" role="TZ5H$">
+        <node concept="1dT_AC" id="alE3w2ldMo" role="1dT_Ay">
+          <property role="1dT_AB" value="[1] &quot;Staples&quot; as in a stapler holding together a stack of paper." />
+        </node>
+      </node>
+      <node concept="TUZQ0" id="alE3w2ldUz" role="3nqlJM">
+        <property role="TUZQ4" value="Java LionCore as instances of &lt;tt&gt;io.lionweb.lioncore.java.language&lt;/tt&gt;" />
+        <node concept="zr_56" id="alE3w2ldU_" role="zr_5Q">
+          <ref role="zr_51" node="7OJcYqxQZLr" resolve="JSON" />
+        </node>
+      </node>
+      <node concept="TUZQ0" id="alE3w2ldUA" role="3nqlJM">
+        <property role="TUZQ4" value="Corresponding {@link IKeyedStaple}." />
+        <node concept="zr_56" id="alE3w2ldUC" role="zr_5Q">
+          <ref role="zr_51" node="7OJcYqxQZJU" resolve="STAPLE" />
+        </node>
+      </node>
+      <node concept="VUp57" id="alE3w2lf4x" role="3nqlJM">
+        <node concept="VXe08" id="alE3w2lfjM" role="VUp5m">
+          <ref role="VXe09" to="y7p:7OJcYqvKf0O" resolve="IKeyedStaple" />
+        </node>
       </node>
     </node>
   </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
@@ -267,6 +267,9 @@
       <concept id="8465538089690331492" name="jetbrains.mps.baseLanguage.javadoc.structure.DeprecatedBlockDocTag" flags="ng" index="TZ5HI">
         <child id="2667874559098216723" name="text" index="3HnX3l" />
       </concept>
+      <concept id="2217234381367190443" name="jetbrains.mps.baseLanguage.javadoc.structure.SeeBlockDocTag" flags="ng" index="VUp57">
+        <child id="2217234381367190458" name="reference" index="VUp5m" />
+      </concept>
       <concept id="2217234381367530212" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocReference" flags="ng" index="VXe08">
         <reference id="2217234381367530213" name="classifier" index="VXe09" />
       </concept>
@@ -597,7 +600,7 @@
                     <ref role="3cqZAo" node="5hsSXrmC_NE" resolve="jsonConstants" />
                   </node>
                   <node concept="liA8E" id="5hsSXrmCCfP" role="2OqNvi">
-                    <ref role="37wK5l" node="7OJcYqyaYLW" resolve="getSpecificLanguageX" />
+                    <ref role="37wK5l" node="7OJcYqyaYLW" resolve="getSpecificLanguage" />
                   </node>
                 </node>
                 <node concept="liA8E" id="7OJcYqz_2uH" role="2OqNvi">
@@ -1127,12 +1130,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqy7LqL" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqy8pi6" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqy8pi7" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
         </node>
         <node concept="3uibUv" id="7OJcYqy8pi8" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageStaple" />
         </node>
       </node>
     </node>
@@ -1141,12 +1144,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqy7P4w" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqy8PmV" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqy8PmW" role="11_B2D">
           <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
         </node>
         <node concept="3uibUv" id="7OJcYqy8PmX" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
         </node>
       </node>
     </node>
@@ -1155,12 +1158,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqy7SKm" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqy9iNB" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqy9iNC" role="11_B2D">
           <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
         </node>
         <node concept="3uibUv" id="7OJcYqy9iND" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
         </node>
       </node>
     </node>
@@ -1169,12 +1172,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqy7Wt2" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqy9mWH" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqy9mWI" role="11_B2D">
           <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
         </node>
         <node concept="3uibUv" id="7OJcYqy9mWJ" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
         </node>
       </node>
     </node>
@@ -1183,12 +1186,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqy80a$" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqy9qdT" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqy9qdU" role="11_B2D">
           <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
         </node>
         <node concept="3uibUv" id="7OJcYqy9qdV" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
         </node>
       </node>
     </node>
@@ -1197,12 +1200,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqy83SW" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqy9C$D" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqy9C$E" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Interface" resolve="Interface" />
         </node>
         <node concept="3uibUv" id="7OJcYqy9C$F" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvXZ8V" resolve="InterfaceKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvXZ8V" resolve="InterfaceStaple" />
         </node>
       </node>
     </node>
@@ -1211,12 +1214,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqy87Ca" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqy9K3u" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqy9K3v" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
         </node>
         <node concept="3uibUv" id="7OJcYqy9K3w" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
         </node>
       </node>
     </node>
@@ -1253,7 +1256,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqy7Lr4" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqy7Lr5" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="10QFUN" id="7OJcYqy8A9g" role="37wK5m">
                   <node concept="37vLTw" id="7OJcYqy8A9f" role="10QFUP">
                     <ref role="3cqZAo" node="5TNjoy1vedD" resolve="builtins" />
@@ -1267,14 +1270,14 @@
                     <ref role="3cqZAo" node="7OJcYqxTzQb" resolve="constants" />
                   </node>
                   <node concept="liA8E" id="7OJcYqy7Lr9" role="2OqNvi">
-                    <ref role="37wK5l" to="y7p:7OJcYqwQm1b" resolve="getLioncoreBuiltins" />
+                    <ref role="37wK5l" to="y7p:7OJcYqwQm1b" resolve="getBuiltins" />
                   </node>
                 </node>
                 <node concept="3uibUv" id="7OJcYqy8FMH" role="1pMfVU">
                   <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
                 </node>
                 <node concept="3uibUv" id="7OJcYqy8GQR" role="1pMfVU">
-                  <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+                  <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageStaple" />
                 </node>
               </node>
             </node>
@@ -1290,7 +1293,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqy7P4P" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqy7P4Q" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="2OqwBi" id="7OJcYqy7P4R" role="37wK5m">
                   <node concept="37vLTw" id="7OJcYqy7P4S" role="2Oq$k0">
                     <ref role="3cqZAo" node="5TNjoy1vedD" resolve="builtins" />
@@ -1311,7 +1314,7 @@
                   <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
                 </node>
                 <node concept="3uibUv" id="7OJcYqy8XsK" role="1pMfVU">
-                  <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+                  <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
                 </node>
               </node>
             </node>
@@ -1327,7 +1330,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqy7SKF" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqy7SKG" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="2OqwBi" id="7OJcYqy7SKH" role="37wK5m">
                   <node concept="37vLTw" id="7OJcYqy7SKI" role="2Oq$k0">
                     <ref role="3cqZAo" node="5TNjoy1vedD" resolve="builtins" />
@@ -1348,7 +1351,7 @@
                   <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
                 </node>
                 <node concept="3uibUv" id="7OJcYqy91zo" role="1pMfVU">
-                  <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+                  <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
                 </node>
               </node>
             </node>
@@ -1364,7 +1367,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqy7Wtn" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqy7Wto" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="2OqwBi" id="7OJcYqy7Wtp" role="37wK5m">
                   <node concept="37vLTw" id="7OJcYqy7Wtq" role="2Oq$k0">
                     <ref role="3cqZAo" node="5TNjoy1vedD" resolve="builtins" />
@@ -1385,7 +1388,7 @@
                   <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
                 </node>
                 <node concept="3uibUv" id="7OJcYqy93Ga" role="1pMfVU">
-                  <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+                  <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
                 </node>
               </node>
             </node>
@@ -1401,7 +1404,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqy80aT" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqy80aU" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="2OqwBi" id="7OJcYqy80aV" role="37wK5m">
                   <node concept="37vLTw" id="7OJcYqy80aW" role="2Oq$k0">
                     <ref role="3cqZAo" node="5TNjoy1vedD" resolve="builtins" />
@@ -1422,7 +1425,7 @@
                   <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
                 </node>
                 <node concept="3uibUv" id="7OJcYqy96Ms" role="1pMfVU">
-                  <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+                  <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
                 </node>
               </node>
             </node>
@@ -1438,7 +1441,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqy83Th" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqy83Ti" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="2OqwBi" id="7OJcYqy83Tj" role="37wK5m">
                   <node concept="37vLTw" id="7OJcYqy83Tk" role="2Oq$k0">
                     <ref role="3cqZAo" node="5TNjoy1vedD" resolve="builtins" />
@@ -1459,7 +1462,7 @@
                   <ref role="3uigEE" to="imb3:~Interface" resolve="Interface" />
                 </node>
                 <node concept="3uibUv" id="7OJcYqy9IIi" role="1pMfVU">
-                  <ref role="3uigEE" to="y7p:7OJcYqvXZ8V" resolve="InterfaceKeyedMapping" />
+                  <ref role="3uigEE" to="y7p:7OJcYqvXZ8V" resolve="InterfaceStaple" />
                 </node>
               </node>
             </node>
@@ -1475,7 +1478,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqy87Cv" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqy87Cw" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="2OqwBi" id="7OJcYqy87Cx" role="37wK5m">
                   <node concept="37vLTw" id="7OJcYqy87Cy" role="2Oq$k0">
                     <ref role="3cqZAo" node="5TNjoy1vedD" resolve="builtins" />
@@ -1496,7 +1499,7 @@
                   <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
                 </node>
                 <node concept="3uibUv" id="7OJcYqy9XnL" role="1pMfVU">
-                  <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+                  <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
                 </node>
               </node>
             </node>
@@ -1506,16 +1509,16 @@
     </node>
     <node concept="2tJIrI" id="5TNjoy1vfuc" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTKjk" role="jymVt">
-      <property role="TrG5h" value="listPrimitiveTypesX" />
+      <property role="TrG5h" value="listLcPrimitiveTypes" />
       <node concept="3Tm1VV" id="7OJcYqxTKjm" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqxTKjn" role="3clF45">
         <node concept="3uibUv" id="7OJcYqxTKjo" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
           <node concept="3uibUv" id="7OJcYqxTKjp" role="11_B2D">
             <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
           </node>
           <node concept="3uibUv" id="7OJcYqxTKjq" role="11_B2D">
-            <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+            <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
           </node>
         </node>
       </node>
@@ -1524,25 +1527,25 @@
           <node concept="2ShNRf" id="7OJcYqxUBUM" role="3clFbG">
             <node concept="Tc6Ow" id="7OJcYqxUFnC" role="2ShVmc">
               <node concept="3uibUv" id="7OJcYqxUJEz" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
                 <node concept="3uibUv" id="7OJcYqxUJE$" role="11_B2D">
                   <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
                 </node>
                 <node concept="3uibUv" id="7OJcYqxUJE_" role="11_B2D">
-                  <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+                  <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
                 </node>
               </node>
               <node concept="1rXfSq" id="7OJcYqxUPiH" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqxTCCR" resolve="getBooleanX" />
+                <ref role="37wK5l" node="7OJcYqxTCCR" resolve="getBoolean" />
               </node>
               <node concept="1rXfSq" id="7OJcYqxUTfm" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqxTAF2" resolve="getIntegerX" />
+                <ref role="37wK5l" node="7OJcYqxTAF2" resolve="getInteger" />
               </node>
               <node concept="1rXfSq" id="7OJcYqxUVx$" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getStringX" />
+                <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getString" />
               </node>
               <node concept="1rXfSq" id="7OJcYqxUZyX" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqxTERH" resolve="getJsonX" />
+                <ref role="37wK5l" node="7OJcYqxTERH" resolve="getJson" />
               </node>
             </node>
           </node>
@@ -1554,11 +1557,11 @@
     </node>
     <node concept="2tJIrI" id="39$JcGGbiRJ" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTMvG" role="jymVt">
-      <property role="TrG5h" value="listClassifiersX" />
+      <property role="TrG5h" value="listLcClassifiers" />
       <node concept="3Tm1VV" id="7OJcYqxTMvI" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqxTMvJ" role="3clF45">
         <node concept="3uibUv" id="7OJcYqxTMvK" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
           <node concept="3qUE_q" id="7OJcYqxVE1n" role="11_B2D">
             <node concept="3uibUv" id="7OJcYqxVHHa" role="3qUE_r">
               <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
@@ -1566,7 +1569,7 @@
           </node>
           <node concept="3qUE_q" id="7OJcYqxVLqQ" role="11_B2D">
             <node concept="3uibUv" id="7OJcYqxVP8t" role="3qUE_r">
-              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierStaple" />
             </node>
           </node>
         </node>
@@ -1576,7 +1579,7 @@
           <node concept="2ShNRf" id="7OJcYqxV0j9" role="3clFbG">
             <node concept="Tc6Ow" id="7OJcYqxV3Pt" role="2ShVmc">
               <node concept="3uibUv" id="7OJcYqxV8Fc" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
                 <node concept="3qUE_q" id="7OJcYqxVQg6" role="11_B2D">
                   <node concept="3uibUv" id="7OJcYqxVQg7" role="3qUE_r">
                     <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
@@ -1584,15 +1587,15 @@
                 </node>
                 <node concept="3qUE_q" id="7OJcYqxVQg8" role="11_B2D">
                   <node concept="3uibUv" id="7OJcYqxVQg9" role="3qUE_r">
-                    <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+                    <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierStaple" />
                   </node>
                 </node>
               </node>
               <node concept="1rXfSq" id="7OJcYqxVmbT" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqxTIfx" resolve="getNodeX" />
+                <ref role="37wK5l" node="7OJcYqxTIfx" resolve="getNode" />
               </node>
               <node concept="1rXfSq" id="7OJcYqxVuG3" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamedX" />
+                <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamed" />
               </node>
             </node>
           </node>
@@ -1604,15 +1607,15 @@
     </node>
     <node concept="2tJIrI" id="5TNjoy1vtg4" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxT$o7" role="jymVt">
-      <property role="TrG5h" value="getBuiltinsX" />
+      <property role="TrG5h" value="getBuiltins" />
       <node concept="3Tm1VV" id="7OJcYqxT$o9" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqxT$oa" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqxT$ob" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
         </node>
         <node concept="3uibUv" id="7OJcYqxT$oc" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqxT$od" role="3clF47">
@@ -1631,15 +1634,15 @@
     </node>
     <node concept="2tJIrI" id="4Yo3buYJQ$9" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxT_$X" role="jymVt">
-      <property role="TrG5h" value="getStringX" />
+      <property role="TrG5h" value="getString" />
       <node concept="3Tm1VV" id="7OJcYqxT_$Z" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqxT__0" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqxT__1" role="11_B2D">
           <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
         </node>
         <node concept="3uibUv" id="7OJcYqxT__2" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqxT__3" role="3clF47">
@@ -1658,15 +1661,15 @@
     </node>
     <node concept="2tJIrI" id="4Yo3buYJT1B" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTAF2" role="jymVt">
-      <property role="TrG5h" value="getIntegerX" />
+      <property role="TrG5h" value="getInteger" />
       <node concept="3Tm1VV" id="7OJcYqxTAF4" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqxTAF5" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqxTAF6" role="11_B2D">
           <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
         </node>
         <node concept="3uibUv" id="7OJcYqxTAF7" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqxTAF8" role="3clF47">
@@ -1685,15 +1688,15 @@
     </node>
     <node concept="2tJIrI" id="4Yo3buYJTGT" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTCCR" role="jymVt">
-      <property role="TrG5h" value="getBooleanX" />
+      <property role="TrG5h" value="getBoolean" />
       <node concept="3Tm1VV" id="7OJcYqxTCCT" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqxTCCU" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqxTCCV" role="11_B2D">
           <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
         </node>
         <node concept="3uibUv" id="7OJcYqxTCCW" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqxTCCX" role="3clF47">
@@ -1712,15 +1715,15 @@
     </node>
     <node concept="2tJIrI" id="4Yo3buYJUog" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTERH" role="jymVt">
-      <property role="TrG5h" value="getJsonX" />
+      <property role="TrG5h" value="getJson" />
       <node concept="3Tm1VV" id="7OJcYqxTERJ" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqxTERK" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqxTERL" role="11_B2D">
           <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
         </node>
         <node concept="3uibUv" id="7OJcYqxTERM" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqxTERN" role="3clF47">
@@ -1739,15 +1742,15 @@
     </node>
     <node concept="2tJIrI" id="4Yo3buYJV3G" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTGtE" role="jymVt">
-      <property role="TrG5h" value="getINamedX" />
+      <property role="TrG5h" value="getINamed" />
       <node concept="3Tm1VV" id="7OJcYqxTGtG" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqxTGtH" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqxTGtI" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Interface" resolve="Interface" />
         </node>
         <node concept="3uibUv" id="7OJcYqxTGtJ" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvXZ8V" resolve="InterfaceKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvXZ8V" resolve="InterfaceStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqxTGtK" role="3clF47">
@@ -1766,15 +1769,15 @@
     </node>
     <node concept="2tJIrI" id="4Yo3buYJVJd" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTIfx" role="jymVt">
-      <property role="TrG5h" value="getNodeX" />
+      <property role="TrG5h" value="getNode" />
       <node concept="3Tm1VV" id="7OJcYqxTIfz" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqxTIf$" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqxTIf_" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
         </node>
         <node concept="3uibUv" id="7OJcYqxTIfA" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqxTIfB" role="3clF47">
@@ -5172,29 +5175,36 @@
     <property role="3GE5qa" value="jsonConstants" />
     <property role="TrG5h" value="IJsonConstants_2023_1" />
     <node concept="3clFb_" id="7OJcYqxTsMO" role="jymVt">
-      <property role="TrG5h" value="listPrimitiveTypesX" />
+      <property role="TrG5h" value="listLcPrimitiveTypes" />
       <node concept="3clFbS" id="7OJcYqxTsMP" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqxTsMQ" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqxTv7t" role="3clF45">
         <node concept="3uibUv" id="7OJcYqxTsMR" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
           <node concept="3uibUv" id="7OJcYqxTwtc" role="11_B2D">
             <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
           </node>
           <node concept="3uibUv" id="7OJcYqxTwtd" role="11_B2D">
-            <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+            <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
+          </node>
+        </node>
+      </node>
+      <node concept="P$JXv" id="7OJcYq$tM1x" role="lGtFl">
+        <node concept="VUp57" id="7OJcYq$tM36" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$tM4$" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
           </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqxTsMU" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTwQ8" role="jymVt">
-      <property role="TrG5h" value="listClassifiersX" />
+      <property role="TrG5h" value="listLcClassifiers" />
       <node concept="3clFbS" id="7OJcYqxTwQ9" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqxTwQa" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqxTwQb" role="3clF45">
         <node concept="3uibUv" id="7OJcYqxTwQc" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
           <node concept="3qUE_q" id="7OJcYqxVZMX" role="11_B2D">
             <node concept="3uibUv" id="7OJcYqxVZMY" role="3qUE_r">
               <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
@@ -5202,114 +5212,170 @@
           </node>
           <node concept="3qUE_q" id="7OJcYqxVZMZ" role="11_B2D">
             <node concept="3uibUv" id="7OJcYqxVZN0" role="3qUE_r">
-              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierStaple" />
             </node>
+          </node>
+        </node>
+      </node>
+      <node concept="P$JXv" id="7OJcYq$tMiB" role="lGtFl">
+        <node concept="VUp57" id="7OJcYq$tMkc" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$tMlE" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwYDTB" resolve="listLcClassifiers" />
           </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqxTwLu" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxR6CI" role="jymVt">
-      <property role="TrG5h" value="getBuiltinsX" />
+      <property role="TrG5h" value="getBuiltins" />
       <node concept="3clFbS" id="7OJcYqxR6CJ" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqxR6CK" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqxR6CL" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqxR6CM" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
         </node>
         <node concept="3uibUv" id="7OJcYqxR6CN" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="7OJcYq$tLjU" role="lGtFl">
+        <node concept="VUp57" id="7OJcYq$tLlv" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$tLn8" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwQm1b" resolve="getBuiltins" />
+          </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqxR6_Q" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxR63A" role="jymVt">
-      <property role="TrG5h" value="getStringX" />
+      <property role="TrG5h" value="getString" />
       <node concept="3clFbS" id="7OJcYqxR63D" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqxR63E" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqxR5F2" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqxR5HM" role="11_B2D">
           <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
         </node>
         <node concept="3uibUv" id="7OJcYqxR5NE" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="7OJcYq$tLq9" role="lGtFl">
+        <node concept="VUp57" id="7OJcYq$tLrI" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$tLtc" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwQm1k" resolve="getString" />
+          </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqz_0mW" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTgBk" role="jymVt">
-      <property role="TrG5h" value="getIntegerX" />
+      <property role="TrG5h" value="getInteger" />
       <node concept="3clFbS" id="7OJcYqxTgBl" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqxTgBm" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqxTgBn" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqxThfp" role="11_B2D">
           <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
         </node>
         <node concept="3uibUv" id="7OJcYqxThfq" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="7OJcYq$tLwl" role="lGtFl">
+        <node concept="VUp57" id="7OJcYq$tLxU" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$tLzo" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwQm1A" resolve="getInteger" />
+          </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqxTg$c" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxThz6" role="jymVt">
-      <property role="TrG5h" value="getBooleanX" />
+      <property role="TrG5h" value="getBoolean" />
       <node concept="3clFbS" id="7OJcYqxThz7" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqxThz8" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqxThz9" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqxThza" role="11_B2D">
           <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
         </node>
         <node concept="3uibUv" id="7OJcYqxThzb" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="7OJcYq$tLAp" role="lGtFl">
+        <node concept="VUp57" id="7OJcYq$tLBY" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$tLDs" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwQm1t" resolve="getBoolean" />
+          </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqxThvI" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTinV" role="jymVt">
-      <property role="TrG5h" value="getJsonX" />
+      <property role="TrG5h" value="getJson" />
       <node concept="3clFbS" id="7OJcYqxTinW" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqxTinX" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqxTinY" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqxTinZ" role="11_B2D">
           <ref role="3uigEE" to="imb3:~PrimitiveType" resolve="PrimitiveType" />
         </node>
         <node concept="3uibUv" id="7OJcYqxTio0" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="7OJcYq$tLGt" role="lGtFl">
+        <node concept="VUp57" id="7OJcYq$tLI2" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$tLJw" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwQm1J" resolve="getJson" />
+          </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqxTimg" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTjiV" role="jymVt">
-      <property role="TrG5h" value="getINamedX" />
+      <property role="TrG5h" value="getINamed" />
       <node concept="3clFbS" id="7OJcYqxTjiW" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqxTjiX" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqxTjiY" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqxTjiZ" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Interface" resolve="Interface" />
         </node>
         <node concept="3uibUv" id="7OJcYqxTjj0" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvXZ8V" resolve="InterfaceKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvXZ8V" resolve="InterfaceStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="7OJcYq$tLMx" role="lGtFl">
+        <node concept="VUp57" id="7OJcYq$tLO6" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$tLP$" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwQm2j" resolve="getINamed" />
+          </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqxTjh9" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxTras" role="jymVt">
-      <property role="TrG5h" value="getNodeX" />
+      <property role="TrG5h" value="getNode" />
       <node concept="3clFbS" id="7OJcYqxTrat" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqxTrau" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqxTrav" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqxTraw" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
         </node>
         <node concept="3uibUv" id="7OJcYqxTrax" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="7OJcYq$tLSH" role="lGtFl">
+        <node concept="VUp57" id="7OJcYq$tLVL" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$tLXf" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwQm1S" resolve="getNode" />
+          </node>
         </node>
       </node>
     </node>
@@ -5324,76 +5390,97 @@
     <property role="3GE5qa" value="jsonConstants" />
     <property role="TrG5h" value="IJsonConstants" />
     <node concept="3clFb_" id="7OJcYqyaYLW" role="jymVt">
-      <property role="TrG5h" value="getSpecificLanguageX" />
+      <property role="TrG5h" value="getSpecificLanguage" />
       <node concept="3clFbS" id="7OJcYqyaYLX" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqyaYLY" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyaYLZ" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqyaYM0" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
         </node>
         <node concept="3uibUv" id="7OJcYqyaYM1" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="7OJcYq$tLar" role="lGtFl">
+        <node concept="VUp57" id="7OJcYq$tLdp" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$tRrO" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwUzr1" resolve="getSpecificLanguage" />
+          </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskj6wPP" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyb0Gn" role="jymVt">
-      <property role="TrG5h" value="getVirtualPackageX" />
+      <property role="TrG5h" value="getVirtualPackage" />
       <node concept="3clFbS" id="7OJcYqyb0Go" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqyb0Gp" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyb0Gq" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqyb0Gr" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
         </node>
         <node concept="3uibUv" id="7OJcYqyb0Gs" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="7OJcYq$tRxD" role="lGtFl">
+        <node concept="VUp57" id="7OJcYq$tR$B" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$tRBu" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwQyzV" resolve="getVirtualPackage" />
+          </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqyb4hc" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyb2JF" role="jymVt">
-      <property role="TrG5h" value="getVirtualPackage_NameX" />
+      <property role="TrG5h" value="getVirtualPackage_Name" />
       <node concept="3clFbS" id="7OJcYqyb2JG" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqyb2JH" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyb2JI" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqyb2JJ" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
         </node>
         <node concept="3uibUv" id="7OJcYqyb2JK" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqyb2Cw" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyb4U4" role="jymVt">
-      <property role="TrG5h" value="getShortDescriptionX" />
+      <property role="TrG5h" value="getShortDescription" />
       <node concept="3clFbS" id="7OJcYqyb4U5" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqyb4U6" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyb4U7" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqyb4U8" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
         </node>
         <node concept="3uibUv" id="7OJcYqyb4U9" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="7OJcYq$tRL$" role="lGtFl">
+        <node concept="VUp57" id="7OJcYq$tROy" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$tRRp" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwQy$4" resolve="getShortDescription" />
+          </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqyb4PP" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyb6S2" role="jymVt">
-      <property role="TrG5h" value="getShortDescription_DescriptionX" />
+      <property role="TrG5h" value="getShortDescription_Description" />
       <node concept="3clFbS" id="7OJcYqyb6S3" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqyb6S4" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyb6S5" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqyb6S6" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
         </node>
         <node concept="3uibUv" id="7OJcYqyb6S7" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
         </node>
       </node>
     </node>
@@ -5427,6 +5514,11 @@
         <node concept="x79VA" id="5JNiskiswU$" role="3nqlJM">
           <property role="x79VB" value="`true` if `element` needs special treatment, `false` otherwise." />
         </node>
+        <node concept="VUp57" id="7OJcYq$tS01" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$tS2W" role="VUp5m">
+            <ref role="VXe0S" to="y7p:5JNiski3k1Z" resolve="isMpsInternalConcept" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3k2c" role="jymVt" />
@@ -5459,21 +5551,26 @@
         <node concept="x79VA" id="5JNiski3k2p" role="3nqlJM">
           <property role="x79VB" value="`true` if `element` needs special treatment, `false` otherwise." />
         </node>
+        <node concept="VUp57" id="7OJcYq$u2ga" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$u2j5" role="VUp5m">
+            <ref role="VXe0S" to="y7p:5JNiski3k2d" resolve="isMpsInternalFeature" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskj5YQq" role="jymVt" />
     <node concept="3clFb_" id="5JNiskjpjPN" role="jymVt">
-      <property role="TrG5h" value="listSpecificAnnotations" />
+      <property role="TrG5h" value="listMpsM1Annotations" />
       <node concept="3clFbS" id="5JNiskjpjPQ" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiskjpjPR" role="1B3o_S" />
       <node concept="_YKpA" id="5JNiskjpjNC" role="3clF45">
         <node concept="3uibUv" id="7OJcYqzLjhJ" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
           <node concept="3uibUv" id="7OJcYqzLjhK" role="11_B2D">
             <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
           </node>
           <node concept="3uibUv" id="7OJcYqzLjhL" role="11_B2D">
-            <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+            <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
           </node>
         </node>
       </node>
@@ -5483,20 +5580,25 @@
             <property role="1dT_AB" value="All M1 JSON annotations that are converted from MPS node properties." />
           </node>
         </node>
+        <node concept="VUp57" id="7OJcYq$u2I9" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$u2KZ" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqxreEB" resolve="listMpsM1AnnotationProperties" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskjpjYQ" role="jymVt">
-      <property role="TrG5h" value="listSpecificAnnotationMembers" />
+      <property role="TrG5h" value="listMpsM1AnnotationPropertyMembers" />
       <node concept="3clFbS" id="5JNiskjpjYT" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiskjpjYU" role="1B3o_S" />
       <node concept="_YKpA" id="5JNiskjpjW$" role="3clF45">
         <node concept="3uibUv" id="7OJcYqzLld7" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
           <node concept="3uibUv" id="7OJcYqzLld8" role="11_B2D">
             <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
           </node>
           <node concept="3uibUv" id="7OJcYqzLld9" role="11_B2D">
-            <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+            <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
           </node>
         </node>
       </node>
@@ -5504,6 +5606,16 @@
         <node concept="TZ5HA" id="5M8g5cS_$4v" role="TZ5H$">
           <node concept="1dT_AC" id="5M8g5cS_$4w" role="1dT_Ay">
             <property role="1dT_AB" value="All M1 JSON annotation properties that are converted from MPS node properties." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYq$u6GN" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYq$u6GO" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="VUp57" id="7OJcYq$u6JF" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$u6Mx" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqxreEB" resolve="listMpsM1AnnotationProperties" />
           </node>
         </node>
       </node>
@@ -5529,7 +5641,7 @@
             <node concept="92FcH" id="5M8g5cS_Bsl" role="qph3F">
               <node concept="TZ5HA" id="5M8g5cS_Bsn" role="2XjZqd" />
               <node concept="VXe0Z" id="5M8g5cS_BsA" role="92FcQ">
-                <ref role="VXe0S" node="5JNiskjpjPN" resolve="listSpecificAnnotations" />
+                <ref role="VXe0S" node="5JNiskjpjPN" resolve="listMpsM1Annotations" />
               </node>
             </node>
           </node>
@@ -5540,7 +5652,7 @@
             <node concept="92FcH" id="5M8g5cS_BtJ" role="qph3F">
               <node concept="TZ5HA" id="5M8g5cS_BtL" role="2XjZqd" />
               <node concept="VXe0Z" id="5M8g5cS_Bu0" role="92FcQ">
-                <ref role="VXe0S" node="5JNiskjpjYQ" resolve="listSpecificAnnotationMembers" />
+                <ref role="VXe0S" node="5JNiskjpjYQ" resolve="listMpsM1AnnotationPropertyMembers" />
               </node>
             </node>
           </node>
@@ -5563,70 +5675,77 @@
     </node>
     <node concept="2tJIrI" id="34Q84zN_wDu" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyb96D" role="jymVt">
-      <property role="TrG5h" value="getConceptDescriptionAnnotationX" />
+      <property role="TrG5h" value="getConceptDescriptionAnnotation" />
       <node concept="3clFbS" id="7OJcYqyb96E" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqyb96F" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyb96G" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqyb96H" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
         </node>
         <node concept="3uibUv" id="7OJcYqyb96I" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
-        </node>
-      </node>
-      <node concept="P$JXv" id="7OJcYqzAThC" role="lGtFl">
-        <node concept="TZ5HA" id="7OJcYqzAThD" role="TZ5H$">
-          <node concept="1dT_AC" id="7OJcYqzAThE" role="1dT_Ay">
-            <property role="1dT_AB" value="All M2 JSON annotations that are converted from MPS concept properties." />
-          </node>
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqyb8YG" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqybbS1" role="jymVt">
-      <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptAliasX" />
+      <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptAlias" />
       <node concept="3clFbS" id="7OJcYqybbS2" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqybbS3" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqybbS4" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqybbS5" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
         </node>
         <node concept="3uibUv" id="7OJcYqybbS6" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="7OJcYq$u726" role="lGtFl">
+        <node concept="VUp57" id="7OJcYq$u754" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$u77V" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwQy$L" resolve="getConceptAlias" />
+          </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqybbNr" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqybeup" role="jymVt">
-      <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptShortDescriptionX" />
+      <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptShortDescription" />
       <node concept="3clFbS" id="7OJcYqybeuq" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqybeur" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqybeus" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqybeut" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
         </node>
         <node concept="3uibUv" id="7OJcYqybeuu" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="7OJcYq$u7dK" role="lGtFl">
+        <node concept="VUp57" id="7OJcYq$u7gI" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$u7j_" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwQy$U" resolve="getConceptShortDescription" />
+          </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqybelU" role="jymVt" />
     <node concept="2tJIrI" id="7OJcYqzAUGl" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqzAV4V" role="jymVt">
-      <property role="TrG5h" value="listConceptDescriptionPropertiesX" />
+      <property role="TrG5h" value="listMpsM2AnnotationProperties" />
       <node concept="3clFbS" id="7OJcYqzAV4Y" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqzAV4Z" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqzAUWE" role="3clF45">
         <node concept="3uibUv" id="7OJcYqzAVoU" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
           <node concept="3uibUv" id="7OJcYqzAVoV" role="11_B2D">
             <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
           </node>
           <node concept="3uibUv" id="7OJcYqzAVoW" role="11_B2D">
-            <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+            <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
           </node>
         </node>
       </node>
@@ -5636,76 +5755,81 @@
             <property role="1dT_AB" value="All M2 JSON annotation properties that are converted from MPS concept properties." />
           </node>
         </node>
+        <node concept="VUp57" id="7OJcYq$u7se" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$u7v4" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqxrfm4" resolve="listMpsM2AnnotationProperties" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7weWCFlvJ3J" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqybgVi" role="jymVt">
-      <property role="TrG5h" value="getAnnotationConceptX" />
+      <property role="TrG5h" value="getAnnotationConcept" />
       <node concept="3clFbS" id="7OJcYqybgVj" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqybgVk" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqybgVl" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqybgVm" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
         </node>
         <node concept="3uibUv" id="7OJcYqybgVn" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqybjHa" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqybjR1" role="jymVt">
-      <property role="TrG5h" value="getClassifierConceptX" />
+      <property role="TrG5h" value="getClassifierConcept" />
       <node concept="3clFbS" id="7OJcYqybjR2" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqybjR3" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqybjR4" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqybjR5" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
         </node>
         <node concept="3uibUv" id="7OJcYqybjR6" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqybjM5" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqybmuB" role="jymVt">
-      <property role="TrG5h" value="getConceptConceptX" />
+      <property role="TrG5h" value="getConceptConcept" />
       <node concept="3clFbS" id="7OJcYqybmuC" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqybmuD" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqybmuE" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqybmuF" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
         </node>
         <node concept="3uibUv" id="7OJcYqybmuG" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqybmpz" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqybpgf" role="jymVt">
-      <property role="TrG5h" value="getInterfaceConceptX" />
+      <property role="TrG5h" value="getInterfaceConcept" />
       <node concept="3clFbS" id="7OJcYqybpgg" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqybpgh" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqybpgi" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqybpgj" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
         </node>
         <node concept="3uibUv" id="7OJcYqybpgk" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqybpb3" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyVkp8" role="jymVt">
-      <property role="TrG5h" value="listReplacementMpsSpecificClassifiersX" />
+      <property role="TrG5h" value="listMpsInternalClassifiers" />
       <node concept="3clFbS" id="7OJcYqyVkp9" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqyVkpa" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqyVkpb" role="3clF45">
         <node concept="3uibUv" id="7OJcYqzKD6v" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
           <node concept="3qUE_q" id="7OJcYqzKVIa" role="11_B2D">
             <node concept="3uibUv" id="7OJcYqzKVIb" role="3qUE_r">
               <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
@@ -5713,7 +5837,7 @@
           </node>
           <node concept="3qUE_q" id="7OJcYqzKD6x" role="11_B2D">
             <node concept="3uibUv" id="7OJcYqzKD6y" role="3qUE_r">
-              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierStaple" />
             </node>
           </node>
         </node>
@@ -5722,6 +5846,11 @@
         <node concept="TZ5HA" id="7OJcYqyVkpe" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqyVkpf" role="1dT_Ay">
             <property role="1dT_AB" value="All JSON classifiers that need special treatment" />
+          </node>
+        </node>
+        <node concept="VUp57" id="7OJcYq$u7Hx" role="3nqlJM">
+          <node concept="VXe0Z" id="7OJcYq$u9KL" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqx1HDk" resolve="listMpsInternalClassifiers" />
           </node>
         </node>
       </node>
@@ -5742,12 +5871,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqyctMr" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyctMs" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
         <node concept="3uibUv" id="7OJcYqyctMt" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
         </node>
         <node concept="3uibUv" id="7OJcYqyctMu" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageStaple" />
         </node>
       </node>
     </node>
@@ -5756,12 +5885,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqyd5wx" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyd5wy" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
         <node concept="3uibUv" id="7OJcYqygH8i" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
         </node>
         <node concept="3uibUv" id="7OJcYqygH8j" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
         </node>
       </node>
     </node>
@@ -5770,12 +5899,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqydvJV" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqydvJW" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
         <node concept="3uibUv" id="7OJcYqyh4JR" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
         </node>
         <node concept="3uibUv" id="7OJcYqyh4JS" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
         </node>
       </node>
     </node>
@@ -5784,12 +5913,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqydNSS" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqydNST" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
         <node concept="3uibUv" id="7OJcYqyjm$8" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
         </node>
         <node concept="3uibUv" id="7OJcYqyjm$9" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
         </node>
       </node>
     </node>
@@ -5798,12 +5927,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqyeaqX" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyeaqY" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
         <node concept="3uibUv" id="7OJcYqyjsr2" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
         </node>
         <node concept="3uibUv" id="7OJcYqyjsr3" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
         </node>
       </node>
     </node>
@@ -5812,12 +5941,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqyexdl" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyexdm" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
         <node concept="3uibUv" id="7OJcYqyjub8" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
         </node>
         <node concept="3uibUv" id="7OJcYqyjub9" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
         </node>
       </node>
     </node>
@@ -5826,12 +5955,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqyeRGW" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyeRGX" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
         <node concept="3uibUv" id="7OJcYqyjzkQ" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
         </node>
         <node concept="3uibUv" id="7OJcYqyjzkR" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
         </node>
       </node>
     </node>
@@ -5840,12 +5969,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqyfkgJ" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyfkgK" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
         <node concept="3uibUv" id="7OJcYqyhA1D" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
         </node>
         <node concept="3uibUv" id="7OJcYqyhA1E" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
         </node>
       </node>
     </node>
@@ -5854,12 +5983,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqyfGaP" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyfGaQ" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
         <node concept="3uibUv" id="7OJcYqyi6YV" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
         </node>
         <node concept="3uibUv" id="7OJcYqyi6YW" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
         </node>
       </node>
     </node>
@@ -5868,12 +5997,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqygecq" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqygecr" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
         <node concept="3uibUv" id="7OJcYqyiRxW" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
         </node>
         <node concept="3uibUv" id="7OJcYqyiRxX" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
         </node>
       </node>
     </node>
@@ -5882,12 +6011,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqylZ6m" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqylZ6n" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
         <node concept="3uibUv" id="7OJcYqymltJ" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
         </node>
         <node concept="3uibUv" id="7OJcYqymltK" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
         </node>
       </node>
     </node>
@@ -5896,12 +6025,12 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqymLcz" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqymLc$" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
         <node concept="3uibUv" id="7OJcYqyn2$k" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
         </node>
         <node concept="3uibUv" id="7OJcYqyn2$l" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
         </node>
       </node>
     </node>
@@ -5938,7 +6067,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqydNTb" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqydNTc" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="2OqwBi" id="7weWCFlxmzL" role="37wK5m">
                   <node concept="37vLTw" id="7weWCFlxmke" role="2Oq$k0">
                     <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
@@ -5969,7 +6098,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqyearg" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqyearh" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="2OqwBi" id="7weWCFlxsjJ" role="37wK5m">
                   <node concept="37vLTw" id="7weWCFlxs3F" role="2Oq$k0">
                     <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
@@ -6000,7 +6129,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqyexdC" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqyexdD" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="2OqwBi" id="7weWCFlxyXS" role="37wK5m">
                   <node concept="37vLTw" id="7weWCFlxyHj" role="2Oq$k0">
                     <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
@@ -6031,7 +6160,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqyeRHf" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqyeRHg" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="2OqwBi" id="7weWCFlxDsZ" role="37wK5m">
                   <node concept="37vLTw" id="7weWCFlxDbT" role="2Oq$k0">
                     <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
@@ -6089,12 +6218,12 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqyctMM" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqyctMN" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="3uibUv" id="7OJcYqyctMO" role="1pMfVU">
                   <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
                 </node>
                 <node concept="3uibUv" id="7OJcYqyctMP" role="1pMfVU">
-                  <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+                  <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageStaple" />
                 </node>
                 <node concept="37vLTw" id="7OJcYqyctMQ" role="37wK5m">
                   <ref role="3cqZAo" node="7OJcYqypXxl" resolve="specificLanguage" />
@@ -6146,7 +6275,7 @@
               <ref role="37wK5l" to="imb3:~Annotation.addImplementedInterface(io.lionweb.lioncore.java.language.Interface)" resolve="addImplementedInterface" />
               <node concept="2OqwBi" id="7OJcYqzFMTY" role="37wK5m">
                 <node concept="1rXfSq" id="5JNiskj6PIG" role="2Oq$k0">
-                  <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamedX" />
+                  <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamed" />
                 </node>
                 <node concept="liA8E" id="7OJcYqzFPqR" role="2OqNvi">
                   <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
@@ -6166,7 +6295,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqyd5wO" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqyd5wP" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="37vLTw" id="7OJcYqyd5wQ" role="37wK5m">
                   <ref role="3cqZAo" node="7OJcYqyqdur" resolve="virtualPackage" />
                 </node>
@@ -6192,7 +6321,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqylZ6J" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqylZ6K" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="2OqwBi" id="7OJcYqylZ6L" role="37wK5m">
                   <node concept="2OqwBi" id="7OJcYqylZ6M" role="2Oq$k0">
                     <node concept="2OqwBi" id="7OJcYqylZ6N" role="2Oq$k0">
@@ -6201,7 +6330,7 @@
                       </node>
                       <node concept="2OqwBi" id="7OJcYqzFRFN" role="2Oq$k0">
                         <node concept="1rXfSq" id="7OJcYqzFRFO" role="2Oq$k0">
-                          <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamedX" />
+                          <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamed" />
                         </node>
                         <node concept="liA8E" id="7OJcYqzFRFP" role="2OqNvi">
                           <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
@@ -6271,7 +6400,7 @@
                     </node>
                     <node concept="2OqwBi" id="7OJcYqzFVRb" role="37wK5m">
                       <node concept="1rXfSq" id="5JNiskj6Xd0" role="2Oq$k0">
-                        <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getStringX" />
+                        <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getString" />
                       </node>
                       <node concept="liA8E" id="7OJcYqzFXGf" role="2OqNvi">
                         <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
@@ -6309,7 +6438,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqydvKe" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqydvKf" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="37vLTw" id="7OJcYqydvKg" role="37wK5m">
                   <ref role="3cqZAo" node="7OJcYqyqtIN" resolve="shortDescription" />
                 </node>
@@ -6335,13 +6464,13 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqymLcW" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqymLcX" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="2OqwBi" id="7OJcYqymLcY" role="37wK5m">
                   <node concept="2OqwBi" id="7OJcYqymLcZ" role="2Oq$k0">
                     <node concept="2OqwBi" id="7OJcYqymLd0" role="2Oq$k0">
                       <node concept="2OqwBi" id="7OJcYqzNJkr" role="2Oq$k0">
                         <node concept="1rXfSq" id="7OJcYqymLd1" role="2Oq$k0">
-                          <ref role="37wK5l" node="7OJcYqygOBN" resolve="getShortDescriptionX" />
+                          <ref role="37wK5l" node="7OJcYqygOBN" resolve="getShortDescription" />
                         </node>
                         <node concept="liA8E" id="7OJcYqzNL_v" role="2OqNvi">
                           <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
@@ -6414,7 +6543,7 @@
                   </node>
                   <node concept="2OqwBi" id="7OJcYqzGdXf" role="37wK5m">
                     <node concept="1rXfSq" id="7OJcYqyr1o7" role="2Oq$k0">
-                      <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getStringX" />
+                      <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getString" />
                     </node>
                     <node concept="liA8E" id="7OJcYqzGgMy" role="2OqNvi">
                       <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
@@ -6463,7 +6592,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqyfGb8" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqyfGb9" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="37vLTw" id="7OJcYqyfGba" role="37wK5m">
                   <ref role="3cqZAo" node="7OJcYqyr1o2" resolve="conceptAlias" />
                 </node>
@@ -6496,7 +6625,7 @@
                   </node>
                   <node concept="2OqwBi" id="7OJcYqzGkCa" role="37wK5m">
                     <node concept="1rXfSq" id="7OJcYqyrmfE" role="2Oq$k0">
-                      <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getStringX" />
+                      <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getString" />
                     </node>
                     <node concept="liA8E" id="7OJcYqzGlZH" role="2OqNvi">
                       <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
@@ -6545,7 +6674,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqygecH" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqygecI" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="37vLTw" id="7OJcYqygecJ" role="37wK5m">
                   <ref role="3cqZAo" node="7OJcYqyrmf_" resolve="conceptShortDescription" />
                 </node>
@@ -6572,7 +6701,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqyfkh2" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqyfkh3" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonKeyedMapper" />
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
                 <node concept="37vLTw" id="7OJcYqyfkh4" role="37wK5m">
                   <ref role="3cqZAo" node="7OJcYqyqMhr" resolve="conceptDescription" />
                 </node>
@@ -6610,15 +6739,15 @@
     </node>
     <node concept="2tJIrI" id="5JNiskj6tqO" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqybDcU" role="jymVt">
-      <property role="TrG5h" value="getSpecificLanguageX" />
+      <property role="TrG5h" value="getSpecificLanguage" />
       <node concept="3Tm1VV" id="7OJcYqybDcW" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqybDcX" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqybDcY" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
         </node>
         <node concept="3uibUv" id="7OJcYqybDcZ" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqybDd1" role="3clF47">
@@ -6634,15 +6763,15 @@
     </node>
     <node concept="2tJIrI" id="5JNiskj64xG" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqygnxo" role="jymVt">
-      <property role="TrG5h" value="getVirtualPackageX" />
+      <property role="TrG5h" value="getVirtualPackage" />
       <node concept="3Tm1VV" id="7OJcYqygnxq" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqygnxr" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqygnxs" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
         </node>
         <node concept="3uibUv" id="7OJcYqygnxt" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqygnxv" role="3clF47">
@@ -6658,15 +6787,15 @@
     </node>
     <node concept="2tJIrI" id="7OJcYqyliQo" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqylp3c" role="jymVt">
-      <property role="TrG5h" value="getVirtualPackage_NameX" />
+      <property role="TrG5h" value="getVirtualPackage_Name" />
       <node concept="3Tm1VV" id="7OJcYqylp3e" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqylp3f" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqylp3g" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
         </node>
         <node concept="3uibUv" id="7OJcYqylp3h" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqylp3j" role="3clF47">
@@ -6682,15 +6811,15 @@
     </node>
     <node concept="2tJIrI" id="5JNiskj6e2B" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqygOBN" role="jymVt">
-      <property role="TrG5h" value="getShortDescriptionX" />
+      <property role="TrG5h" value="getShortDescription" />
       <node concept="3Tm1VV" id="7OJcYqygOBP" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqygOBQ" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqygOBR" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
         </node>
         <node concept="3uibUv" id="7OJcYqygOBS" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqygOBU" role="3clF47">
@@ -6706,15 +6835,15 @@
     </node>
     <node concept="2tJIrI" id="7OJcYqykZXv" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyl4JA" role="jymVt">
-      <property role="TrG5h" value="getShortDescription_DescriptionX" />
+      <property role="TrG5h" value="getShortDescription_Description" />
       <node concept="3Tm1VV" id="7OJcYqyl4JC" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyl4JD" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqyl4JE" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
         </node>
         <node concept="3uibUv" id="7OJcYqyl4JF" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqyl4JH" role="3clF47">
@@ -6730,15 +6859,15 @@
     </node>
     <node concept="2tJIrI" id="34Q84zNSLh9" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyhdSU" role="jymVt">
-      <property role="TrG5h" value="getConceptDescriptionAnnotationX" />
+      <property role="TrG5h" value="getConceptDescriptionAnnotation" />
       <node concept="3Tm1VV" id="7OJcYqyhdSW" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyhdSX" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqyhdSY" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
         </node>
         <node concept="3uibUv" id="7OJcYqyhdSZ" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqyhdT1" role="3clF47">
@@ -6754,15 +6883,15 @@
     </node>
     <node concept="2tJIrI" id="7OJcYqyijIi" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyhHPP" role="jymVt">
-      <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptAliasX" />
+      <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptAlias" />
       <node concept="3Tm1VV" id="7OJcYqyhHPR" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyhHPS" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqyhHPT" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
         </node>
         <node concept="3uibUv" id="7OJcYqyhHPU" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqyhHPW" role="3clF47">
@@ -6778,15 +6907,15 @@
     </node>
     <node concept="2tJIrI" id="7OJcYqyiatN" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyisuh" role="jymVt">
-      <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptShortDescriptionX" />
+      <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptShortDescription" />
       <node concept="3Tm1VV" id="7OJcYqyisuj" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyisuk" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqyisul" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
         </node>
         <node concept="3uibUv" id="7OJcYqyisum" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqyisuo" role="3clF47">
@@ -6820,7 +6949,7 @@
           <node concept="2OqwBi" id="5JNiskj65vu" role="3clFbG">
             <node concept="2OqwBi" id="5JNiskj$YCa" role="2Oq$k0">
               <node concept="1rXfSq" id="5JNiskj64Tp" role="2Oq$k0">
-                <ref role="37wK5l" node="5JNiskjzWq_" resolve="listSpecificAnnotations" />
+                <ref role="37wK5l" node="5JNiskjzWq_" resolve="listMpsM1Annotations" />
               </node>
               <node concept="3$u5V9" id="5JNiskj_14O" role="2OqNvi">
                 <node concept="1bVj0M" id="5JNiskj_14Q" role="23t8la">
@@ -6878,7 +7007,7 @@
           <node concept="2OqwBi" id="5JNiskj669S" role="3clFbG">
             <node concept="2OqwBi" id="5JNiskj_9sT" role="2Oq$k0">
               <node concept="1rXfSq" id="5JNiskj669T" role="2Oq$k0">
-                <ref role="37wK5l" node="5JNiskjzWqH" resolve="listSpecificAnnotationMembers" />
+                <ref role="37wK5l" node="5JNiskjzWqH" resolve="listMpsM1AnnotationPropertyMembers" />
               </node>
               <node concept="3$u5V9" id="5JNiskj_bOB" role="2OqNvi">
                 <node concept="1bVj0M" id="5JNiskj_bOD" role="23t8la">
@@ -6919,16 +7048,16 @@
     </node>
     <node concept="2tJIrI" id="5JNiskj62Hj" role="jymVt" />
     <node concept="3clFb_" id="5JNiskjzWq_" role="jymVt">
-      <property role="TrG5h" value="listSpecificAnnotations" />
+      <property role="TrG5h" value="listMpsM1Annotations" />
       <node concept="3Tm1VV" id="5JNiskjzWqB" role="1B3o_S" />
       <node concept="_YKpA" id="5JNiskjzWqC" role="3clF45">
         <node concept="3uibUv" id="7OJcYqzM6gg" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
           <node concept="3uibUv" id="7OJcYqzM6gh" role="11_B2D">
             <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
           </node>
           <node concept="3uibUv" id="7OJcYqzM6gi" role="11_B2D">
-            <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+            <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
           </node>
         </node>
       </node>
@@ -6937,18 +7066,18 @@
           <node concept="2ShNRf" id="5JNiskj$yyq" role="3clFbG">
             <node concept="Tc6Ow" id="5JNiskj$yyr" role="2ShVmc">
               <node concept="1rXfSq" id="5JNiskj$yyt" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqygnxo" resolve="getVirtualPackageX" />
+                <ref role="37wK5l" node="7OJcYqygnxo" resolve="getVirtualPackage" />
               </node>
               <node concept="1rXfSq" id="5JNiskj$IW2" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqygOBN" resolve="getShortDescriptionX" />
+                <ref role="37wK5l" node="7OJcYqygOBN" resolve="getShortDescription" />
               </node>
               <node concept="3uibUv" id="7OJcYqzLZrs" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
                 <node concept="3uibUv" id="7OJcYqzLZrt" role="11_B2D">
                   <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
                 </node>
                 <node concept="3uibUv" id="7OJcYqzLZru" role="11_B2D">
-                  <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+                  <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
                 </node>
               </node>
             </node>
@@ -6961,16 +7090,16 @@
     </node>
     <node concept="2tJIrI" id="5JNiskjzYuJ" role="jymVt" />
     <node concept="3clFb_" id="5JNiskjzWqH" role="jymVt">
-      <property role="TrG5h" value="listSpecificAnnotationMembers" />
+      <property role="TrG5h" value="listMpsM1AnnotationPropertyMembers" />
       <node concept="3Tm1VV" id="5JNiskjzWqJ" role="1B3o_S" />
       <node concept="_YKpA" id="5JNiskjzWqK" role="3clF45">
         <node concept="3uibUv" id="7OJcYqzMr5s" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
           <node concept="3uibUv" id="7OJcYqzMr5t" role="11_B2D">
             <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
           </node>
           <node concept="3uibUv" id="7OJcYqzMr5u" role="11_B2D">
-            <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+            <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
           </node>
         </node>
       </node>
@@ -6979,18 +7108,18 @@
           <node concept="2ShNRf" id="5JNiskj$KeJ" role="3clFbG">
             <node concept="Tc6Ow" id="5JNiskj$KeK" role="2ShVmc">
               <node concept="1rXfSq" id="5JNiskj$KeO" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqylp3c" resolve="getVirtualPackage_NameX" />
+                <ref role="37wK5l" node="7OJcYqylp3c" resolve="getVirtualPackage_Name" />
               </node>
               <node concept="1rXfSq" id="5JNiskj$KeS" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqyl4JA" resolve="getShortDescription_DescriptionX" />
+                <ref role="37wK5l" node="7OJcYqyl4JA" resolve="getShortDescription_Description" />
               </node>
               <node concept="3uibUv" id="7OJcYqzMkcU" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
                 <node concept="3uibUv" id="7OJcYqzMkcV" role="11_B2D">
                   <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
                 </node>
                 <node concept="3uibUv" id="7OJcYqzMkcW" role="11_B2D">
-                  <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+                  <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
                 </node>
               </node>
             </node>
@@ -7025,7 +7154,7 @@
             <node concept="2OqwBi" id="5JNiskjrcbS" role="33vP2m">
               <node concept="2OqwBi" id="5JNiskjrcbT" role="2Oq$k0">
                 <node concept="1rXfSq" id="5JNiskj$4kk" role="2Oq$k0">
-                  <ref role="37wK5l" node="5JNiskjzWq_" resolve="listSpecificAnnotations" />
+                  <ref role="37wK5l" node="5JNiskjzWq_" resolve="listMpsM1Annotations" />
                 </node>
                 <node concept="3$u5V9" id="5JNiskjrcbX" role="2OqNvi">
                   <node concept="1bVj0M" id="5JNiskjrcbY" role="23t8la">
@@ -7113,7 +7242,7 @@
             <node concept="2OqwBi" id="5JNiskjsbHY" role="33vP2m">
               <node concept="2OqwBi" id="5JNiskjsbHZ" role="2Oq$k0">
                 <node concept="1rXfSq" id="5JNiskj$7v6" role="2Oq$k0">
-                  <ref role="37wK5l" node="5JNiskjzWqH" resolve="listSpecificAnnotationMembers" />
+                  <ref role="37wK5l" node="5JNiskjzWqH" resolve="listMpsM1AnnotationPropertyMembers" />
                 </node>
                 <node concept="3$u5V9" id="5JNiskjsbI3" role="2OqNvi">
                   <node concept="1bVj0M" id="5JNiskjsbI4" role="23t8la">
@@ -7196,16 +7325,16 @@
     </node>
     <node concept="2tJIrI" id="34Q84zNSIta" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqzI5x6" role="jymVt">
-      <property role="TrG5h" value="listConceptDescriptionPropertiesX" />
+      <property role="TrG5h" value="listMpsM2AnnotationProperties" />
       <node concept="3Tm1VV" id="7OJcYqzI5x8" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqzI5x9" role="3clF45">
         <node concept="3uibUv" id="7OJcYqzI5xa" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
           <node concept="3uibUv" id="7OJcYqzI5xb" role="11_B2D">
             <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
           </node>
           <node concept="3uibUv" id="7OJcYqzI5xc" role="11_B2D">
-            <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+            <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
           </node>
         </node>
       </node>
@@ -7214,18 +7343,18 @@
           <node concept="2ShNRf" id="7OJcYqzIIar" role="3clFbG">
             <node concept="Tc6Ow" id="7OJcYqzILpB" role="2ShVmc">
               <node concept="1rXfSq" id="7OJcYqzISSx" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqyhHPP" resolve="getConceptDescriptionAnnotation_ConceptAliasX" />
+                <ref role="37wK5l" node="7OJcYqyhHPP" resolve="getConceptDescriptionAnnotation_ConceptAlias" />
               </node>
               <node concept="1rXfSq" id="7OJcYqzJ07G" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqyisuh" resolve="getConceptDescriptionAnnotation_ConceptShortDescriptionX" />
+                <ref role="37wK5l" node="7OJcYqyisuh" resolve="getConceptDescriptionAnnotation_ConceptShortDescription" />
               </node>
               <node concept="3uibUv" id="7OJcYqzJ5xC" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
                 <node concept="3uibUv" id="7OJcYqzJ5xD" role="11_B2D">
                   <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
                 </node>
                 <node concept="3uibUv" id="7OJcYqzJ5xE" role="11_B2D">
-                  <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+                  <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
                 </node>
               </node>
             </node>
@@ -7238,15 +7367,15 @@
     </node>
     <node concept="2tJIrI" id="7weWCFlwstm" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyiZMB" role="jymVt">
-      <property role="TrG5h" value="getAnnotationConceptX" />
+      <property role="TrG5h" value="getAnnotationConcept" />
       <node concept="3Tm1VV" id="7OJcYqyiZMD" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyiZME" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqyiZMF" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
         </node>
         <node concept="3uibUv" id="7OJcYqyiZMG" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqyiZMI" role="3clF47">
@@ -7262,15 +7391,15 @@
     </node>
     <node concept="2tJIrI" id="7OJcYqyjDll" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyjHUZ" role="jymVt">
-      <property role="TrG5h" value="getClassifierConceptX" />
+      <property role="TrG5h" value="getClassifierConcept" />
       <node concept="3Tm1VV" id="7OJcYqyjHV1" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyjHV2" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqyjHV3" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
         </node>
         <node concept="3uibUv" id="7OJcYqyjHV4" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqyjHV6" role="3clF47">
@@ -7286,15 +7415,15 @@
     </node>
     <node concept="2tJIrI" id="7OJcYqyk8yX" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqykdbt" role="jymVt">
-      <property role="TrG5h" value="getConceptConceptX" />
+      <property role="TrG5h" value="getConceptConcept" />
       <node concept="3Tm1VV" id="7OJcYqykdbv" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqykdbw" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqykdbx" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
         </node>
         <node concept="3uibUv" id="7OJcYqykdby" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqykdb$" role="3clF47">
@@ -7310,15 +7439,15 @@
     </node>
     <node concept="2tJIrI" id="7OJcYqyk$0J" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqykHtf" role="jymVt">
-      <property role="TrG5h" value="getInterfaceConceptX" />
+      <property role="TrG5h" value="getInterfaceConcept" />
       <node concept="3Tm1VV" id="7OJcYqykHth" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqykHti" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
         <node concept="3uibUv" id="7OJcYqykHtj" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
         </node>
         <node concept="3uibUv" id="7OJcYqykHtk" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+          <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqykHtm" role="3clF47">
@@ -7334,11 +7463,11 @@
     </node>
     <node concept="2tJIrI" id="7weWCFlvQOd" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqzJd1s" role="jymVt">
-      <property role="TrG5h" value="listReplacementMpsSpecificClassifiersX" />
+      <property role="TrG5h" value="listMpsInternalClassifiers" />
       <node concept="3Tm1VV" id="7OJcYqzJd1u" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqzJd1v" role="3clF45">
         <node concept="3uibUv" id="7OJcYqzJd1w" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
           <node concept="3qUE_q" id="7OJcYqzKLSe" role="11_B2D">
             <node concept="3uibUv" id="7OJcYqzKOwD" role="3qUE_r">
               <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
@@ -7346,7 +7475,7 @@
           </node>
           <node concept="3qUE_q" id="7OJcYqzKfLg" role="11_B2D">
             <node concept="3uibUv" id="7OJcYqzKiwU" role="3qUE_r">
-              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+              <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierStaple" />
             </node>
           </node>
         </node>
@@ -7356,25 +7485,25 @@
           <node concept="2ShNRf" id="7OJcYqzJmaM" role="3clFbG">
             <node concept="Tc6Ow" id="7OJcYqzJpGh" role="2ShVmc">
               <node concept="1rXfSq" id="7OJcYqzJwgX" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqxTIfx" resolve="getNodeX" />
+                <ref role="37wK5l" node="7OJcYqxTIfx" resolve="getNode" />
               </node>
               <node concept="1rXfSq" id="7OJcYqzJAGU" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqyiZMB" resolve="getAnnotationConceptX" />
+                <ref role="37wK5l" node="7OJcYqyiZMB" resolve="getAnnotationConcept" />
               </node>
               <node concept="1rXfSq" id="7OJcYqzJGB1" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqyjHUZ" resolve="getClassifierConceptX" />
+                <ref role="37wK5l" node="7OJcYqyjHUZ" resolve="getClassifierConcept" />
               </node>
               <node concept="1rXfSq" id="7OJcYqzJNX_" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqykdbt" resolve="getConceptConceptX" />
+                <ref role="37wK5l" node="7OJcYqykdbt" resolve="getConceptConcept" />
               </node>
               <node concept="1rXfSq" id="7OJcYqzJUtB" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqykHtf" resolve="getInterfaceConceptX" />
+                <ref role="37wK5l" node="7OJcYqykHtf" resolve="getInterfaceConcept" />
               </node>
               <node concept="1rXfSq" id="7OJcYqzJZXA" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamedX" />
+                <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamed" />
               </node>
               <node concept="3uibUv" id="7OJcYqzK6CI" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
                 <node concept="3qUE_q" id="7OJcYqzKS81" role="11_B2D">
                   <node concept="3uibUv" id="7OJcYqzKS82" role="3qUE_r">
                     <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
@@ -7382,7 +7511,7 @@
                 </node>
                 <node concept="3qUE_q" id="7OJcYqzKm22" role="11_B2D">
                   <node concept="3uibUv" id="7OJcYqzKm23" role="3qUE_r">
-                    <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+                    <ref role="3uigEE" to="y7p:7OJcYqwYeSL" resolve="IClassifierStaple" />
                   </node>
                 </node>
               </node>
@@ -7837,7 +7966,7 @@
   </node>
   <node concept="3HP615" id="7OJcYqxQZIZ">
     <property role="3GE5qa" value="jsonConstants" />
-    <property role="TrG5h" value="IJsonKeyedMapper" />
+    <property role="TrG5h" value="IJsonStaple" />
     <node concept="3clFb_" id="7OJcYqxR0RG" role="jymVt">
       <property role="TrG5h" value="getJson" />
       <node concept="3clFbS" id="7OJcYqxR0RJ" role="3clF47" />
@@ -7847,11 +7976,11 @@
       </node>
     </node>
     <node concept="3clFb_" id="7OJcYqxR0T3" role="jymVt">
-      <property role="TrG5h" value="getMapping" />
+      <property role="TrG5h" value="getStaple" />
       <node concept="3clFbS" id="7OJcYqxR0T6" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqxR0T7" role="1B3o_S" />
       <node concept="16syzq" id="7OJcYqxR0S_" role="3clF45">
-        <ref role="16sUi3" node="7OJcYqxQZJU" resolve="MAPPING" />
+        <ref role="16sUi3" node="7OJcYqxQZJU" resolve="STAPLE" />
       </node>
     </node>
     <node concept="3Tm1VV" id="7OJcYqxQZJ0" role="1B3o_S" />
@@ -7862,23 +7991,23 @@
       </node>
     </node>
     <node concept="16euLQ" id="7OJcYqxQZJU" role="16eVyc">
-      <property role="TrG5h" value="MAPPING" />
+      <property role="TrG5h" value="STAPLE" />
       <node concept="3uibUv" id="7OJcYqxQZL0" role="3ztrMU">
-        <ref role="3uigEE" to="y7p:7OJcYqvKf0O" resolve="IKeyedMapping" />
+        <ref role="3uigEE" to="y7p:7OJcYqvKf0O" resolve="IKeyedStaple" />
       </node>
     </node>
   </node>
   <node concept="312cEu" id="7OJcYqxTPY1">
     <property role="3GE5qa" value="jsonConstants" />
-    <property role="TrG5h" value="JsonKeyedMapper" />
+    <property role="TrG5h" value="JsonStaple" />
     <node concept="3Tm1VV" id="7OJcYqxTPY2" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqxTPYR" role="EKbjA">
-      <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonKeyedMapper" />
+      <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
       <node concept="16syzq" id="7OJcYqxTQ0M" role="11_B2D">
         <ref role="16sUi3" node="7OJcYqxTPZF" resolve="JSON" />
       </node>
       <node concept="16syzq" id="7OJcYqxTQ1D" role="11_B2D">
-        <ref role="16sUi3" node="7OJcYqxTPZH" resolve="MAPPING" />
+        <ref role="16sUi3" node="7OJcYqxTPZH" resolve="STAPLE" />
       </node>
     </node>
     <node concept="16euLQ" id="7OJcYqxTPZF" role="16eVyc">
@@ -7888,9 +8017,9 @@
       </node>
     </node>
     <node concept="16euLQ" id="7OJcYqxTPZH" role="16eVyc">
-      <property role="TrG5h" value="MAPPING" />
+      <property role="TrG5h" value="STAPLE" />
       <node concept="3uibUv" id="7OJcYqxTPZI" role="3ztrMU">
-        <ref role="3uigEE" to="y7p:7OJcYqvKf0O" resolve="IKeyedMapping" />
+        <ref role="3uigEE" to="y7p:7OJcYqvKf0O" resolve="IKeyedStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqxTQrm" role="jymVt">
@@ -7902,11 +8031,11 @@
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqxTQEC" role="jymVt">
-      <property role="TrG5h" value="mapping" />
+      <property role="TrG5h" value="staple" />
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqxTQED" role="1B3o_S" />
       <node concept="16syzq" id="7OJcYqxTQEF" role="1tU5fm">
-        <ref role="16sUi3" node="7OJcYqxTPZH" resolve="MAPPING" />
+        <ref role="16sUi3" node="7OJcYqxTPZH" resolve="STAPLE" />
       </node>
     </node>
     <node concept="3clFbW" id="7OJcYqxTQa5" role="jymVt">
@@ -7931,11 +8060,11 @@
             <node concept="2OqwBi" id="7OJcYqxTQKz" role="37vLTJ">
               <node concept="Xjq3P" id="7OJcYqxTQOl" role="2Oq$k0" />
               <node concept="2OwXpG" id="7OJcYqxTQKA" role="2OqNvi">
-                <ref role="2Oxat5" node="7OJcYqxTQEC" resolve="mapping" />
+                <ref role="2Oxat5" node="7OJcYqxTQEC" resolve="staple" />
               </node>
             </node>
             <node concept="37vLTw" id="7OJcYqxTQEM" role="37vLTx">
-              <ref role="3cqZAo" node="7OJcYqxTQhv" resolve="mapping" />
+              <ref role="3cqZAo" node="7OJcYqxTQhv" resolve="staple" />
             </node>
           </node>
         </node>
@@ -7950,9 +8079,9 @@
         </node>
       </node>
       <node concept="37vLTG" id="7OJcYqxTQhv" role="3clF46">
-        <property role="TrG5h" value="mapping" />
+        <property role="TrG5h" value="staple" />
         <node concept="16syzq" id="7OJcYqxTQlC" role="1tU5fm">
-          <ref role="16sUi3" node="7OJcYqxTPZH" resolve="MAPPING" />
+          <ref role="16sUi3" node="7OJcYqxTPZH" resolve="STAPLE" />
         </node>
         <node concept="2AHcQZ" id="7OJcYqxTQoB" role="2AJF6D">
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
@@ -7977,15 +8106,15 @@
       </node>
     </node>
     <node concept="3clFb_" id="7OJcYqxTQ2q" role="jymVt">
-      <property role="TrG5h" value="getMapping" />
+      <property role="TrG5h" value="getStaple" />
       <node concept="3Tm1VV" id="7OJcYqxTQ2s" role="1B3o_S" />
       <node concept="16syzq" id="7OJcYqxTQ2u" role="3clF45">
-        <ref role="16sUi3" node="7OJcYqxTPZH" resolve="MAPPING" />
+        <ref role="16sUi3" node="7OJcYqxTPZH" resolve="STAPLE" />
       </node>
       <node concept="3clFbS" id="7OJcYqxTQ2v" role="3clF47">
         <node concept="3clFbF" id="7OJcYqxTRpx" role="3cqZAp">
           <node concept="37vLTw" id="7OJcYqxTRpw" role="3clFbG">
-            <ref role="3cqZAo" node="7OJcYqxTQEC" resolve="mapping" />
+            <ref role="3cqZAo" node="7OJcYqxTQEC" resolve="staple" />
           </node>
         </node>
       </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
@@ -6365,7 +6365,7 @@
               <node concept="1pGfFk" id="7OJcYqydvKf" role="2ShVmc">
                 <ref role="37wK5l" node="7OJcYq_2OAc" resolve="JsonAnnotationPropertyStaple" />
                 <node concept="37vLTw" id="7OJcYq_4yl5" role="37wK5m">
-                  <ref role="3cqZAo" node="7OJcYq_4ykU" resolve="iNamedName" />
+                  <ref role="3cqZAo" node="7OJcYq_1K_1" resolve="description" />
                 </node>
                 <node concept="37vLTw" id="7OJcYqydvKg" role="37wK5m">
                   <ref role="3cqZAo" node="7OJcYqyqtIN" resolve="shortDescription" />

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
@@ -47,9 +47,6 @@
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
-      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
-        <child id="1076505808688" name="condition" index="2$JKZa" />
-      </concept>
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
@@ -231,7 +228,6 @@
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
       <concept id="1178893518978" name="jetbrains.mps.baseLanguage.structure.ThisConstructorInvocation" flags="nn" index="1VxSAg" />
-      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -307,12 +303,6 @@
       <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
         <child id="1226511765987" name="elementType" index="2hN53Y" />
       </concept>
-      <concept id="1237467461002" name="jetbrains.mps.baseLanguage.collections.structure.GetIteratorOperation" flags="nn" index="uNJiE" />
-      <concept id="1237467705688" name="jetbrains.mps.baseLanguage.collections.structure.IteratorType" flags="in" index="uOF1S">
-        <child id="1237467730343" name="elementType" index="uOL27" />
-      </concept>
-      <concept id="1237470895604" name="jetbrains.mps.baseLanguage.collections.structure.HasNextOperation" flags="nn" index="v0PNk" />
-      <concept id="1237471031357" name="jetbrains.mps.baseLanguage.collections.structure.GetNextOperation" flags="nn" index="v1n4t" />
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -342,23 +332,12 @@
       <concept id="4611582986551314327" name="jetbrains.mps.baseLanguage.collections.structure.OfTypeOperation" flags="nn" index="UnYns">
         <child id="4611582986551314344" name="requestedType" index="UnYnz" />
       </concept>
-      <concept id="1240216724530" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashMapCreator" flags="nn" index="32Fmki" />
       <concept id="1240217271293" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashSetCreator" flags="nn" index="32HrFt" />
-      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
         <child id="1197683466920" name="keyType" index="3rvQeY" />
         <child id="1197683475734" name="valueType" index="3rvSg0" />
       </concept>
-      <concept id="1197686869805" name="jetbrains.mps.baseLanguage.collections.structure.HashMapCreator" flags="nn" index="3rGOSV">
-        <child id="1562299158921034623" name="initSize" index="3lNPQL" />
-        <child id="1197687026896" name="keyType" index="3rHrn6" />
-        <child id="1197687035757" name="valueType" index="3rHtpV" />
-      </concept>
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
-      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
-        <child id="1197932505799" name="map" index="3ElQJh" />
-        <child id="1197932525128" name="key" index="3ElVtu" />
-      </concept>
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
     </language>
   </registry>
@@ -5415,21 +5394,15 @@
       <property role="TrG5h" value="getVirtualPackage" />
       <node concept="3clFbS" id="7OJcYqyb0Go" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqyb0Gp" role="1B3o_S" />
-      <node concept="3uibUv" id="7OJcYqyb0Gq" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
-        <node concept="3uibUv" id="7OJcYqyb0Gr" role="11_B2D">
-          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-        </node>
-        <node concept="3uibUv" id="7OJcYqyb0Gs" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
-        </node>
-      </node>
       <node concept="P$JXv" id="7OJcYq$tRxD" role="lGtFl">
         <node concept="VUp57" id="7OJcYq$tR$B" role="3nqlJM">
           <node concept="VXe0Z" id="7OJcYq$tRBu" role="VUp5m">
             <ref role="VXe0S" to="y7p:7OJcYqwQyzV" resolve="getVirtualPackage" />
           </node>
         </node>
+      </node>
+      <node concept="3uibUv" id="7OJcYq_3UM2" role="3clF45">
+        <ref role="3uigEE" node="7OJcYq_2Ogv" resolve="JsonAnnotationPropertyStaple" />
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqyb4hc" role="jymVt" />
@@ -5452,21 +5425,15 @@
       <property role="TrG5h" value="getShortDescription" />
       <node concept="3clFbS" id="7OJcYqyb4U5" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqyb4U6" role="1B3o_S" />
-      <node concept="3uibUv" id="7OJcYqyb4U7" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
-        <node concept="3uibUv" id="7OJcYqyb4U8" role="11_B2D">
-          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-        </node>
-        <node concept="3uibUv" id="7OJcYqyb4U9" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
-        </node>
-      </node>
       <node concept="P$JXv" id="7OJcYq$tRL$" role="lGtFl">
         <node concept="VUp57" id="7OJcYq$tROy" role="3nqlJM">
           <node concept="VXe0Z" id="7OJcYq$tRRp" role="VUp5m">
             <ref role="VXe0S" to="y7p:7OJcYqwQy$4" resolve="getShortDescription" />
           </node>
         </node>
+      </node>
+      <node concept="3uibUv" id="7OJcYq_48QK" role="3clF45">
+        <ref role="3uigEE" node="7OJcYq_2Ogv" resolve="JsonAnnotationPropertyStaple" />
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqyb4PP" role="jymVt" />
@@ -5564,14 +5531,8 @@
       <node concept="3clFbS" id="5JNiskjpjPQ" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiskjpjPR" role="1B3o_S" />
       <node concept="_YKpA" id="5JNiskjpjNC" role="3clF45">
-        <node concept="3uibUv" id="7OJcYqzLjhJ" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
-          <node concept="3uibUv" id="7OJcYqzLjhK" role="11_B2D">
-            <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-          </node>
-          <node concept="3uibUv" id="7OJcYqzLjhL" role="11_B2D">
-            <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
-          </node>
+        <node concept="3uibUv" id="7OJcYq_2SqS" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYq_2Ogv" resolve="JsonAnnotationPropertyStaple" />
         </node>
       </node>
       <node concept="P$JXv" id="5M8g5cS_zYE" role="lGtFl">
@@ -5583,81 +5544,6 @@
         <node concept="VUp57" id="7OJcYq$u2I9" role="3nqlJM">
           <node concept="VXe0Z" id="7OJcYq$u2KZ" role="VUp5m">
             <ref role="VXe0S" to="y7p:7OJcYqxreEB" resolve="listMpsM1AnnotationProperties" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskjpjYQ" role="jymVt">
-      <property role="TrG5h" value="listMpsM1AnnotationPropertyMembers" />
-      <node concept="3clFbS" id="5JNiskjpjYT" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskjpjYU" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskjpjW$" role="3clF45">
-        <node concept="3uibUv" id="7OJcYqzLld7" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
-          <node concept="3uibUv" id="7OJcYqzLld8" role="11_B2D">
-            <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
-          </node>
-          <node concept="3uibUv" id="7OJcYqzLld9" role="11_B2D">
-            <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
-          </node>
-        </node>
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_$4u" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_$4v" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_$4w" role="1dT_Ay">
-            <property role="1dT_AB" value="All M1 JSON annotation properties that are converted from MPS node properties." />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="7OJcYq$u6GN" role="TZ5H$">
-          <node concept="1dT_AC" id="7OJcYq$u6GO" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-        <node concept="VUp57" id="7OJcYq$u6JF" role="3nqlJM">
-          <node concept="VXe0Z" id="7OJcYq$u6Mx" role="VUp5m">
-            <ref role="VXe0S" to="y7p:7OJcYqxreEB" resolve="listMpsM1AnnotationProperties" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskjt_st" role="jymVt">
-      <property role="TrG5h" value="mapSpecificAnnotationMembers" />
-      <node concept="3clFbS" id="5JNiskjt_sw" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskjt_sx" role="1B3o_S" />
-      <node concept="3rvAFt" id="5JNiskjt_pD" role="3clF45">
-        <node concept="3uibUv" id="5JNiskjt_s9" role="3rvQeY">
-          <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-        </node>
-        <node concept="3uibUv" id="5JNiskjt_sj" role="3rvSg0">
-          <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-        </node>
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_AkF" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_AkG" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_AkH" role="1dT_Ay">
-            <property role="1dT_AB" value="Map from " />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS_Bsf" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS_Bsl" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS_Bsn" role="2XjZqd" />
-              <node concept="VXe0Z" id="5M8g5cS_BsA" role="92FcQ">
-                <ref role="VXe0S" node="5JNiskjpjPN" resolve="listMpsM1Annotations" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS_Bse" role="1dT_Ay">
-            <property role="1dT_AB" value=" to " />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS_Bts" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS_BtJ" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS_BtL" role="2XjZqd" />
-              <node concept="VXe0Z" id="5M8g5cS_Bu0" role="92FcQ">
-                <ref role="VXe0S" node="5JNiskjpjYQ" resolve="listMpsM1AnnotationPropertyMembers" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS_Btr" role="1dT_Ay">
-            <property role="1dT_AB" value="." />
           </node>
         </node>
       </node>
@@ -5678,13 +5564,13 @@
       <property role="TrG5h" value="getConceptDescriptionAnnotation" />
       <node concept="3clFbS" id="7OJcYqyb96E" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqyb96F" role="1B3o_S" />
-      <node concept="3uibUv" id="7OJcYqyb96G" role="3clF45">
+      <node concept="3uibUv" id="7OJcYq$R218" role="3clF45">
         <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
-        <node concept="3uibUv" id="7OJcYqyb96H" role="11_B2D">
+        <node concept="3uibUv" id="7OJcYq$R219" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
         </node>
-        <node concept="3uibUv" id="7OJcYqyb96I" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
+        <node concept="3uibUv" id="7OJcYq$R21a" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageStaple" />
         </node>
       </node>
     </node>
@@ -5693,20 +5579,20 @@
       <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptAlias" />
       <node concept="3clFbS" id="7OJcYqybbS2" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqybbS3" role="1B3o_S" />
-      <node concept="3uibUv" id="7OJcYqybbS4" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
-        <node concept="3uibUv" id="7OJcYqybbS5" role="11_B2D">
-          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
-        </node>
-        <node concept="3uibUv" id="7OJcYqybbS6" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
-        </node>
-      </node>
       <node concept="P$JXv" id="7OJcYq$u726" role="lGtFl">
         <node concept="VUp57" id="7OJcYq$u754" role="3nqlJM">
           <node concept="VXe0Z" id="7OJcYq$u77V" role="VUp5m">
             <ref role="VXe0S" to="y7p:7OJcYqwQy$L" resolve="getConceptAlias" />
           </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="7OJcYq$RmEQ" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
+        <node concept="3uibUv" id="7OJcYq$RmER" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="7OJcYq$RmES" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
         </node>
       </node>
     </node>
@@ -5715,20 +5601,20 @@
       <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptShortDescription" />
       <node concept="3clFbS" id="7OJcYqybeuq" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqybeur" role="1B3o_S" />
-      <node concept="3uibUv" id="7OJcYqybeus" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
-        <node concept="3uibUv" id="7OJcYqybeut" role="11_B2D">
-          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
-        </node>
-        <node concept="3uibUv" id="7OJcYqybeuu" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
-        </node>
-      </node>
       <node concept="P$JXv" id="7OJcYq$u7dK" role="lGtFl">
         <node concept="VUp57" id="7OJcYq$u7gI" role="3nqlJM">
           <node concept="VXe0Z" id="7OJcYq$u7j_" role="VUp5m">
             <ref role="VXe0S" to="y7p:7OJcYqwQy$U" resolve="getConceptShortDescription" />
           </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="7OJcYq$RFnj" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
+        <node concept="3uibUv" id="7OJcYq$RFnk" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="7OJcYq$RFnl" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
         </node>
       </node>
     </node>
@@ -5744,8 +5630,10 @@
           <node concept="3uibUv" id="7OJcYqzAVoV" role="11_B2D">
             <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
           </node>
-          <node concept="3uibUv" id="7OJcYqzAVoW" role="11_B2D">
-            <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
+          <node concept="3qUE_q" id="7OJcYq$Tjnq" role="11_B2D">
+            <node concept="3uibUv" id="7OJcYq$Tjnr" role="3qUE_r">
+              <ref role="3uigEE" to="y7p:7OJcYq$EbsZ" resolve="IPropertyStaple" />
+            </node>
           </node>
         </node>
       </node>
@@ -5884,28 +5772,16 @@
       <property role="TrG5h" value="VIRTUAL_PACKAGE" />
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqyd5wx" role="1B3o_S" />
-      <node concept="3uibUv" id="7OJcYqyd5wy" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
-        <node concept="3uibUv" id="7OJcYqygH8i" role="11_B2D">
-          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-        </node>
-        <node concept="3uibUv" id="7OJcYqygH8j" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
-        </node>
+      <node concept="3uibUv" id="7OJcYq_3uGv" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYq_2Ogv" resolve="JsonAnnotationPropertyStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqydvJX" role="jymVt">
       <property role="TrG5h" value="SHORT_DESCRIPTION" />
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqydvJV" role="1B3o_S" />
-      <node concept="3uibUv" id="7OJcYqydvJW" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
-        <node concept="3uibUv" id="7OJcYqyh4JR" role="11_B2D">
-          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-        </node>
-        <node concept="3uibUv" id="7OJcYqyh4JS" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
-        </node>
+      <node concept="3uibUv" id="7OJcYq_4dIx" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYq_2Ogv" resolve="JsonAnnotationPropertyStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqydNSU" role="jymVt">
@@ -5974,7 +5850,7 @@
           <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
         </node>
         <node concept="3uibUv" id="7OJcYqyhA1E" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
+          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageStaple" />
         </node>
       </node>
     </node>
@@ -5984,11 +5860,11 @@
       <node concept="3Tm6S6" id="7OJcYqyfGaP" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqyfGaQ" role="1tU5fm">
         <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
-        <node concept="3uibUv" id="7OJcYqyi6YV" role="11_B2D">
+        <node concept="3uibUv" id="7OJcYq$NgxK" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
         </node>
-        <node concept="3uibUv" id="7OJcYqyi6YW" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
+        <node concept="3uibUv" id="7OJcYq$NgxL" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
         </node>
       </node>
     </node>
@@ -5998,11 +5874,11 @@
       <node concept="3Tm6S6" id="7OJcYqygecq" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqygecr" role="1tU5fm">
         <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
-        <node concept="3uibUv" id="7OJcYqyiRxW" role="11_B2D">
+        <node concept="3uibUv" id="7OJcYq$OUVB" role="11_B2D">
           <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
         </node>
-        <node concept="3uibUv" id="7OJcYqyiRxX" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
+        <node concept="3uibUv" id="7OJcYq$OUVC" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
         </node>
       </node>
     </node>
@@ -6084,6 +5960,12 @@
                     <ref role="37wK5l" to="y7p:7OJcYqwQm21" resolve="getAnnotation" />
                   </node>
                 </node>
+                <node concept="3uibUv" id="7OJcYq$NFrE" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+                </node>
+                <node concept="3uibUv" id="7OJcYq$NKsj" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
+                </node>
               </node>
             </node>
           </node>
@@ -6114,6 +5996,12 @@
                   <node concept="liA8E" id="7OJcYqyearl" role="2OqNvi">
                     <ref role="37wK5l" to="y7p:7OJcYqwQy$m" resolve="getClassifier" />
                   </node>
+                </node>
+                <node concept="3uibUv" id="7OJcYq$NXTx" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+                </node>
+                <node concept="3uibUv" id="7OJcYq$NXTy" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
                 </node>
               </node>
             </node>
@@ -6146,6 +6034,12 @@
                     <ref role="37wK5l" to="y7p:7OJcYqwQy$v" resolve="getConcept" />
                   </node>
                 </node>
+                <node concept="3uibUv" id="7OJcYq$O2b8" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+                </node>
+                <node concept="3uibUv" id="7OJcYq$O2b9" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
+                </node>
               </node>
             </node>
           </node>
@@ -6176,6 +6070,12 @@
                   <node concept="liA8E" id="7OJcYqyeRHk" role="2OqNvi">
                     <ref role="37wK5l" to="y7p:7OJcYqwQy$C" resolve="getInterface" />
                   </node>
+                </node>
+                <node concept="3uibUv" id="7OJcYq$O5KA" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~Concept" resolve="Concept" />
+                </node>
+                <node concept="3uibUv" id="7OJcYq$O5KB" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
                 </node>
               </node>
             </node>
@@ -6285,6 +6185,37 @@
           </node>
         </node>
         <node concept="3clFbH" id="5JNiskj6Qe2" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYq_4ykT" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_4ykU" role="3cpWs9">
+            <property role="TrG5h" value="iNamedName" />
+            <node concept="3uibUv" id="7OJcYq_4vPa" role="1tU5fm">
+              <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYq_4ykV" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYq_4ykW" role="2Oq$k0">
+                <node concept="2OqwBi" id="7OJcYq_4ykX" role="2Oq$k0">
+                  <node concept="liA8E" id="7OJcYq_4ykY" role="2OqNvi">
+                    <ref role="37wK5l" to="imb3:~Classifier.allProperties()" resolve="allProperties" />
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYq_4ykZ" role="2Oq$k0">
+                    <node concept="1rXfSq" id="7OJcYq_4yl0" role="2Oq$k0">
+                      <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamed" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYq_4yl1" role="2OqNvi">
+                      <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="7OJcYq_4yl2" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7OJcYq_4yl3" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="7OJcYqyd5wJ" role="3cqZAp">
           <node concept="37vLTI" id="7OJcYqyd5wK" role="3clFbG">
             <node concept="2OqwBi" id="7OJcYqyd5wL" role="37vLTJ">
@@ -6295,7 +6226,10 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqyd5wO" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqyd5wP" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
+                <ref role="37wK5l" node="7OJcYq_2OAc" resolve="JsonAnnotationPropertyStaple" />
+                <node concept="37vLTw" id="7OJcYq_4Hk7" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYq_4ykU" resolve="iNamedName" />
+                </node>
                 <node concept="37vLTw" id="7OJcYqyd5wQ" role="37wK5m">
                   <ref role="3cqZAo" node="7OJcYqyqdur" resolve="virtualPackage" />
                 </node>
@@ -6322,28 +6256,8 @@
             <node concept="2ShNRf" id="7OJcYqylZ6J" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqylZ6K" role="2ShVmc">
                 <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
-                <node concept="2OqwBi" id="7OJcYqylZ6L" role="37wK5m">
-                  <node concept="2OqwBi" id="7OJcYqylZ6M" role="2Oq$k0">
-                    <node concept="2OqwBi" id="7OJcYqylZ6N" role="2Oq$k0">
-                      <node concept="liA8E" id="7OJcYqylZ6P" role="2OqNvi">
-                        <ref role="37wK5l" to="imb3:~Classifier.allProperties()" resolve="allProperties" />
-                      </node>
-                      <node concept="2OqwBi" id="7OJcYqzFRFN" role="2Oq$k0">
-                        <node concept="1rXfSq" id="7OJcYqzFRFO" role="2Oq$k0">
-                          <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamed" />
-                        </node>
-                        <node concept="liA8E" id="7OJcYqzFRFP" role="2OqNvi">
-                          <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="7OJcYqylZ6Q" role="2OqNvi">
-                      <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="7OJcYqylZ6R" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-                  </node>
+                <node concept="37vLTw" id="7OJcYq_4yl4" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYq_4ykU" resolve="iNamedName" />
                 </node>
                 <node concept="2OqwBi" id="7OJcYqylZ6S" role="37wK5m">
                   <node concept="37vLTw" id="7OJcYqylZ6T" role="2Oq$k0">
@@ -6383,6 +6297,48 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="7OJcYq_1K_0" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_1K_1" role="3cpWs9">
+            <property role="TrG5h" value="description" />
+            <node concept="3uibUv" id="7OJcYq_1yBL" role="1tU5fm">
+              <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYq_1K_2" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYq_1K_3" role="2Oq$k0">
+                <node concept="2YIFZM" id="7OJcYq_1K_4" role="2Oq$k0">
+                  <ref role="1Pybhc" to="imb3:~Property" resolve="Property" />
+                  <ref role="37wK5l" to="imb3:~Property.createOptional(java.lang.String,io.lionweb.lioncore.java.language.DataType,java.lang.String)" resolve="createOptional" />
+                  <node concept="Xl_RD" id="7OJcYq_1K_5" role="37wK5m">
+                    <property role="Xl_RC" value="description" />
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYq_1K_6" role="37wK5m">
+                    <node concept="1rXfSq" id="7OJcYq_1K_7" role="2Oq$k0">
+                      <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getString" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYq_1K_8" role="2OqNvi">
+                      <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="7OJcYq_1K_9" role="37wK5m">
+                    <property role="Xl_RC" value="description" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="7OJcYq_1K_a" role="2OqNvi">
+                  <ref role="37wK5l" to="imb3:~Feature.setKey(java.lang.String)" resolve="setKey" />
+                  <node concept="Xl_RD" id="7OJcYq_1K_b" role="37wK5m">
+                    <property role="Xl_RC" value="ShortDescription-description" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="7OJcYq_1K_c" role="2OqNvi">
+                <ref role="37wK5l" to="tzx8:~M3Node.setParent(io.lionweb.lioncore.java.model.Node)" resolve="setParent" />
+                <node concept="37vLTw" id="7OJcYq_1K_d" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqyqtIN" resolve="shortDescription" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="5JNiskj6SFB" role="3cqZAp">
           <node concept="2OqwBi" id="5JNiskj6TwW" role="3clFbG">
             <node concept="37vLTw" id="5JNiskj6SF_" role="2Oq$k0">
@@ -6390,39 +6346,8 @@
             </node>
             <node concept="liA8E" id="5JNiskj6UtL" role="2OqNvi">
               <ref role="37wK5l" to="imb3:~Classifier.addFeature(io.lionweb.lioncore.java.language.Feature)" resolve="addFeature" />
-              <node concept="2OqwBi" id="5JNiskjo_B9" role="37wK5m">
-                <node concept="2OqwBi" id="5JNiskjos9O" role="2Oq$k0">
-                  <node concept="2YIFZM" id="5JNiskj6Vwf" role="2Oq$k0">
-                    <ref role="1Pybhc" to="imb3:~Property" resolve="Property" />
-                    <ref role="37wK5l" to="imb3:~Property.createOptional(java.lang.String,io.lionweb.lioncore.java.language.DataType,java.lang.String)" resolve="createOptional" />
-                    <node concept="Xl_RD" id="5JNiskj6VU3" role="37wK5m">
-                      <property role="Xl_RC" value="description" />
-                    </node>
-                    <node concept="2OqwBi" id="7OJcYqzFVRb" role="37wK5m">
-                      <node concept="1rXfSq" id="5JNiskj6Xd0" role="2Oq$k0">
-                        <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getString" />
-                      </node>
-                      <node concept="liA8E" id="7OJcYqzFXGf" role="2OqNvi">
-                        <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-                      </node>
-                    </node>
-                    <node concept="Xl_RD" id="5JNiskj6Ye5" role="37wK5m">
-                      <property role="Xl_RC" value="description" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="5JNiskjoteh" role="2OqNvi">
-                    <ref role="37wK5l" to="imb3:~Feature.setKey(java.lang.String)" resolve="setKey" />
-                    <node concept="Xl_RD" id="5JNiskjotGx" role="37wK5m">
-                      <property role="Xl_RC" value="ShortDescription-description" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="liA8E" id="5JNiskjoB4o" role="2OqNvi">
-                  <ref role="37wK5l" to="tzx8:~M3Node.setParent(io.lionweb.lioncore.java.model.Node)" resolve="setParent" />
-                  <node concept="37vLTw" id="5JNiskjoB_g" role="37wK5m">
-                    <ref role="3cqZAo" node="7OJcYqyqtIN" resolve="shortDescription" />
-                  </node>
-                </node>
+              <node concept="37vLTw" id="7OJcYq_1K_e" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYq_1K_1" resolve="description" />
               </node>
             </node>
           </node>
@@ -6438,7 +6363,10 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqydvKe" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqydvKf" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
+                <ref role="37wK5l" node="7OJcYq_2OAc" resolve="JsonAnnotationPropertyStaple" />
+                <node concept="37vLTw" id="7OJcYq_4yl5" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYq_4ykU" resolve="iNamedName" />
+                </node>
                 <node concept="37vLTw" id="7OJcYqydvKg" role="37wK5m">
                   <ref role="3cqZAo" node="7OJcYqyqtIN" resolve="shortDescription" />
                 </node>
@@ -6465,28 +6393,8 @@
             <node concept="2ShNRf" id="7OJcYqymLcW" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqymLcX" role="2ShVmc">
                 <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
-                <node concept="2OqwBi" id="7OJcYqymLcY" role="37wK5m">
-                  <node concept="2OqwBi" id="7OJcYqymLcZ" role="2Oq$k0">
-                    <node concept="2OqwBi" id="7OJcYqymLd0" role="2Oq$k0">
-                      <node concept="2OqwBi" id="7OJcYqzNJkr" role="2Oq$k0">
-                        <node concept="1rXfSq" id="7OJcYqymLd1" role="2Oq$k0">
-                          <ref role="37wK5l" node="7OJcYqygOBN" resolve="getShortDescription" />
-                        </node>
-                        <node concept="liA8E" id="7OJcYqzNL_v" role="2OqNvi">
-                          <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="7OJcYqymLd2" role="2OqNvi">
-                        <ref role="37wK5l" to="imb3:~Classifier.allProperties()" resolve="allProperties" />
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="7OJcYqymLd3" role="2OqNvi">
-                      <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="7OJcYqymLd4" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-                  </node>
+                <node concept="37vLTw" id="7OJcYq_1VLn" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYq_1K_1" resolve="description" />
                 </node>
                 <node concept="2OqwBi" id="7OJcYqymLd5" role="37wK5m">
                   <node concept="37vLTw" id="7OJcYqymLd6" role="2Oq$k0">
@@ -6495,6 +6403,12 @@
                   <node concept="liA8E" id="7OJcYqymLd7" role="2OqNvi">
                     <ref role="37wK5l" to="y7p:7OJcYqwQy$4" resolve="getShortDescription" />
                   </node>
+                </node>
+                <node concept="3uibUv" id="7OJcYq$Oym2" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+                </node>
+                <node concept="3uibUv" id="7OJcYq$OEbl" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
                 </node>
               </node>
             </node>
@@ -6604,6 +6518,12 @@
                     <ref role="37wK5l" to="y7p:7OJcYqwQy$L" resolve="getConceptAlias" />
                   </node>
                 </node>
+                <node concept="3uibUv" id="7OJcYq$N8MQ" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+                </node>
+                <node concept="3uibUv" id="7OJcYq$N8MR" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
+                </node>
               </node>
             </node>
           </node>
@@ -6686,6 +6606,12 @@
                     <ref role="37wK5l" to="y7p:7OJcYqwQy$U" resolve="getConceptShortDescription" />
                   </node>
                 </node>
+                <node concept="3uibUv" id="7OJcYq$OLDl" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+                </node>
+                <node concept="3uibUv" id="7OJcYq$OR60" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
+                </node>
               </node>
             </node>
           </node>
@@ -6712,6 +6638,12 @@
                   <node concept="liA8E" id="7OJcYqyrCcO" role="2OqNvi">
                     <ref role="37wK5l" to="y7p:7OJcYqwUzr1" resolve="getSpecificLanguage" />
                   </node>
+                </node>
+                <node concept="3uibUv" id="7OJcYq$P5lG" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+                </node>
+                <node concept="3uibUv" id="7OJcYq$PcLY" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageStaple" />
                 </node>
               </node>
             </node>
@@ -6765,15 +6697,6 @@
     <node concept="3clFb_" id="7OJcYqygnxo" role="jymVt">
       <property role="TrG5h" value="getVirtualPackage" />
       <node concept="3Tm1VV" id="7OJcYqygnxq" role="1B3o_S" />
-      <node concept="3uibUv" id="7OJcYqygnxr" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
-        <node concept="3uibUv" id="7OJcYqygnxs" role="11_B2D">
-          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-        </node>
-        <node concept="3uibUv" id="7OJcYqygnxt" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
-        </node>
-      </node>
       <node concept="3clFbS" id="7OJcYqygnxv" role="3clF47">
         <node concept="3clFbF" id="7OJcYqyg_CB" role="3cqZAp">
           <node concept="37vLTw" id="7OJcYqyg_C$" role="3clFbG">
@@ -6783,6 +6706,9 @@
       </node>
       <node concept="2AHcQZ" id="7OJcYqygnxw" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3uibUv" id="7OJcYq_3nhw" role="3clF45">
+        <ref role="3uigEE" node="7OJcYq_2Ogv" resolve="JsonAnnotationPropertyStaple" />
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqyliQo" role="jymVt" />
@@ -6813,15 +6739,6 @@
     <node concept="3clFb_" id="7OJcYqygOBN" role="jymVt">
       <property role="TrG5h" value="getShortDescription" />
       <node concept="3Tm1VV" id="7OJcYqygOBP" role="1B3o_S" />
-      <node concept="3uibUv" id="7OJcYqygOBQ" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
-        <node concept="3uibUv" id="7OJcYqygOBR" role="11_B2D">
-          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-        </node>
-        <node concept="3uibUv" id="7OJcYqygOBS" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
-        </node>
-      </node>
       <node concept="3clFbS" id="7OJcYqygOBU" role="3clF47">
         <node concept="3clFbF" id="7OJcYqygOBX" role="3cqZAp">
           <node concept="37vLTw" id="7OJcYqygUiR" role="3clFbG">
@@ -6831,6 +6748,9 @@
       </node>
       <node concept="2AHcQZ" id="7OJcYqygOBV" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3uibUv" id="7OJcYq_405q" role="3clF45">
+        <ref role="3uigEE" node="7OJcYq_2Ogv" resolve="JsonAnnotationPropertyStaple" />
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqykZXv" role="jymVt" />
@@ -6861,15 +6781,6 @@
     <node concept="3clFb_" id="7OJcYqyhdSU" role="jymVt">
       <property role="TrG5h" value="getConceptDescriptionAnnotation" />
       <node concept="3Tm1VV" id="7OJcYqyhdSW" role="1B3o_S" />
-      <node concept="3uibUv" id="7OJcYqyhdSX" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
-        <node concept="3uibUv" id="7OJcYqyhdSY" role="11_B2D">
-          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-        </node>
-        <node concept="3uibUv" id="7OJcYqyhdSZ" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
-        </node>
-      </node>
       <node concept="3clFbS" id="7OJcYqyhdT1" role="3clF47">
         <node concept="3clFbF" id="7OJcYqyhunt" role="3cqZAp">
           <node concept="37vLTw" id="7OJcYqyhunq" role="3clFbG">
@@ -6880,20 +6791,20 @@
       <node concept="2AHcQZ" id="7OJcYqyhdT2" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
+      <node concept="3uibUv" id="7OJcYq$QPX3" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
+        <node concept="3uibUv" id="7OJcYq$QPX4" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+        </node>
+        <node concept="3uibUv" id="7OJcYq$QPX5" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageStaple" />
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqyijIi" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyhHPP" role="jymVt">
       <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptAlias" />
       <node concept="3Tm1VV" id="7OJcYqyhHPR" role="1B3o_S" />
-      <node concept="3uibUv" id="7OJcYqyhHPS" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
-        <node concept="3uibUv" id="7OJcYqyhHPT" role="11_B2D">
-          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
-        </node>
-        <node concept="3uibUv" id="7OJcYqyhHPU" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
-        </node>
-      </node>
       <node concept="3clFbS" id="7OJcYqyhHPW" role="3clF47">
         <node concept="3clFbF" id="7OJcYqyhYYY" role="3cqZAp">
           <node concept="37vLTw" id="7OJcYqyhYYV" role="3clFbG">
@@ -6904,20 +6815,20 @@
       <node concept="2AHcQZ" id="7OJcYqyhHPX" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
+      <node concept="3uibUv" id="7OJcYq$Rb75" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
+        <node concept="3uibUv" id="7OJcYq$Rb76" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="7OJcYq$Rb77" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqyiatN" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyisuh" role="jymVt">
       <property role="TrG5h" value="getConceptDescriptionAnnotation_ConceptShortDescription" />
       <node concept="3Tm1VV" id="7OJcYqyisuj" role="1B3o_S" />
-      <node concept="3uibUv" id="7OJcYqyisuk" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
-        <node concept="3uibUv" id="7OJcYqyisul" role="11_B2D">
-          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
-        </node>
-        <node concept="3uibUv" id="7OJcYqyisum" role="11_B2D">
-          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
-        </node>
-      </node>
       <node concept="3clFbS" id="7OJcYqyisuo" role="3clF47">
         <node concept="3clFbF" id="7OJcYqyiIpI" role="3cqZAp">
           <node concept="37vLTw" id="7OJcYqyiIpF" role="3clFbG">
@@ -6927,6 +6838,15 @@
       </node>
       <node concept="2AHcQZ" id="7OJcYqyisup" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3uibUv" id="7OJcYq$Rvya" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
+        <node concept="3uibUv" id="7OJcYq$Rvyb" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="7OJcYq$Rvyc" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNSLlx" role="jymVt" />
@@ -6963,7 +6883,7 @@
                             <ref role="3cqZAo" node="5JNiskj_14S" resolve="it" />
                           </node>
                           <node concept="liA8E" id="7OJcYqzMKKi" role="2OqNvi">
-                            <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+                            <ref role="37wK5l" node="7OJcYq_2Qii" resolve="getJsonAnnotation" />
                           </node>
                         </node>
                       </node>
@@ -7007,7 +6927,7 @@
           <node concept="2OqwBi" id="5JNiskj669S" role="3clFbG">
             <node concept="2OqwBi" id="5JNiskj_9sT" role="2Oq$k0">
               <node concept="1rXfSq" id="5JNiskj669T" role="2Oq$k0">
-                <ref role="37wK5l" node="5JNiskjzWqH" resolve="listMpsM1AnnotationPropertyMembers" />
+                <ref role="37wK5l" node="5JNiskjzWq_" resolve="listMpsM1Annotations" />
               </node>
               <node concept="3$u5V9" id="5JNiskj_bOB" role="2OqNvi">
                 <node concept="1bVj0M" id="5JNiskj_bOD" role="23t8la">
@@ -7021,7 +6941,7 @@
                             <ref role="3cqZAo" node="5JNiskj_bOF" resolve="it" />
                           </node>
                           <node concept="liA8E" id="7OJcYqzMT2L" role="2OqNvi">
-                            <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+                            <ref role="37wK5l" node="7OJcYqxTQ2j" resolve="getJson" />
                           </node>
                         </node>
                       </node>
@@ -7051,14 +6971,8 @@
       <property role="TrG5h" value="listMpsM1Annotations" />
       <node concept="3Tm1VV" id="5JNiskjzWqB" role="1B3o_S" />
       <node concept="_YKpA" id="5JNiskjzWqC" role="3clF45">
-        <node concept="3uibUv" id="7OJcYqzM6gg" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
-          <node concept="3uibUv" id="7OJcYqzM6gh" role="11_B2D">
-            <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-          </node>
-          <node concept="3uibUv" id="7OJcYqzM6gi" role="11_B2D">
-            <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
-          </node>
+        <node concept="3uibUv" id="7OJcYq_33js" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYq_2Ogv" resolve="JsonAnnotationPropertyStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="5JNiskjzWqF" role="3clF47">
@@ -7071,14 +6985,8 @@
               <node concept="1rXfSq" id="5JNiskj$IW2" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqygOBN" resolve="getShortDescription" />
               </node>
-              <node concept="3uibUv" id="7OJcYqzLZrs" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
-                <node concept="3uibUv" id="7OJcYqzLZrt" role="11_B2D">
-                  <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
-                </node>
-                <node concept="3uibUv" id="7OJcYqzLZru" role="11_B2D">
-                  <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
-                </node>
+              <node concept="3uibUv" id="7OJcYq_3gQ9" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYq_2Ogv" resolve="JsonAnnotationPropertyStaple" />
               </node>
             </node>
           </node>
@@ -7089,241 +6997,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskjzYuJ" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskjzWqH" role="jymVt">
-      <property role="TrG5h" value="listMpsM1AnnotationPropertyMembers" />
-      <node concept="3Tm1VV" id="5JNiskjzWqJ" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskjzWqK" role="3clF45">
-        <node concept="3uibUv" id="7OJcYqzMr5s" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
-          <node concept="3uibUv" id="7OJcYqzMr5t" role="11_B2D">
-            <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
-          </node>
-          <node concept="3uibUv" id="7OJcYqzMr5u" role="11_B2D">
-            <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
-          </node>
-        </node>
-      </node>
-      <node concept="3clFbS" id="5JNiskjzWqN" role="3clF47">
-        <node concept="3clFbF" id="5JNiskj$KeI" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskj$KeJ" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskj$KeK" role="2ShVmc">
-              <node concept="1rXfSq" id="5JNiskj$KeO" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqylp3c" resolve="getVirtualPackage_Name" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskj$KeS" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqyl4JA" resolve="getShortDescription_Description" />
-              </node>
-              <node concept="3uibUv" id="7OJcYqzMkcU" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
-                <node concept="3uibUv" id="7OJcYqzMkcV" role="11_B2D">
-                  <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
-                </node>
-                <node concept="3uibUv" id="7OJcYqzMkcW" role="11_B2D">
-                  <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5JNiskjzWqO" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiskjzZp5" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskjzWqP" role="jymVt">
-      <property role="TrG5h" value="mapSpecificAnnotationMembers" />
-      <node concept="3Tm1VV" id="5JNiskjzWqR" role="1B3o_S" />
-      <node concept="3rvAFt" id="5JNiskjzWqS" role="3clF45">
-        <node concept="3uibUv" id="5JNiskjzWqT" role="3rvQeY">
-          <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-        </node>
-        <node concept="3uibUv" id="5JNiskjzWqU" role="3rvSg0">
-          <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-        </node>
-      </node>
-      <node concept="3clFbS" id="5JNiskjzWqW" role="3clF47">
-        <node concept="3cpWs8" id="5JNiskjrcbQ" role="3cqZAp">
-          <node concept="3cpWsn" id="5JNiskjrcbR" role="3cpWs9">
-            <property role="TrG5h" value="conceptMetaPointers" />
-            <node concept="_YKpA" id="5JNiskjrbM0" role="1tU5fm">
-              <node concept="3uibUv" id="5JNiskjrbM3" role="_ZDj9">
-                <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5JNiskjrcbS" role="33vP2m">
-              <node concept="2OqwBi" id="5JNiskjrcbT" role="2Oq$k0">
-                <node concept="1rXfSq" id="5JNiskj$4kk" role="2Oq$k0">
-                  <ref role="37wK5l" node="5JNiskjzWq_" resolve="listMpsM1Annotations" />
-                </node>
-                <node concept="3$u5V9" id="5JNiskjrcbX" role="2OqNvi">
-                  <node concept="1bVj0M" id="5JNiskjrcbY" role="23t8la">
-                    <node concept="3clFbS" id="5JNiskjrcbZ" role="1bW5cS">
-                      <node concept="3clFbF" id="5JNiskjrcc0" role="3cqZAp">
-                        <node concept="2YIFZM" id="7OJcYqzQLTz" role="3clFbG">
-                          <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-                          <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.LanguageEntity)" resolve="from" />
-                          <node concept="2OqwBi" id="7OJcYqzQLT_" role="37wK5m">
-                            <node concept="37vLTw" id="7OJcYqzQLTA" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5JNiskjrcc3" resolve="it" />
-                            </node>
-                            <node concept="liA8E" id="7OJcYqzQLTB" role="2OqNvi">
-                              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Rh6nW" id="5JNiskjrcc3" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="5JNiskjrcc4" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="ANE8D" id="5JNiskjrcc5" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="5JNiskjdXnc" role="3cqZAp">
-          <node concept="3cpWsn" id="5JNiskjdXnd" role="3cpWs9">
-            <property role="TrG5h" value="result" />
-            <node concept="3rvAFt" id="5JNiskjdXne" role="1tU5fm">
-              <node concept="3uibUv" id="5JNiskjdXnf" role="3rvQeY">
-                <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-              </node>
-              <node concept="3uibUv" id="5JNiskjdXng" role="3rvSg0">
-                <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-              </node>
-            </node>
-            <node concept="2ShNRf" id="5JNiskjdXnh" role="33vP2m">
-              <node concept="32Fmki" id="5JNiskjdXni" role="2ShVmc">
-                <node concept="3uibUv" id="5JNiskjdXnj" role="3rHrn6">
-                  <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-                </node>
-                <node concept="3uibUv" id="5JNiskjdXnk" role="3rHtpV">
-                  <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-                </node>
-                <node concept="2OqwBi" id="5JNiskj$nwJ" role="3lNPQL">
-                  <node concept="37vLTw" id="5JNiskj$lIZ" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5JNiskjrcbR" resolve="conceptMetaPointers" />
-                  </node>
-                  <node concept="34oBXx" id="5JNiskj$oAH" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5JNiskjrp1A" role="3cqZAp" />
-        <node concept="3cpWs8" id="5JNiskjrI_N" role="3cqZAp">
-          <node concept="3cpWsn" id="5JNiskjrI_O" role="3cpWs9">
-            <property role="TrG5h" value="conceptIter1" />
-            <node concept="uOF1S" id="5JNiskj$q7b" role="1tU5fm">
-              <node concept="3uibUv" id="5JNiskj$rD4" role="uOL27">
-                <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5JNiskjrI_R" role="33vP2m">
-              <node concept="37vLTw" id="5JNiskjrI_S" role="2Oq$k0">
-                <ref role="3cqZAo" node="5JNiskjrcbR" resolve="conceptMetaPointers" />
-              </node>
-              <node concept="uNJiE" id="5JNiskjrI_T" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="5JNiskjsbHW" role="3cqZAp">
-          <node concept="3cpWsn" id="5JNiskjsbHX" role="3cpWs9">
-            <property role="TrG5h" value="metaPointerIter" />
-            <node concept="uOF1S" id="5JNiskjsbcF" role="1tU5fm">
-              <node concept="3uibUv" id="5JNiskjsbcI" role="uOL27">
-                <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5JNiskjsbHY" role="33vP2m">
-              <node concept="2OqwBi" id="5JNiskjsbHZ" role="2Oq$k0">
-                <node concept="1rXfSq" id="5JNiskj$7v6" role="2Oq$k0">
-                  <ref role="37wK5l" node="5JNiskjzWqH" resolve="listMpsM1AnnotationPropertyMembers" />
-                </node>
-                <node concept="3$u5V9" id="5JNiskjsbI3" role="2OqNvi">
-                  <node concept="1bVj0M" id="5JNiskjsbI4" role="23t8la">
-                    <node concept="3clFbS" id="5JNiskjsbI5" role="1bW5cS">
-                      <node concept="3clFbF" id="5JNiskjsbI6" role="3cqZAp">
-                        <node concept="2YIFZM" id="5JNiskjsbI7" role="3clFbG">
-                          <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.Feature)" resolve="from" />
-                          <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-                          <node concept="2OqwBi" id="7OJcYqzNkAn" role="37wK5m">
-                            <node concept="37vLTw" id="5JNiskjsbI8" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5JNiskjsbI9" resolve="it" />
-                            </node>
-                            <node concept="liA8E" id="7OJcYqzNpO_" role="2OqNvi">
-                              <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Rh6nW" id="5JNiskjsbI9" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="5JNiskjsbIa" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="uNJiE" id="5JNiskjsbIb" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="2$JKZl" id="5JNiskjsm3d" role="3cqZAp">
-          <node concept="3clFbS" id="5JNiskjsm3f" role="2LFqv$">
-            <node concept="3clFbF" id="5JNiskjsBwp" role="3cqZAp">
-              <node concept="37vLTI" id="5JNiskjsNwA" role="3clFbG">
-                <node concept="2OqwBi" id="5JNiskjsSzL" role="37vLTx">
-                  <node concept="37vLTw" id="5JNiskjsQ4q" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5JNiskjsbHX" resolve="metaPointerIter" />
-                  </node>
-                  <node concept="v1n4t" id="5JNiskjsUtY" role="2OqNvi" />
-                </node>
-                <node concept="3EllGN" id="5JNiskjsDHi" role="37vLTJ">
-                  <node concept="2OqwBi" id="5JNiskjsIz0" role="3ElVtu">
-                    <node concept="37vLTw" id="5JNiskjsG43" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5JNiskjrI_O" resolve="conceptIter1" />
-                    </node>
-                    <node concept="v1n4t" id="5JNiskjsL8r" role="2OqNvi" />
-                  </node>
-                  <node concept="37vLTw" id="5JNiskjsBwo" role="3ElQJh">
-                    <ref role="3cqZAo" node="5JNiskjdXnd" resolve="result" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="1Wc70l" id="5JNiskjsuGt" role="2$JKZa">
-            <node concept="2OqwBi" id="5JNiskjsz2I" role="3uHU7w">
-              <node concept="37vLTw" id="5JNiskjswMR" role="2Oq$k0">
-                <ref role="3cqZAo" node="5JNiskjsbHX" resolve="metaPointerIter" />
-              </node>
-              <node concept="v0PNk" id="5JNiskjs_o4" role="2OqNvi" />
-            </node>
-            <node concept="2OqwBi" id="5JNiskjsqkU" role="3uHU7B">
-              <node concept="37vLTw" id="5JNiskjsorJ" role="2Oq$k0">
-                <ref role="3cqZAo" node="5JNiskjrI_O" resolve="conceptIter1" />
-              </node>
-              <node concept="v0PNk" id="5JNiskjssvc" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5JNiskj$utn" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiskj$x0N" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskj$x0L" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskjdXnd" resolve="result" />
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5JNiskjzWqX" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="34Q84zNSIta" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqzI5x6" role="jymVt">
       <property role="TrG5h" value="listMpsM2AnnotationProperties" />
       <node concept="3Tm1VV" id="7OJcYqzI5x8" role="1B3o_S" />
@@ -7333,8 +7006,10 @@
           <node concept="3uibUv" id="7OJcYqzI5xb" role="11_B2D">
             <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
           </node>
-          <node concept="3uibUv" id="7OJcYqzI5xc" role="11_B2D">
-            <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
+          <node concept="3qUE_q" id="7OJcYq$SMWI" role="11_B2D">
+            <node concept="3uibUv" id="7OJcYq$STAU" role="3qUE_r">
+              <ref role="3uigEE" to="y7p:7OJcYq$EbsZ" resolve="IPropertyStaple" />
+            </node>
           </node>
         </node>
       </node>
@@ -7353,8 +7028,10 @@
                 <node concept="3uibUv" id="7OJcYqzJ5xD" role="11_B2D">
                   <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
                 </node>
-                <node concept="3uibUv" id="7OJcYqzJ5xE" role="11_B2D">
-                  <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
+                <node concept="3qUE_q" id="7OJcYq$T5wW" role="11_B2D">
+                  <node concept="3uibUv" id="7OJcYq$TcfV" role="3qUE_r">
+                    <ref role="3uigEE" to="y7p:7OJcYq$EbsZ" resolve="IPropertyStaple" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -8120,6 +7797,105 @@
       </node>
       <node concept="2AHcQZ" id="7OJcYqxTQ2w" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="7OJcYq_2Ogv">
+    <property role="3GE5qa" value="jsonConstants" />
+    <property role="TrG5h" value="JsonAnnotationPropertyStaple" />
+    <node concept="3Tm1VV" id="7OJcYq_2Ogw" role="1B3o_S" />
+    <node concept="3uibUv" id="7OJcYq_2Oi7" role="1zkMxy">
+      <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
+      <node concept="3uibUv" id="7OJcYq_2OiC" role="11_B2D">
+        <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+      </node>
+      <node concept="3uibUv" id="7OJcYq_2Ong" role="11_B2D">
+        <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYq_2PvO" role="jymVt">
+      <property role="TrG5h" value="jsonAnnotation" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYq_2PvP" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYq_2PvR" role="1tU5fm">
+        <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYq_2PRT" role="jymVt" />
+    <node concept="3clFbW" id="7OJcYq_2OAc" role="jymVt">
+      <node concept="3cqZAl" id="7OJcYq_2OAd" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYq_2OAe" role="1B3o_S" />
+      <node concept="37vLTG" id="7OJcYq_2OAs" role="3clF46">
+        <property role="TrG5h" value="json" />
+        <node concept="3uibUv" id="7OJcYq_2OOi" role="1tU5fm">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYq_2OAu" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYq_2Pt$" role="3clF46">
+        <property role="TrG5h" value="jsonAnnotation" />
+        <node concept="3uibUv" id="7OJcYq_2PuZ" role="1tU5fm">
+          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYq_2Q6b" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYq_2OAv" role="3clF46">
+        <property role="TrG5h" value="staple" />
+        <node concept="3uibUv" id="7OJcYq_2OVw" role="1tU5fm">
+          <ref role="3uigEE" to="y7p:7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYq_2OAx" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYq_2OAy" role="3clF47">
+        <node concept="XkiVB" id="7OJcYq_2OAz" role="3cqZAp">
+          <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
+          <node concept="37vLTw" id="7OJcYq_2OA$" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYq_2OAs" resolve="json" />
+          </node>
+          <node concept="37vLTw" id="7OJcYq_2OA_" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYq_2OAv" resolve="staple" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYq_2PvS" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYq_2PvU" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYq_2PEx" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYq_2PFu" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYq_2PE$" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYq_2PvO" resolve="jsonAnnotation" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7OJcYq_2PvY" role="37vLTx">
+              <ref role="3cqZAo" node="7OJcYq_2Pt$" resolve="jsonAnnotation" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYq_2QlC" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYq_2Qii" role="jymVt">
+      <property role="TrG5h" value="getJsonAnnotation" />
+      <node concept="3uibUv" id="7OJcYq_2Qij" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYq_2Qik" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYq_2Qil" role="3clF47">
+        <node concept="3clFbF" id="7OJcYq_2Qim" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq_2Qif" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYq_2Qig" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYq_2Qih" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYq_2PvO" resolve="jsonAnnotation" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYq_2Qot" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
       </node>
     </node>
   </node>

--- a/solutions/io.lionweb.mps.m3.runtime/io.lionweb.mps.m3.runtime.msd
+++ b/solutions/io.lionweb.mps.m3.runtime/io.lionweb.mps.m3.runtime.msd
@@ -17,6 +17,7 @@
     <dependency reexport="false">7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)</dependency>
     <dependency reexport="false">411e5b27-8a76-482e-8af8-1704262b4468(io.lionweb.mps.structure.attribute)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">e92f782f-6faf-41c2-bf76-2b1a350c0516(io.lionweb.mps.specific)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:e92f782f-6faf-41c2-bf76-2b1a350c0516:io.lionweb.mps.specific" version="0" />
@@ -37,6 +38,7 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="01cf0d82-8d29-4fc4-be96-28abaf4ad33d(io.lionweb.mps.m3)" version="0" />
     <module reference="7350a1d7-537e-4f0d-9965-e91c82522d7d(io.lionweb.mps.m3.runtime)" version="0" />
+    <module reference="e92f782f-6faf-41c2-bf76-2b1a350c0516(io.lionweb.mps.specific)" version="0" />
     <module reference="411e5b27-8a76-482e-8af8-1704262b4468(io.lionweb.mps.structure.attribute)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -110,7 +110,6 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
-      <concept id="1068431790191" name="jetbrains.mps.baseLanguage.structure.Expression" flags="nn" index="33vP2n" />
       <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ">
         <child id="1214996921760" name="bound" index="3ztrMU" />
       </concept>
@@ -284,17 +283,6 @@
         <reference id="7256306938026143658" name="target" index="2aWVGs" />
         <child id="7256306938026143676" name="child" index="2aWVGa" />
       </concept>
-      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
-        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
-        <child id="679099339649067980" name="name" index="1j$8Uc" />
-      </concept>
-      <concept id="361130699826193247" name="jetbrains.mps.lang.modelapi.structure.NodePointer" flags="ng" index="1dCxOE">
-        <property id="5035511943546916744" name="nodeId" index="2OI7jA" />
-        <child id="5035511943546916740" name="modelRef" index="2OI7jE" />
-      </concept>
-      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
-        <property id="679099339649053841" name="value" index="1j_P7h" />
-      </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
@@ -322,9 +310,6 @@
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
-      </concept>
-      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
-        <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
       <concept id="1966870290088668512" name="jetbrains.mps.lang.smodel.structure.Enum_MemberLiteral" flags="ng" index="2ViDtV">
         <reference id="1966870290088668516" name="memberDeclaration" index="2ViDtZ" />
@@ -587,97 +572,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="5JNiskiqTwm" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwsbri" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiLd$U" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiLd$V" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiLd$W" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskiKYx9" resolve="SLANG_SPECIFIC_LANGUAGE" />
-              </node>
-              <node concept="pHN19" id="5JNiskiLd$X" role="37vLTx">
-                <node concept="2V$Bhx" id="5JNiskiLken" role="2V$M_3">
-                  <property role="2V$B1T" value="e92f782f-6faf-41c2-bf76-2b1a350c0516" />
-                  <property role="2V$B1Q" value="io.lionweb.mps.specific" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwsbrj" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiLd$Z" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiLd_0" role="3clFbG">
-              <node concept="2YIFZM" id="5JNiskiLd_1" role="37vLTx">
-                <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
-                <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-                <node concept="37vLTw" id="5JNiskiLd_2" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiskiKYx9" resolve="SLANG_SPECIFIC_LANGUAGE" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiLd_3" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskiKYx0" resolve="SLANG_SPECIFIC_LANGUAGE_ID" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwsbrk" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiLd_i" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiLd_j" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiLd_k" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskiKYxi" resolve="KEY_SPECIFIC_LANGUAGE" />
-              </node>
-              <node concept="Xl_RD" id="5JNiskiLd_l" role="37vLTx">
-                <property role="Xl_RC" value="io-lionweb-mps-specific" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwsbrl" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiLd_m" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiLd_n" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiLd_o" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskiKYxr" resolve="ID_SPECIFIC_LANGUAGE" />
-              </node>
-              <node concept="2OqwBi" id="5JNiskiLd_p" role="37vLTx">
-                <node concept="37vLTw" id="5JNiskiLd_q" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5JNiskiKYx9" resolve="SLANG_SPECIFIC_LANGUAGE" />
-                </node>
-                <node concept="liA8E" id="5JNiskiLd_r" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwsbrm" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiLd_s" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiLd_t" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiLd_v" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskiKYx$" resolve="VERSION_SPECIFIC_LANGUAGE" />
-              </node>
-              <node concept="2YIFZM" id="5JNiskiLIv8" role="37vLTx">
-                <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
-                <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
-                <node concept="2YIFZM" id="5JNiskiLD74" role="37wK5m">
-                  <ref role="1Pybhc" node="6jTTMHD72IS" resolve="MpsLanguageUtil" />
-                  <ref role="37wK5l" node="6jTTMHD72KX" resolve="getLanguageVersion" />
-                  <node concept="37vLTw" id="5JNiskiLDWr" role="37wK5m">
-                    <ref role="3cqZAo" node="5JNiskiKYx9" resolve="SLANG_SPECIFIC_LANGUAGE" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5JNiskiLcO1" role="3cqZAp" />
         <node concept="3cpWs8" id="7OJcYqw9N$4" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqw9N$5" role="3cpWs9">
             <property role="TrG5h" value="attributeLc" />
@@ -744,186 +638,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="7OJcYqwVLdv" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwspqa" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiqveL" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiqveM" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqveN" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskiq_M0" resolve="LC_VIRTUAL_PACKAGE_ANNOTATION" />
-              </node>
-              <node concept="2OqwBi" id="5JNiskiqveO" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiskiqveP" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiskiqveQ" role="2tJFKM">
-                    <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
-                    <node concept="ZC_QK" id="5JNiskiqveR" role="2aWVGa">
-                      <ref role="2aWVGs" to="4xw4:5JNiskir1qK" resolve="VirtualPackage" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiskiqveT" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiskiqveU" role="Vysub">
-                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwspqb" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiqveV" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiqveW" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiskiqveX" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiskiqveY" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiskiqveZ" role="2tJFKM">
-                    <ref role="2aWVGs" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                    <node concept="ZC_QK" id="5JNiskiqvf0" role="2aWVGa">
-                      <ref role="2aWVGs" to="tpck:hnGE5uv" resolve="virtualPackage" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiskiqvf1" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiskiqvf2" role="Vysub">
-                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqvf3" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskiq_M9" resolve="MPS_VIRTUAL_PACKAGE_PROPERTY" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwspqc" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiqvf4" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiqvf5" role="3clFbG">
-              <node concept="2YIFZM" id="5JNiskiqvf6" role="37vLTx">
-                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
-                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-                <node concept="37vLTw" id="5JNiskiqvf7" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiskiqTF2" resolve="coreLangHighBits" />
-                </node>
-                <node concept="37vLTw" id="5JNiskiqvf8" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiskiqTF8" resolve="coreLangLowBits" />
-                </node>
-                <node concept="2YIFZM" id="5JNiskiqvf9" role="37wK5m">
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <node concept="2OqwBi" id="5JNiskiqvfa" role="37wK5m">
-                    <node concept="37vLTw" id="5JNiskiqvfb" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
-                    </node>
-                    <node concept="3TrcHB" id="5JNiskiqvfc" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2YIFZM" id="5JNiskiqvfd" role="37wK5m">
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <node concept="2OqwBi" id="5JNiskiqvfe" role="37wK5m">
-                    <node concept="37vLTw" id="5JNiskiqvff" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5JNiskiq_M9" resolve="MPS_VIRTUAL_PACKAGE_PROPERTY" />
-                    </node>
-                    <node concept="3TrcHB" id="5JNiskiqvfg" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="5JNiskiqvfh" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiskiqvfi" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5JNiskiq_M9" resolve="MPS_VIRTUAL_PACKAGE_PROPERTY" />
-                  </node>
-                  <node concept="3TrcHB" id="5JNiskiqvfj" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqvfk" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskiq_Mi" resolve="SLANG_VIRTUAL_PACKAGE_PROPERTY" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwspqd" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiqvfl" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiqvfm" role="3clFbG">
-              <node concept="2YIFZM" id="7OJcYqwPrVe" role="37vLTx">
-                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
-                <node concept="37vLTw" id="5JNiskiqvfo" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiskiq_M0" resolve="LC_VIRTUAL_PACKAGE_ANNOTATION" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqvfp" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskiq_Mr" resolve="KEY_VIRTUAL_PACKAGE_ANNOTATION" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwspqe" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiqvfq" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiqvfr" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqvfs" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskiq_M$" resolve="ID_VIRTUAL_PACKAGE_PROPERTY" />
-              </node>
-              <node concept="2OqwBi" id="5JNiskiqvft" role="37vLTx">
-                <node concept="2YIFZM" id="5JNiskiqvfu" role="2Oq$k0">
-                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getPropId(org.jetbrains.mps.openapi.model.SNode)" resolve="getPropId" />
-                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                  <node concept="37vLTw" id="5JNiskiqvfv" role="37wK5m">
-                    <ref role="3cqZAo" node="5JNiskiq_M9" resolve="MPS_VIRTUAL_PACKAGE_PROPERTY" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="5JNiskiqvfw" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SPropertyId.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwspqf" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbH" id="5JNiskirCzz" role="8Wnug" />
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwspqg" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskirDae" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskirDVC" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskirEvM" role="37vLTx">
-                <ref role="3cqZAo" node="5AGBwuFJEKi" resolve="LC_NAME_PROPERTY" />
-              </node>
-              <node concept="37vLTw" id="5JNiskirDac" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskirrGQ" resolve="LC_VIRTUAL_PACKAGE_NAME_PROPERTY" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwspqh" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskirFu0" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskirGhZ" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskirGWw" role="37vLTx">
-                <ref role="3cqZAo" node="5M3rB6_PC4J" resolve="KEY_NAME_PROPERTY" />
-              </node>
-              <node concept="37vLTw" id="5JNiskirFtY" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskirATB" resolve="KEY_VIRTUAL_PACKAGE_NAME_PROPERTY" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="7OJcYqwnyFp" role="3cqZAp" />
         <node concept="3cpWs8" id="7OJcYqwstkt" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqwstku" role="3cpWs9">
             <property role="TrG5h" value="mpsVirtualPackageProp" />
@@ -1047,205 +761,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="5JNiskiqvea" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwsC4F" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiqUBL" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiqUBM" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqUBN" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskiqAL0" resolve="LC_SHORT_DESCRIPTION_ANNOTATION" />
-              </node>
-              <node concept="2OqwBi" id="5JNiskiqUBO" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiskiqUBP" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiskiqUBQ" role="2tJFKM">
-                    <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
-                    <node concept="ZC_QK" id="5JNiskiqUBR" role="2aWVGa">
-                      <ref role="2aWVGs" to="4xw4:5JNiskir1qS" resolve="ShortDescription" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiskiqUBT" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiskiqUBU" role="Vysub">
-                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwsC4G" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiqUBC" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiqUBD" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiskiqUBE" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiskiqUBF" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiskiqUBG" role="2tJFKM">
-                    <ref role="2aWVGs" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                    <node concept="ZC_QK" id="5JNiskiqUBH" role="2aWVGa">
-                      <ref role="2aWVGs" to="tpck:gOOYnlO" resolve="shortDescription" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiskiqUBI" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiskiqUBJ" role="Vysub">
-                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqUBK" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskiqAL9" resolve="MPS_SHORT_DESCRIPTION_PROPERTY" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwsC4H" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiqUBn" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiqUBo" role="3clFbG">
-              <node concept="2YIFZM" id="5JNiskiqUBp" role="37vLTx">
-                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
-                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-                <node concept="37vLTw" id="5JNiskiqUBq" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiskiqTF2" resolve="coreLangHighBits" />
-                </node>
-                <node concept="37vLTw" id="5JNiskiqUBr" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiskiqTF8" resolve="coreLangLowBits" />
-                </node>
-                <node concept="2YIFZM" id="5JNiskiqUBs" role="37wK5m">
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <node concept="2OqwBi" id="5JNiskiqUBt" role="37wK5m">
-                    <node concept="37vLTw" id="5JNiskiqUBu" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
-                    </node>
-                    <node concept="3TrcHB" id="5JNiskiqUBv" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2YIFZM" id="5JNiskiqUBw" role="37wK5m">
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <node concept="2OqwBi" id="5JNiskiqUBx" role="37wK5m">
-                    <node concept="37vLTw" id="5JNiskiqUBy" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5JNiskiqAL9" resolve="MPS_SHORT_DESCRIPTION_PROPERTY" />
-                    </node>
-                    <node concept="3TrcHB" id="5JNiskiqUBz" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="5JNiskiqUB$" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiskiqUB_" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5JNiskiqAL9" resolve="MPS_SHORT_DESCRIPTION_PROPERTY" />
-                  </node>
-                  <node concept="3TrcHB" id="5JNiskiqUBA" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqUBB" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskiqALi" resolve="SLANG_SHORT_DESCRIPTION_PROPERTY" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwsC4I" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiqUBi" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiqUBj" role="3clFbG">
-              <node concept="2YIFZM" id="7OJcYqwPrVf" role="37vLTx">
-                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
-                <node concept="37vLTw" id="5JNiskiqUBl" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiskiqAL0" resolve="LC_SHORT_DESCRIPTION_ANNOTATION" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqUBm" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskiqALr" resolve="KEY_SHORT_DESCRIPTION_ANNOTATION" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwsC4J" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiqUBb" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiqUBc" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqUBd" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskiqAL$" resolve="ID_SHORT_DESCRIPTION_PROPERTY" />
-              </node>
-              <node concept="2OqwBi" id="5JNiskiqUBe" role="37vLTx">
-                <node concept="2YIFZM" id="5JNiskiqUBf" role="2Oq$k0">
-                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getPropId(org.jetbrains.mps.openapi.model.SNode)" resolve="getPropId" />
-                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                  <node concept="37vLTw" id="5JNiskiqUBg" role="37wK5m">
-                    <ref role="3cqZAo" node="5JNiskiqAL9" resolve="MPS_SHORT_DESCRIPTION_PROPERTY" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="5JNiskiqUBh" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SPropertyId.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwsC4K" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbH" id="5JNiskiqUBa" role="8Wnug" />
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwsC4L" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskirIur" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskirIXA" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskirIup" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskirxyP" resolve="LC_SHORT_DESCRIPTION_DESCRIPTION_PROPERTY" />
-              </node>
-              <node concept="2OqwBi" id="5JNiskirJE0" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiskirJE1" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiskirJE2" role="2tJFKM">
-                    <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
-                    <node concept="ZC_QK" id="5JNiskirJE3" role="2aWVGa">
-                      <ref role="2aWVGs" to="4xw4:5JNiskir1qS" resolve="ShortDescription" />
-                      <node concept="ZC_QK" id="5JNiskirKgZ" role="2aWVGa">
-                        <ref role="2aWVGs" to="4xw4:5JNiskir1qZ" resolve="description" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiskirJE4" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiskirJE5" role="Vysub">
-                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwsC4M" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskirLBn" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskirMdt" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskirLBl" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskirzDP" resolve="KEY_SHORT_DESCRIPTION_DESCRIPTION_PROPERTY" />
-              </node>
-              <node concept="2YIFZM" id="7OJcYqwPrVg" role="37vLTx">
-                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
-                <node concept="37vLTw" id="5JNiskirMKR" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiskirxyP" resolve="LC_SHORT_DESCRIPTION_DESCRIPTION_PROPERTY" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="34Q84zNOgJd" role="3cqZAp" />
         <node concept="3cpWs8" id="7OJcYqwsFRR" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqwsFRS" role="3cpWs9">
             <property role="TrG5h" value="mpsShortDescriptionProp" />
@@ -1363,101 +878,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="7OJcYqwpPmO" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwsXHV" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="34Q84zNQalK" role="8Wnug">
-            <node concept="37vLTI" id="34Q84zNQalL" role="3clFbG">
-              <node concept="37vLTw" id="34Q84zNQalM" role="37vLTJ">
-                <ref role="3cqZAo" node="34Q84zNPNje" resolve="SLANG_STRUCTURE_LANGUAGE" />
-              </node>
-              <node concept="pHN19" id="34Q84zNQalN" role="37vLTx">
-                <node concept="2V$Bhx" id="34Q84zNQhza" role="2V$M_3">
-                  <property role="2V$B1T" value="c72da2b9-7cce-4447-8389-f407dc1158b7" />
-                  <property role="2V$B1Q" value="jetbrains.mps.lang.structure" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwsXHW" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="34Q84zNQalP" role="8Wnug">
-            <node concept="37vLTI" id="34Q84zNQalQ" role="3clFbG">
-              <node concept="2YIFZM" id="34Q84zNQalR" role="37vLTx">
-                <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
-                <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-                <node concept="37vLTw" id="34Q84zNQalS" role="37wK5m">
-                  <ref role="3cqZAo" node="34Q84zNPNje" resolve="SLANG_STRUCTURE_LANGUAGE" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="34Q84zNQalT" role="37vLTJ">
-                <ref role="3cqZAo" node="34Q84zNPKIX" resolve="SLANG_STRUCTURE_LANGUAGE_ID" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwsXHX" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="34Q84zNQalU" role="8Wnug">
-            <node concept="37vLTI" id="34Q84zNQalV" role="3clFbG">
-              <node concept="37vLTw" id="34Q84zNQalW" role="37vLTJ">
-                <ref role="3cqZAo" node="34Q84zNPOE1" resolve="KEY_STRUCTURE_LANGUAGE" />
-              </node>
-              <node concept="2YIFZM" id="7OJcYqwPrVh" role="37vLTx">
-                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
-                <node concept="37vLTw" id="5M8g5cT0H0A" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiskiqAL0" resolve="LC_SHORT_DESCRIPTION_ANNOTATION" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwsXHY" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="34Q84zNQalY" role="8Wnug">
-            <node concept="37vLTI" id="34Q84zNQalZ" role="3clFbG">
-              <node concept="37vLTw" id="34Q84zNQam0" role="37vLTJ">
-                <ref role="3cqZAo" node="34Q84zNPQ8E" resolve="ID_STRUCTURE_LANGUAGE" />
-              </node>
-              <node concept="2OqwBi" id="34Q84zNQam1" role="37vLTx">
-                <node concept="37vLTw" id="34Q84zNQam2" role="2Oq$k0">
-                  <ref role="3cqZAo" node="34Q84zNPNje" resolve="SLANG_STRUCTURE_LANGUAGE" />
-                </node>
-                <node concept="liA8E" id="34Q84zNQam3" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwsXHZ" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="34Q84zNQam4" role="8Wnug">
-            <node concept="37vLTI" id="34Q84zNQam5" role="3clFbG">
-              <node concept="37vLTw" id="34Q84zNQam6" role="37vLTJ">
-                <ref role="3cqZAo" node="34Q84zNPRvz" resolve="VERSION_STRUCTURE_LANGUAGE" />
-              </node>
-              <node concept="2YIFZM" id="34Q84zNQam7" role="37vLTx">
-                <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
-                <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
-                <node concept="2YIFZM" id="34Q84zNQam8" role="37wK5m">
-                  <ref role="1Pybhc" node="6jTTMHD72IS" resolve="MpsLanguageUtil" />
-                  <ref role="37wK5l" node="6jTTMHD72KX" resolve="getLanguageVersion" />
-                  <node concept="37vLTw" id="34Q84zNQam9" role="37wK5m">
-                    <ref role="3cqZAo" node="34Q84zNPNje" resolve="SLANG_STRUCTURE_LANGUAGE" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="34Q84zNQ9lf" role="3cqZAp" />
         <node concept="3clFbF" id="7OJcYqwuwtA" role="3cqZAp">
           <node concept="37vLTI" id="7OJcYqwuwtB" role="3clFbG">
             <node concept="2OqwBi" id="7OJcYqwuwtC" role="37vLTJ">
@@ -1521,97 +941,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="34Q84zNQEPO" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwt1nW" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="34Q84zNOhCM" role="8Wnug">
-            <node concept="37vLTI" id="34Q84zNOiG9" role="3clFbG">
-              <node concept="2OqwBi" id="34Q84zNOmSj" role="37vLTx">
-                <node concept="2tJFMh" id="34Q84zNOjEG" role="2Oq$k0">
-                  <node concept="ZC_QK" id="34Q84zNOkwm" role="2tJFKM">
-                    <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
-                    <node concept="ZC_QK" id="34Q84zNOlm5" role="2aWVGa">
-                      <ref role="2aWVGs" to="4xw4:34Q84zMNsGk" resolve="ConceptDescription" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="34Q84zNOo1s" role="2OqNvi">
-                  <node concept="37vLTw" id="34Q84zNOoK9" role="Vysub">
-                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="34Q84zNOhCK" role="37vLTJ">
-                <ref role="3cqZAo" node="34Q84zNNvVS" resolve="LC_CONCEPT_DESCRIPTION_ANNOTATION" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwt1nX" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="34Q84zNRqnP" role="8Wnug">
-            <node concept="37vLTI" id="34Q84zNRrsU" role="3clFbG">
-              <node concept="37vLTw" id="34Q84zNRqnN" role="37vLTJ">
-                <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
-              </node>
-              <node concept="2OqwBi" id="34Q84zNRv_k" role="37vLTx">
-                <node concept="2tJFMh" id="34Q84zNRv_l" role="2Oq$k0">
-                  <node concept="ZC_QK" id="34Q84zNRv_m" role="2tJFKM">
-                    <ref role="2aWVGs" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                  </node>
-                </node>
-                <node concept="Vyspw" id="34Q84zNRv_n" role="2OqNvi">
-                  <node concept="37vLTw" id="34Q84zNRv_o" role="Vysub">
-                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwt1nY" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="7weWCFlnuRC" role="8Wnug">
-            <node concept="37vLTI" id="7weWCFlnwgk" role="3clFbG">
-              <node concept="2YIFZM" id="7weWCFlnY$f" role="37vLTx">
-                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
-                <node concept="37vLTw" id="7weWCFlnY$g" role="37wK5m">
-                  <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
-                </node>
-                <node concept="37vLTw" id="7weWCFlo0Q3" role="37wK5m">
-                  <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
-                </node>
-                <node concept="2YIFZM" id="7weWCFlo4mC" role="37wK5m">
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <node concept="2OqwBi" id="7weWCFlo6pf" role="37wK5m">
-                    <node concept="37vLTw" id="7weWCFlo5rf" role="2Oq$k0">
-                      <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
-                    </node>
-                    <node concept="3TrcHB" id="7weWCFlo898" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="7weWCFlobCi" role="37wK5m">
-                  <node concept="37vLTw" id="7weWCFloahn" role="2Oq$k0">
-                    <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
-                  </node>
-                  <node concept="3TrcHB" id="7weWCFlod5n" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="7weWCFlnuRA" role="37vLTJ">
-                <ref role="3cqZAo" node="7weWCFlnksG" resolve="SLANG_ABSTRACT_CONCEPT_CONCEPT" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="7weWCFloe7n" role="3cqZAp" />
         <node concept="3cpWs8" id="7OJcYqwt4hL" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqwt4hM" role="3cpWs9">
             <property role="TrG5h" value="mpsClassifier" />
@@ -1696,71 +1025,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="7OJcYqwqY8j" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwtcQ8" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5M8g5cSBlZU" role="8Wnug">
-            <node concept="37vLTI" id="5M8g5cSBlZV" role="3clFbG">
-              <node concept="37vLTw" id="5M8g5cSBlZW" role="37vLTJ">
-                <ref role="3cqZAo" node="5M8g5cSB02I" resolve="MPS_CONCEPT_DECLARATION_CONCEPT" />
-              </node>
-              <node concept="2OqwBi" id="5M8g5cSBlZX" role="37vLTx">
-                <node concept="2tJFMh" id="5M8g5cSBlZY" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5M8g5cSBlZZ" role="2tJFKM">
-                    <ref role="2aWVGs" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5M8g5cSBm00" role="2OqNvi">
-                  <node concept="37vLTw" id="5M8g5cSBm01" role="Vysub">
-                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwtcQ9" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5M8g5cSBlZH" role="8Wnug">
-            <node concept="37vLTI" id="5M8g5cSBlZI" role="3clFbG">
-              <node concept="2YIFZM" id="5M8g5cSBlZJ" role="37vLTx">
-                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
-                <node concept="37vLTw" id="5M8g5cSBlZK" role="37wK5m">
-                  <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
-                </node>
-                <node concept="37vLTw" id="5M8g5cSBlZL" role="37wK5m">
-                  <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
-                </node>
-                <node concept="2YIFZM" id="5M8g5cSBlZM" role="37wK5m">
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <node concept="2OqwBi" id="5M8g5cSBlZN" role="37wK5m">
-                    <node concept="37vLTw" id="5M8g5cSBlZO" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M8g5cSB02I" resolve="MPS_CONCEPT_DECLARATION_CONCEPT" />
-                    </node>
-                    <node concept="3TrcHB" id="5M8g5cSBlZP" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="5M8g5cSBlZQ" role="37wK5m">
-                  <node concept="37vLTw" id="5M8g5cSBlZR" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5M8g5cSB02I" resolve="MPS_CONCEPT_DECLARATION_CONCEPT" />
-                  </node>
-                  <node concept="3TrcHB" id="5M8g5cSBlZS" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5M8g5cSBlZT" role="37vLTJ">
-                <ref role="3cqZAo" node="5M8g5cSB02$" resolve="SLANG_CONCEPT_CONCEPT" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5M8g5cSBlZG" role="3cqZAp" />
         <node concept="3cpWs8" id="7OJcYqwtwQE" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqwtwQF" role="3cpWs9">
             <property role="TrG5h" value="mpsConcept" />
@@ -1831,71 +1095,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="7OJcYqwrbLp" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwtEip" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5M8g5cSBug_" role="8Wnug">
-            <node concept="37vLTI" id="5M8g5cSBugA" role="3clFbG">
-              <node concept="37vLTw" id="5M8g5cSBugB" role="37vLTJ">
-                <ref role="3cqZAo" node="5M8g5cSAY3o" resolve="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
-              </node>
-              <node concept="2OqwBi" id="5M8g5cSBugC" role="37vLTx">
-                <node concept="2tJFMh" id="5M8g5cSBugD" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5M8g5cSBugE" role="2tJFKM">
-                    <ref role="2aWVGs" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5M8g5cSBugF" role="2OqNvi">
-                  <node concept="37vLTw" id="5M8g5cSBugG" role="Vysub">
-                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwtEiq" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5M8g5cSBugo" role="8Wnug">
-            <node concept="37vLTI" id="5M8g5cSBugp" role="3clFbG">
-              <node concept="2YIFZM" id="5M8g5cSBugq" role="37vLTx">
-                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
-                <node concept="37vLTw" id="5M8g5cSBugr" role="37wK5m">
-                  <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
-                </node>
-                <node concept="37vLTw" id="5M8g5cSBugs" role="37wK5m">
-                  <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
-                </node>
-                <node concept="2YIFZM" id="5M8g5cSBugt" role="37wK5m">
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <node concept="2OqwBi" id="5M8g5cSBugu" role="37wK5m">
-                    <node concept="37vLTw" id="5M8g5cSBugv" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5M8g5cSAY3o" resolve="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
-                    </node>
-                    <node concept="3TrcHB" id="5M8g5cSBugw" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="5M8g5cSBugx" role="37wK5m">
-                  <node concept="37vLTw" id="5M8g5cSBugy" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5M8g5cSAY3o" resolve="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
-                  </node>
-                  <node concept="3TrcHB" id="5M8g5cSBugz" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5M8g5cSBug$" role="37vLTJ">
-                <ref role="3cqZAo" node="5M8g5cSAY3e" resolve="SLANG_INTERFACE_CONCEPT_CONCEPT" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5M8g5cSBugn" role="3cqZAp" />
         <node concept="3cpWs8" id="7OJcYqwtH6Q" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqwtH6R" role="3cpWs9">
             <property role="TrG5h" value="mpsInterface" />
@@ -1966,86 +1165,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="7OJcYqwrsVZ" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwtOYf" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="34Q84zNOpJK" role="8Wnug">
-            <node concept="37vLTI" id="34Q84zNOpJL" role="3clFbG">
-              <node concept="2OqwBi" id="34Q84zNOpJM" role="37vLTx">
-                <node concept="2tJFMh" id="34Q84zNOpJN" role="2Oq$k0">
-                  <node concept="ZC_QK" id="34Q84zNOpJO" role="2tJFKM">
-                    <ref role="2aWVGs" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                    <node concept="ZC_QK" id="34Q84zNOpJP" role="2aWVGa">
-                      <ref role="2aWVGs" to="tpce:4qF2Hm2r7ja" resolve="conceptAlias" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="34Q84zNOpJQ" role="2OqNvi">
-                  <node concept="37vLTw" id="34Q84zNOpJR" role="Vysub">
-                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="34Q84zNOpJS" role="37vLTJ">
-                <ref role="3cqZAo" node="34Q84zNNvW1" resolve="MPS_CONCEPT_ALIAS_PROPERTY" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwtOYg" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="34Q84zNOpJT" role="8Wnug">
-            <node concept="37vLTI" id="34Q84zNOpJU" role="3clFbG">
-              <node concept="2YIFZM" id="34Q84zNOpJV" role="37vLTx">
-                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
-                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-                <node concept="37vLTw" id="34Q84zNOpJW" role="37wK5m">
-                  <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
-                </node>
-                <node concept="37vLTw" id="34Q84zNOpJX" role="37wK5m">
-                  <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
-                </node>
-                <node concept="2YIFZM" id="34Q84zNOpJY" role="37wK5m">
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <node concept="2OqwBi" id="34Q84zNOpJZ" role="37wK5m">
-                    <node concept="37vLTw" id="34Q84zNOpK0" role="2Oq$k0">
-                      <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
-                    </node>
-                    <node concept="3TrcHB" id="34Q84zNOpK1" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2YIFZM" id="34Q84zNOpK2" role="37wK5m">
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <node concept="2OqwBi" id="34Q84zNOpK3" role="37wK5m">
-                    <node concept="37vLTw" id="34Q84zNOpK4" role="2Oq$k0">
-                      <ref role="3cqZAo" node="34Q84zNNvW1" resolve="MPS_CONCEPT_ALIAS_PROPERTY" />
-                    </node>
-                    <node concept="3TrcHB" id="34Q84zNOpK5" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="34Q84zNOpK6" role="37wK5m">
-                  <node concept="37vLTw" id="34Q84zNOpK7" role="2Oq$k0">
-                    <ref role="3cqZAo" node="34Q84zNNvW1" resolve="MPS_CONCEPT_ALIAS_PROPERTY" />
-                  </node>
-                  <node concept="3TrcHB" id="34Q84zNOpK8" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="34Q84zNOpK9" role="37vLTJ">
-                <ref role="3cqZAo" node="34Q84zNNvWa" resolve="SLANG_CONCEPT_ALIAS_PROPERTY" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="34Q84zNOpH1" role="3cqZAp" />
         <node concept="3cpWs8" id="7OJcYqwtTqJ" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqwtTqK" role="3cpWs9">
             <property role="TrG5h" value="mpsConceptAliasProp" />
@@ -2131,86 +1250,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="7OJcYqwrH7_" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwu3cE" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="34Q84zNRLkB" role="8Wnug">
-            <node concept="37vLTI" id="34Q84zNRLkC" role="3clFbG">
-              <node concept="2OqwBi" id="34Q84zNRLkD" role="37vLTx">
-                <node concept="2tJFMh" id="34Q84zNRLkE" role="2Oq$k0">
-                  <node concept="ZC_QK" id="34Q84zNRLkF" role="2tJFKM">
-                    <ref role="2aWVGs" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                    <node concept="ZC_QK" id="34Q84zNRLkG" role="2aWVGa">
-                      <ref role="2aWVGs" to="tpce:40UcGlRaVSw" resolve="conceptShortDescription" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="34Q84zNRLkH" role="2OqNvi">
-                  <node concept="37vLTw" id="34Q84zNRLkI" role="Vysub">
-                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="34Q84zNRLkJ" role="37vLTJ">
-                <ref role="3cqZAo" node="34Q84zNO3Ig" resolve="MPS_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwu3cF" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="34Q84zNRLkm" role="8Wnug">
-            <node concept="37vLTI" id="34Q84zNRLkn" role="3clFbG">
-              <node concept="2YIFZM" id="34Q84zNRLko" role="37vLTx">
-                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
-                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-                <node concept="37vLTw" id="34Q84zNRLkp" role="37wK5m">
-                  <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
-                </node>
-                <node concept="37vLTw" id="34Q84zNRLkq" role="37wK5m">
-                  <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
-                </node>
-                <node concept="2YIFZM" id="34Q84zNRLkr" role="37wK5m">
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <node concept="2OqwBi" id="34Q84zNRLks" role="37wK5m">
-                    <node concept="37vLTw" id="34Q84zNRLkt" role="2Oq$k0">
-                      <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
-                    </node>
-                    <node concept="3TrcHB" id="34Q84zNRLku" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2YIFZM" id="34Q84zNRLkv" role="37wK5m">
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <node concept="2OqwBi" id="34Q84zNRLkw" role="37wK5m">
-                    <node concept="37vLTw" id="34Q84zNRLkx" role="2Oq$k0">
-                      <ref role="3cqZAo" node="34Q84zNO3Ig" resolve="MPS_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
-                    </node>
-                    <node concept="3TrcHB" id="34Q84zNRLky" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="34Q84zNRLkz" role="37wK5m">
-                  <node concept="37vLTw" id="34Q84zNRLk$" role="2Oq$k0">
-                    <ref role="3cqZAo" node="34Q84zNO3Ig" resolve="MPS_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
-                  </node>
-                  <node concept="3TrcHB" id="34Q84zNRLk_" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="34Q84zNRLkA" role="37vLTJ">
-                <ref role="3cqZAo" node="34Q84zNO3I7" resolve="SLANG_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="7OJcYqwrXbJ" role="3cqZAp" />
         <node concept="3cpWs8" id="7OJcYqwu7gu" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqwu7gv" role="3cpWs9">
             <property role="TrG5h" value="mpsConceptShortDescriptionProp" />
@@ -2312,18 +1351,6 @@
     <node concept="3uibUv" id="5JNiskhZoZC" role="1zkMxy">
       <ref role="3uigEE" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
     </node>
-    <node concept="1X3_iC" id="7OJcYqwvQgW" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskiq_M0" role="8Wnug">
-        <property role="TrG5h" value="LC_VIRTUAL_PACKAGE_ANNOTATION" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskiq_M1" role="1B3o_S" />
-        <node concept="3Tqbb2" id="5JNiskiq_M2" role="1tU5fm">
-          <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskiq_M3" role="jymVt">
       <property role="TrG5h" value="lcVirtualPackageAnnotation" />
       <node concept="3clFbS" id="5JNiskiq_M4" role="3clF47">
@@ -2341,18 +1368,6 @@
       <node concept="3Tm1VV" id="5JNiskiq_M7" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiskiq_M8" role="3clF45">
         <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwvSs5" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskiq_M9" role="8Wnug">
-        <property role="TrG5h" value="MPS_VIRTUAL_PACKAGE_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskiq_Ma" role="1B3o_S" />
-        <node concept="3Tqbb2" id="5JNiskiq_Mb" role="1tU5fm">
-          <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiq_Mc" role="jymVt">
@@ -2374,18 +1389,6 @@
         <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwvWr6" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskiq_Mi" role="8Wnug">
-        <property role="TrG5h" value="SLANG_VIRTUAL_PACKAGE_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskiq_Mj" role="1B3o_S" />
-        <node concept="3uibUv" id="5JNiskiq_Mk" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskiq_Ml" role="jymVt">
       <property role="TrG5h" value="slangVirtualPackageProperty" />
       <node concept="3clFbS" id="5JNiskiq_Mm" role="3clF47">
@@ -2405,16 +1408,6 @@
         <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqww0_s" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskiq_Mr" role="8Wnug">
-        <property role="TrG5h" value="KEY_VIRTUAL_PACKAGE_ANNOTATION" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskiq_Ms" role="1B3o_S" />
-        <node concept="17QB3L" id="5JNiskiq_Mt" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskiq_Mu" role="jymVt">
       <property role="TrG5h" value="keyVirtualPackageAnnotation" />
       <node concept="3clFbS" id="5JNiskiq_Mv" role="3clF47">
@@ -2431,16 +1424,6 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskiq_My" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskiq_Mz" role="3clF45" />
-    </node>
-    <node concept="1X3_iC" id="7OJcYqww3ei" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskiq_M$" role="8Wnug">
-        <property role="TrG5h" value="ID_VIRTUAL_PACKAGE_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskiq_M_" role="1B3o_S" />
-        <node concept="17QB3L" id="5JNiskiq_MA" role="1tU5fm" />
-      </node>
     </node>
     <node concept="3clFb_" id="5JNiskiq_MB" role="jymVt">
       <property role="TrG5h" value="idVirtualPackageProperty" />
@@ -2460,18 +1443,6 @@
       <node concept="17QB3L" id="5JNiskiq_MG" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5JNiskirocj" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqww5SI" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskirrGQ" role="8Wnug">
-        <property role="TrG5h" value="LC_VIRTUAL_PACKAGE_NAME_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskirrGR" role="1B3o_S" />
-        <node concept="3Tqbb2" id="5JNiskirrGS" role="1tU5fm">
-          <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskiroj0" role="jymVt">
       <property role="TrG5h" value="lcVirtualPackage_NameProperty" />
       <node concept="3clFbS" id="5JNiskiroj1" role="3clF47">
@@ -2489,16 +1460,6 @@
       <node concept="3Tm1VV" id="5JNiskiroj2" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiskiroj3" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqww9S2" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskirATB" role="8Wnug">
-        <property role="TrG5h" value="KEY_VIRTUAL_PACKAGE_NAME_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskirA5G" role="1B3o_S" />
-        <node concept="17QB3L" id="5JNiskirAGG" role="1tU5fm" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiroj4" role="jymVt">
@@ -2520,18 +1481,6 @@
     </node>
     <node concept="2tJIrI" id="5JNiskirofD" role="jymVt" />
     <node concept="2tJIrI" id="5JNiskiqAo0" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwwc$_" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskiqAL0" role="8Wnug">
-        <property role="TrG5h" value="LC_SHORT_DESCRIPTION_ANNOTATION" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskiqAL1" role="1B3o_S" />
-        <node concept="3Tqbb2" id="5JNiskiqAL2" role="1tU5fm">
-          <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskiqAL3" role="jymVt">
       <property role="TrG5h" value="lcShortDescriptionAnnotation" />
       <node concept="3clFbS" id="5JNiskiqAL4" role="3clF47">
@@ -2549,18 +1498,6 @@
       <node concept="3Tm1VV" id="5JNiskiqAL7" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiskiqAL8" role="3clF45">
         <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwwffh" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskiqAL9" role="8Wnug">
-        <property role="TrG5h" value="MPS_SHORT_DESCRIPTION_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskiqALa" role="1B3o_S" />
-        <node concept="3Tqbb2" id="5JNiskiqALb" role="1tU5fm">
-          <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiqALc" role="jymVt">
@@ -2582,18 +1519,6 @@
         <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwwjgv" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskiqALi" role="8Wnug">
-        <property role="TrG5h" value="SLANG_SHORT_DESCRIPTION_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskiqALj" role="1B3o_S" />
-        <node concept="3uibUv" id="5JNiskiqALk" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskiqALl" role="jymVt">
       <property role="TrG5h" value="slangShortDescriptionProperty" />
       <node concept="3clFbS" id="5JNiskiqALm" role="3clF47">
@@ -2613,16 +1538,6 @@
         <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwwnoS" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskiqALr" role="8Wnug">
-        <property role="TrG5h" value="KEY_SHORT_DESCRIPTION_ANNOTATION" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskiqALs" role="1B3o_S" />
-        <node concept="17QB3L" id="5JNiskiqALt" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskiqALu" role="jymVt">
       <property role="TrG5h" value="keyShortDescriptionAnnotation" />
       <node concept="3clFbS" id="5JNiskiqALv" role="3clF47">
@@ -2639,16 +1554,6 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskiqALy" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskiqALz" role="3clF45" />
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwwq1N" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskiqAL$" role="8Wnug">
-        <property role="TrG5h" value="ID_SHORT_DESCRIPTION_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskiqAL_" role="1B3o_S" />
-        <node concept="17QB3L" id="5JNiskiqALA" role="1tU5fm" />
-      </node>
     </node>
     <node concept="3clFb_" id="5JNiskiqALB" role="jymVt">
       <property role="TrG5h" value="idShortDescriptionProperty" />
@@ -2668,18 +1573,6 @@
       <node concept="17QB3L" id="5JNiskiqALG" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5JNiskiqApF" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwwsG$" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskirxyP" role="8Wnug">
-        <property role="TrG5h" value="LC_SHORT_DESCRIPTION_DESCRIPTION_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskirxyQ" role="1B3o_S" />
-        <node concept="3Tqbb2" id="5JNiskirxyR" role="1tU5fm">
-          <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskiroSo" role="jymVt">
       <property role="TrG5h" value="lcShortDescription_DescriptionProperty" />
       <node concept="3clFbS" id="5JNiskiroSp" role="3clF47">
@@ -2697,16 +1590,6 @@
       <node concept="3Tm1VV" id="5JNiskiroSq" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiskiroSr" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwwwDX" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskirzDP" role="8Wnug">
-        <property role="TrG5h" value="KEY_SHORT_DESCRIPTION_DESCRIPTION_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskirzDQ" role="1B3o_S" />
-        <node concept="17QB3L" id="5JNiskirzDR" role="1tU5fm" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiroSs" role="jymVt">
@@ -2727,18 +1610,6 @@
       <node concept="17QB3L" id="5JNiskiroSv" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5JNiskiroOS" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwwzkK" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskiKYx0" role="8Wnug">
-        <property role="TrG5h" value="SLANG_SPECIFIC_LANGUAGE_ID" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskiKYx1" role="1B3o_S" />
-        <node concept="3uibUv" id="5JNiskiKYx2" role="1tU5fm">
-          <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskiKYx3" role="jymVt">
       <property role="TrG5h" value="slangSpecificLanguageId" />
       <node concept="3clFbS" id="5JNiskiKYx4" role="3clF47">
@@ -2756,18 +1627,6 @@
       <node concept="3Tm1VV" id="5JNiskiKYx7" role="1B3o_S" />
       <node concept="3uibUv" id="5JNiskiKYx8" role="3clF45">
         <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwwBpW" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskiKYx9" role="8Wnug">
-        <property role="TrG5h" value="SLANG_SPECIFIC_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskiKYxa" role="1B3o_S" />
-        <node concept="3uibUv" id="5JNiskiKYxb" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiKYxc" role="jymVt">
@@ -2789,16 +1648,6 @@
         <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwwFMO" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskiKYxi" role="8Wnug">
-        <property role="TrG5h" value="KEY_SPECIFIC_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskiKYxj" role="1B3o_S" />
-        <node concept="17QB3L" id="5JNiskiKYxk" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskiKYxl" role="jymVt">
       <property role="TrG5h" value="keySpecificLanguage" />
       <node concept="3clFbS" id="5JNiskiKYxm" role="3clF47">
@@ -2816,16 +1665,6 @@
       <node concept="3Tm1VV" id="5JNiskiKYxp" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskiKYxq" role="3clF45" />
     </node>
-    <node concept="1X3_iC" id="7OJcYqwwIpL" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskiKYxr" role="8Wnug">
-        <property role="TrG5h" value="ID_SPECIFIC_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskiKYxs" role="1B3o_S" />
-        <node concept="17QB3L" id="5JNiskiKYxt" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskiKYxu" role="jymVt">
       <property role="TrG5h" value="idSpecificLanguage" />
       <node concept="3clFbS" id="5JNiskiKYxv" role="3clF47">
@@ -2842,16 +1681,6 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskiKYxy" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskiKYxz" role="3clF45" />
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwwL4B" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskiKYx$" role="8Wnug">
-        <property role="TrG5h" value="VERSION_SPECIFIC_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskiKYx_" role="1B3o_S" />
-        <node concept="17QB3L" id="5JNiskiKYxA" role="1tU5fm" />
-      </node>
     </node>
     <node concept="3clFb_" id="5JNiskiKYxB" role="jymVt">
       <property role="TrG5h" value="versionSpecificLanguage" />
@@ -2871,18 +1700,6 @@
       <node concept="17QB3L" id="5JNiskiKYxG" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5JNiskjpl83" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwwNJw" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="34Q84zNPKIX" role="8Wnug">
-        <property role="TrG5h" value="SLANG_STRUCTURE_LANGUAGE_ID" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="34Q84zNPKIY" role="1B3o_S" />
-        <node concept="3uibUv" id="34Q84zNPKIZ" role="1tU5fm">
-          <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="34Q84zNPHRO" role="jymVt">
       <property role="TrG5h" value="slangStructureLanguageId" />
       <node concept="3Tm1VV" id="34Q84zNPHRQ" role="1B3o_S" />
@@ -2903,18 +1720,6 @@
       </node>
       <node concept="2AHcQZ" id="34Q84zNPHS2" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwwRQA" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="34Q84zNPNje" role="8Wnug">
-        <property role="TrG5h" value="SLANG_STRUCTURE_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="34Q84zNPNjf" role="1B3o_S" />
-        <node concept="3uibUv" id="34Q84zNPNjg" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNPHS5" role="jymVt">
@@ -2939,16 +1744,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwwWfM" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="34Q84zNPOE1" role="8Wnug">
-        <property role="TrG5h" value="KEY_STRUCTURE_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="34Q84zNPOE2" role="1B3o_S" />
-        <node concept="17QB3L" id="34Q84zNPOE3" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="34Q84zNPHSm" role="jymVt">
       <property role="TrG5h" value="keyStructureLanguage" />
       <node concept="3Tm1VV" id="34Q84zNPHSo" role="1B3o_S" />
@@ -2969,16 +1764,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwwYSS" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="34Q84zNPQ8E" role="8Wnug">
-        <property role="TrG5h" value="ID_STRUCTURE_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="34Q84zNPQ8F" role="1B3o_S" />
-        <node concept="17QB3L" id="34Q84zNPQ8G" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="34Q84zNPHSy" role="jymVt">
       <property role="TrG5h" value="idStructureLanguage" />
       <node concept="3Tm1VV" id="34Q84zNPHS$" role="1B3o_S" />
@@ -2997,16 +1782,6 @@
       </node>
       <node concept="2AHcQZ" id="34Q84zNPHSF" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwx1zQ" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="34Q84zNPRvz" role="8Wnug">
-        <property role="TrG5h" value="VERSION_STRUCTURE_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="34Q84zNPRv$" role="1B3o_S" />
-        <node concept="17QB3L" id="34Q84zNPRv_" role="1tU5fm" />
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNPHSI" role="jymVt">
@@ -3031,18 +1806,6 @@
     </node>
     <node concept="2tJIrI" id="34Q84zNNuO4" role="jymVt" />
     <node concept="2tJIrI" id="34Q84zNR0So" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwx3Fu" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="34Q84zNRm0K" role="8Wnug">
-        <property role="TrG5h" value="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="34Q84zNRm0L" role="1B3o_S" />
-        <node concept="3Tqbb2" id="34Q84zNRm0M" role="1tU5fm">
-          <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="34Q84zNR2iW" role="jymVt">
       <property role="TrG5h" value="mpsAbstractConceptDeclarationConcept" />
       <node concept="3Tm1VV" id="34Q84zNR2iY" role="1B3o_S" />
@@ -3063,18 +1826,6 @@
       </node>
       <node concept="2AHcQZ" id="34Q84zNR2j2" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwx7GT" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="7weWCFlnksG" role="8Wnug">
-        <property role="TrG5h" value="SLANG_ABSTRACT_CONCEPT_CONCEPT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="7weWCFlnhL_" role="1B3o_S" />
-        <node concept="3uibUv" id="7weWCFlnjU3" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="7weWCFlnoxb" role="jymVt">
@@ -3100,18 +1851,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNS0hq" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwxbR0" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5M8g5cSB02I" role="8Wnug">
-        <property role="TrG5h" value="MPS_CONCEPT_DECLARATION_CONCEPT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5M8g5cSB02J" role="1B3o_S" />
-        <node concept="3Tqbb2" id="5M8g5cSB02K" role="1tU5fm">
-          <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5M8g5cSB02B" role="jymVt">
       <property role="TrG5h" value="mpsConceptDeclarationConcept" />
       <node concept="3Tm1VV" id="5M8g5cSB02C" role="1B3o_S" />
@@ -3132,18 +1871,6 @@
       </node>
       <node concept="2AHcQZ" id="5M8g5cSB02H" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwxfON" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5M8g5cSB02$" role="8Wnug">
-        <property role="TrG5h" value="SLANG_CONCEPT_CONCEPT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5M8g5cSB02_" role="1B3o_S" />
-        <node concept="3uibUv" id="5M8g5cSB02A" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5M8g5cSB02t" role="jymVt">
@@ -3169,18 +1896,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5M8g5cSB02s" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwxjOf" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5M8g5cSAY3o" role="8Wnug">
-        <property role="TrG5h" value="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5M8g5cSAY3p" role="1B3o_S" />
-        <node concept="3Tqbb2" id="5M8g5cSAY3q" role="1tU5fm">
-          <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5M8g5cSAY3h" role="jymVt">
       <property role="TrG5h" value="mpsInterfaceConceptDeclarationConcept" />
       <node concept="3Tm1VV" id="5M8g5cSAY3i" role="1B3o_S" />
@@ -3201,18 +1916,6 @@
       </node>
       <node concept="2AHcQZ" id="5M8g5cSAY3n" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwxnPL" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5M8g5cSAY3e" role="8Wnug">
-        <property role="TrG5h" value="SLANG_INTERFACE_CONCEPT_CONCEPT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5M8g5cSAY3f" role="1B3o_S" />
-        <node concept="3uibUv" id="5M8g5cSAY3g" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5M8g5cSAY37" role="jymVt">
@@ -3238,18 +1941,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5M8g5cSAY36" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwxrRi" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="34Q84zNNvW1" role="8Wnug">
-        <property role="TrG5h" value="MPS_CONCEPT_ALIAS_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="34Q84zNNvW2" role="1B3o_S" />
-        <node concept="3Tqbb2" id="34Q84zNNvW3" role="1tU5fm">
-          <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="34Q84zNR2j3" role="jymVt">
       <property role="TrG5h" value="mpsConceptAliasProperty" />
       <node concept="3Tm1VV" id="34Q84zNR2j5" role="1B3o_S" />
@@ -3272,18 +1963,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwxvSP" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="34Q84zNNvWa" role="8Wnug">
-        <property role="TrG5h" value="SLANG_CONCEPT_ALIAS_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="34Q84zNNvWb" role="1B3o_S" />
-        <node concept="3uibUv" id="34Q84zNNvWc" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="34Q84zNNvWd" role="jymVt">
       <property role="TrG5h" value="slangConceptAliasProperty" />
       <node concept="3clFbS" id="34Q84zNNvWe" role="3clF47">
@@ -3304,18 +1983,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNS8TW" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwx$3n" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="34Q84zNO3Ig" role="8Wnug">
-        <property role="TrG5h" value="MPS_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="34Q84zNO3Ih" role="1B3o_S" />
-        <node concept="3Tqbb2" id="34Q84zNO3Ii" role="1tU5fm">
-          <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="34Q84zNR2ja" role="jymVt">
       <property role="TrG5h" value="mpsConceptShortDescriptionProperty" />
       <node concept="3Tm1VV" id="34Q84zNR2jc" role="1B3o_S" />
@@ -3338,18 +2005,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwxC4q" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="34Q84zNO3I7" role="8Wnug">
-        <property role="TrG5h" value="SLANG_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="34Q84zNO3I8" role="1B3o_S" />
-        <node concept="3uibUv" id="34Q84zNO3I9" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="34Q84zNO3I1" role="jymVt">
       <property role="TrG5h" value="slangConceptShortDescriptionProperty" />
       <node concept="3clFbS" id="34Q84zNO3I2" role="3clF47">
@@ -3370,18 +2025,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNSe_t" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwxGdq" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="34Q84zNNvVS" role="8Wnug">
-        <property role="TrG5h" value="LC_CONCEPT_DESCRIPTION_ANNOTATION" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="34Q84zNNvVT" role="1B3o_S" />
-        <node concept="3Tqbb2" id="34Q84zNNvVU" role="1tU5fm">
-          <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="34Q84zNNvVV" role="jymVt">
       <property role="TrG5h" value="lcConceptDescriptionAnnotation" />
       <node concept="3clFbS" id="34Q84zNNvVW" role="3clF47">
@@ -9349,41 +7992,6 @@
       <node concept="3Tm1VV" id="5JNiski3MAS" role="1B3o_S" />
       <node concept="3clFbS" id="5JNiski3MAT" role="3clF47">
         <node concept="3clFbH" id="5JNiski3MAU" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwaPSW" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MAV" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MAW" role="3clFbG">
-              <node concept="37vLTw" id="5JNiski3MAX" role="37vLTJ">
-                <ref role="3cqZAo" node="4R9posq8YbX" resolve="SLANG_M3_LANGUAGE" />
-              </node>
-              <node concept="pHN19" id="5JNiski3MAY" role="37vLTx">
-                <node concept="2V$Bhx" id="5JNiski3MAZ" role="2V$M_3">
-                  <property role="2V$B1T" value="01cf0d82-8d29-4fc4-be96-28abaf4ad33d" />
-                  <property role="2V$B1Q" value="io.lionweb.mps.m3" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwaPSX" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MB0" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MB1" role="3clFbG">
-              <node concept="2YIFZM" id="5JNiski3MB2" role="37vLTx">
-                <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-                <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
-                <node concept="37vLTw" id="5JNiski3MB3" role="37wK5m">
-                  <ref role="3cqZAo" node="4R9posq8YbX" resolve="SLANG_M3_LANGUAGE" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiski3MB4" role="37vLTJ">
-                <ref role="3cqZAo" node="5AGBwuFFqaM" resolve="SLANG_M3_LANGUAGE_ID" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3cpWs8" id="7OJcYqwcE0M" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqwcE0N" role="3cpWs9">
             <property role="TrG5h" value="m3LanguageId" />
@@ -9398,133 +8006,6 @@
                   <property role="2V$B1T" value="01cf0d82-8d29-4fc4-be96-28abaf4ad33d" />
                   <property role="2V$B1Q" value="io.lionweb.mps.m3" />
                 </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3SKdUt" id="5JNiski3MB5" role="3cqZAp">
-          <node concept="1PaTwC" id="5JNiski3MB6" role="1aUNEU">
-            <node concept="3oM_SD" id="5JNiski3MB7" role="1PaTwD">
-              <property role="3oM_SC" value="TODO" />
-            </node>
-            <node concept="3oM_SD" id="5JNiski3MB8" role="1PaTwD">
-              <property role="3oM_SC" value="reactivate" />
-            </node>
-            <node concept="3oM_SD" id="5JNiski3MB9" role="1PaTwD">
-              <property role="3oM_SC" value="model" />
-            </node>
-            <node concept="3oM_SD" id="5JNiski3MBa" role="1PaTwD">
-              <property role="3oM_SC" value="query," />
-            </node>
-            <node concept="3oM_SD" id="5JNiski3MBb" role="1PaTwD">
-              <property role="3oM_SC" value="does" />
-            </node>
-            <node concept="3oM_SD" id="5JNiski3MBc" role="1PaTwD">
-              <property role="3oM_SC" value="not" />
-            </node>
-            <node concept="3oM_SD" id="5JNiski3MBd" role="1PaTwD">
-              <property role="3oM_SC" value="work" />
-            </node>
-            <node concept="3oM_SD" id="5JNiski3MBe" role="1PaTwD">
-              <property role="3oM_SC" value="on" />
-            </node>
-            <node concept="3oM_SD" id="5JNiski3MBf" role="1PaTwD">
-              <property role="3oM_SC" value="lionweb" />
-            </node>
-            <node concept="3oM_SD" id="5JNiski3MBg" role="1PaTwD">
-              <property role="3oM_SC" value="client" />
-            </node>
-            <node concept="3oM_SD" id="5JNiski3MBh" role="1PaTwD">
-              <property role="3oM_SC" value="plugin" />
-            </node>
-            <node concept="3oM_SD" id="5JNiski3MBi" role="1PaTwD">
-              <property role="3oM_SC" value="startup" />
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwaTGd" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MBk" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MBl" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiski3MBm" role="37vLTx">
-                <node concept="2JrnkZ" id="5JNiski3MBn" role="2Oq$k0">
-                  <node concept="2OqwBi" id="5JNiski3MBo" role="2JrQYb">
-                    <node concept="2tJFMh" id="5JNiski3MBp" role="2Oq$k0">
-                      <node concept="1dCxOE" id="5JNiski3MBq" role="2tJFKM">
-                        <property role="2OI7jA" value="6461713321117288976" />
-                        <node concept="1dCxOl" id="5JNiski3MBr" role="2OI7jE">
-                          <property role="1XweGQ" value="r:11596e6a-4231-47c9-b3df-0dcce1111a54" />
-                          <node concept="1j_P7g" id="5JNiski3MBs" role="1j$8Uc">
-                            <property role="1j_P7h" value="io.lionweb.mps.m3.structure" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Vyspw" id="5JNiski3MBt" role="2OqNvi">
-                      <node concept="37vLTw" id="5JNiski3MBu" role="Vysub">
-                        <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="liA8E" id="5JNiski3MBv" role="2OqNvi">
-                  <ref role="37wK5l" to="mhbf:~SNode.getProperty(org.jetbrains.mps.openapi.language.SProperty)" resolve="getProperty" />
-                  <node concept="355D3s" id="5JNiski3MBw" role="37wK5m">
-                    <ref role="355D3t" to="h3y3:6jTTMHCXLTP" resolve="IKeyed" />
-                    <ref role="355D3u" to="h3y3:2ju2syjkkk9" resolve="key" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiski3MBx" role="37vLTJ">
-                <ref role="3cqZAo" node="5AGBwuFF_qd" resolve="KEY_M3_LANGUAGE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwaTGe" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MBy" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MBz" role="3clFbG">
-              <node concept="37vLTw" id="5JNiski3MB$" role="37vLTJ">
-                <ref role="3cqZAo" node="5AGBwuFF_qd" resolve="KEY_M3_LANGUAGE" />
-              </node>
-              <node concept="Xl_RD" id="5JNiski3MB_" role="37vLTx">
-                <property role="Xl_RC" value="LionCore-M3" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwaTGf" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MBA" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MBB" role="3clFbG">
-              <node concept="37vLTw" id="5JNiski3MBC" role="37vLTJ">
-                <ref role="3cqZAo" node="2mPmTXsy5za" resolve="ID_M3_LANGUAGE" />
-              </node>
-              <node concept="2OqwBi" id="5JNiski3MBD" role="37vLTx">
-                <node concept="37vLTw" id="5JNiski3MBE" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5AGBwuFFqaM" resolve="SLANG_M3_LANGUAGE_ID" />
-                </node>
-                <node concept="liA8E" id="5JNiski3MBF" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SLanguageId.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwaTGg" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MBG" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MBH" role="3clFbG">
-              <node concept="37vLTw" id="5JNiski3MBI" role="37vLTx">
-                <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
-              </node>
-              <node concept="37vLTw" id="5JNiski3MBJ" role="37vLTJ">
-                <ref role="3cqZAo" node="1ryFPTS4XtL" resolve="VERSION_M3_LANGUAGE" />
               </node>
             </node>
           </node>
@@ -9560,23 +8041,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="5JNiski3MBK" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwaXmA" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MBL" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MBM" role="3clFbG">
-              <node concept="pHN19" id="5JNiski3MBN" role="37vLTx">
-                <node concept="2V$Bhx" id="5JNiski3MBO" role="2V$M_3">
-                  <property role="2V$B1T" value="411e5b27-8a76-482e-8af8-1704262b4468" />
-                  <property role="2V$B1Q" value="io.lionweb.mps.structure.attribute" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiski3MBP" role="37vLTJ">
-                <ref role="3cqZAo" node="4WflrVaDO5l" resolve="SLANG_ATTRIBUTE_LANGUAGE" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3clFbF" id="7OJcYqw99Yp" role="3cqZAp">
           <node concept="37vLTI" id="7OJcYqw99Yq" role="3clFbG">
             <node concept="2OqwBi" id="7OJcYqw99Yr" role="37vLTJ">
@@ -9599,41 +8063,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="5JNiski3MBQ" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwb0S7" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MBR" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MBS" role="3clFbG">
-              <node concept="37vLTw" id="5JNiski3MBT" role="37vLTJ">
-                <ref role="3cqZAo" node="4R9posq8ZVS" resolve="SLANG_CORE_LANGUAGE" />
-              </node>
-              <node concept="pHN19" id="5JNiski3MBU" role="37vLTx">
-                <node concept="2V$Bhx" id="5JNiski3MBV" role="2V$M_3">
-                  <property role="2V$B1T" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
-                  <property role="2V$B1Q" value="jetbrains.mps.lang.core" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwb0S8" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MBW" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MBX" role="3clFbG">
-              <node concept="2YIFZM" id="5JNiski3MBY" role="37vLTx">
-                <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
-                <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-                <node concept="37vLTw" id="5JNiski3MBZ" role="37wK5m">
-                  <ref role="3cqZAo" node="4R9posq8ZVS" resolve="SLANG_CORE_LANGUAGE" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiski3MC0" role="37vLTJ">
-                <ref role="3cqZAo" node="5AGBwuFFuSI" resolve="SLANG_CORE_LANGUAGE_ID" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3cpWs8" id="7OJcYqwchFV" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqwchFW" role="3cpWs9">
             <property role="TrG5h" value="coreLanguageId" />
@@ -9649,87 +8078,6 @@
                   <property role="2V$B1T" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
                   <property role="2V$B1Q" value="jetbrains.mps.lang.core" />
                 </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="5JNiski3MC1" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MC2" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MC3" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiski3MC4" role="37vLTx">
-                <node concept="2JrnkZ" id="5JNiski3MC5" role="2Oq$k0">
-                  <node concept="2OqwBi" id="5JNiski3MC6" role="2JrQYb">
-                    <node concept="2tJFMh" id="5JNiski3MC7" role="2Oq$k0">
-                      <node concept="ZC_QK" id="5JNiski3MC8" role="2tJFKM">
-                        <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
-                      </node>
-                    </node>
-                    <node concept="Vyspw" id="5JNiski3MC9" role="2OqNvi">
-                      <node concept="37vLTw" id="5JNiski3MCa" role="Vysub">
-                        <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="liA8E" id="5JNiski3MCb" role="2OqNvi">
-                  <ref role="37wK5l" to="mhbf:~SNode.getProperty(org.jetbrains.mps.openapi.language.SProperty)" resolve="getProperty" />
-                  <node concept="355D3s" id="5JNiski3MCc" role="37wK5m">
-                    <ref role="355D3t" to="h3y3:6jTTMHCXLTP" resolve="IKeyed" />
-                    <ref role="355D3u" to="h3y3:2ju2syjkkk9" resolve="key" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiski3MCd" role="37vLTJ">
-                <ref role="3cqZAo" node="5AGBwuFFBJV" resolve="KEY_BUILTIN_LANGUAGE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwb4uw" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MCe" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MCf" role="3clFbG">
-              <node concept="Xl_RD" id="5JNiski3MCg" role="37vLTx">
-                <property role="Xl_RC" value="LionCore-builtins" />
-              </node>
-              <node concept="37vLTw" id="5JNiski3MCh" role="37vLTJ">
-                <ref role="3cqZAo" node="5AGBwuFFBJV" resolve="KEY_BUILTIN_LANGUAGE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwb4ux" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MCi" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MCj" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiski3MCk" role="37vLTx">
-                <node concept="37vLTw" id="5JNiski3MCl" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5AGBwuFFuSI" resolve="SLANG_CORE_LANGUAGE_ID" />
-                </node>
-                <node concept="liA8E" id="5JNiski3MCm" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SLanguageId.toString()" resolve="toString" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiski3MCn" role="37vLTJ">
-                <ref role="3cqZAo" node="2mPmTXsy76l" resolve="ID_BUILTIN_LANGUAGE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwb4uy" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MCo" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MCp" role="3clFbG">
-              <node concept="37vLTw" id="5JNiski3MCq" role="37vLTJ">
-                <ref role="3cqZAo" node="1ryFPTS4Z8M" resolve="VERSION_BUILTIN_LANGUAGE" />
-              </node>
-              <node concept="37vLTw" id="5JNiski3MCr" role="37vLTx">
-                <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
               </node>
             </node>
           </node>
@@ -9766,131 +8114,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="7OJcYqvUqCi" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwb7WL" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MCt" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MCu" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiski3MCv" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiski3MCw" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiski3MCx" role="2tJFKM">
-                    <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
-                    <node concept="ZC_QK" id="5JNiski3MCy" role="2aWVGa">
-                      <ref role="2aWVGs" to="2pzz:2ju2syjnJjX" resolve="String" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiski3MCz" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiski3MC$" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrD9" role="37vLTJ">
-                <ref role="3cqZAo" node="2ju2syjsm_6" resolve="LC_STRING_TYPE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwb7WM" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MCC" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MCD" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqrDa" role="37vLTJ">
-                <ref role="3cqZAo" node="DUXtH0nMqB" resolve="MPS_STRING_TYPE" />
-              </node>
-              <node concept="2OqwBi" id="5JNiski3MCH" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiski3MCI" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiski3MCJ" role="2tJFKM">
-                    <ref role="2aWVGs" to="tpck:fKAOsGN" resolve="string" />
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiski3MCK" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiski3MCL" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwb7WN" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MCM" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MCN" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqrDb" role="37vLTJ">
-                <ref role="3cqZAo" node="39$JcGGWFCK" resolve="SLANG_STRING_TYPE" />
-              </node>
-              <node concept="10M0yZ" id="5JNiski3MCR" role="37vLTx">
-                <ref role="3cqZAo" to="xx25:~SPrimitiveTypes.STRING" resolve="STRING" />
-                <ref role="1PxDUh" to="xx25:~SPrimitiveTypes" resolve="SPrimitiveTypes" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwb7WO" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MCS" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MCT" role="3clFbG">
-              <node concept="2YIFZM" id="7OJcYqwPrVi" role="37vLTx">
-                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
-                <node concept="37vLTw" id="5JNiski3MCV" role="37wK5m">
-                  <ref role="3cqZAo" node="2ju2syjsm_6" resolve="LC_STRING_TYPE" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDc" role="37vLTJ">
-                <ref role="3cqZAo" node="5M3rB6_Plke" resolve="KEY_STRING_TYPE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="5JNiski3MCZ" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MD0" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MD1" role="3clFbG">
-              <node concept="3cpWs3" id="5JNiski3MD2" role="37vLTx">
-                <node concept="37vLTw" id="5JNiski3MD3" role="3uHU7B">
-                  <ref role="3cqZAo" node="5AGBwuFFBJV" resolve="KEY_BUILTIN_LANGUAGE" />
-                </node>
-                <node concept="Xl_RD" id="5JNiski3MD4" role="3uHU7w">
-                  <property role="Xl_RC" value="-String" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDd" role="37vLTJ">
-                <ref role="3cqZAo" node="5M3rB6_Plke" resolve="KEY_STRING_TYPE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbbIv" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MD8" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MD9" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqrDe" role="37vLTJ">
-                <ref role="3cqZAo" node="2mPmTXsxVhr" resolve="ID_STRING_TYPE" />
-              </node>
-              <node concept="2OqwBi" id="5JNiski3MDd" role="37vLTx">
-                <node concept="2YIFZM" id="5JNiski3MDe" role="2Oq$k0">
-                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
-                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                  <node concept="37vLTw" id="5JNiski3MDf" role="37wK5m">
-                    <ref role="3cqZAo" node="DUXtH0nMqB" resolve="MPS_STRING_TYPE" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="5JNiski3MDg" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5JNiski3MDh" role="3cqZAp" />
         <node concept="3clFbF" id="7OJcYqvSkES" role="3cqZAp">
           <node concept="37vLTI" id="7OJcYqvSkET" role="3clFbG">
             <node concept="2OqwBi" id="7OJcYqvSkEU" role="37vLTJ">
@@ -9938,131 +8161,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="7OJcYqvUGns" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwbfjx" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MDi" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MDj" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiski3MDk" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiski3MDl" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiski3MDm" role="2tJFKM">
-                    <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
-                    <node concept="ZC_QK" id="5JNiski3MDn" role="2aWVGa">
-                      <ref role="2aWVGs" to="2pzz:2ju2syjnJk2" resolve="Boolean" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiski3MDo" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiski3MDp" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDf" role="37vLTJ">
-                <ref role="3cqZAo" node="2ju2syjsnG3" resolve="LC_BOOLEAN_TYPE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbfjy" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MDt" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MDu" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqrDg" role="37vLTJ">
-                <ref role="3cqZAo" node="DUXtH0nRhx" resolve="MPS_BOOLEAN_TYPE" />
-              </node>
-              <node concept="2OqwBi" id="5JNiski3MDy" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiski3MDz" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiski3MD$" role="2tJFKM">
-                    <ref role="2aWVGs" to="tpck:fKAQMTB" resolve="boolean" />
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiski3MD_" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiski3MDA" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbfjz" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MDB" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MDC" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqrDh" role="37vLTJ">
-                <ref role="3cqZAo" node="39$JcGGWAx4" resolve="SLANG_BOOLEAN_TYPE" />
-              </node>
-              <node concept="10M0yZ" id="5JNiski3MDG" role="37vLTx">
-                <ref role="1PxDUh" to="xx25:~SPrimitiveTypes" resolve="SPrimitiveTypes" />
-                <ref role="3cqZAo" to="xx25:~SPrimitiveTypes.BOOLEAN" resolve="BOOLEAN" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbfj$" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MDH" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MDI" role="3clFbG">
-              <node concept="2YIFZM" id="7OJcYqwPrVj" role="37vLTx">
-                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
-                <node concept="37vLTw" id="5JNiski3MDK" role="37wK5m">
-                  <ref role="3cqZAo" node="2ju2syjsnG3" resolve="LC_BOOLEAN_TYPE" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDi" role="37vLTJ">
-                <ref role="3cqZAo" node="5M3rB6_PmED" resolve="KEY_BOOLEAN_TYPE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="5JNiski3MDO" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MDP" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MDQ" role="3clFbG">
-              <node concept="3cpWs3" id="5JNiski3MDR" role="37vLTx">
-                <node concept="37vLTw" id="5JNiski3MDS" role="3uHU7B">
-                  <ref role="3cqZAo" node="5AGBwuFFBJV" resolve="KEY_BUILTIN_LANGUAGE" />
-                </node>
-                <node concept="Xl_RD" id="5JNiski3MDT" role="3uHU7w">
-                  <property role="Xl_RC" value="-Boolean" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDj" role="37vLTJ">
-                <ref role="3cqZAo" node="5M3rB6_PmED" resolve="KEY_BOOLEAN_TYPE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbj1L" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MDX" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MDY" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqrDk" role="37vLTJ">
-                <ref role="3cqZAo" node="2mPmTXsxWOq" resolve="ID_BOOLEAN_TYPE" />
-              </node>
-              <node concept="2OqwBi" id="5JNiski3ME2" role="37vLTx">
-                <node concept="2YIFZM" id="5JNiski3ME3" role="2Oq$k0">
-                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
-                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                  <node concept="37vLTw" id="5JNiski3ME4" role="37wK5m">
-                    <ref role="3cqZAo" node="DUXtH0nRhx" resolve="MPS_BOOLEAN_TYPE" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="5JNiski3ME5" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5JNiski3ME6" role="3cqZAp" />
         <node concept="3clFbF" id="7OJcYqvSsAz" role="3cqZAp">
           <node concept="37vLTI" id="7OJcYqvSsA$" role="3clFbG">
             <node concept="2OqwBi" id="7OJcYqvSsA_" role="37vLTJ">
@@ -10110,131 +8208,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="7OJcYqvVdoV" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwbmro" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3ME7" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3ME8" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiski3ME9" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiski3MEa" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiski3MEb" role="2tJFKM">
-                    <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
-                    <node concept="ZC_QK" id="5JNiski3MEc" role="2aWVGa">
-                      <ref role="2aWVGs" to="2pzz:48csSBPfMBo" resolve="Integer" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiski3MEd" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiski3MEe" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDl" role="37vLTJ">
-                <ref role="3cqZAo" node="48csSBPf4M9" resolve="LC_INTEGER_TYPE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbmrp" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MEi" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MEj" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqrDm" role="37vLTJ">
-                <ref role="3cqZAo" node="48csSBPf4M6" resolve="MPS_INTEGER_TYPE" />
-              </node>
-              <node concept="2OqwBi" id="5JNiski3MEn" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiski3MEo" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiski3MEp" role="2tJFKM">
-                    <ref role="2aWVGs" to="tpck:fKAQMTA" resolve="integer" />
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiski3MEq" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiski3MEr" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbmrq" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MEs" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MEt" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqrDn" role="37vLTJ">
-                <ref role="3cqZAo" node="39$JcGGWu$v" resolve="SLANG_INTEGER_TYPE" />
-              </node>
-              <node concept="10M0yZ" id="5JNiski3MEx" role="37vLTx">
-                <ref role="1PxDUh" to="xx25:~SPrimitiveTypes" resolve="SPrimitiveTypes" />
-                <ref role="3cqZAo" to="xx25:~SPrimitiveTypes.INTEGER" resolve="INTEGER" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbmrr" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MEy" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MEz" role="3clFbG">
-              <node concept="2YIFZM" id="7OJcYqwPrVk" role="37vLTx">
-                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
-                <node concept="37vLTw" id="5JNiski3ME_" role="37wK5m">
-                  <ref role="3cqZAo" node="48csSBPf4M9" resolve="LC_INTEGER_TYPE" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDo" role="37vLTJ">
-                <ref role="3cqZAo" node="5M3rB6_Ppp8" resolve="KEY_INTEGER_TYPE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="5JNiski3MED" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MEE" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MEF" role="3clFbG">
-              <node concept="3cpWs3" id="5JNiski3MEG" role="37vLTx">
-                <node concept="37vLTw" id="5JNiski3MEH" role="3uHU7B">
-                  <ref role="3cqZAo" node="5AGBwuFFBJV" resolve="KEY_BUILTIN_LANGUAGE" />
-                </node>
-                <node concept="Xl_RD" id="5JNiski3MEI" role="3uHU7w">
-                  <property role="Xl_RC" value="-Integer" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDp" role="37vLTJ">
-                <ref role="3cqZAo" node="5M3rB6_Ppp8" resolve="KEY_INTEGER_TYPE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbq2s" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MEM" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MEN" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqrDq" role="37vLTJ">
-                <ref role="3cqZAo" node="2mPmTXsxYns" resolve="ID_INTEGER_TYPE" />
-              </node>
-              <node concept="2OqwBi" id="5JNiski3MER" role="37vLTx">
-                <node concept="2YIFZM" id="5JNiski3MES" role="2Oq$k0">
-                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
-                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                  <node concept="37vLTw" id="5JNiski3MET" role="37wK5m">
-                    <ref role="3cqZAo" node="48csSBPf4M6" resolve="MPS_INTEGER_TYPE" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="5JNiski3MEU" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5JNiski3MEV" role="3cqZAp" />
         <node concept="3clFbF" id="7OJcYqvSxpx" role="3cqZAp">
           <node concept="37vLTI" id="7OJcYqvSxpy" role="3clFbG">
             <node concept="2OqwBi" id="7OJcYqvSxpz" role="37vLTJ">
@@ -10282,167 +8255,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="7OJcYqvVA7e" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwbtqV" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MEW" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MEX" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiski3MEY" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiski3MEZ" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiski3MF0" role="2tJFKM">
-                    <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
-                    <node concept="ZC_QK" id="5JNiski3MF1" role="2aWVGa">
-                      <ref role="2aWVGs" to="2pzz:39$JcGFBN1E" resolve="JSON" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiski3MF2" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiski3MF3" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDr" role="37vLTJ">
-                <ref role="3cqZAo" node="39$JcGFBNeh" resolve="LC_JSON_TYPE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbtqW" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MF7" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MF8" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiski3MF9" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiski3MFa" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiski3MFb" role="2tJFKM">
-                    <ref role="2aWVGs" to="h3y3:39$JcGFBYkI" resolve="JSON" />
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiski3MFc" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiski3MFd" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDs" role="37vLTJ">
-                <ref role="3cqZAo" node="39$JcGFBYPi" resolve="MPS_JSON_TYPE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbtqX" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MFh" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MFi" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqrDt" role="37vLTJ">
-                <ref role="3cqZAo" node="39$JcGFCmtL" resolve="SLANG_JSON_TYPE" />
-              </node>
-              <node concept="2YIFZM" id="5JNiski3MFm" role="37vLTx">
-                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConstrainedStringDataType(long,long,long,java.lang.String)" resolve="getConstrainedStringDataType" />
-                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-                <node concept="2OqwBi" id="5JNiski3MFn" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiski3MFo" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5AGBwuFFqaM" resolve="SLANG_M3_LANGUAGE_ID" />
-                  </node>
-                  <node concept="liA8E" id="5JNiski3MFp" role="2OqNvi">
-                    <ref role="37wK5l" to="e8bb:~SLanguageId.getHighBits()" resolve="getHighBits" />
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="5JNiski3MFq" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiski3MFr" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5AGBwuFFqaM" resolve="SLANG_M3_LANGUAGE_ID" />
-                  </node>
-                  <node concept="liA8E" id="5JNiski3MFs" role="2OqNvi">
-                    <ref role="37wK5l" to="e8bb:~SLanguageId.getLowBits()" resolve="getLowBits" />
-                  </node>
-                </node>
-                <node concept="2YIFZM" id="5JNiski3MFt" role="37wK5m">
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <node concept="2OqwBi" id="5JNiski3MFu" role="37wK5m">
-                    <node concept="37vLTw" id="5JNiski3MFv" role="2Oq$k0">
-                      <ref role="3cqZAo" node="39$JcGFBYPi" resolve="MPS_JSON_TYPE" />
-                    </node>
-                    <node concept="3TrcHB" id="5JNiski3MFw" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:6Kv_6E714g3" resolve="datatypeId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="5JNiski3MFx" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiski3MFy" role="2Oq$k0">
-                    <ref role="3cqZAo" node="39$JcGFBYPi" resolve="MPS_JSON_TYPE" />
-                  </node>
-                  <node concept="3TrcHB" id="5JNiski3MFz" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbtqY" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MF$" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MF_" role="3clFbG">
-              <node concept="2YIFZM" id="7OJcYqwPrVl" role="37vLTx">
-                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
-                <node concept="37vLTw" id="5JNiski3MFB" role="37wK5m">
-                  <ref role="3cqZAo" node="39$JcGFBNeh" resolve="LC_JSON_TYPE" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDu" role="37vLTJ">
-                <ref role="3cqZAo" node="5M3rB6_Psos" resolve="KEY_JSON_TYPE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="5JNiski3MFF" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MFG" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MFH" role="3clFbG">
-              <node concept="3cpWs3" id="5JNiski3MFI" role="37vLTx">
-                <node concept="37vLTw" id="5JNiski3MFJ" role="3uHU7B">
-                  <ref role="3cqZAo" node="5AGBwuFFBJV" resolve="KEY_BUILTIN_LANGUAGE" />
-                </node>
-                <node concept="Xl_RD" id="5JNiski3MFK" role="3uHU7w">
-                  <property role="Xl_RC" value="-JSON" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDv" role="37vLTJ">
-                <ref role="3cqZAo" node="5M3rB6_Psos" resolve="KEY_JSON_TYPE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbwSb" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MFO" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MFP" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqrDw" role="37vLTJ">
-                <ref role="3cqZAo" node="2mPmTXsxZUx" resolve="ID_JSON_TYPE" />
-              </node>
-              <node concept="2OqwBi" id="5JNiski3MFT" role="37vLTx">
-                <node concept="2YIFZM" id="5JNiski3MFU" role="2Oq$k0">
-                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
-                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                  <node concept="37vLTw" id="5JNiski3MFV" role="37wK5m">
-                    <ref role="3cqZAo" node="39$JcGFBYPi" resolve="MPS_JSON_TYPE" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="5JNiski3MFW" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5JNiski3MFX" role="3cqZAp" />
         <node concept="3cpWs8" id="5JNiski3MGj" role="3cqZAp">
           <node concept="3cpWsn" id="5JNiski3MGk" role="3cpWs9">
             <property role="TrG5h" value="coreLangHighBits" />
@@ -10566,157 +8378,6 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="7OJcYqvW5v6" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwb$hr" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MFY" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MFZ" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiski3MG0" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiski3MG1" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiski3MG2" role="2tJFKM">
-                    <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
-                    <node concept="ZC_QK" id="5JNiski3MG3" role="2aWVGa">
-                      <ref role="2aWVGs" to="2pzz:39$JcGFBN1$" resolve="Node" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiski3MG4" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiski3MG5" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDx" role="37vLTJ">
-                <ref role="3cqZAo" node="39$JcGFBNUw" resolve="LC_NODE_CONCEPT" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwb$hs" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MG9" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MGa" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiski3MGb" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiski3MGc" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiski3MGd" role="2tJFKM">
-                    <ref role="2aWVGs" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiski3MGe" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiski3MGf" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDy" role="37vLTJ">
-                <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbBx8" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MGv" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MGw" role="3clFbG">
-              <node concept="2YIFZM" id="5JNiski3MGx" role="37vLTx">
-                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
-                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-                <node concept="37vLTw" id="5JNiski3MGy" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiski3MGk" resolve="coreLangHighBits" />
-                </node>
-                <node concept="37vLTw" id="5JNiski3MGz" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiski3MGq" resolve="coreLangLowBits" />
-                </node>
-                <node concept="2YIFZM" id="5JNiski3MG$" role="37wK5m">
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <node concept="2OqwBi" id="5JNiski3MG_" role="37wK5m">
-                    <node concept="37vLTw" id="5JNiski3MGA" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
-                    </node>
-                    <node concept="3TrcHB" id="5JNiski3MGB" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="5JNiski3MGC" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiski3MGD" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
-                  </node>
-                  <node concept="3TrcHB" id="5JNiski3MGE" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDz" role="37vLTJ">
-                <ref role="3cqZAo" node="39$JcGG9w_Q" resolve="SLANG_NODE_CONCEPT" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbBx9" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MGI" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MGJ" role="3clFbG">
-              <node concept="2YIFZM" id="7OJcYqwPrVm" role="37vLTx">
-                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
-                <node concept="37vLTw" id="5JNiski3MGL" role="37wK5m">
-                  <ref role="3cqZAo" node="39$JcGFBNUw" resolve="LC_NODE_CONCEPT" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrD$" role="37vLTJ">
-                <ref role="3cqZAo" node="5M3rB6_PuRS" resolve="KEY_NODE_CONCEPT" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="5JNiski3MGP" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MGQ" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MGR" role="3clFbG">
-              <node concept="3cpWs3" id="5JNiski3MGS" role="37vLTx">
-                <node concept="37vLTw" id="5JNiski3MGT" role="3uHU7B">
-                  <ref role="3cqZAo" node="5AGBwuFFBJV" resolve="KEY_BUILTIN_LANGUAGE" />
-                </node>
-                <node concept="Xl_RD" id="5JNiski3MGU" role="3uHU7w">
-                  <property role="Xl_RC" value="-Node" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrD_" role="37vLTJ">
-                <ref role="3cqZAo" node="5M3rB6_PuRS" resolve="KEY_NODE_CONCEPT" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbESv" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MGY" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MGZ" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqrDA" role="37vLTJ">
-                <ref role="3cqZAo" node="2mPmTXsy1tD" resolve="ID_NODE_CONCEPT" />
-              </node>
-              <node concept="2OqwBi" id="5JNiski3MH3" role="37vLTx">
-                <node concept="2YIFZM" id="5JNiski3MH4" role="2Oq$k0">
-                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getConceptId(org.jetbrains.mps.openapi.model.SNode)" resolve="getConceptId" />
-                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                  <node concept="37vLTw" id="5JNiski3MH5" role="37wK5m">
-                    <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="5JNiski3MH6" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SConceptId.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3clFbH" id="5JNiski3MH7" role="3cqZAp" />
         <node concept="3cpWs8" id="7OJcYqwdvVk" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqwdvVl" role="3cpWs9">
@@ -10813,128 +8474,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="7OJcYqvMjrl" role="3cqZAp" />
-        <node concept="1X3_iC" id="5JNiski3MH8" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MH9" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MHa" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiski3MHb" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiski3MHc" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiski3MHd" role="2tJFKM">
-                    <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
-                    <node concept="ZC_QK" id="5JNiski3MHe" role="2aWVGa">
-                      <ref role="2aWVGs" to="2pzz:39$JcGFBN1$" resolve="Node" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiski3MHf" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiski3MHg" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDB" role="37vLTJ" />
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbIh8" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MHk" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MHl" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiski3MHm" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiski3MHn" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiski3MHo" role="2tJFKM">
-                    <ref role="2aWVGs" to="tpck:2ULFgo8_XDk" resolve="NodeAttribute" />
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiski3MHp" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiski3MHq" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDC" role="37vLTJ">
-                <ref role="3cqZAo" node="30uXOOfMilR" resolve="MPS_ANNOTATION_CONCEPT" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbIh9" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MHu" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MHv" role="3clFbG">
-              <node concept="2YIFZM" id="5JNiski3MHw" role="37vLTx">
-                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
-                <node concept="37vLTw" id="5JNiski3MHx" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiski3MGk" resolve="coreLangHighBits" />
-                </node>
-                <node concept="37vLTw" id="5JNiski3MHy" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiski3MGq" resolve="coreLangLowBits" />
-                </node>
-                <node concept="2YIFZM" id="5JNiski3MHz" role="37wK5m">
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <node concept="2OqwBi" id="5JNiski3MH$" role="37wK5m">
-                    <node concept="37vLTw" id="5JNiski3MH_" role="2Oq$k0">
-                      <ref role="3cqZAo" node="30uXOOfMilR" resolve="MPS_ANNOTATION_CONCEPT" />
-                    </node>
-                    <node concept="3TrcHB" id="5JNiski3MHA" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="5JNiski3MHB" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiski3MHC" role="2Oq$k0">
-                    <ref role="3cqZAo" node="30uXOOfMilR" resolve="MPS_ANNOTATION_CONCEPT" />
-                  </node>
-                  <node concept="3TrcHB" id="5JNiski3MHD" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDD" role="37vLTJ">
-                <ref role="3cqZAo" node="30uXOOfMilO" resolve="SLANG_ANNOTATION_CONCEPT" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="5JNiski3MHH" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MHI" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MHJ" role="3clFbG">
-              <node concept="33vP2n" id="5JNiski3MHK" role="37vLTx" />
-              <node concept="37vLTw" id="5JNiskiqrDE" role="37vLTJ" />
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbLAv" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MHO" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MHP" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqrDF" role="37vLTJ">
-                <ref role="3cqZAo" node="6Pr6izIcvKD" resolve="ID_ANNOTATION_CONCEPT" />
-              </node>
-              <node concept="2OqwBi" id="5JNiski3MHT" role="37vLTx">
-                <node concept="2YIFZM" id="5JNiski3MHU" role="2Oq$k0">
-                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getConceptId(org.jetbrains.mps.openapi.model.SNode)" resolve="getConceptId" />
-                  <node concept="37vLTw" id="5JNiski3MHV" role="37wK5m">
-                    <ref role="3cqZAo" node="30uXOOfMilR" resolve="MPS_ANNOTATION_CONCEPT" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="5JNiski3MHW" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SConceptId.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="7OJcYqvPv4U" role="3cqZAp" />
         <node concept="3cpWs8" id="7OJcYqwdEvZ" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqwdEw0" role="3cpWs9">
             <property role="TrG5h" value="mpsAnnotation" />
@@ -11004,85 +8543,6 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="7OJcYqvPZ16" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwbOKP" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MHX" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MHY" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiski3MHZ" role="37vLTx">
-                <node concept="2OqwBi" id="5JNiski3MI0" role="2Oq$k0">
-                  <node concept="2OqwBi" id="5JNiski3MI1" role="2Oq$k0">
-                    <node concept="37vLTw" id="5JNiski3MI2" role="2Oq$k0">
-                      <ref role="3cqZAo" node="39$JcGG9w_Q" resolve="SLANG_NODE_CONCEPT" />
-                    </node>
-                    <node concept="liA8E" id="5JNiski3MI3" role="2OqNvi">
-                      <ref role="37wK5l" to="c17a:~SAbstractConcept.getContainmentLinks()" resolve="getContainmentLinks" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="5JNiski3MI4" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~Collection.iterator()" resolve="iterator" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="5JNiski3MI5" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDG" role="37vLTJ">
-                <ref role="3cqZAo" node="4WflrVajnwK" resolve="SLANG_ANNOTATION_CONTAINMENT" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbOKQ" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiu6k7" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiuc64" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiskiuo8P" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiskiueD1" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiskiugYq" role="2tJFKM">
-                    <ref role="2aWVGs" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                    <node concept="ZC_QK" id="5JNiskiujkr" role="2aWVGa">
-                      <ref role="2aWVGs" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiskiuprT" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiskiurNJ" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiu6k5" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskitK$o" resolve="MPS_ANNOTATION_CONTAINMENT" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbOKR" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiskiyL18" role="8Wnug">
-            <node concept="37vLTI" id="5JNiskiyNCf" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiskiyYaD" role="37vLTx">
-                <node concept="2YIFZM" id="5JNiskiySZV" role="2Oq$k0">
-                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getLinkId(org.jetbrains.mps.openapi.model.SNode)" resolve="getLinkId" />
-                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                  <node concept="37vLTw" id="5JNiskiyVqd" role="37wK5m">
-                    <ref role="3cqZAo" node="5JNiskitK$o" resolve="MPS_ANNOTATION_CONTAINMENT" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="5JNiskiz1gs" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SContainmentLinkId.toString()" resolve="toString" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiyL16" role="37vLTJ">
-                <ref role="3cqZAo" node="5JNiskiyDwd" resolve="ID_ANNOTATION_CONTAINMENT" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3clFbH" id="7OJcYqvQ20y" role="3cqZAp" />
         <node concept="3clFbF" id="7OJcYqvT58J" role="3cqZAp">
           <node concept="37vLTI" id="7OJcYqvT58K" role="3clFbG">
@@ -11134,157 +8594,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="7OJcYqvQ55q" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwbRQB" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MIa" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MIb" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiski3MIc" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiski3MId" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiski3MIe" role="2tJFKM">
-                    <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
-                    <node concept="ZC_QK" id="5JNiski3MIf" role="2aWVGa">
-                      <ref role="2aWVGs" to="2pzz:6jTTMHCZNUU" resolve="INamed" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiski3MIg" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiski3MIh" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDH" role="37vLTJ">
-                <ref role="3cqZAo" node="6jTTMHCZPnj" resolve="LC_INAMED_INTERFACE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbRQC" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MIl" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MIm" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiski3MIn" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiski3MIo" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiski3MIp" role="2tJFKM">
-                    <ref role="2aWVGs" to="tpck:h0TrEE$" resolve="INamedConcept" />
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiski3MIq" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiski3MIr" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDI" role="37vLTJ">
-                <ref role="3cqZAo" node="6jTTMHCZPng" resolve="MPS_INAMED_INTERFACE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbRQD" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MIv" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MIw" role="3clFbG">
-              <node concept="2YIFZM" id="5JNiski3MIx" role="37vLTx">
-                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getInterfaceConcept(long,long,long,java.lang.String)" resolve="getInterfaceConcept" />
-                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-                <node concept="37vLTw" id="5JNiski3MIy" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiski3MGk" resolve="coreLangHighBits" />
-                </node>
-                <node concept="37vLTw" id="5JNiski3MIz" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiski3MGq" resolve="coreLangLowBits" />
-                </node>
-                <node concept="2YIFZM" id="5JNiski3MI$" role="37wK5m">
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <node concept="2OqwBi" id="5JNiski3MI_" role="37wK5m">
-                    <node concept="37vLTw" id="5JNiski3MIA" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6jTTMHCZPng" resolve="MPS_INAMED_INTERFACE" />
-                    </node>
-                    <node concept="3TrcHB" id="5JNiski3MIB" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="5JNiski3MIC" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiski3MID" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6jTTMHCZPng" resolve="MPS_INAMED_INTERFACE" />
-                  </node>
-                  <node concept="3TrcHB" id="5JNiski3MIE" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDJ" role="37vLTJ">
-                <ref role="3cqZAo" node="6jTTMHCZPnd" resolve="SLANG_INAMED_INTERFACE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbRQE" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MII" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MIJ" role="3clFbG">
-              <node concept="2YIFZM" id="7OJcYqwPrVn" role="37vLTx">
-                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
-                <node concept="37vLTw" id="5JNiski3MIL" role="37wK5m">
-                  <ref role="3cqZAo" node="6jTTMHCZPnj" resolve="LC_INAMED_INTERFACE" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDK" role="37vLTJ">
-                <ref role="3cqZAo" node="5M3rB6_P$Vq" resolve="KEY_INAMED_INTERFACE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="5JNiski3MIP" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MIQ" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MIR" role="3clFbG">
-              <node concept="3cpWs3" id="5JNiski3MIS" role="37vLTx">
-                <node concept="37vLTw" id="5JNiski3MIT" role="3uHU7B">
-                  <ref role="3cqZAo" node="5AGBwuFFBJV" resolve="KEY_BUILTIN_LANGUAGE" />
-                </node>
-                <node concept="Xl_RD" id="5JNiski3MIU" role="3uHU7w">
-                  <property role="Xl_RC" value="-INamed" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDL" role="37vLTJ">
-                <ref role="3cqZAo" node="5M3rB6_P$Vq" resolve="KEY_INAMED_INTERFACE" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbUXd" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MIY" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MIZ" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqrDM" role="37vLTJ">
-                <ref role="3cqZAo" node="2mPmTXsy2Sr" resolve="ID_INAMED_INTERFACE" />
-              </node>
-              <node concept="2OqwBi" id="5JNiski3MJ3" role="37vLTx">
-                <node concept="2YIFZM" id="5JNiski3MJ4" role="2Oq$k0">
-                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getConceptId(org.jetbrains.mps.openapi.model.SNode)" resolve="getConceptId" />
-                  <node concept="37vLTw" id="5JNiski3MJ5" role="37wK5m">
-                    <ref role="3cqZAo" node="6jTTMHCZPng" resolve="MPS_INAMED_INTERFACE" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="5JNiski3MJ6" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SConceptId.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5JNiski3MJ7" role="3cqZAp" />
         <node concept="3cpWs8" id="7OJcYqwdWS4" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqwdWS5" role="3cpWs9">
             <property role="TrG5h" value="mpsINamed" />
@@ -11363,175 +8672,6 @@
                       <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                     </node>
                   </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="7OJcYqvQZmU" role="3cqZAp" />
-        <node concept="1X3_iC" id="7OJcYqwbXTI" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MJ8" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MJ9" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqrDN" role="37vLTJ">
-                <ref role="3cqZAo" node="5AGBwuFJEKi" resolve="LC_NAME_PROPERTY" />
-              </node>
-              <node concept="2OqwBi" id="5JNiski3MJd" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiski3MJe" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiski3MJf" role="2tJFKM">
-                    <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
-                    <node concept="ZC_QK" id="5JNiski3MJg" role="2aWVGa">
-                      <ref role="2aWVGs" to="2pzz:6jTTMHCZNUU" resolve="INamed" />
-                      <node concept="ZC_QK" id="5JNiski3MJh" role="2aWVGa">
-                        <ref role="2aWVGs" to="2pzz:6jTTMHCZNV2" resolve="name" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiski3MJi" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiski3MJj" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbXTJ" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MJk" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MJl" role="3clFbG">
-              <node concept="2OqwBi" id="5JNiski3MJm" role="37vLTx">
-                <node concept="2tJFMh" id="5JNiski3MJn" role="2Oq$k0">
-                  <node concept="ZC_QK" id="5JNiski3MJo" role="2tJFKM">
-                    <ref role="2aWVGs" to="tpck:h0TrEE$" resolve="INamedConcept" />
-                    <node concept="ZC_QK" id="5JNiski3MJp" role="2aWVGa">
-                      <ref role="2aWVGs" to="tpck:h0TrG11" resolve="name" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Vyspw" id="5JNiski3MJq" role="2OqNvi">
-                  <node concept="37vLTw" id="5JNiski3MJr" role="Vysub">
-                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDO" role="37vLTJ">
-                <ref role="3cqZAo" node="5AGBwuFJEKf" resolve="MPS_NAME_PROPERTY" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbXTK" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MJv" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MJw" role="3clFbG">
-              <node concept="2YIFZM" id="5JNiski3MJx" role="37vLTx">
-                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
-                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-                <node concept="37vLTw" id="5JNiski3MJy" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiski3MGk" resolve="coreLangHighBits" />
-                </node>
-                <node concept="37vLTw" id="5JNiski3MJz" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiski3MGq" resolve="coreLangLowBits" />
-                </node>
-                <node concept="2YIFZM" id="5JNiski3MJ$" role="37wK5m">
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <node concept="2OqwBi" id="5JNiski3MJ_" role="37wK5m">
-                    <node concept="37vLTw" id="5JNiski3MJA" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6jTTMHCZPng" resolve="MPS_INAMED_INTERFACE" />
-                    </node>
-                    <node concept="3TrcHB" id="5JNiski3MJB" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2YIFZM" id="5JNiski3MJC" role="37wK5m">
-                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                  <node concept="2OqwBi" id="5JNiski3MJD" role="37wK5m">
-                    <node concept="37vLTw" id="5JNiski3MJE" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5AGBwuFJEKf" resolve="MPS_NAME_PROPERTY" />
-                    </node>
-                    <node concept="3TrcHB" id="5JNiski3MJF" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="5JNiski3MJG" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiski3MJH" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5AGBwuFJEKf" resolve="MPS_NAME_PROPERTY" />
-                  </node>
-                  <node concept="3TrcHB" id="5JNiski3MJI" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDP" role="37vLTJ">
-                <ref role="3cqZAo" node="5AGBwuFJEKc" resolve="SLANG_NAME_PROPERTY" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwbXTL" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MJM" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MJN" role="3clFbG">
-              <node concept="2YIFZM" id="7OJcYqwPrVo" role="37vLTx">
-                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
-                <node concept="37vLTw" id="5JNiski3MJP" role="37wK5m">
-                  <ref role="3cqZAo" node="5AGBwuFJEKi" resolve="LC_NAME_PROPERTY" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDQ" role="37vLTJ">
-                <ref role="3cqZAo" node="5M3rB6_PC4J" resolve="KEY_NAME_PROPERTY" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="5JNiski3MJT" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MJU" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MJV" role="3clFbG">
-              <node concept="3cpWs3" id="5JNiski3MJW" role="37vLTx">
-                <node concept="37vLTw" id="5JNiski3MJX" role="3uHU7B">
-                  <ref role="3cqZAo" node="5M3rB6_P$Vq" resolve="KEY_INAMED_INTERFACE" />
-                </node>
-                <node concept="Xl_RD" id="5JNiski3MJY" role="3uHU7w">
-                  <property role="Xl_RC" value="-name" />
-                </node>
-              </node>
-              <node concept="37vLTw" id="5JNiskiqrDR" role="37vLTJ">
-                <ref role="3cqZAo" node="5M3rB6_PC4J" resolve="KEY_NAME_PROPERTY" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="7OJcYqwc14a" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5JNiski3MK2" role="8Wnug">
-            <node concept="37vLTI" id="5JNiski3MK3" role="3clFbG">
-              <node concept="37vLTw" id="5JNiskiqrDS" role="37vLTJ">
-                <ref role="3cqZAo" node="2mPmTXsy402" resolve="ID_NAME_PROPERTY" />
-              </node>
-              <node concept="2OqwBi" id="5JNiski3MK7" role="37vLTx">
-                <node concept="2YIFZM" id="5JNiski3MK8" role="2Oq$k0">
-                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getPropId(org.jetbrains.mps.openapi.model.SNode)" resolve="getPropId" />
-                  <node concept="37vLTw" id="5JNiski3MK9" role="37wK5m">
-                    <ref role="3cqZAo" node="5AGBwuFJEKf" resolve="MPS_NAME_PROPERTY" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="5JNiski3MKa" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SPropertyId.toString()" resolve="toString" />
                 </node>
               </node>
             </node>
@@ -11664,18 +8804,6 @@
       <node concept="17QB3L" id="5JNiskhmwT4" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5JNiskhmsVz" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqweqfe" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="2ju2syjsm_6" role="8Wnug">
-        <property role="TrG5h" value="LC_STRING_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tqbb2" id="2ju2syjsmuv" role="1tU5fm">
-          <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-        </node>
-        <node concept="3Tmbuc" id="5JNiskhwcR3" role="1B3o_S" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhmCGz" role="jymVt">
       <property role="TrG5h" value="lcStringType" />
       <node concept="3clFbS" id="5JNiskhmCGA" role="3clF47">
@@ -11693,18 +8821,6 @@
       <node concept="3Tm1VV" id="5JNiskhmAEc" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiskhmCD_" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqweuur" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="DUXtH0nMqB" role="8Wnug">
-        <property role="TrG5h" value="MPS_STRING_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhweUV" role="1B3o_S" />
-        <node concept="3Tqbb2" id="DUXtH0nMqn" role="1tU5fm">
-          <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhmKpL" role="jymVt">
@@ -11726,18 +8842,6 @@
         <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqweyHD" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="39$JcGGWFCK" role="8Wnug">
-        <property role="TrG5h" value="SLANG_STRING_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwgS5" role="1B3o_S" />
-        <node concept="3uibUv" id="39$JcGGWFCM" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhnnGw" role="jymVt">
       <property role="TrG5h" value="slangStringType" />
       <node concept="3clFbS" id="5JNiskhnnGx" role="3clF47">
@@ -11757,16 +8861,6 @@
         <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqweAV$" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5M3rB6_Plke" role="8Wnug">
-        <property role="TrG5h" value="KEY_STRING_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwiSe" role="1B3o_S" />
-        <node concept="17QB3L" id="5M3rB6_Pljn" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhntM$" role="jymVt">
       <property role="TrG5h" value="keyStringType" />
       <node concept="3clFbS" id="5JNiskhntM_" role="3clF47">
@@ -11783,16 +8877,6 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskhntMC" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhntMD" role="3clF45" />
-    </node>
-    <node concept="1X3_iC" id="7OJcYqweJNK" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="2mPmTXsxVhr" role="8Wnug">
-        <property role="TrG5h" value="ID_STRING_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwkL5" role="1B3o_S" />
-        <node concept="17QB3L" id="2mPmTXsxVht" role="1tU5fm" />
-      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhnzc0" role="jymVt">
       <property role="TrG5h" value="idStringType" />
@@ -11812,18 +8896,6 @@
       <node concept="17QB3L" id="5JNiskhnzc5" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="DUXtH0nOOu" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqweO31" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="2ju2syjsnG3" role="8Wnug">
-        <property role="TrG5h" value="LC_BOOLEAN_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tqbb2" id="2ju2syjsnG4" role="1tU5fm">
-          <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-        </node>
-        <node concept="3Tmbuc" id="5JNiskhwn4Z" role="1B3o_S" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhnMfh" role="jymVt">
       <property role="TrG5h" value="lcBooleanType" />
       <node concept="3clFbS" id="5JNiskhnMfi" role="3clF47">
@@ -11841,18 +8913,6 @@
       <node concept="3Tm1VV" id="5JNiskhnMfj" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiskhnMfk" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqweSgZ" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="DUXtH0nRhx" role="8Wnug">
-        <property role="TrG5h" value="MPS_BOOLEAN_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwoXU" role="1B3o_S" />
-        <node concept="3Tqbb2" id="DUXtH0nRhz" role="1tU5fm">
-          <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhnMfd" role="jymVt">
@@ -11874,18 +8934,6 @@
         <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqweWwi" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="39$JcGGWAx4" role="8Wnug">
-        <property role="TrG5h" value="SLANG_BOOLEAN_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwqV6" role="1B3o_S" />
-        <node concept="3uibUv" id="39$JcGGWAx6" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhnMf9" role="jymVt">
       <property role="TrG5h" value="slangBooleanType" />
       <node concept="3clFbS" id="5JNiskhnMfa" role="3clF47">
@@ -11905,16 +8953,6 @@
         <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwf0JA" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5M3rB6_PmED" role="8Wnug">
-        <property role="TrG5h" value="KEY_BOOLEAN_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwsNX" role="1B3o_S" />
-        <node concept="17QB3L" id="5M3rB6_PmEF" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhnMf5" role="jymVt">
       <property role="TrG5h" value="keyBooleanType" />
       <node concept="3clFbS" id="5JNiskhnMf6" role="3clF47">
@@ -11931,16 +8969,6 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskhnMf7" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhnMf8" role="3clF45" />
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwf513" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="2mPmTXsxWOq" role="8Wnug">
-        <property role="TrG5h" value="ID_BOOLEAN_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwuGO" role="1B3o_S" />
-        <node concept="17QB3L" id="2mPmTXsxWOs" role="1tU5fm" />
-      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhnMf1" role="jymVt">
       <property role="TrG5h" value="idBooleanType" />
@@ -11960,18 +8988,6 @@
       <node concept="17QB3L" id="5JNiskhnMf4" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="DUXtGZOqx1" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwf9f5" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="48csSBPf4M9" role="8Wnug">
-        <property role="TrG5h" value="LC_INTEGER_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tqbb2" id="48csSBPf4Ma" role="1tU5fm">
-          <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-        </node>
-        <node concept="3Tmbuc" id="5JNiskhwwA3" role="1B3o_S" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhnZtN" role="jymVt">
       <property role="TrG5h" value="lcIntegerType" />
       <node concept="3clFbS" id="5JNiskhnZtO" role="3clF47">
@@ -11989,18 +9005,6 @@
       <node concept="3Tm1VV" id="5JNiskhnZtP" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiskhnZtQ" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwfdt8" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="48csSBPf4M6" role="8Wnug">
-        <property role="TrG5h" value="MPS_INTEGER_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwy_S" role="1B3o_S" />
-        <node concept="3Tqbb2" id="48csSBPf4M8" role="1tU5fm">
-          <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhnZtJ" role="jymVt">
@@ -12022,18 +9026,6 @@
         <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwfhFc" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="39$JcGGWu$v" role="8Wnug">
-        <property role="TrG5h" value="SLANG_INTEGER_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhw$uN" role="1B3o_S" />
-        <node concept="3uibUv" id="39$JcGGWu$x" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhnZtF" role="jymVt">
       <property role="TrG5h" value="slangIntegerType" />
       <node concept="3clFbS" id="5JNiskhnZtG" role="3clF47">
@@ -12053,16 +9045,6 @@
         <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwflTh" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5M3rB6_Ppp8" role="8Wnug">
-        <property role="TrG5h" value="KEY_INTEGER_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwAnE" role="1B3o_S" />
-        <node concept="17QB3L" id="5M3rB6_Pppa" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhnZtB" role="jymVt">
       <property role="TrG5h" value="keyIntegerType" />
       <node concept="3clFbS" id="5JNiskhnZtC" role="3clF47">
@@ -12079,16 +9061,6 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskhnZtD" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhnZtE" role="3clF45" />
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwfq7n" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="2mPmTXsxYns" role="8Wnug">
-        <property role="TrG5h" value="ID_INTEGER_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwC9f" role="1B3o_S" />
-        <node concept="17QB3L" id="2mPmTXsxYnu" role="1tU5fm" />
-      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhnZtz" role="jymVt">
       <property role="TrG5h" value="idIntegerType" />
@@ -12108,18 +9080,6 @@
       <node concept="17QB3L" id="5JNiskhnZtA" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="48csSBPf4M5" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwfF9o" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="39$JcGFBNeh" role="8Wnug">
-        <property role="TrG5h" value="LC_JSON_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tqbb2" id="39$JcGFBNei" role="1tU5fm">
-          <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-        </node>
-        <node concept="3Tmbuc" id="5JNiskhwE7P" role="1B3o_S" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhoaPB" role="jymVt">
       <property role="TrG5h" value="lcJsonType" />
       <node concept="3clFbS" id="5JNiskhoaPC" role="3clF47">
@@ -12137,18 +9097,6 @@
       <node concept="3Tm1VV" id="5JNiskhoaPD" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiskhoaPE" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwfJoO" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="39$JcGFBYPi" role="8Wnug">
-        <property role="TrG5h" value="MPS_JSON_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwG0K" role="1B3o_S" />
-        <node concept="3Tqbb2" id="39$JcGFBYPk" role="1tU5fm">
-          <ref role="ehGHo" to="tpce:fKAz7CR" resolve="ConstrainedDataTypeDeclaration" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhoaPz" role="jymVt">
@@ -12170,18 +9118,6 @@
         <ref role="ehGHo" to="tpce:fKAz7CR" resolve="ConstrainedDataTypeDeclaration" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwfNFb" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="39$JcGFCmtL" role="8Wnug">
-        <property role="TrG5h" value="SLANG_JSON_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwHV7" role="1B3o_S" />
-        <node concept="3uibUv" id="39$JcGFCmt_" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhoaPv" role="jymVt">
       <property role="TrG5h" value="slangJsonType" />
       <node concept="3clFbS" id="5JNiskhoaPw" role="3clF47">
@@ -12201,16 +9137,6 @@
         <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwfRUD" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5M3rB6_Psos" role="8Wnug">
-        <property role="TrG5h" value="KEY_JSON_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwJOm" role="1B3o_S" />
-        <node concept="17QB3L" id="5M3rB6_Psou" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhoaPr" role="jymVt">
       <property role="TrG5h" value="keyJsonType" />
       <node concept="3clFbS" id="5JNiskhoaPs" role="3clF47">
@@ -12227,16 +9153,6 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskhoaPt" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhoaPu" role="3clF45" />
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwfW8O" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="2mPmTXsxZUx" role="8Wnug">
-        <property role="TrG5h" value="ID_JSON_TYPE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwLO7" role="1B3o_S" />
-        <node concept="17QB3L" id="2mPmTXsxZUz" role="1tU5fm" />
-      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhoaPn" role="jymVt">
       <property role="TrG5h" value="idJsonType" />
@@ -12256,18 +9172,6 @@
       <node concept="17QB3L" id="5JNiskhoaPq" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="39$JcGFBYDh" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwg0Cb" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="39$JcGFBNUw" role="8Wnug">
-        <property role="TrG5h" value="LC_NODE_CONCEPT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwNGY" role="1B3o_S" />
-        <node concept="3Tqbb2" id="39$JcGFBNUg" role="1tU5fm">
-          <ref role="ehGHo" to="h3y3:2ju2syjklrv" resolve="Concept" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhqgVp" role="jymVt">
       <property role="TrG5h" value="lcNodeConcept" />
       <node concept="3clFbS" id="5JNiskhqgVq" role="3clF47">
@@ -12285,18 +9189,6 @@
       <node concept="3Tm1VV" id="5JNiskhqgVr" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiskhqgVs" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjklrv" resolve="Concept" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwg4Qo" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="3ePT3MaQsZ_" role="8Wnug">
-        <property role="TrG5h" value="MPS_NODE_CONCEPT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwP_T" role="1B3o_S" />
-        <node concept="3Tqbb2" id="3ePT3MaQsZB" role="1tU5fm">
-          <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqgVl" role="jymVt">
@@ -12318,18 +9210,6 @@
         <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwg95U" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="39$JcGG9w_Q" role="8Wnug">
-        <property role="TrG5h" value="SLANG_NODE_CONCEPT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwRnI" role="1B3o_S" />
-        <node concept="3uibUv" id="39$JcGG9x5k" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhqgVh" role="jymVt">
       <property role="TrG5h" value="slangNodeConcept" />
       <node concept="3clFbS" id="5JNiskhqgVi" role="3clF47">
@@ -12349,16 +9229,6 @@
         <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwgdr3" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5M3rB6_PuRS" role="8Wnug">
-        <property role="TrG5h" value="KEY_NODE_CONCEPT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwTpu" role="1B3o_S" />
-        <node concept="17QB3L" id="5M3rB6_PuRU" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhqgVd" role="jymVt">
       <property role="TrG5h" value="keyNodeConcept" />
       <node concept="3clFbS" id="5JNiskhqgVe" role="3clF47">
@@ -12375,16 +9245,6 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskhqgVf" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhqgVg" role="3clF45" />
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwghJm" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="2mPmTXsy1tD" role="8Wnug">
-        <property role="TrG5h" value="ID_NODE_CONCEPT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwVil" role="1B3o_S" />
-        <node concept="17QB3L" id="2mPmTXsy1tF" role="1tU5fm" />
-      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqgV9" role="jymVt">
       <property role="TrG5h" value="idNodeConcept" />
@@ -12404,18 +9264,6 @@
       <node concept="17QB3L" id="5JNiskhqgVc" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="6jTTMHCZQ3M" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwglZ0" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="30uXOOfMilR" role="8Wnug">
-        <property role="TrG5h" value="MPS_ANNOTATION_CONCEPT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwXcB" role="1B3o_S" />
-        <node concept="3Tqbb2" id="30uXOOfMilT" role="1tU5fm">
-          <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhqsXL" role="jymVt">
       <property role="TrG5h" value="mpsAnnotationConcept" />
       <node concept="3clFbS" id="5JNiskhqsXM" role="3clF47">
@@ -12433,18 +9281,6 @@
       <node concept="3Tm1VV" id="5JNiskhqsXN" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiskhqsXO" role="3clF45">
         <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwgqeF" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="30uXOOfMilO" role="8Wnug">
-        <property role="TrG5h" value="SLANG_ANNOTATION_CONCEPT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhwZcW" role="1B3o_S" />
-        <node concept="3uibUv" id="30uXOOfMilQ" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqsXH" role="jymVt">
@@ -12466,16 +9302,6 @@
         <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwguuj" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="6Pr6izIcvKD" role="8Wnug">
-        <property role="TrG5h" value="ID_ANNOTATION_CONCEPT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhx0Y$" role="1B3o_S" />
-        <node concept="17QB3L" id="6Pr6izIcvKF" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhqsX_" role="jymVt">
       <property role="TrG5h" value="idAnnotationConcept" />
       <node concept="3clFbS" id="5JNiskhqsXA" role="3clF47">
@@ -12492,18 +9318,6 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskhqsXB" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhqsXC" role="3clF45" />
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwgyHZ" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="4WflrVajnwK" role="8Wnug">
-        <property role="TrG5h" value="SLANG_ANNOTATION_CONTAINMENT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhx2SJ" role="1B3o_S" />
-        <node concept="3uibUv" id="4WflrVajnv2" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
-        </node>
-      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhsfjt" role="jymVt">
       <property role="TrG5h" value="slangAnnotationContainment" />
@@ -12524,18 +9338,6 @@
         <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwgB0q" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskitK$o" role="8Wnug">
-        <property role="TrG5h" value="MPS_ANNOTATION_CONTAINMENT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskitK$p" role="1B3o_S" />
-        <node concept="3Tqbb2" id="5JNiskitX4f" role="1tU5fm">
-          <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskitK$i" role="jymVt">
       <property role="TrG5h" value="mpsAnnotationContainment" />
       <node concept="3clFbS" id="5JNiskitK$j" role="3clF47">
@@ -12553,16 +9355,6 @@
       <node concept="3Tm1VV" id="5JNiskitK$m" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiskitNZh" role="3clF45">
         <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwgFg9" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5JNiskiyDwd" role="8Wnug">
-        <property role="TrG5h" value="ID_ANNOTATION_CONTAINMENT" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskiyyfS" role="1B3o_S" />
-        <node concept="17QB3L" id="5JNiskiyBVU" role="1tU5fm" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiyneZ" role="jymVt">
@@ -12586,18 +9378,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="30uXOOfMilH" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwgJvT" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="6jTTMHCZPnj" role="8Wnug">
-        <property role="TrG5h" value="LC_INAMED_INTERFACE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhx4LY" role="1B3o_S" />
-        <node concept="3Tqbb2" id="6jTTMHCZPnl" role="1tU5fm">
-          <ref role="ehGHo" to="h3y3:2ju2syjklHQ" resolve="Interface" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhqBwh" role="jymVt">
       <property role="TrG5h" value="lcINamedInterface" />
       <node concept="3clFbS" id="5JNiskhqBwi" role="3clF47">
@@ -12615,18 +9395,6 @@
       <node concept="3Tm1VV" id="5JNiskhqBwj" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiskhqBwk" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjklHQ" resolve="Interface" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwgNJE" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="6jTTMHCZPng" role="8Wnug">
-        <property role="TrG5h" value="MPS_INAMED_INTERFACE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhx6LN" role="1B3o_S" />
-        <node concept="3Tqbb2" id="6jTTMHCZPni" role="1tU5fm">
-          <ref role="ehGHo" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqBwd" role="jymVt">
@@ -12648,18 +9416,6 @@
         <ref role="ehGHo" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwgRZs" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="6jTTMHCZPnd" role="8Wnug">
-        <property role="TrG5h" value="SLANG_INAMED_INTERFACE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhx8EU" role="1B3o_S" />
-        <node concept="3uibUv" id="6jTTMHCZPnf" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SInterfaceConcept" resolve="SInterfaceConcept" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhqBw9" role="jymVt">
       <property role="TrG5h" value="slangINamedInterface" />
       <node concept="3clFbS" id="5JNiskhqBwa" role="3clF47">
@@ -12679,16 +9435,6 @@
         <ref role="3uigEE" to="c17a:~SInterfaceConcept" resolve="SInterfaceConcept" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwgWfb" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5M3rB6_P$Vq" role="8Wnug">
-        <property role="TrG5h" value="KEY_INAMED_INTERFACE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxasv" role="1B3o_S" />
-        <node concept="17QB3L" id="5M3rB6_P$Vs" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhqBw5" role="jymVt">
       <property role="TrG5h" value="keyINamedInterface" />
       <node concept="3clFbS" id="5JNiskhqBw6" role="3clF47">
@@ -12705,16 +9451,6 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskhqBw7" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhqBw8" role="3clF45" />
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwh0wj" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="2mPmTXsy2Sr" role="8Wnug">
-        <property role="TrG5h" value="ID_INAMED_INTERFACE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxclm" role="1B3o_S" />
-        <node concept="17QB3L" id="2mPmTXsy2St" role="1tU5fm" />
-      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqBw1" role="jymVt">
       <property role="TrG5h" value="idINamedInterface" />
@@ -12734,18 +9470,6 @@
       <node concept="17QB3L" id="5JNiskhqBw4" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5AGBwuFJGvp" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwh4Lw" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5AGBwuFJEKi" role="8Wnug">
-        <property role="TrG5h" value="LC_NAME_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxeed" role="1B3o_S" />
-        <node concept="3Tqbb2" id="5AGBwuFJEKk" role="1tU5fm">
-          <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhqJpu" role="jymVt">
       <property role="TrG5h" value="lcNameProperty" />
       <node concept="3clFbS" id="5JNiskhqJpv" role="3clF47">
@@ -12763,18 +9487,6 @@
       <node concept="3Tm1VV" id="5JNiskhqJpw" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiskhqJpx" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwh91m" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5AGBwuFJEKf" role="8Wnug">
-        <property role="TrG5h" value="MPS_NAME_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxg8s" role="1B3o_S" />
-        <node concept="3Tqbb2" id="5AGBwuFJEKh" role="1tU5fm">
-          <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqJpq" role="jymVt">
@@ -12796,18 +9508,6 @@
         <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwhdix" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5AGBwuFJEKc" role="8Wnug">
-        <property role="TrG5h" value="SLANG_NAME_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxi1R" role="1B3o_S" />
-        <node concept="3uibUv" id="5AGBwuFJEKe" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhqJpm" role="jymVt">
       <property role="TrG5h" value="slangNameProperty" />
       <node concept="3clFbS" id="5JNiskhqJpn" role="3clF47">
@@ -12827,16 +9527,6 @@
         <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwhhFI" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5M3rB6_PC4J" role="8Wnug">
-        <property role="TrG5h" value="KEY_NAME_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxjUI" role="1B3o_S" />
-        <node concept="17QB3L" id="5M3rB6_PC4L" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhqJpi" role="jymVt">
       <property role="TrG5h" value="keyNameProperty" />
       <node concept="3clFbS" id="5JNiskhqJpj" role="3clF47">
@@ -12853,16 +9543,6 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskhqJpk" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhqJpl" role="3clF45" />
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwhlVB" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="2mPmTXsy402" role="8Wnug">
-        <property role="TrG5h" value="ID_NAME_PROPERTY" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxlUv" role="1B3o_S" />
-        <node concept="17QB3L" id="2mPmTXsy404" role="1tU5fm" />
-      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqJpe" role="jymVt">
       <property role="TrG5h" value="idNameProperty" />
@@ -12882,18 +9562,6 @@
       <node concept="17QB3L" id="5JNiskhqJph" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="39$JcGFBN$Q" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwhqbx" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5AGBwuFFqaM" role="8Wnug">
-        <property role="TrG5h" value="SLANG_M3_LANGUAGE_ID" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxnNm" role="1B3o_S" />
-        <node concept="3uibUv" id="39$JcGFEy9F" role="1tU5fm">
-          <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhqTRf" role="jymVt">
       <property role="TrG5h" value="slangM3LanguageId" />
       <node concept="3clFbS" id="5JNiskhqTRg" role="3clF47">
@@ -12911,18 +9579,6 @@
       <node concept="3Tm1VV" id="5JNiskhqTRh" role="1B3o_S" />
       <node concept="3uibUv" id="5JNiskhurRH" role="3clF45">
         <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwhutM" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="4R9posq8YbX" role="8Wnug">
-        <property role="TrG5h" value="SLANG_M3_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxp$W" role="1B3o_S" />
-        <node concept="3uibUv" id="4R9posq8YbZ" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqTRb" role="jymVt">
@@ -12944,16 +9600,6 @@
         <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwhyIk" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5AGBwuFF_qd" role="8Wnug">
-        <property role="TrG5h" value="KEY_M3_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxrwm" role="1B3o_S" />
-        <node concept="17QB3L" id="5AGBwuFF_ps" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhqTR7" role="jymVt">
       <property role="TrG5h" value="keyM3Language" />
       <node concept="3clFbS" id="5JNiskhqTR8" role="3clF47">
@@ -12971,16 +9617,6 @@
       <node concept="3Tm1VV" id="5JNiskhqTR9" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhqTRa" role="3clF45" />
     </node>
-    <node concept="1X3_iC" id="7OJcYqwhBnH" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="2mPmTXsy5za" role="8Wnug">
-        <property role="TrG5h" value="ID_M3_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxtqq" role="1B3o_S" />
-        <node concept="17QB3L" id="2mPmTXsy5zc" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhqTR3" role="jymVt">
       <property role="TrG5h" value="idM3Language" />
       <node concept="3clFbS" id="5JNiskhqTR4" role="3clF47">
@@ -12997,16 +9633,6 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskhqTR5" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhqTR6" role="3clF45" />
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwhFEo" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="1ryFPTS4XtL" role="8Wnug">
-        <property role="TrG5h" value="VERSION_M3_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxvja" role="1B3o_S" />
-        <node concept="17QB3L" id="1ryFPTS4Xtj" role="1tU5fm" />
-      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqTRj" role="jymVt">
       <property role="TrG5h" value="versionM3Language" />
@@ -13026,18 +9652,6 @@
       <node concept="17QB3L" id="5JNiskhuHOn" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5AGBwuFFBkK" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwhJUn" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5AGBwuFFuSI" role="8Wnug">
-        <property role="TrG5h" value="SLANG_CORE_LANGUAGE_ID" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxxci" role="1B3o_S" />
-        <node concept="3uibUv" id="39$JcGG9EyC" role="1tU5fm">
-          <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhvkMR" role="jymVt">
       <property role="TrG5h" value="slangCoreLanguageId" />
       <node concept="3clFbS" id="5JNiskhvkMS" role="3clF47">
@@ -13055,18 +9669,6 @@
       <node concept="3Tm1VV" id="5JNiskhvkMV" role="1B3o_S" />
       <node concept="3uibUv" id="5JNiskhvkMW" role="3clF45">
         <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-      </node>
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwhOeL" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="4R9posq8ZVS" role="8Wnug">
-        <property role="TrG5h" value="SLANG_CORE_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxzc4" role="1B3o_S" />
-        <node concept="3uibUv" id="4R9posq8ZVU" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhv7gW" role="jymVt">
@@ -13088,16 +9690,6 @@
         <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
       </node>
     </node>
-    <node concept="1X3_iC" id="7OJcYqwhSwK" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="5AGBwuFFBJV" role="8Wnug">
-        <property role="TrG5h" value="KEY_BUILTIN_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhx_4S" role="1B3o_S" />
-        <node concept="17QB3L" id="5AGBwuFFBJX" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhv1Rx" role="jymVt">
       <property role="TrG5h" value="keyBuiltinLanguage" />
       <node concept="3clFbS" id="5JNiskhv1Ry" role="3clF47">
@@ -13115,16 +9707,6 @@
       <node concept="3Tm1VV" id="5JNiskhv1R_" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhv1RA" role="3clF45" />
     </node>
-    <node concept="1X3_iC" id="7OJcYqwhWPX" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="2mPmTXsy76l" role="8Wnug">
-        <property role="TrG5h" value="ID_BUILTIN_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxBpl" role="1B3o_S" />
-        <node concept="17QB3L" id="2mPmTXsy76n" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhuV1t" role="jymVt">
       <property role="TrG5h" value="idBuiltinLanguage" />
       <node concept="3clFbS" id="5JNiskhuV1u" role="3clF47">
@@ -13141,16 +9723,6 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskhuV1x" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhuV1y" role="3clF45" />
-    </node>
-    <node concept="1X3_iC" id="7OJcYqwi17l" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="1ryFPTS4Z8M" role="8Wnug">
-        <property role="TrG5h" value="VERSION_BUILTIN_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxDl7" role="1B3o_S" />
-        <node concept="17QB3L" id="1ryFPTS4Z8O" role="1tU5fm" />
-      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhuLWh" role="jymVt">
       <property role="TrG5h" value="versionBuiltinLanguage" />
@@ -13170,18 +9742,6 @@
       <node concept="17QB3L" id="5JNiskhuLWm" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5AGBwuFFq4f" role="jymVt" />
-    <node concept="1X3_iC" id="7OJcYqwi5oH" role="lGtFl">
-      <property role="3V$3am" value="member" />
-      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
-      <node concept="312cEg" id="4WflrVaDO5l" role="8Wnug">
-        <property role="TrG5h" value="SLANG_ATTRIBUTE_LANGUAGE" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tmbuc" id="5JNiskhxFfb" role="1B3o_S" />
-        <node concept="3uibUv" id="4WflrVaDNUB" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-        </node>
-      </node>
-    </node>
     <node concept="3clFb_" id="5JNiskhvXBZ" role="jymVt">
       <property role="TrG5h" value="slangAttributeLanguage" />
       <node concept="3clFbS" id="5JNiskhvXC0" role="3clF47">

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -604,6 +604,9 @@
             <node concept="2ShNRf" id="7OJcYqwWzAC" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqwWzAD" role="2ShVmc">
                 <ref role="37wK5l" node="7OJcYqvMRo3" resolve="LanguageKeyedMapping" />
+                <node concept="37vLTw" id="7OJcYqxRFcI" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqw9N$5" resolve="attributeLc" />
+                </node>
                 <node concept="pHN19" id="7OJcYqwWzAE" role="37wK5m">
                   <node concept="2V$Bhx" id="7OJcYqwWzAF" role="2V$M_3">
                     <property role="2V$B1T" value="e92f782f-6faf-41c2-bf76-2b1a350c0516" />
@@ -1701,7 +1704,7 @@
               <ref role="37wK5l" node="7OJcYqwWDfJ" resolve="getSpecificLanguage" />
             </node>
             <node concept="liA8E" id="7OJcYqwzoWn" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0Q9" resolve="getSlang" />
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
             </node>
           </node>
         </node>
@@ -1720,7 +1723,7 @@
               <ref role="37wK5l" node="7OJcYqwWDfJ" resolve="getSpecificLanguage" />
             </node>
             <node concept="liA8E" id="7OJcYqwzvGp" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0QD" resolve="getLcKey" />
+              <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
             </node>
           </node>
         </node>
@@ -1737,7 +1740,7 @@
               <ref role="37wK5l" node="7OJcYqwWDfJ" resolve="getSpecificLanguage" />
             </node>
             <node concept="liA8E" id="7OJcYqwzAw1" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0Qx" resolve="getLcId" />
+              <ref role="37wK5l" node="7OJcYqvKqdm" resolve="getLcId" />
             </node>
           </node>
         </node>
@@ -1798,7 +1801,7 @@
               <ref role="37wK5l" node="7OJcYqwv4t2" resolve="getStructureLanguage" />
             </node>
             <node concept="liA8E" id="7OJcYqwzVqb" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0Q9" resolve="getSlang" />
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
             </node>
           </node>
         </node>
@@ -1818,7 +1821,7 @@
               <ref role="37wK5l" node="7OJcYqwv4t2" resolve="getStructureLanguage" />
             </node>
             <node concept="liA8E" id="7OJcYqw$03j" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0QD" resolve="getLcKey" />
+              <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
             </node>
           </node>
         </node>
@@ -1838,7 +1841,7 @@
               <ref role="37wK5l" node="7OJcYqwv4t2" resolve="getStructureLanguage" />
             </node>
             <node concept="liA8E" id="7OJcYqw$58$" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0Qx" resolve="getLcId" />
+              <ref role="37wK5l" node="7OJcYqvKqdm" resolve="getLcId" />
             </node>
           </node>
         </node>
@@ -8496,6 +8499,14 @@
         <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
       </node>
     </node>
+    <node concept="312cEg" id="7OJcYqxKJ7c" role="jymVt">
+      <property role="TrG5h" value="CORE_LANGUAGE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqxKJ7d" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqxKJ7e" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      </node>
+    </node>
     <node concept="312cEg" id="7OJcYqvSkE$" role="jymVt">
       <property role="TrG5h" value="STRING" />
       <property role="3TUv4t" value="true" />
@@ -8619,6 +8630,18 @@
             <node concept="2ShNRf" id="7OJcYqvS5c5" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqvS5c6" role="2ShVmc">
                 <ref role="37wK5l" node="7OJcYqvMRo3" resolve="LanguageKeyedMapping" />
+                <node concept="2OqwBi" id="7OJcYqxS4_I" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqxRWOn" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqxRZZk" role="2tJFKM">
+                      <ref role="2aWVGs" to="i2js:5sACIIs$PgG" resolve="LionCore_M3" />
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqxS5L7" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqxS922" role="Vysub">
+                      <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
                 <node concept="pHN19" id="7OJcYqvS5c7" role="37wK5m">
                   <node concept="2V$Bhx" id="7OJcYqvS5c8" role="2V$M_3">
                     <property role="2V$B1T" value="01cf0d82-8d29-4fc4-be96-28abaf4ad33d" />
@@ -8692,6 +8715,18 @@
             <node concept="2ShNRf" id="7OJcYqvScR3" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqvScR4" role="2ShVmc">
                 <ref role="37wK5l" node="7OJcYqvMRo3" resolve="LanguageKeyedMapping" />
+                <node concept="2OqwBi" id="7OJcYqxSlWn" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqxSfwh" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqxSiFu" role="2tJFKM">
+                      <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqxSoRN" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqxSs2Y" role="Vysub">
+                      <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
                 <node concept="pHN19" id="7OJcYqvScR5" role="37wK5m">
                   <node concept="2V$Bhx" id="7OJcYqvScR6" role="2V$M_3">
                     <property role="2V$B1T" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
@@ -8712,6 +8747,28 @@
           </node>
         </node>
         <node concept="3clFbH" id="7OJcYqvUqCi" role="3cqZAp" />
+        <node concept="3clFbF" id="7OJcYqxKXdm" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqxL4GB" role="3clFbG">
+            <node concept="2ShNRf" id="7OJcYqxL7Ot" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqxLbgm" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqwqm3V" resolve="LanguageKeyedMapping" />
+                <node concept="pHN19" id="7OJcYqxLenn" role="37wK5m">
+                  <node concept="2V$Bhx" id="7OJcYqxLhtV" role="2V$M_3">
+                    <property role="2V$B1T" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
+                    <property role="2V$B1Q" value="jetbrains.mps.lang.core" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7OJcYqxKYbm" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqxKXdk" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqxL1v5" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqxKJ7c" resolve="CORE_LANGUAGE" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqxKVaV" role="3cqZAp" />
         <node concept="3clFbF" id="7OJcYqvSkES" role="3cqZAp">
           <node concept="37vLTI" id="7OJcYqvSkET" role="3clFbG">
             <node concept="2OqwBi" id="7OJcYqvSkEU" role="37vLTJ">
@@ -10199,7 +10256,7 @@
         <node concept="3clFbF" id="5JNiskhuzuI" role="3cqZAp">
           <node concept="2OqwBi" id="7OJcYqvWb0a" role="3clFbG">
             <node concept="liA8E" id="7OJcYqvWej4" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0Q9" resolve="getSlang" />
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
             </node>
             <node concept="1rXfSq" id="7OJcYqwmh6k" role="2Oq$k0">
               <ref role="37wK5l" node="7OJcYqwirz6" resolve="getM3" />
@@ -10218,7 +10275,7 @@
         <node concept="3clFbF" id="7OJcYqw7pno" role="3cqZAp">
           <node concept="2OqwBi" id="7OJcYqw7pnp" role="3clFbG">
             <node concept="liA8E" id="7OJcYqw7pnr" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0QD" resolve="getLcKey" />
+              <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
             </node>
             <node concept="1rXfSq" id="7OJcYqwmkZn" role="2Oq$k0">
               <ref role="37wK5l" node="7OJcYqwirz6" resolve="getM3" />
@@ -10235,7 +10292,7 @@
         <node concept="3clFbF" id="7OJcYqw7yPc" role="3cqZAp">
           <node concept="2OqwBi" id="7OJcYqw7yPd" role="3clFbG">
             <node concept="liA8E" id="7OJcYqw7yPf" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0Qh" resolve="getMpsId" />
+              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
             </node>
             <node concept="1rXfSq" id="7OJcYqwmoWN" role="2Oq$k0">
               <ref role="37wK5l" node="7OJcYqwirz6" resolve="getM3" />
@@ -10289,7 +10346,7 @@
         <node concept="3clFbF" id="7OJcYqw83LK" role="3cqZAp">
           <node concept="2OqwBi" id="7OJcYqw83LL" role="3clFbG">
             <node concept="liA8E" id="7OJcYqw83LN" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0Q9" resolve="getSlang" />
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
             </node>
             <node concept="1rXfSq" id="7OJcYqwm$bI" role="2Oq$k0">
               <ref role="37wK5l" node="7OJcYqwirze" resolve="getLioncoreBuiltins" />
@@ -10308,7 +10365,7 @@
         <node concept="3clFbF" id="7OJcYqw8d2S" role="3cqZAp">
           <node concept="2OqwBi" id="7OJcYqw8d2T" role="3clFbG">
             <node concept="liA8E" id="7OJcYqw8d2V" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0QD" resolve="getLcKey" />
+              <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
             </node>
             <node concept="1rXfSq" id="7OJcYqwmBYp" role="2Oq$k0">
               <ref role="37wK5l" node="7OJcYqwirze" resolve="getLioncoreBuiltins" />
@@ -10325,7 +10382,7 @@
         <node concept="3clFbF" id="7OJcYqw8mSI" role="3cqZAp">
           <node concept="2OqwBi" id="7OJcYqw8mSJ" role="3clFbG">
             <node concept="liA8E" id="7OJcYqw8mSL" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0Qx" resolve="getLcId" />
+              <ref role="37wK5l" node="7OJcYqvKqdm" resolve="getLcId" />
             </node>
             <node concept="1rXfSq" id="7OJcYqwmFQa" role="2Oq$k0">
               <ref role="37wK5l" node="7OJcYqwirze" resolve="getLioncoreBuiltins" />
@@ -10363,7 +10420,7 @@
               <ref role="37wK5l" node="7OJcYqwUZco" resolve="getAttributeLanguage" />
             </node>
             <node concept="liA8E" id="7OJcYqwaDtk" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0Q9" resolve="getSlang" />
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
             </node>
           </node>
         </node>
@@ -11888,6 +11945,26 @@
         </node>
       </node>
     </node>
+    <node concept="3clFb_" id="7OJcYqxLl6m" role="jymVt">
+      <property role="TrG5h" value="getCoreLanguage" />
+      <node concept="3uibUv" id="7OJcYqxLl6n" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqxLl6o" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqxLl6P" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqxLs98" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqxLuWi" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqxLs95" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqxL_h9" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqxKJ7c" resolve="CORE_LANGUAGE" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxLl6Q" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="7OJcYqwirzm" role="jymVt">
       <property role="TrG5h" value="getString" />
       <node concept="3uibUv" id="7OJcYqwirzn" role="3clF45">
@@ -12121,38 +12198,6 @@
             <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c/1082983041843" />
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jVi" role="jymVt">
-      <property role="TrG5h" value="lcStringType" />
-      <node concept="3clFbS" id="5JNiski3jVj" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jVk" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jVl" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxEQZu" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxEQZv" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxEQZw" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxEQZx" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jVm" role="jymVt">
-      <property role="TrG5h" value="mpsStringType" />
-      <node concept="3clFbS" id="5JNiski3jVn" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jVo" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jVp" role="3clF45">
-        <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxERxj" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxERxk" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxERxl" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxERxm" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVq" role="jymVt">
@@ -13365,6 +13410,74 @@
         <node concept="TZ5HA" id="7OJcYqwUkXC" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqwUkXD" role="1dT_Ay">
             <property role="1dT_AB" value="lcKey: LionCore-builtins" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqxK_pb" role="jymVt">
+      <property role="TrG5h" value="getCoreLanguage" />
+      <node concept="3uibUv" id="7OJcYqxK_pc" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqxK_pd" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqxK_pe" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqxK_pf" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqxK_pg" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxK_ph" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxK_pi" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxK_pj" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.core as " />
+          </node>
+          <node concept="1dT_AA" id="7OJcYqxK_pk" role="1dT_Ay">
+            <node concept="92FcH" id="7OJcYqxK_pl" role="qph3F">
+              <node concept="TZ5HA" id="7OJcYqxK_pm" role="2XjZqd" />
+              <node concept="VXe08" id="7OJcYqxK_pn" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SLanguage" resolve="SLanguage" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="7OJcYqxK_po" role="1dT_Ay" />
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxK_pp" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxK_pq" role="1dT_Ay">
+            <property role="1dT_AB" value="slangId: " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxK_pr" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxK_ps" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.core as " />
+          </node>
+          <node concept="1dT_AA" id="7OJcYqxK_pt" role="1dT_Ay">
+            <node concept="92FcH" id="7OJcYqxK_pu" role="qph3F">
+              <node concept="TZ5HA" id="7OJcYqxK_pv" role="2XjZqd" />
+              <node concept="VXe08" id="7OJcYqxK_pw" role="92FcQ">
+                <ref role="VXe09" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="7OJcYqxK_px" role="1dT_Ay" />
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxK_py" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxK_pz" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxK_p$" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxK_p_" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsVersion: 2" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxK_pA" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxK_pB" role="1dT_Ay">
+            <property role="1dT_AB" value="lcVersion: 2" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxK_pC" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxK_pD" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
           </node>
         </node>
       </node>
@@ -14820,7 +14933,7 @@
           <ref role="16sUi3" node="7OJcYqvKyqX" resolve="MPS" />
         </node>
         <node concept="2AHcQZ" id="7OJcYqwLG8m" role="2AJF6D">
-          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
         </node>
       </node>
       <node concept="37vLTG" id="7OJcYqvKsJF" role="3clF46">
@@ -14890,8 +15003,8 @@
       <node concept="2AHcQZ" id="7OJcYqvKqcY" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
-      <node concept="2AHcQZ" id="7OJcYqwNNqd" role="2AJF6D">
-        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      <node concept="2AHcQZ" id="7OJcYqxRrXs" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
     </node>
     <node concept="3clFb_" id="7OJcYqvKqcZ" role="jymVt">
@@ -15352,14 +15465,6 @@
   <node concept="312cEu" id="7OJcYqvMQ8$">
     <property role="3GE5qa" value="keyedMapping" />
     <property role="TrG5h" value="LanguageKeyedMapping" />
-    <node concept="312cEg" id="7OJcYqvMRnR" role="jymVt">
-      <property role="TrG5h" value="slang" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tm6S6" id="7OJcYqvMRnS" role="1B3o_S" />
-      <node concept="3uibUv" id="7OJcYqvMSEK" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-      </node>
-    </node>
     <node concept="312cEg" id="7OJcYqvNQAN" role="jymVt">
       <property role="TrG5h" value="slangId" />
       <property role="3TUv4t" value="true" />
@@ -15368,51 +15473,48 @@
         <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
       </node>
     </node>
-    <node concept="312cEg" id="7OJcYqvMRnU" role="jymVt">
-      <property role="TrG5h" value="mpsId" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tm6S6" id="7OJcYqvMRnV" role="1B3o_S" />
-      <node concept="17QB3L" id="7OJcYqvNDGR" role="1tU5fm" />
-    </node>
     <node concept="312cEg" id="7OJcYqwoq92" role="jymVt">
       <property role="TrG5h" value="mpsVersion" />
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqwopVI" role="1B3o_S" />
       <node concept="10Oyi0" id="7OJcYqwoq8T" role="1tU5fm" />
     </node>
-    <node concept="312cEg" id="7OJcYqvMUJj" role="jymVt">
+    <node concept="312cEg" id="7OJcYqxRpgA" role="jymVt">
       <property role="TrG5h" value="lcVersion" />
       <property role="3TUv4t" value="true" />
-      <node concept="3Tm6S6" id="7OJcYqvMUD_" role="1B3o_S" />
-      <node concept="17QB3L" id="7OJcYqvMUJa" role="1tU5fm" />
-    </node>
-    <node concept="312cEg" id="7OJcYqvMRnX" role="jymVt">
-      <property role="TrG5h" value="lcId" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tm6S6" id="7OJcYqvMRnY" role="1B3o_S" />
-      <node concept="17QB3L" id="7OJcYqvMRnZ" role="1tU5fm" />
-    </node>
-    <node concept="312cEg" id="7OJcYqvMRo0" role="jymVt">
-      <property role="TrG5h" value="lcKey" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tm6S6" id="7OJcYqvMRo1" role="1B3o_S" />
-      <node concept="17QB3L" id="7OJcYqvMRo2" role="1tU5fm" />
+      <node concept="3Tm6S6" id="7OJcYqxRoR8" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqxRpbY" role="1tU5fm" />
     </node>
     <node concept="3clFbW" id="7OJcYqvMRo3" role="jymVt">
       <node concept="3cqZAl" id="7OJcYqvMRo4" role="3clF45" />
       <node concept="3Tm1VV" id="7OJcYqvMRo5" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqvMRo6" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqvMRoj" role="3cqZAp">
-          <node concept="37vLTI" id="7OJcYqvMRok" role="3clFbG">
-            <node concept="2OqwBi" id="7OJcYqvMRol" role="37vLTJ">
-              <node concept="Xjq3P" id="7OJcYqvMRom" role="2Oq$k0" />
-              <node concept="2OwXpG" id="7OJcYqvMRon" role="2OqNvi">
-                <ref role="2Oxat5" node="7OJcYqvMRnR" resolve="slang" />
+        <node concept="XkiVB" id="7OJcYqxRfZi" role="3cqZAp">
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <node concept="37vLTw" id="7OJcYqxRgaQ" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqxRdhz" resolve="lc" />
+          </node>
+          <node concept="10Nm6u" id="7OJcYqxRgZ3" role="37wK5m" />
+          <node concept="37vLTw" id="7OJcYqxRhnJ" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvMRoH" resolve="slang" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqvO0ZH" role="37wK5m">
+            <node concept="liA8E" id="7OJcYqvO1e3" role="2OqNvi">
+              <ref role="37wK5l" to="e8bb:~SLanguageId.toString()" resolve="toString" />
+            </node>
+            <node concept="2YIFZM" id="7OJcYqxRj0J" role="2Oq$k0">
+              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
+              <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
+              <node concept="37vLTw" id="7OJcYqxRj0K" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqvMRoH" resolve="slang" />
               </node>
             </node>
-            <node concept="37vLTw" id="7OJcYqvMRoo" role="37vLTx">
-              <ref role="3cqZAo" node="7OJcYqvMRoH" resolve="slang" />
-            </node>
+          </node>
+          <node concept="37vLTw" id="7OJcYqxRjw4" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvMRoN" resolve="lcId" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqxRknX" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvMRoP" resolve="lcKey" />
           </node>
         </node>
         <node concept="3clFbF" id="7OJcYqvNTvz" role="3cqZAp">
@@ -15428,24 +15530,6 @@
               <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
               <node concept="37vLTw" id="7OJcYqvNU7e" role="37wK5m">
                 <ref role="3cqZAo" node="7OJcYqvMRoH" resolve="slang" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7OJcYqvMRop" role="3cqZAp">
-          <node concept="37vLTI" id="7OJcYqvMRoq" role="3clFbG">
-            <node concept="2OqwBi" id="7OJcYqvMRos" role="37vLTJ">
-              <node concept="Xjq3P" id="7OJcYqvMRot" role="2Oq$k0" />
-              <node concept="2OwXpG" id="7OJcYqvMRou" role="2OqNvi">
-                <ref role="2Oxat5" node="7OJcYqvMRnU" resolve="mpsId" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="7OJcYqvO0ZH" role="37vLTx">
-              <node concept="37vLTw" id="7OJcYqvMRo$" role="2Oq$k0">
-                <ref role="3cqZAo" node="7OJcYqvNQAN" resolve="slangId" />
-              </node>
-              <node concept="liA8E" id="7OJcYqvO1e3" role="2OqNvi">
-                <ref role="37wK5l" to="e8bb:~SLanguageId.toString()" resolve="toString" />
               </node>
             </node>
           </node>
@@ -15475,36 +15559,19 @@
             <node concept="2OqwBi" id="7OJcYqvMZEN" role="37vLTJ">
               <node concept="Xjq3P" id="7OJcYqvMZys" role="2Oq$k0" />
               <node concept="2OwXpG" id="7OJcYqvMZNH" role="2OqNvi">
-                <ref role="2Oxat5" node="7OJcYqvMUJj" resolve="lcVersion" />
+                <ref role="2Oxat5" node="7OJcYqxRpgA" resolve="lcVersion" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="7OJcYqvMRov" role="3cqZAp">
-          <node concept="37vLTI" id="7OJcYqvMRow" role="3clFbG">
-            <node concept="2OqwBi" id="7OJcYqvMRox" role="37vLTJ">
-              <node concept="Xjq3P" id="7OJcYqvMRoy" role="2Oq$k0" />
-              <node concept="2OwXpG" id="7OJcYqvMRoz" role="2OqNvi">
-                <ref role="2Oxat5" node="7OJcYqvMRnX" resolve="lcId" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="7OJcYqvOcYk" role="37vLTx">
-              <ref role="3cqZAo" node="7OJcYqvMRoN" resolve="lcId" />
-            </node>
-          </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqxRdhz" role="3clF46">
+        <property role="TrG5h" value="lc" />
+        <node concept="3Tqbb2" id="7OJcYqxRe66" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjkngz" resolve="Language" />
         </node>
-        <node concept="3clFbF" id="7OJcYqvMRo_" role="3cqZAp">
-          <node concept="37vLTI" id="7OJcYqvMRoA" role="3clFbG">
-            <node concept="2OqwBi" id="7OJcYqvMRoB" role="37vLTJ">
-              <node concept="Xjq3P" id="7OJcYqvMRoC" role="2Oq$k0" />
-              <node concept="2OwXpG" id="7OJcYqvMRoD" role="2OqNvi">
-                <ref role="2Oxat5" node="7OJcYqvMRo0" resolve="lcKey" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="7OJcYqvMRoE" role="37vLTx">
-              <ref role="3cqZAo" node="7OJcYqvMRoP" resolve="lcKey" />
-            </node>
-          </node>
+        <node concept="2AHcQZ" id="7OJcYqxRfjH" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
         </node>
       </node>
       <node concept="37vLTG" id="7OJcYqvMRoH" role="3clF46">
@@ -15544,6 +15611,7 @@
       <node concept="3clFbS" id="7OJcYqwqm3Y" role="3clF47">
         <node concept="1VxSAg" id="7OJcYqwqqWB" role="3cqZAp">
           <ref role="37wK5l" node="7OJcYqvMRo3" resolve="LanguageKeyedMapping" />
+          <node concept="10Nm6u" id="7OJcYqxRofy" role="37wK5m" />
           <node concept="37vLTw" id="7OJcYqwqr1O" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqwqm4H" resolve="slang" />
           </node>
@@ -15588,26 +15656,6 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="7OJcYqvMQ8_" role="1B3o_S" />
-    <node concept="3clFb_" id="7OJcYqvN0Q9" role="jymVt">
-      <property role="TrG5h" value="getSlang" />
-      <node concept="3uibUv" id="7OJcYqvN0Qa" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-      </node>
-      <node concept="3Tm1VV" id="7OJcYqvN0Qb" role="1B3o_S" />
-      <node concept="3clFbS" id="7OJcYqvN0Qc" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqvN0Qd" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvN0Q6" role="3clFbG">
-            <node concept="Xjq3P" id="7OJcYqvN0Q7" role="2Oq$k0" />
-            <node concept="2OwXpG" id="7OJcYqvN0Q8" role="2OqNvi">
-              <ref role="2Oxat5" node="7OJcYqvMRnR" resolve="slang" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqwMGrb" role="2AJF6D">
-        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
-      </node>
-    </node>
     <node concept="3clFb_" id="7OJcYqw7aei" role="jymVt">
       <property role="TrG5h" value="getSlangId" />
       <node concept="3uibUv" id="7OJcYqw7aej" role="3clF45">
@@ -15625,24 +15673,6 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqwMND3" role="2AJF6D">
-        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="7OJcYqvN0Qh" role="jymVt">
-      <property role="TrG5h" value="getMpsId" />
-      <node concept="17QB3L" id="7OJcYqvN0Qi" role="3clF45" />
-      <node concept="3Tm1VV" id="7OJcYqvN0Qj" role="1B3o_S" />
-      <node concept="3clFbS" id="7OJcYqvN0Qk" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqvN0Ql" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvN0Qe" role="3clFbG">
-            <node concept="Xjq3P" id="7OJcYqvN0Qf" role="2Oq$k0" />
-            <node concept="2OwXpG" id="7OJcYqvN0Qg" role="2OqNvi">
-              <ref role="2Oxat5" node="7OJcYqvMRnU" resolve="mpsId" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqwMSRo" role="2AJF6D">
         <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
       </node>
     </node>
@@ -15670,7 +15700,7 @@
           <node concept="2OqwBi" id="7OJcYqvN0Qm" role="3clFbG">
             <node concept="Xjq3P" id="7OJcYqvN0Qn" role="2Oq$k0" />
             <node concept="2OwXpG" id="7OJcYqvN0Qo" role="2OqNvi">
-              <ref role="2Oxat5" node="7OJcYqvMUJj" resolve="lcVersion" />
+              <ref role="2Oxat5" node="7OJcYqxRpgA" resolve="lcVersion" />
             </node>
           </node>
         </node>
@@ -15679,40 +15709,16 @@
         <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
       </node>
     </node>
-    <node concept="3clFb_" id="7OJcYqvN0Qx" role="jymVt">
-      <property role="TrG5h" value="getLcId" />
-      <node concept="17QB3L" id="7OJcYqvN0Qy" role="3clF45" />
-      <node concept="3Tm1VV" id="7OJcYqvN0Qz" role="1B3o_S" />
-      <node concept="3clFbS" id="7OJcYqvN0Q$" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqvN0Q_" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvN0Qu" role="3clFbG">
-            <node concept="Xjq3P" id="7OJcYqvN0Qv" role="2Oq$k0" />
-            <node concept="2OwXpG" id="7OJcYqvN0Qw" role="2OqNvi">
-              <ref role="2Oxat5" node="7OJcYqvMRnX" resolve="lcId" />
-            </node>
-          </node>
-        </node>
+    <node concept="3uibUv" id="7OJcYqxR8Gt" role="1zkMxy">
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqxRaqI" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:2ju2syjkngz" resolve="Language" />
       </node>
-      <node concept="2AHcQZ" id="7OJcYqwN6Bh" role="2AJF6D">
-        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      <node concept="3Tqbb2" id="7OJcYqxRbQ2" role="11_B2D">
+        <ref role="ehGHo" to="tpce:1ob16QT2yIl" resolve="INamedStructureElement" />
       </node>
-    </node>
-    <node concept="3clFb_" id="7OJcYqvN0QD" role="jymVt">
-      <property role="TrG5h" value="getLcKey" />
-      <node concept="17QB3L" id="7OJcYqvN0QE" role="3clF45" />
-      <node concept="3Tm1VV" id="7OJcYqvN0QF" role="1B3o_S" />
-      <node concept="3clFbS" id="7OJcYqvN0QG" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqvN0QH" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvN0QA" role="3clFbG">
-            <node concept="Xjq3P" id="7OJcYqvN0QB" role="2Oq$k0" />
-            <node concept="2OwXpG" id="7OJcYqvN0QC" role="2OqNvi">
-              <ref role="2Oxat5" node="7OJcYqvMRo0" resolve="lcKey" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqwNdmB" role="2AJF6D">
-        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      <node concept="3uibUv" id="7OJcYqxRcLM" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
       </node>
     </node>
   </node>

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -424,7 +424,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqwumEK" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqwumEL" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqwusrr" role="jymVt">
@@ -432,7 +432,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqwusrp" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqwusrq" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqwuwts" role="jymVt">
@@ -440,7 +440,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqwuwtq" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqwuwtr" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqwuG9p" role="jymVt">
@@ -448,7 +448,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqwuG9n" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqwuG9o" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqwuLVt" role="jymVt">
@@ -456,7 +456,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqwuLVr" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqwuLVs" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqwuQlg" role="jymVt">
@@ -464,7 +464,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqwuQle" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqwuQlf" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqwuUL4" role="jymVt">
@@ -472,7 +472,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqwuUL2" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqwuUL3" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqwuZhZ" role="jymVt">
@@ -480,7 +480,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqwuZhX" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqwuZhY" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqwWzAg" role="jymVt">
@@ -488,9 +488,10 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqwWzAe" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqwWzAf" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
     </node>
+    <node concept="2tJIrI" id="7OJcYq$uTr8" role="jymVt" />
     <node concept="3clFbW" id="DUXtGZOlxP" role="jymVt">
       <node concept="37vLTG" id="DUXtGZOlyn" role="3clF46">
         <property role="TrG5h" value="repository" />
@@ -590,7 +591,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqwWzAC" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqwWzAD" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqvMRo3" resolve="LanguageKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqvMRo3" resolve="LanguageStaple" />
                 <node concept="37vLTw" id="7OJcYqxRFcI" role="37wK5m">
                   <ref role="3cqZAo" node="7OJcYqw9N$5" resolve="attributeLc" />
                 </node>
@@ -678,7 +679,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqwumFn" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqwumFo" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqwnwCo" resolve="AnnotationPropertyKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqwnwCo" resolve="AnnotationPropertyStaple" />
                 <node concept="2OqwBi" id="7OJcYqwumFp" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqwumFq" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqwumFr" role="2tJFKM">
@@ -785,7 +786,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqwuss4" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqwuss5" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqwnwCo" resolve="AnnotationPropertyKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqwnwCo" resolve="AnnotationPropertyStaple" />
                 <node concept="2OqwBi" id="7OJcYqwuss6" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqwuss7" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqwuss8" role="2tJFKM">
@@ -879,7 +880,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqwuwtF" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqwuwtG" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqwqm3V" resolve="LanguageKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqwqm3V" resolve="LanguageStaple" />
                 <node concept="pHN19" id="7OJcYqwuwtH" role="37wK5m">
                   <node concept="2V$Bhx" id="7OJcYqwuwtI" role="2V$M_3">
                     <property role="2V$B1T" value="c72da2b9-7cce-4447-8389-f407dc1158b7" />
@@ -962,7 +963,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqwuG9R" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqwuG9S" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptStaple" />
                 <node concept="2OqwBi" id="7OJcYqxyU$z" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqxyU$$" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqxyU$_" role="2tJFKM">
@@ -1046,7 +1047,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqwuLVQ" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqwuLVR" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptStaple" />
                 <node concept="2OqwBi" id="7OJcYqxyKk_" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqxyKkA" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqxyKkB" role="2tJFKM">
@@ -1130,7 +1131,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqwuQlD" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqwuQlE" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptStaple" />
                 <node concept="2OqwBi" id="7OJcYqxyBTW" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqxywqd" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqxyyn2" role="2tJFKM">
@@ -1217,7 +1218,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqwuULx" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqwuULy" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqvRxYF" resolve="PropertyKeyMapping" />
+                <ref role="37wK5l" node="7OJcYqvRxYF" resolve="PropertyStaple" />
                 <node concept="2OqwBi" id="7OJcYqxx6ng" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqxx6nh" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqxx6ni" role="2tJFKM">
@@ -1319,7 +1320,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqwuZis" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqwuZit" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqvRxYF" resolve="PropertyKeyMapping" />
+                <ref role="37wK5l" node="7OJcYqvRxYF" resolve="PropertyStaple" />
                 <node concept="2OqwBi" id="7OJcYqxwYIB" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqxwYIC" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqxwYID" role="2tJFKM">
@@ -1405,11 +1406,11 @@
     </node>
     <node concept="2tJIrI" id="7OJcYqxrjYk" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxrn6T" role="jymVt">
-      <property role="TrG5h" value="listSpecificAnnotationProperty" />
+      <property role="TrG5h" value="listMpsM1AnnotationProperties" />
       <node concept="3Tm1VV" id="7OJcYqxrn6V" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqxrn6W" role="3clF45">
         <node concept="3uibUv" id="7OJcYqxrn6X" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqxrn6Z" role="3clF47">
@@ -1417,7 +1418,7 @@
           <node concept="2ShNRf" id="7OJcYqxrqN4" role="3clFbG">
             <node concept="Tc6Ow" id="7OJcYqxrtDV" role="2ShVmc">
               <node concept="3uibUv" id="7OJcYqxrz8N" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+                <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
               </node>
               <node concept="1rXfSq" id="7OJcYqxrCQw" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
@@ -1435,11 +1436,11 @@
     </node>
     <node concept="2tJIrI" id="7OJcYqx_9nN" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqx_dgL" role="jymVt">
-      <property role="TrG5h" value="listMpsInternalFeature" />
+      <property role="TrG5h" value="listMpsInternalFeatures" />
       <node concept="3Tm1VV" id="7OJcYqx_dgM" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqx_dgN" role="3clF45">
         <node concept="3uibUv" id="7OJcYqx_dgO" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
+          <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqx_dgV" role="2AJF6D">
@@ -1450,7 +1451,7 @@
           <node concept="2ShNRf" id="7OJcYqx_f5g" role="3clFbG">
             <node concept="Tc6Ow" id="7OJcYqx_h8A" role="2ShVmc">
               <node concept="3uibUv" id="7OJcYqx_ldi" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
+                <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
               </node>
               <node concept="1rXfSq" id="7OJcYqx_rFe" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqwir$6" resolve="getAnnotationContainment" />
@@ -1468,11 +1469,11 @@
     </node>
     <node concept="2tJIrI" id="5JNiski$9iK" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxrYau" role="jymVt">
-      <property role="TrG5h" value="listConceptDescriptionProperty" />
+      <property role="TrG5h" value="listMpsM2AnnotationProperties" />
       <node concept="3Tm1VV" id="7OJcYqxrYaw" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqxrYax" role="3clF45">
         <node concept="3uibUv" id="7OJcYqxrYay" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+          <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqxrYa$" role="3clF47">
@@ -1480,7 +1481,7 @@
           <node concept="2ShNRf" id="7OJcYqxs4Kk" role="3clFbG">
             <node concept="Tc6Ow" id="7OJcYqxs7mo" role="2ShVmc">
               <node concept="3uibUv" id="7OJcYqxsd5i" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+                <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
               </node>
               <node concept="1rXfSq" id="7OJcYqxsiXX" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqwv4ty" resolve="getConceptAlias" />
@@ -1502,7 +1503,7 @@
       <node concept="3Tm1VV" id="7OJcYqx$xY8" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqx$xY9" role="3clF45">
         <node concept="3uibUv" id="7OJcYqx$xYa" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+          <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqx$xYi" role="2AJF6D">
@@ -1514,7 +1515,7 @@
             <property role="TrG5h" value="result" />
             <node concept="_YKpA" id="7OJcYqx$z_H" role="1tU5fm">
               <node concept="3uibUv" id="7OJcYqx$z_K" role="_ZDj9">
-                <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+                <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
               </node>
             </node>
             <node concept="3nyPlj" id="7OJcYqx$Hf9" role="33vP2m">
@@ -1543,11 +1544,11 @@
     </node>
     <node concept="2tJIrI" id="7weWCFln0QZ" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxzJ_1" role="jymVt">
-      <property role="TrG5h" value="listMpsInternalClassifier" />
+      <property role="TrG5h" value="listMpsInternalClassifiers" />
       <node concept="3Tm1VV" id="7OJcYqxzJ_2" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqxzJ_3" role="3clF45">
         <node concept="3uibUv" id="7OJcYqxzJ_4" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+          <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierStaple" />
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqxzJ_c" role="2AJF6D">
@@ -1558,7 +1559,7 @@
           <node concept="2ShNRf" id="7OJcYqxzQG3" role="3clFbG">
             <node concept="Tc6Ow" id="7OJcYqxzTks" role="2ShVmc">
               <node concept="3uibUv" id="7OJcYqxzYG0" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+                <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierStaple" />
               </node>
               <node concept="1rXfSq" id="7OJcYqx$4zE" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
@@ -1586,7 +1587,7 @@
     <node concept="3clFb_" id="7OJcYqwv4sM" role="jymVt">
       <property role="TrG5h" value="getVirtualPackage" />
       <node concept="3uibUv" id="7OJcYqwv4sN" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwv4sO" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwv4sP" role="3clF47">
@@ -1599,11 +1600,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$v34v" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwv4sU" role="jymVt">
       <property role="TrG5h" value="getShortDescription" />
       <node concept="3uibUv" id="7OJcYqwv4sV" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwv4sW" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwv4sX" role="3clF47">
@@ -1616,11 +1620,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$v4JE" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwv4t2" role="jymVt">
       <property role="TrG5h" value="getStructureLanguage" />
       <node concept="3uibUv" id="7OJcYqwv4t3" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwv4t4" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwv4t5" role="3clF47">
@@ -1633,11 +1640,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$v6r0" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwv4ta" role="jymVt">
       <property role="TrG5h" value="getClassifier" />
       <node concept="3uibUv" id="7OJcYqwv4tb" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwv4tc" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwv4td" role="3clF47">
@@ -1650,11 +1660,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$v85X" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwv4ti" role="jymVt">
       <property role="TrG5h" value="getConcept" />
       <node concept="3uibUv" id="7OJcYqwv4tj" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwv4tk" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwv4tl" role="3clF47">
@@ -1667,11 +1680,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$v98I" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwv4tq" role="jymVt">
       <property role="TrG5h" value="getInterface" />
       <node concept="3uibUv" id="7OJcYqwv4tr" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwv4ts" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwv4tt" role="3clF47">
@@ -1684,11 +1700,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$vaLX" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwv4ty" role="jymVt">
       <property role="TrG5h" value="getConceptAlias" />
       <node concept="3uibUv" id="7OJcYqwv4tz" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwv4t$" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwv4t_" role="3clF47">
@@ -1701,11 +1720,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$vcra" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwv4tE" role="jymVt">
       <property role="TrG5h" value="getConceptShortDescription" />
       <node concept="3uibUv" id="7OJcYqwv4tF" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwv4tG" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwv4tH" role="3clF47">
@@ -1718,11 +1740,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$ve4p" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwWDfJ" role="jymVt">
       <property role="TrG5h" value="getSpecificLanguage" />
       <node concept="3uibUv" id="7OJcYqwWDfK" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwWDfL" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwWDgf" role="3clF47">
@@ -3399,9 +3424,9 @@
       <node concept="3clFbS" id="3M8YG$9CnuT" role="3clF47">
         <node concept="3cpWs8" id="7OJcYq$oexp" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYq$oexq" role="3cpWs9">
-            <property role="TrG5h" value="mapping" />
+            <property role="TrG5h" value="staple" />
             <node concept="3uibUv" id="7OJcYq$o1GQ" role="1tU5fm">
-              <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+              <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
             </node>
             <node concept="2OqwBi" id="7OJcYq$oexr" role="33vP2m">
               <node concept="2OqwBi" id="7OJcYq$oexs" role="2Oq$k0">
@@ -3445,7 +3470,7 @@
             <node concept="3cpWs6" id="7OJcYq$os8$" role="3cqZAp">
               <node concept="2OqwBi" id="7OJcYqzdYsT" role="3cqZAk">
                 <node concept="37vLTw" id="7OJcYq$oexE" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7OJcYq$oexq" resolve="mapping" />
+                  <ref role="3cqZAo" node="7OJcYq$oexq" resolve="staple" />
                 </node>
                 <node concept="liA8E" id="7OJcYqze1Y_" role="2OqNvi">
                   <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
@@ -3456,7 +3481,7 @@
           <node concept="3y3z36" id="7OJcYq$oopA" role="3clFbw">
             <node concept="10Nm6u" id="7OJcYq$opvL" role="3uHU7w" />
             <node concept="37vLTw" id="7OJcYq$olwk" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYq$oexq" resolve="mapping" />
+              <ref role="3cqZAo" node="7OJcYq$oexq" resolve="staple" />
             </node>
           </node>
         </node>
@@ -3485,9 +3510,9 @@
           <node concept="3clFbS" id="5AGBwuFGC18" role="3clFbx">
             <node concept="3cpWs8" id="7OJcYqzewib" role="3cqZAp">
               <node concept="3cpWsn" id="7OJcYqzewic" role="3cpWs9">
-                <property role="TrG5h" value="mapping" />
+                <property role="TrG5h" value="staple" />
                 <node concept="3uibUv" id="7OJcYqzevMm" role="1tU5fm">
-                  <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+                  <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierStaple" />
                 </node>
                 <node concept="2OqwBi" id="7OJcYqzewid" role="33vP2m">
                   <node concept="2OqwBi" id="7OJcYqzewie" role="2Oq$k0">
@@ -3495,7 +3520,7 @@
                       <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
                     </node>
                     <node concept="liA8E" id="7OJcYqzewig" role="2OqNvi">
-                      <ref role="37wK5l" node="7OJcYqwYDTB" resolve="listClassifiers" />
+                      <ref role="37wK5l" node="7OJcYqwYDTB" resolve="listLcClassifiers" />
                     </node>
                   </node>
                   <node concept="1z4cxt" id="7OJcYqzewih" role="2OqNvi">
@@ -3531,7 +3556,7 @@
                 <node concept="3cpWs6" id="5AGBwuFKihJ" role="3cqZAp">
                   <node concept="2OqwBi" id="7OJcYqzeJw7" role="3cqZAk">
                     <node concept="37vLTw" id="7OJcYqzeI8K" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7OJcYqzewic" resolve="mapping" />
+                      <ref role="3cqZAo" node="7OJcYqzewic" resolve="staple" />
                     </node>
                     <node concept="liA8E" id="7OJcYqzeMgd" role="2OqNvi">
                       <ref role="37wK5l" node="7OJcYqvKjL5" resolve="getLcKey" />
@@ -3542,7 +3567,7 @@
               <node concept="3y3z36" id="7OJcYqzeDTH" role="3clFbw">
                 <node concept="10Nm6u" id="7OJcYqzeFu3" role="3uHU7w" />
                 <node concept="37vLTw" id="7OJcYqzeBaf" role="3uHU7B">
-                  <ref role="3cqZAo" node="7OJcYqzewic" resolve="mapping" />
+                  <ref role="3cqZAo" node="7OJcYqzewic" resolve="staple" />
                 </node>
               </node>
             </node>
@@ -3559,9 +3584,9 @@
             <node concept="3clFbS" id="5AGBwuFIGGv" role="3eOfB_">
               <node concept="3cpWs8" id="7OJcYqzffLn" role="3cqZAp">
                 <node concept="3cpWsn" id="7OJcYqzffLo" role="3cpWs9">
-                  <property role="TrG5h" value="mapping" />
+                  <property role="TrG5h" value="staple" />
                   <node concept="3uibUv" id="7OJcYqzfe5K" role="1tU5fm">
-                    <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+                    <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
                   </node>
                   <node concept="2OqwBi" id="7OJcYqzffLp" role="33vP2m">
                     <node concept="2OqwBi" id="7OJcYqzffLq" role="2Oq$k0">
@@ -3569,7 +3594,7 @@
                         <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
                       </node>
                       <node concept="liA8E" id="7OJcYqzffLs" role="2OqNvi">
-                        <ref role="37wK5l" node="7OJcYqwZxOH" resolve="listLcProperty" />
+                        <ref role="37wK5l" node="7OJcYqwZxOH" resolve="listLcProperties" />
                       </node>
                     </node>
                     <node concept="1z4cxt" id="7OJcYqzffLt" role="2OqNvi">
@@ -3605,7 +3630,7 @@
                   <node concept="3cpWs6" id="5AGBwuFHFs8" role="3cqZAp">
                     <node concept="2OqwBi" id="7OJcYqzfx95" role="3cqZAk">
                       <node concept="37vLTw" id="7OJcYqzfvm_" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7OJcYqzffLo" resolve="mapping" />
+                        <ref role="3cqZAo" node="7OJcYqzffLo" resolve="staple" />
                       </node>
                       <node concept="liA8E" id="7OJcYqzf$pg" role="2OqNvi">
                         <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
@@ -3616,7 +3641,7 @@
                 <node concept="3y3z36" id="7OJcYqzfoIH" role="3clFbw">
                   <node concept="10Nm6u" id="7OJcYqzfrDw" role="3uHU7w" />
                   <node concept="37vLTw" id="7OJcYqzfmO4" role="3uHU7B">
-                    <ref role="3cqZAo" node="7OJcYqzffLo" resolve="mapping" />
+                    <ref role="3cqZAo" node="7OJcYqzffLo" resolve="staple" />
                   </node>
                 </node>
               </node>
@@ -3794,9 +3819,9 @@
       <node concept="3clFbS" id="4oHUzWXHJlR" role="3clF47">
         <node concept="3cpWs8" id="7OJcYqzfZ3V" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqzfZ3W" role="3cpWs9">
-            <property role="TrG5h" value="mapping" />
+            <property role="TrG5h" value="staple" />
             <node concept="3uibUv" id="7OJcYqzfXzE" role="1tU5fm">
-              <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+              <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
             </node>
             <node concept="2OqwBi" id="7OJcYqzfZ3X" role="33vP2m">
               <node concept="2OqwBi" id="7OJcYqzfZ3Y" role="2Oq$k0">
@@ -3804,7 +3829,7 @@
                   <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
                 </node>
                 <node concept="liA8E" id="7OJcYqzfZ40" role="2OqNvi">
-                  <ref role="37wK5l" node="7OJcYqx0tbv" resolve="listLcPrimitiveType" />
+                  <ref role="37wK5l" node="7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
                 </node>
               </node>
               <node concept="1z4cxt" id="7OJcYqzfZ41" role="2OqNvi">
@@ -3840,7 +3865,7 @@
             <node concept="3cpWs6" id="4oHUzWXHJm7" role="3cqZAp">
               <node concept="2OqwBi" id="7OJcYqzgem5" role="3cqZAk">
                 <node concept="37vLTw" id="7OJcYqzgcRe" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7OJcYqzfZ3W" resolve="mapping" />
+                  <ref role="3cqZAo" node="7OJcYqzfZ3W" resolve="staple" />
                 </node>
                 <node concept="liA8E" id="7OJcYqzghcE" role="2OqNvi">
                   <ref role="37wK5l" node="7OJcYqvKjL5" resolve="getLcKey" />
@@ -3851,7 +3876,7 @@
           <node concept="3y3z36" id="7OJcYqzg6sn" role="3clFbw">
             <node concept="10Nm6u" id="7OJcYqzg99H" role="3uHU7w" />
             <node concept="37vLTw" id="7OJcYqzg3Au" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYqzfZ3W" resolve="mapping" />
+              <ref role="3cqZAo" node="7OJcYqzfZ3W" resolve="staple" />
             </node>
           </node>
         </node>
@@ -6288,7 +6313,7 @@
     <node concept="3clFb_" id="7OJcYqwQyzV" role="jymVt">
       <property role="TrG5h" value="getVirtualPackage" />
       <node concept="3uibUv" id="7OJcYqwQyzW" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQyzX" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQyzY" role="3clF47" />
@@ -6351,7 +6376,7 @@
     <node concept="3clFb_" id="7OJcYqwQy$4" role="jymVt">
       <property role="TrG5h" value="getShortDescription" />
       <node concept="3uibUv" id="7OJcYqwQy$5" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQy$6" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQy$7" role="3clF47" />
@@ -6414,7 +6439,7 @@
     <node concept="3clFb_" id="7OJcYqwUzr1" role="jymVt">
       <property role="TrG5h" value="getSpecificLanguage" />
       <node concept="3uibUv" id="7OJcYqwUzr2" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwUzr3" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwUzr4" role="3clF47" />
@@ -6483,7 +6508,7 @@
     <node concept="3clFb_" id="7OJcYqwQy$d" role="jymVt">
       <property role="TrG5h" value="getStructureLanguage" />
       <node concept="3uibUv" id="7OJcYqwQy$e" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQy$f" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQy$g" role="3clF47" />
@@ -6556,7 +6581,7 @@
     <node concept="3clFb_" id="7OJcYqwQy$m" role="jymVt">
       <property role="TrG5h" value="getClassifier" />
       <node concept="3uibUv" id="7OJcYqwQy$n" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQy$o" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQy$p" role="3clF47" />
@@ -6608,7 +6633,7 @@
     <node concept="3clFb_" id="7OJcYqwQy$v" role="jymVt">
       <property role="TrG5h" value="getConcept" />
       <node concept="3uibUv" id="7OJcYqwQy$w" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQy$x" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQy$y" role="3clF47" />
@@ -6660,7 +6685,7 @@
     <node concept="3clFb_" id="7OJcYqwQy$C" role="jymVt">
       <property role="TrG5h" value="getInterface" />
       <node concept="3uibUv" id="7OJcYqwQy$D" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQy$E" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQy$F" role="3clF47" />
@@ -6712,7 +6737,7 @@
     <node concept="3clFb_" id="7OJcYqwQy$L" role="jymVt">
       <property role="TrG5h" value="getConceptAlias" />
       <node concept="3uibUv" id="7OJcYqwQy$M" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQy$N" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQy$O" role="3clF47" />
@@ -6759,7 +6784,7 @@
     <node concept="3clFb_" id="7OJcYqwQy$U" role="jymVt">
       <property role="TrG5h" value="getConceptShortDescription" />
       <node concept="3uibUv" id="7OJcYqwQy$V" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQy$W" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQy$X" role="3clF47" />
@@ -6804,12 +6829,12 @@
     </node>
     <node concept="2tJIrI" id="34Q84zNQO5q" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxreEB" role="jymVt">
-      <property role="TrG5h" value="listSpecificAnnotationProperty" />
+      <property role="TrG5h" value="listMpsM1AnnotationProperties" />
       <node concept="3clFbS" id="7OJcYqxreEE" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqxreEF" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqxreug" role="3clF45">
         <node concept="3uibUv" id="7OJcYqxreE$" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+          <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
         </node>
       </node>
       <node concept="P$JXv" id="7OJcYqyNMNX" role="lGtFl">
@@ -6822,12 +6847,12 @@
     </node>
     <node concept="2tJIrI" id="7OJcYqxrf3I" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxrfm4" role="jymVt">
-      <property role="TrG5h" value="listConceptDescriptionProperty" />
+      <property role="TrG5h" value="listMpsM2AnnotationProperties" />
       <node concept="3clFbS" id="7OJcYqxrfm5" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqxrfm6" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqxrfm7" role="3clF45">
         <node concept="3uibUv" id="7OJcYqxrfm8" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+          <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
         </node>
       </node>
       <node concept="P$JXv" id="7OJcYqyZqsX" role="lGtFl">
@@ -6850,7 +6875,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqvS5bL" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqvS5bM" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqvScQL" role="jymVt">
@@ -6858,7 +6883,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqvScQJ" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqvScQK" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqxKJ7c" role="jymVt">
@@ -6866,7 +6891,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqxKJ7d" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqxKJ7e" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqvSkE$" role="jymVt">
@@ -6874,7 +6899,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqvSkEy" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqvSkEz" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqvSsAf" role="jymVt">
@@ -6882,7 +6907,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqvSsAd" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqvSsAe" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqvSxpd" role="jymVt">
@@ -6890,7 +6915,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqvSxpb" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqvSxpc" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqvSGCF" role="jymVt">
@@ -6898,7 +6923,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqvSGCD" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqvSGCE" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqw2ryQ" resolve="ConstrainedPrimitiveTypeKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqw2ryQ" resolve="ConstrainedPrimitiveTypeStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqvSOTI" role="jymVt">
@@ -6906,7 +6931,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqvSOTG" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqvSOTH" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqvSX4c" role="jymVt">
@@ -6914,7 +6939,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqvSX4a" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqvSX4b" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqvT58p" role="jymVt">
@@ -6922,7 +6947,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqvT58n" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqvT58o" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvQ8aH" resolve="ContainmentKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvQ8aH" resolve="ContainmentStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqvTdFq" role="jymVt">
@@ -6930,7 +6955,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqvTdFo" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqvTdFp" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvXZ8V" resolve="InterfaceKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvXZ8V" resolve="InterfaceStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqvTlIS" role="jymVt">
@@ -6938,7 +6963,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqvTlIQ" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqvTlIR" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqw99Yc" role="jymVt">
@@ -6946,9 +6971,10 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqw99Ya" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqw99Yb" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
     </node>
+    <node concept="2tJIrI" id="7OJcYq$uYjD" role="jymVt" />
     <node concept="3clFbW" id="5JNiski3MAN" role="jymVt">
       <node concept="37vLTG" id="5JNiski3MAO" role="3clF46">
         <property role="TrG5h" value="repository" />
@@ -6991,7 +7017,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqvS5c5" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqvS5c6" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqvMRo3" resolve="LanguageKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqvMRo3" resolve="LanguageStaple" />
                 <node concept="2OqwBi" id="7OJcYqxS4_I" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqxRWOn" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqxRZZk" role="2tJFKM">
@@ -7034,7 +7060,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqw99Yu" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqw99Yv" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqwqm3V" resolve="LanguageKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqwqm3V" resolve="LanguageStaple" />
                 <node concept="pHN19" id="7OJcYqw99Yw" role="37wK5m">
                   <node concept="2V$Bhx" id="7OJcYqwUMaB" role="2V$M_3">
                     <property role="2V$B1T" value="411e5b27-8a76-482e-8af8-1704262b4468" />
@@ -7076,7 +7102,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqvScR3" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqvScR4" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqvMRo3" resolve="LanguageKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqvMRo3" resolve="LanguageStaple" />
                 <node concept="2OqwBi" id="7OJcYqxSlWn" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqxSfwh" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqxSiFu" role="2tJFKM">
@@ -7113,7 +7139,7 @@
           <node concept="37vLTI" id="7OJcYqxL4GB" role="3clFbG">
             <node concept="2ShNRf" id="7OJcYqxL7Ot" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqxLbgm" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqwqm3V" resolve="LanguageKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqwqm3V" resolve="LanguageStaple" />
                 <node concept="pHN19" id="7OJcYqxLenn" role="37wK5m">
                   <node concept="2V$Bhx" id="7OJcYqxLhtV" role="2V$M_3">
                     <property role="2V$B1T" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
@@ -7141,7 +7167,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqvSkEX" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqvSkEY" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqvLccW" resolve="PrimitiveTypeKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqvLccW" resolve="PrimitiveTypeStaple" />
                 <node concept="2OqwBi" id="7OJcYqvSkEZ" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqvSkF0" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqvSkF1" role="2tJFKM">
@@ -7188,7 +7214,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqvSsAC" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqvSsAD" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqvLccW" resolve="PrimitiveTypeKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqvLccW" resolve="PrimitiveTypeStaple" />
                 <node concept="2OqwBi" id="7OJcYqvSsAE" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqvSsAF" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqvSsAG" role="2tJFKM">
@@ -7235,7 +7261,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqvSxpA" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqvSxpB" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqvLccW" resolve="PrimitiveTypeKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqvLccW" resolve="PrimitiveTypeStaple" />
                 <node concept="2OqwBi" id="7OJcYqvSxpC" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqvSxpD" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqvSxpE" role="2tJFKM">
@@ -7332,7 +7358,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqvSGDh" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqvSGDi" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqw2ryW" resolve="ConstrainedPrimitiveTypeKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqw2ryW" resolve="ConstrainedPrimitiveTypeStaple" />
                 <node concept="2OqwBi" id="7OJcYqvSGDj" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqvSGDk" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqvSGDl" role="2tJFKM">
@@ -7464,7 +7490,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqvSOUg" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqvSOUh" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptStaple" />
                 <node concept="2OqwBi" id="7OJcYqvSOUi" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqvSOUj" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqvSOUk" role="2tJFKM">
@@ -7521,7 +7547,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqvSX4D" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqvSX4E" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptStaple" />
                 <node concept="2OqwBi" id="7OJcYqxx$KA" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqxxjCI" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqxxmLD" role="2tJFKM">
@@ -7585,7 +7611,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqvT58O" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqvT58P" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqvQc4u" resolve="ContainmentKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqvQc4u" resolve="ContainmentStaple" />
                 <node concept="10Nm6u" id="7OJcYqvT58Q" role="37wK5m" />
                 <node concept="2OqwBi" id="7OJcYqvT58R" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqvT58S" role="2Oq$k0">
@@ -7655,7 +7681,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqvTdFW" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqvTdFX" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqvXZ91" resolve="InterfaceKeyedMapping" />
+                <ref role="37wK5l" node="7OJcYqvXZ91" resolve="InterfaceStaple" />
                 <node concept="2OqwBi" id="7OJcYqvTdFY" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqvTdFZ" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqvTdG0" role="2tJFKM">
@@ -7742,7 +7768,7 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqvTlJw" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqvTlJx" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqvRxYF" resolve="PropertyKeyMapping" />
+                <ref role="37wK5l" node="7OJcYqvRxYF" resolve="PropertyStaple" />
                 <node concept="2OqwBi" id="7OJcYqvTlJy" role="37wK5m">
                   <node concept="2tJFMh" id="7OJcYqvTlJz" role="2Oq$k0">
                     <node concept="ZC_QK" id="7OJcYqvTlJ$" role="2tJFKM">
@@ -7833,6 +7859,9 @@
       </node>
       <node concept="3Tm1VV" id="5JNiskhmuU6" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhmwT4" role="3clF45" />
+      <node concept="2AHcQZ" id="7OJcYq$umX7" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="2tJIrI" id="5JNiskhmsVz" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwXqX5" role="jymVt">
@@ -7840,7 +7869,7 @@
       <node concept="3Tm1VV" id="7OJcYqwXqX7" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqwXqX8" role="3clF45">
         <node concept="3uibUv" id="7OJcYqwXqX9" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+          <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqwXqXa" role="3clF47">
@@ -7848,13 +7877,13 @@
           <node concept="2ShNRf" id="7OJcYqwX_tV" role="3clFbG">
             <node concept="Tc6Ow" id="7OJcYqwXDP5" role="2ShVmc">
               <node concept="3uibUv" id="7OJcYqwXLtq" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+                <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
               </node>
               <node concept="1rXfSq" id="7OJcYqwXTIv" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqwirz6" resolve="getM3" />
               </node>
               <node concept="1rXfSq" id="7OJcYqwY1OK" role="HW$Y0">
-                <ref role="37wK5l" node="7OJcYqwirze" resolve="getLioncoreBuiltins" />
+                <ref role="37wK5l" node="7OJcYqwirze" resolve="getBuiltins" />
               </node>
             </node>
           </node>
@@ -7866,11 +7895,11 @@
     </node>
     <node concept="2tJIrI" id="5JNiskhYXcG" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwYKHE" role="jymVt">
-      <property role="TrG5h" value="listClassifiers" />
+      <property role="TrG5h" value="listLcClassifiers" />
       <node concept="3Tm1VV" id="7OJcYqwYKHG" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqwYKHH" role="3clF45">
         <node concept="3uibUv" id="7OJcYqwYKHI" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+          <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqwYKHJ" role="3clF47">
@@ -7878,7 +7907,7 @@
           <node concept="2ShNRf" id="7OJcYqwYQMq" role="3clFbG">
             <node concept="Tc6Ow" id="7OJcYqwYUtf" role="2ShVmc">
               <node concept="3uibUv" id="7OJcYqwZ36x" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+                <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierStaple" />
               </node>
               <node concept="1rXfSq" id="7OJcYqwZbAD" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
@@ -7896,11 +7925,11 @@
     </node>
     <node concept="2tJIrI" id="5JNiskhYXe1" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwZBzt" role="jymVt">
-      <property role="TrG5h" value="listLcProperty" />
+      <property role="TrG5h" value="listLcProperties" />
       <node concept="3Tm1VV" id="7OJcYqwZBzv" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqwZBzw" role="3clF45">
         <node concept="3uibUv" id="7OJcYqwZBzx" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+          <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqwZBzy" role="3clF47">
@@ -7908,7 +7937,7 @@
           <node concept="2ShNRf" id="7OJcYqwZM4e" role="3clFbG">
             <node concept="Tc6Ow" id="7OJcYqwZPSo" role="2ShVmc">
               <node concept="3uibUv" id="7OJcYqwZYOw" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+                <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
               </node>
               <node concept="1rXfSq" id="7OJcYqx07B6" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqwir$m" resolve="getINamedName" />
@@ -7923,11 +7952,11 @@
     </node>
     <node concept="2tJIrI" id="7OJcYqx0zJr" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqx0D9N" role="jymVt">
-      <property role="TrG5h" value="listLcPrimitiveType" />
+      <property role="TrG5h" value="listLcPrimitiveTypes" />
       <node concept="3Tm1VV" id="7OJcYqx0D9P" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqx0D9Q" role="3clF45">
         <node concept="3uibUv" id="7OJcYqx0D9R" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+          <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqx0D9S" role="3clF47">
@@ -7935,7 +7964,7 @@
           <node concept="2ShNRf" id="7OJcYqx0JwW" role="3clFbG">
             <node concept="Tc6Ow" id="7OJcYqx0NrY" role="2ShVmc">
               <node concept="3uibUv" id="7OJcYqx0WB1" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+                <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
               </node>
               <node concept="1rXfSq" id="7OJcYqx15UZ" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqwirzu" resolve="getBoolean" />
@@ -7987,7 +8016,7 @@
                   </node>
                   <node concept="2OqwBi" id="7OJcYqx8EcH" role="2Oq$k0">
                     <node concept="1rXfSq" id="7OJcYqx8EcI" role="2Oq$k0">
-                      <ref role="37wK5l" node="7OJcYqx1NIa" resolve="listMpsInternalClassifier" />
+                      <ref role="37wK5l" node="7OJcYqx1NIa" resolve="listMpsInternalClassifiers" />
                     </node>
                     <node concept="3$u5V9" id="7OJcYqx8EcJ" role="2OqNvi">
                       <node concept="1bVj0M" id="7OJcYqx8EcK" role="23t8la">
@@ -8042,7 +8071,7 @@
               <node concept="2OqwBi" id="5JNiskhYXhi" role="3cqZAk">
                 <node concept="2OqwBi" id="7OJcYqx7qdc" role="2Oq$k0">
                   <node concept="1rXfSq" id="5JNiskhYXhj" role="2Oq$k0">
-                    <ref role="37wK5l" node="7OJcYqx1NIa" resolve="listMpsInternalClassifier" />
+                    <ref role="37wK5l" node="7OJcYqx1NIa" resolve="listMpsInternalClassifiers" />
                   </node>
                   <node concept="3$u5V9" id="7OJcYqx7woy" role="2OqNvi">
                     <node concept="1bVj0M" id="7OJcYqx7wo$" role="23t8la">
@@ -8098,7 +8127,7 @@
               <node concept="2OqwBi" id="6Z_tmAeerUd" role="3cqZAk">
                 <node concept="2OqwBi" id="7OJcYqx7S50" role="2Oq$k0">
                   <node concept="1rXfSq" id="6Z_tmAeenH6" role="2Oq$k0">
-                    <ref role="37wK5l" node="7OJcYqx0D9N" resolve="listLcPrimitiveType" />
+                    <ref role="37wK5l" node="7OJcYqx0D9N" resolve="listLcPrimitiveTypes" />
                   </node>
                   <node concept="3$u5V9" id="7OJcYqx7XOy" role="2OqNvi">
                     <node concept="1bVj0M" id="7OJcYqx7XO$" role="23t8la">
@@ -8154,7 +8183,7 @@
               <node concept="2OqwBi" id="6Z_tmAegjuh" role="3cqZAk">
                 <node concept="2OqwBi" id="7OJcYqx8jtI" role="2Oq$k0">
                   <node concept="1rXfSq" id="6Z_tmAefXg3" role="2Oq$k0">
-                    <ref role="37wK5l" node="7OJcYqx2F8j" resolve="listMpsInternalFeature" />
+                    <ref role="37wK5l" node="7OJcYqx2F8j" resolve="listMpsInternalFeatures" />
                   </node>
                   <node concept="3$u5V9" id="7OJcYqx8or$" role="2OqNvi">
                     <node concept="1bVj0M" id="7OJcYqx8orA" role="23t8la">
@@ -8244,7 +8273,7 @@
           <node concept="2OqwBi" id="7OJcYqx6YcO" role="3clFbG">
             <node concept="2OqwBi" id="7OJcYqx6YcP" role="2Oq$k0">
               <node concept="1rXfSq" id="7OJcYqx6YcQ" role="2Oq$k0">
-                <ref role="37wK5l" node="7OJcYqx2F8j" resolve="listMpsInternalFeature" />
+                <ref role="37wK5l" node="7OJcYqx2F8j" resolve="listMpsInternalFeatures" />
               </node>
               <node concept="3$u5V9" id="7OJcYqx6YcR" role="2OqNvi">
                 <node concept="1bVj0M" id="7OJcYqx6YcS" role="23t8la">
@@ -8301,7 +8330,7 @@
           <node concept="2OqwBi" id="5JNiskizLC2" role="3clFbG">
             <node concept="2OqwBi" id="7OJcYqx6sn6" role="2Oq$k0">
               <node concept="1rXfSq" id="5JNiskizHvJ" role="2Oq$k0">
-                <ref role="37wK5l" node="7OJcYqx2F8j" resolve="listMpsInternalFeature" />
+                <ref role="37wK5l" node="7OJcYqx2F8j" resolve="listMpsInternalFeatures" />
               </node>
               <node concept="3$u5V9" id="7OJcYqx6y4M" role="2OqNvi">
                 <node concept="1bVj0M" id="7OJcYqx6y4O" role="23t8la">
@@ -8376,11 +8405,11 @@
     </node>
     <node concept="2tJIrI" id="5JNiskhYXhO" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqx1NIa" role="jymVt">
-      <property role="TrG5h" value="listMpsInternalClassifier" />
+      <property role="TrG5h" value="listMpsInternalClassifiers" />
       <node concept="3Tm1VV" id="7OJcYqx1NIc" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqx1NId" role="3clF45">
         <node concept="3uibUv" id="7OJcYqx1NIe" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+          <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqx1NIf" role="3clF47">
@@ -8388,7 +8417,7 @@
           <node concept="2ShNRf" id="7OJcYqx1Uh4" role="3clFbG">
             <node concept="Tc6Ow" id="7OJcYqx1YAc" role="2ShVmc">
               <node concept="3uibUv" id="7OJcYqx288_" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+                <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierStaple" />
               </node>
               <node concept="1rXfSq" id="7OJcYqx2htG" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
@@ -8406,11 +8435,11 @@
     </node>
     <node concept="2tJIrI" id="5JNiskixn4F" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqx2F8j" role="jymVt">
-      <property role="TrG5h" value="listMpsInternalFeature" />
+      <property role="TrG5h" value="listMpsInternalFeatures" />
       <node concept="3Tm1VV" id="7OJcYqx2F8l" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqx2F8m" role="3clF45">
         <node concept="3uibUv" id="7OJcYqx2F8n" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
+          <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
         </node>
       </node>
       <node concept="3clFbS" id="7OJcYqx2F8o" role="3clF47">
@@ -8418,7 +8447,7 @@
           <node concept="2ShNRf" id="7OJcYqx2QyA" role="3clFbG">
             <node concept="Tc6Ow" id="7OJcYqx2UOb" role="2ShVmc">
               <node concept="3uibUv" id="7OJcYqx33I5" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
+                <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
               </node>
               <node concept="1rXfSq" id="7OJcYqx3dhF" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqwir$6" resolve="getAnnotationContainment" />
@@ -8487,7 +8516,7 @@
     <node concept="3clFb_" id="7OJcYqwirz6" role="jymVt">
       <property role="TrG5h" value="getM3" />
       <node concept="3uibUv" id="7OJcYqwirz7" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwirz8" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwirz9" role="3clF47">
@@ -8500,11 +8529,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$upM9" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwirze" role="jymVt">
-      <property role="TrG5h" value="getLioncoreBuiltins" />
+      <property role="TrG5h" value="getBuiltins" />
       <node concept="3uibUv" id="7OJcYqwirzf" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwirzg" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwirzh" role="3clF47">
@@ -8517,11 +8549,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$usBm" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqxLl6m" role="jymVt">
       <property role="TrG5h" value="getCoreLanguage" />
       <node concept="3uibUv" id="7OJcYqxLl6n" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqxLl6o" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqxLl6P" role="3clF47">
@@ -8541,7 +8576,7 @@
     <node concept="3clFb_" id="7OJcYqwirzm" role="jymVt">
       <property role="TrG5h" value="getString" />
       <node concept="3uibUv" id="7OJcYqwirzn" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwirzo" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwirzp" role="3clF47">
@@ -8554,11 +8589,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$uvsj" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwirzu" role="jymVt">
       <property role="TrG5h" value="getBoolean" />
       <node concept="3uibUv" id="7OJcYqwirzv" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwirzw" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwirzx" role="3clF47">
@@ -8571,11 +8609,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$uyhi" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwirzA" role="jymVt">
       <property role="TrG5h" value="getInteger" />
       <node concept="3uibUv" id="7OJcYqwirzB" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwirzC" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwirzD" role="3clF47">
@@ -8588,11 +8629,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$u_6j" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwirzI" role="jymVt">
       <property role="TrG5h" value="getJson" />
       <node concept="3uibUv" id="7OJcYqwirzJ" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqw2ryQ" resolve="ConstrainedPrimitiveTypeKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqw2ryQ" resolve="ConstrainedPrimitiveTypeStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwirzK" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwirzL" role="3clF47">
@@ -8605,11 +8649,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$uAXz" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwirzQ" role="jymVt">
       <property role="TrG5h" value="getNode" />
       <node concept="3uibUv" id="7OJcYqwirzR" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwirzS" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwirzT" role="3clF47">
@@ -8622,11 +8669,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$uDMC" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwirzY" role="jymVt">
       <property role="TrG5h" value="getAnnotation" />
       <node concept="3uibUv" id="7OJcYqwirzZ" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwir$0" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwir$1" role="3clF47">
@@ -8639,11 +8689,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$uGBS" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwir$6" role="jymVt">
       <property role="TrG5h" value="getAnnotationContainment" />
       <node concept="3uibUv" id="7OJcYqwir$7" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvQ8aH" resolve="ContainmentKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvQ8aH" resolve="ContainmentStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwir$8" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwir$9" role="3clF47">
@@ -8656,11 +8709,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$uK6J" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwir$e" role="jymVt">
       <property role="TrG5h" value="getINamed" />
       <node concept="3uibUv" id="7OJcYqwir$f" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvXZ8V" resolve="InterfaceKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvXZ8V" resolve="InterfaceStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwir$g" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwir$h" role="3clF47">
@@ -8673,11 +8729,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$uMW3" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwir$m" role="jymVt">
       <property role="TrG5h" value="getINamedName" />
       <node concept="3uibUv" id="7OJcYqwir$n" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwir$o" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwir$p" role="3clF47">
@@ -8690,11 +8749,14 @@
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$uONt" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwUZco" role="jymVt">
       <property role="TrG5h" value="getAttributeLanguage" />
       <node concept="3uibUv" id="7OJcYqwUZcp" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwUZcq" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwUZcR" role="3clF47">
@@ -8725,7 +8787,7 @@
     <node concept="3clFb_" id="7OJcYqwQm1k" role="jymVt">
       <property role="TrG5h" value="getString" />
       <node concept="3uibUv" id="7OJcYqwQm1l" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQm1m" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQm1n" role="3clF47" />
@@ -8777,7 +8839,7 @@
     <node concept="3clFb_" id="7OJcYqwQm1t" role="jymVt">
       <property role="TrG5h" value="getBoolean" />
       <node concept="3uibUv" id="7OJcYqwQm1u" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQm1v" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQm1w" role="3clF47" />
@@ -8829,7 +8891,7 @@
     <node concept="3clFb_" id="7OJcYqwQm1A" role="jymVt">
       <property role="TrG5h" value="getInteger" />
       <node concept="3uibUv" id="7OJcYqwQm1B" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQm1C" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQm1D" role="3clF47" />
@@ -8881,7 +8943,7 @@
     <node concept="3clFb_" id="7OJcYqwQm1J" role="jymVt">
       <property role="TrG5h" value="getJson" />
       <node concept="3uibUv" id="7OJcYqwQm1K" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqw2ryQ" resolve="ConstrainedPrimitiveTypeKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqw2ryQ" resolve="ConstrainedPrimitiveTypeStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQm1L" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQm1M" role="3clF47" />
@@ -8931,7 +8993,7 @@
     <node concept="3clFb_" id="7OJcYqwQm1S" role="jymVt">
       <property role="TrG5h" value="getNode" />
       <node concept="3uibUv" id="7OJcYqwQm1T" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQm1U" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQm1V" role="3clF47" />
@@ -8981,7 +9043,7 @@
     <node concept="3clFb_" id="7OJcYqwQm21" role="jymVt">
       <property role="TrG5h" value="getAnnotation" />
       <node concept="3uibUv" id="7OJcYqwQm22" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQm23" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQm24" role="3clF47" />
@@ -9031,7 +9093,7 @@
     <node concept="3clFb_" id="7OJcYqwQm2a" role="jymVt">
       <property role="TrG5h" value="getAnnotationContainment" />
       <node concept="3uibUv" id="7OJcYqwQm2b" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvQ8aH" resolve="ContainmentKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvQ8aH" resolve="ContainmentStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQm2c" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQm2d" role="3clF47" />
@@ -9083,7 +9145,7 @@
     <node concept="3clFb_" id="7OJcYqwQm2j" role="jymVt">
       <property role="TrG5h" value="getINamed" />
       <node concept="3uibUv" id="7OJcYqwQm2k" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvXZ8V" resolve="InterfaceKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvXZ8V" resolve="InterfaceStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQm2l" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQm2m" role="3clF47" />
@@ -9133,7 +9195,7 @@
     <node concept="3clFb_" id="7OJcYqwQm2s" role="jymVt">
       <property role="TrG5h" value="getINamedName" />
       <node concept="3uibUv" id="7OJcYqwQm2t" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQm2u" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQm2v" role="3clF47" />
@@ -9183,7 +9245,7 @@
     <node concept="3clFb_" id="7OJcYqwQm12" role="jymVt">
       <property role="TrG5h" value="getM3" />
       <node concept="3uibUv" id="7OJcYqwQm13" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQm14" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQm15" role="3clF47" />
@@ -9254,9 +9316,9 @@
     </node>
     <node concept="2tJIrI" id="5JNiski3jYa" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwQm1b" role="jymVt">
-      <property role="TrG5h" value="getLioncoreBuiltins" />
+      <property role="TrG5h" value="getBuiltins" />
       <node concept="3uibUv" id="7OJcYqwQm1c" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQm1d" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQm1e" role="3clF47" />
@@ -9324,7 +9386,7 @@
     <node concept="3clFb_" id="7OJcYqxK_pb" role="jymVt">
       <property role="TrG5h" value="getCoreLanguage" />
       <node concept="3uibUv" id="7OJcYqxK_pc" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqxK_pd" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqxK_pe" role="3clF47" />
@@ -9393,7 +9455,7 @@
     <node concept="3clFb_" id="7OJcYqwQm2_" role="jymVt">
       <property role="TrG5h" value="getAttributeLanguage" />
       <node concept="3uibUv" id="7OJcYqwQm2A" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQm2B" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQm2C" role="3clF47" />
@@ -9465,7 +9527,7 @@
       <node concept="3Tm1VV" id="7OJcYqwXhGL" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqwXdK9" role="3clF45">
         <node concept="3uibUv" id="7OJcYqwXgNR" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+          <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
         </node>
       </node>
       <node concept="P$JXv" id="7OJcYqz8mI0" role="lGtFl">
@@ -9478,12 +9540,12 @@
     </node>
     <node concept="2tJIrI" id="5JNiski3jZr" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwYDTB" role="jymVt">
-      <property role="TrG5h" value="listClassifiers" />
+      <property role="TrG5h" value="listLcClassifiers" />
       <node concept="3clFbS" id="7OJcYqwYDTE" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqwYDTF" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqwYaoG" role="3clF45">
         <node concept="3uibUv" id="7OJcYqwYDsj" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+          <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierStaple" />
         </node>
       </node>
       <node concept="P$JXv" id="7OJcYqzglge" role="lGtFl">
@@ -9497,12 +9559,12 @@
     <node concept="2tJIrI" id="5JNiski3k0h" role="jymVt" />
     <node concept="2tJIrI" id="5JNiski3k0i" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwZxOH" role="jymVt">
-      <property role="TrG5h" value="listLcProperty" />
+      <property role="TrG5h" value="listLcProperties" />
       <node concept="3clFbS" id="7OJcYqwZxOK" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqwZxOL" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqwZryI" role="3clF45">
         <node concept="3uibUv" id="7OJcYqwZwhO" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+          <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
         </node>
       </node>
       <node concept="P$JXv" id="7OJcYqzqWrX" role="lGtFl">
@@ -9515,12 +9577,12 @@
     </node>
     <node concept="2tJIrI" id="5JNiski3k18" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqx0tbv" role="jymVt">
-      <property role="TrG5h" value="listLcPrimitiveType" />
+      <property role="TrG5h" value="listLcPrimitiveTypes" />
       <node concept="3clFbS" id="7OJcYqx0tby" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqx0tbz" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqx0gEl" role="3clF45">
         <node concept="3uibUv" id="7OJcYqx0sJp" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+          <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
         </node>
       </node>
       <node concept="P$JXv" id="7OJcYqzr6Eu" role="lGtFl">
@@ -9539,7 +9601,9 @@
       <node concept="10P_77" id="5JNiski3k22" role="3clF45" />
       <node concept="37vLTG" id="5JNiski3k23" role="3clF46">
         <property role="TrG5h" value="mpsConcept" />
-        <node concept="3Tqbb2" id="5JNiski3k24" role="1tU5fm" />
+        <node concept="3uibUv" id="7OJcYq$$0X3" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
         <node concept="2AHcQZ" id="5JNiski3k25" role="2AJF6D">
           <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
         </node>
@@ -9595,12 +9659,12 @@
     </node>
     <node concept="2tJIrI" id="5JNiski3k2c" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqx1HDk" role="jymVt">
-      <property role="TrG5h" value="listMpsInternalClassifier" />
+      <property role="TrG5h" value="listMpsInternalClassifiers" />
       <node concept="3clFbS" id="7OJcYqx1HDn" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqx1HDo" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqx1B4G" role="3clF45">
         <node concept="3uibUv" id="7OJcYqx1G3E" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+          <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierStaple" />
         </node>
       </node>
       <node concept="P$JXv" id="7OJcYqz$mTR" role="lGtFl">
@@ -9675,12 +9739,12 @@
     </node>
     <node concept="2tJIrI" id="5JNiski3k2q" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqx2zDi" role="jymVt">
-      <property role="TrG5h" value="listMpsInternalFeature" />
+      <property role="TrG5h" value="listMpsInternalFeatures" />
       <node concept="3clFbS" id="7OJcYqx2zDl" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqx2zDm" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqx2zai" role="3clF45">
         <node concept="3uibUv" id="7OJcYqx2zBy" role="_ZDj9">
-          <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
+          <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
         </node>
       </node>
       <node concept="P$JXv" id="7OJcYqz$s$f" role="lGtFl">
@@ -9806,8 +9870,8 @@
     </node>
   </node>
   <node concept="3HP615" id="7OJcYqvKf0O">
-    <property role="TrG5h" value="IKeyedMapping" />
-    <property role="3GE5qa" value="keyedMapping" />
+    <property role="TrG5h" value="IKeyedStaple" />
+    <property role="3GE5qa" value="staple" />
     <node concept="3clFb_" id="7OJcYqvKhKf" role="jymVt">
       <property role="TrG5h" value="getLc" />
       <node concept="3clFbS" id="7OJcYqvKhKi" role="3clF47" />
@@ -9886,12 +9950,12 @@
     </node>
   </node>
   <node concept="312cEu" id="7OJcYqvKk3R">
-    <property role="3GE5qa" value="keyedMapping" />
-    <property role="TrG5h" value="AKeyedMapping" />
+    <property role="3GE5qa" value="staple" />
+    <property role="TrG5h" value="AKeyedStaple" />
     <property role="1sVAO0" value="true" />
     <node concept="3Tm1VV" id="7OJcYqvKk3S" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqvKk$F" role="EKbjA">
-      <ref role="3uigEE" node="7OJcYqvKf0O" resolve="IKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqvKf0O" resolve="IKeyedStaple" />
       <node concept="16syzq" id="7OJcYqvKzpv" role="11_B2D">
         <ref role="16sUi3" node="7OJcYqvKyqV" resolve="LC" />
       </node>
@@ -10322,11 +10386,11 @@
     </node>
   </node>
   <node concept="312cEu" id="7OJcYqvKWo$">
-    <property role="3GE5qa" value="keyedMapping" />
-    <property role="TrG5h" value="ConceptKeyedMapping" />
+    <property role="3GE5qa" value="staple" />
+    <property role="TrG5h" value="ConceptStaple" />
     <node concept="3Tm1VV" id="7OJcYqvKWo_" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqvKWTq" role="1zkMxy">
-      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
       <node concept="3Tqbb2" id="7OJcYqvKX9U" role="11_B2D">
         <ref role="ehGHo" to="h3y3:2ju2syjklrv" resolve="Concept" />
       </node>
@@ -10342,7 +10406,7 @@
       <node concept="3Tm1VV" id="7OJcYqvKXdA" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqvKXdC" role="3clF47">
         <node concept="XkiVB" id="7OJcYqvKXdE" role="3cqZAp">
-          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedStaple" />
           <node concept="37vLTw" id="7OJcYqvKXdI" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqvKXdF" resolve="lc" />
           </node>
@@ -10366,14 +10430,14 @@
           </node>
           <node concept="2YIFZM" id="7OJcYqwPEJV" role="37wK5m">
             <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
-            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqwPEJW" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqvKXdF" resolve="lc" />
             </node>
           </node>
           <node concept="2YIFZM" id="7OJcYqwPF25" role="37wK5m">
             <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
-            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqwPF26" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqvKXdF" resolve="lc" />
             </node>
@@ -10409,7 +10473,7 @@
       </node>
     </node>
     <node concept="3uibUv" id="7OJcYqwYpbh" role="EKbjA">
-      <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierStaple" />
       <node concept="3Tqbb2" id="7OJcYqwYxKG" role="11_B2D">
         <ref role="ehGHo" to="h3y3:2ju2syjklrv" resolve="Concept" />
       </node>
@@ -10422,11 +10486,11 @@
     </node>
   </node>
   <node concept="312cEu" id="7OJcYqvL3W3">
-    <property role="3GE5qa" value="keyedMapping" />
-    <property role="TrG5h" value="PrimitiveTypeKeyedMapping" />
+    <property role="3GE5qa" value="staple" />
+    <property role="TrG5h" value="PrimitiveTypeStaple" />
     <node concept="3Tm1VV" id="7OJcYqvL3W4" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqvL4WJ" role="1zkMxy">
-      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
       <node concept="3Tqbb2" id="7OJcYqvL5bz" role="11_B2D">
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
       </node>
@@ -10442,7 +10506,7 @@
       <node concept="3Tm1VV" id="7OJcYqvLccY" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqvLcd0" role="3clF47">
         <node concept="XkiVB" id="7OJcYqvLcd2" role="3cqZAp">
-          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedStaple" />
           <node concept="37vLTw" id="7OJcYqvLcd6" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqvLcd3" resolve="lc" />
           </node>
@@ -10466,14 +10530,14 @@
           </node>
           <node concept="2YIFZM" id="7OJcYqwPrVr" role="37wK5m">
             <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqvLM9o" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqvLcd3" resolve="lc" />
             </node>
           </node>
           <node concept="2YIFZM" id="7OJcYqwPrVs" role="37wK5m">
             <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqvLIAw" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqvLcd3" resolve="lc" />
             </node>
@@ -10565,15 +10629,15 @@
       </node>
     </node>
     <node concept="3uibUv" id="7OJcYqx0qrW" role="EKbjA">
-      <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
       <node concept="3Tqbb2" id="7OJcYqx0rRl" role="11_B2D">
         <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
       </node>
     </node>
   </node>
   <node concept="312cEu" id="7OJcYqvMQ8$">
-    <property role="3GE5qa" value="keyedMapping" />
-    <property role="TrG5h" value="LanguageKeyedMapping" />
+    <property role="3GE5qa" value="staple" />
+    <property role="TrG5h" value="LanguageStaple" />
     <node concept="312cEg" id="7OJcYqvNQAN" role="jymVt">
       <property role="TrG5h" value="slangId" />
       <property role="3TUv4t" value="true" />
@@ -10599,7 +10663,7 @@
       <node concept="3Tm1VV" id="7OJcYqvMRo5" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqvMRo6" role="3clF47">
         <node concept="XkiVB" id="7OJcYqxRfZi" role="3cqZAp">
-          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedStaple" />
           <node concept="37vLTw" id="7OJcYqxRgaQ" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqxRdhz" resolve="lc" />
           </node>
@@ -10719,7 +10783,7 @@
       <node concept="3Tm1VV" id="7OJcYqwqm3X" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwqm3Y" role="3clF47">
         <node concept="1VxSAg" id="7OJcYqwqqWB" role="3cqZAp">
-          <ref role="37wK5l" node="7OJcYqvMRo3" resolve="LanguageKeyedMapping" />
+          <ref role="37wK5l" node="7OJcYqvMRo3" resolve="LanguageStaple" />
           <node concept="10Nm6u" id="7OJcYqxRofy" role="37wK5m" />
           <node concept="37vLTw" id="7OJcYqwqr1O" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqwqm4H" resolve="slang" />
@@ -10819,7 +10883,7 @@
       </node>
     </node>
     <node concept="3uibUv" id="7OJcYqxR8Gt" role="1zkMxy">
-      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
       <node concept="3Tqbb2" id="7OJcYqxRaqI" role="11_B2D">
         <ref role="ehGHo" to="h3y3:2ju2syjkngz" resolve="Language" />
       </node>
@@ -10832,11 +10896,11 @@
     </node>
   </node>
   <node concept="312cEu" id="7OJcYqvQ8aH">
-    <property role="3GE5qa" value="keyedMapping" />
-    <property role="TrG5h" value="ContainmentKeyedMapping" />
+    <property role="3GE5qa" value="staple" />
+    <property role="TrG5h" value="ContainmentStaple" />
     <node concept="3Tm1VV" id="7OJcYqvQ8aI" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqvQ8CZ" role="1zkMxy">
-      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
       <node concept="3Tqbb2" id="7OJcYqvQ91i" role="11_B2D">
         <ref role="ehGHo" to="h3y3:2ju2syjkkU6" resolve="Containment" />
       </node>
@@ -10852,7 +10916,7 @@
       <node concept="3Tm1VV" id="7OJcYqvQc4w" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqvQc4y" role="3clF47">
         <node concept="XkiVB" id="7OJcYqvQc4$" role="3cqZAp">
-          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedStaple" />
           <node concept="37vLTw" id="7OJcYqvQc4C" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqvQc4_" resolve="lc" />
           </node>
@@ -10876,14 +10940,14 @@
           </node>
           <node concept="2YIFZM" id="7OJcYqwPFPA" role="37wK5m">
             <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
-            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqwPFPB" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqvQc4_" resolve="lc" />
             </node>
           </node>
           <node concept="2YIFZM" id="7OJcYqwPG7K" role="37wK5m">
             <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
-            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqwPG7L" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqvQc4_" resolve="lc" />
             </node>
@@ -10919,7 +10983,7 @@
       </node>
     </node>
     <node concept="3uibUv" id="7OJcYqx2xSv" role="EKbjA">
-      <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
       <node concept="3Tqbb2" id="7OJcYqx2yb9" role="11_B2D">
         <ref role="ehGHo" to="h3y3:2ju2syjkkU6" resolve="Containment" />
       </node>
@@ -10932,11 +10996,11 @@
     </node>
   </node>
   <node concept="312cEu" id="7OJcYqvRt75">
-    <property role="3GE5qa" value="keyedMapping" />
-    <property role="TrG5h" value="PropertyKeyMapping" />
+    <property role="3GE5qa" value="staple" />
+    <property role="TrG5h" value="PropertyStaple" />
     <node concept="3Tm1VV" id="7OJcYqvRt76" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqvRt$z" role="1zkMxy">
-      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
       <node concept="3Tqbb2" id="7OJcYqvRtNn" role="11_B2D">
         <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
       </node>
@@ -10952,7 +11016,7 @@
       <node concept="3Tm1VV" id="7OJcYqvRxYH" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqvRxYJ" role="3clF47">
         <node concept="XkiVB" id="7OJcYqvRxYL" role="3cqZAp">
-          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedStaple" />
           <node concept="37vLTw" id="7OJcYqvRxYP" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqvRxYM" resolve="lc" />
           </node>
@@ -10976,14 +11040,14 @@
           </node>
           <node concept="2YIFZM" id="7OJcYqwPH1O" role="37wK5m">
             <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
-            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqwPH1P" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqvRxYM" resolve="lc" />
             </node>
           </node>
           <node concept="2YIFZM" id="7OJcYqwPHjY" role="37wK5m">
             <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
-            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqwPHjZ" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqvRxYM" resolve="lc" />
             </node>
@@ -11019,7 +11083,7 @@
       </node>
     </node>
     <node concept="3uibUv" id="7OJcYqx2wVp" role="EKbjA">
-      <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
       <node concept="3Tqbb2" id="7OJcYqx2xhq" role="11_B2D">
         <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
       </node>
@@ -11032,11 +11096,11 @@
     </node>
   </node>
   <node concept="312cEu" id="7OJcYqvXZ8V">
-    <property role="3GE5qa" value="keyedMapping" />
-    <property role="TrG5h" value="InterfaceKeyedMapping" />
+    <property role="3GE5qa" value="staple" />
+    <property role="TrG5h" value="InterfaceStaple" />
     <node concept="3Tm1VV" id="7OJcYqvXZ8W" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqvXZ8X" role="1zkMxy">
-      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
       <node concept="3Tqbb2" id="7OJcYqvXZ8Y" role="11_B2D">
         <ref role="ehGHo" to="h3y3:2ju2syjklHQ" resolve="Interface" />
       </node>
@@ -11052,7 +11116,7 @@
       <node concept="3Tm1VV" id="7OJcYqvXZ93" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqvXZ94" role="3clF47">
         <node concept="XkiVB" id="7OJcYqvXZ95" role="3cqZAp">
-          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedStaple" />
           <node concept="37vLTw" id="7OJcYqvXZ96" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqvXZ9h" resolve="lc" />
           </node>
@@ -11076,14 +11140,14 @@
           </node>
           <node concept="2YIFZM" id="7OJcYqwPrVx" role="37wK5m">
             <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqvXZ9e" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqvXZ9h" resolve="lc" />
             </node>
           </node>
           <node concept="2YIFZM" id="7OJcYqwPrVy" role="37wK5m">
             <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqvXZ9g" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqvXZ9h" resolve="lc" />
             </node>
@@ -11175,7 +11239,7 @@
       </node>
     </node>
     <node concept="3uibUv" id="7OJcYqwYBUK" role="EKbjA">
-      <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierStaple" />
       <node concept="3Tqbb2" id="7OJcYqx9Y_w" role="11_B2D">
         <ref role="ehGHo" to="h3y3:2ju2syjklHQ" resolve="Interface" />
       </node>
@@ -11188,11 +11252,11 @@
     </node>
   </node>
   <node concept="312cEu" id="7OJcYqw2ryQ">
-    <property role="3GE5qa" value="keyedMapping" />
-    <property role="TrG5h" value="ConstrainedPrimitiveTypeKeyedMapping" />
+    <property role="3GE5qa" value="staple" />
+    <property role="TrG5h" value="ConstrainedPrimitiveTypeStaple" />
     <node concept="3Tm1VV" id="7OJcYqw2ryR" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqw2ryS" role="1zkMxy">
-      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
       <node concept="3Tqbb2" id="7OJcYqw2ryT" role="11_B2D">
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
       </node>
@@ -11208,7 +11272,7 @@
       <node concept="3Tm1VV" id="7OJcYqw2ryY" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqw2ryZ" role="3clF47">
         <node concept="XkiVB" id="7OJcYqw2rz0" role="3cqZAp">
-          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedStaple" />
           <node concept="37vLTw" id="7OJcYqw2rz1" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqw2rzc" resolve="lc" />
           </node>
@@ -11232,14 +11296,14 @@
           </node>
           <node concept="2YIFZM" id="7OJcYqwPrVz" role="37wK5m">
             <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqw2rz9" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqw2rzc" resolve="lc" />
             </node>
           </node>
           <node concept="2YIFZM" id="7OJcYqwPrV$" role="37wK5m">
             <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqw2rzb" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqw2rzc" resolve="lc" />
             </node>
@@ -11331,18 +11395,18 @@
       </node>
     </node>
     <node concept="3uibUv" id="7OJcYqx0o5m" role="EKbjA">
-      <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
       <node concept="3Tqbb2" id="7OJcYqx0pzC" role="11_B2D">
         <ref role="ehGHo" to="tpce:fKAz7CR" resolve="ConstrainedDataTypeDeclaration" />
       </node>
     </node>
   </node>
   <node concept="312cEu" id="7OJcYqwnwCi">
-    <property role="3GE5qa" value="keyedMapping" />
-    <property role="TrG5h" value="AnnotationPropertyKeyedMapping" />
+    <property role="3GE5qa" value="staple" />
+    <property role="TrG5h" value="AnnotationPropertyStaple" />
     <node concept="3Tm1VV" id="7OJcYqwnwCj" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqwnwCk" role="1zkMxy">
-      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
       <node concept="3Tqbb2" id="7OJcYqx_Hfc" role="11_B2D">
         <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
       </node>
@@ -11372,7 +11436,7 @@
       <node concept="3Tm1VV" id="7OJcYqwnwCq" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwnwCr" role="3clF47">
         <node concept="XkiVB" id="7OJcYqwnwCs" role="3cqZAp">
-          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedStaple" />
           <node concept="37vLTw" id="7OJcYqwnwCt" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqwp9Gu" resolve="lcProp" />
           </node>
@@ -11396,14 +11460,14 @@
           </node>
           <node concept="2YIFZM" id="7OJcYqwPrV_" role="37wK5m">
             <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqwnwC_" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqwp9Gu" resolve="lcProp" />
             </node>
           </node>
           <node concept="2YIFZM" id="7OJcYqwPrVA" role="37wK5m">
             <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqwnwCB" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqwp9Gu" resolve="lcProp" />
             </node>
@@ -11432,7 +11496,7 @@
             </node>
             <node concept="2YIFZM" id="7OJcYqwPrVB" role="37vLTx">
               <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-              <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+              <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
               <node concept="37vLTw" id="7OJcYqwypS9" role="37wK5m">
                 <ref role="3cqZAo" node="7OJcYqwnwCC" resolve="lcAnnotation" />
               </node>
@@ -11572,7 +11636,7 @@
       </node>
     </node>
     <node concept="3uibUv" id="7OJcYqx_G_k" role="EKbjA">
-      <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
       <node concept="3Tqbb2" id="7OJcYqx_HDU" role="11_B2D">
         <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
       </node>
@@ -11585,11 +11649,11 @@
     </node>
   </node>
   <node concept="312cEu" id="7OJcYqwqLm4">
-    <property role="3GE5qa" value="keyedMapping" />
-    <property role="TrG5h" value="AnnotationConceptKeyedMapping" />
+    <property role="3GE5qa" value="staple" />
+    <property role="TrG5h" value="AnnotationConceptStaple" />
     <node concept="3Tm1VV" id="7OJcYqwqLm5" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqwqLm6" role="1zkMxy">
-      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
       <node concept="3Tqbb2" id="7OJcYqwqLm7" role="11_B2D">
         <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
       </node>
@@ -11605,7 +11669,7 @@
       <node concept="3Tm1VV" id="7OJcYqwqLmf" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwqLmg" role="3clF47">
         <node concept="XkiVB" id="7OJcYqwqLmh" role="3cqZAp">
-          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedStaple" />
           <node concept="37vLTw" id="7OJcYqwqLmi" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqwqLmz" resolve="lc" />
           </node>
@@ -11629,14 +11693,14 @@
           </node>
           <node concept="2YIFZM" id="7OJcYqwPrVC" role="37wK5m">
             <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqwqLmq" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqwqLmz" resolve="lc" />
             </node>
           </node>
           <node concept="2YIFZM" id="7OJcYqwPrVD" role="37wK5m">
             <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqwqLms" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqwqLmz" resolve="lc" />
             </node>
@@ -11727,13 +11791,25 @@
         </node>
       </node>
     </node>
+    <node concept="3uibUv" id="7OJcYq$p3ep" role="EKbjA">
+      <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierStaple" />
+      <node concept="3Tqbb2" id="7OJcYq$p4tN" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
+      </node>
+      <node concept="3Tqbb2" id="7OJcYq$p5Ew" role="11_B2D">
+        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+      </node>
+      <node concept="3uibUv" id="7OJcYq$p6TT" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+    </node>
   </node>
   <node concept="3HP615" id="7OJcYqwYeSL">
-    <property role="3GE5qa" value="keyedMapping" />
-    <property role="TrG5h" value="IClassifierKeyedMapping" />
+    <property role="3GE5qa" value="staple" />
+    <property role="TrG5h" value="IClassifierStaple" />
     <node concept="3Tm1VV" id="7OJcYqwYeSM" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqwYfpt" role="3HQHJm">
-      <ref role="3uigEE" node="7OJcYqvKf0O" resolve="IKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqvKf0O" resolve="IKeyedStaple" />
       <node concept="16syzq" id="7OJcYqwYksP" role="11_B2D">
         <ref role="16sUi3" node="7OJcYqwYfRg" resolve="LC" />
       </node>
@@ -11764,11 +11840,11 @@
     </node>
   </node>
   <node concept="3HP615" id="7OJcYqx0lp$">
-    <property role="3GE5qa" value="keyedMapping" />
-    <property role="TrG5h" value="IPrimitiveTypeKeyedMapping" />
+    <property role="3GE5qa" value="staple" />
+    <property role="TrG5h" value="IPrimitiveTypeStaple" />
     <node concept="3Tm1VV" id="7OJcYqx0lp_" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqx0lUM" role="3HQHJm">
-      <ref role="3uigEE" node="7OJcYqvKf0O" resolve="IKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqvKf0O" resolve="IKeyedStaple" />
       <node concept="3Tqbb2" id="7OJcYqx0muw" role="11_B2D">
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
       </node>
@@ -11787,11 +11863,11 @@
     </node>
   </node>
   <node concept="3HP615" id="7OJcYqx2vhv">
-    <property role="3GE5qa" value="keyedMapping" />
-    <property role="TrG5h" value="IFeatureKeyedMapping" />
+    <property role="3GE5qa" value="staple" />
+    <property role="TrG5h" value="IFeatureStaple" />
     <node concept="3Tm1VV" id="7OJcYqx2vhw" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqx2vQ1" role="3HQHJm">
-      <ref role="3uigEE" node="7OJcYqvKf0O" resolve="IKeyedMapping" />
+      <ref role="3uigEE" node="7OJcYqvKf0O" resolve="IKeyedStaple" />
       <node concept="16syzq" id="7OJcYqx2wuc" role="11_B2D">
         <ref role="16sUi3" node="7OJcYqx2wsI" resolve="LC" />
       </node>

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -1423,7 +1423,7 @@
               <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
             </node>
             <node concept="liA8E" id="7OJcYqwxOfe" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwOF7L" resolve="getLc" />
+              <ref role="37wK5l" node="7OJcYqwpe0k" resolve="getLcAnnotation" />
             </node>
           </node>
         </node>
@@ -1480,7 +1480,7 @@
               <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
             </node>
             <node concept="liA8E" id="7OJcYqwy6Jg" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwOF81" resolve="getLcKey" />
+              <ref role="37wK5l" node="7OJcYqwysbK" resolve="getLcAnnotationKey" />
             </node>
           </node>
         </node>
@@ -1515,7 +1515,7 @@
               <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
             </node>
             <node concept="liA8E" id="7OJcYqwyhwy" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwpe0k" resolve="getLcProp" />
+              <ref role="37wK5l" node="7OJcYqwOF7L" resolve="getLc" />
             </node>
           </node>
         </node>
@@ -1534,7 +1534,7 @@
               <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
             </node>
             <node concept="liA8E" id="7OJcYqwyzPh" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwysbK" resolve="getLcPropKey" />
+              <ref role="37wK5l" node="7OJcYqwOF81" resolve="getLcKey" />
             </node>
           </node>
         </node>
@@ -1553,7 +1553,7 @@
               <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
             </node>
             <node concept="liA8E" id="7OJcYqwyFja" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwOF7L" resolve="getLc" />
+              <ref role="37wK5l" node="7OJcYqwpe0k" resolve="getLcAnnotation" />
             </node>
           </node>
         </node>
@@ -1610,7 +1610,7 @@
               <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
             </node>
             <node concept="liA8E" id="7OJcYqwyRux" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwOF81" resolve="getLcKey" />
+              <ref role="37wK5l" node="7OJcYqwysbK" resolve="getLcAnnotationKey" />
             </node>
           </node>
         </node>
@@ -1645,7 +1645,7 @@
               <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
             </node>
             <node concept="liA8E" id="7OJcYqwz1K8" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwpe0k" resolve="getLcProp" />
+              <ref role="37wK5l" node="7OJcYqwOF7L" resolve="getLc" />
             </node>
           </node>
         </node>
@@ -1664,7 +1664,7 @@
               <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
             </node>
             <node concept="liA8E" id="7OJcYqwz6oA" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwysbK" resolve="getLcPropKey" />
+              <ref role="37wK5l" node="7OJcYqwOF81" resolve="getLcKey" />
             </node>
           </node>
         </node>
@@ -2097,7 +2097,7 @@
               <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
             </node>
             <node concept="liA8E" id="7OJcYqw_ymv" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwOF7L" resolve="getLc" />
+              <ref role="37wK5l" node="7OJcYqwpe0k" resolve="getLcAnnotation" />
             </node>
           </node>
         </node>
@@ -2168,6 +2168,39 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskix66D" role="jymVt" />
+    <node concept="2tJIrI" id="7OJcYqx_9nN" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqx_dgL" role="jymVt">
+      <property role="TrG5h" value="listMpsInternalFeature" />
+      <node concept="3Tm1VV" id="7OJcYqx_dgM" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqx_dgN" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqx_dgO" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx_dgV" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqx_dgW" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqx_f5m" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqx_f5g" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqx_h8A" role="2ShVmc">
+              <node concept="3uibUv" id="7OJcYqx_ldi" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx_rFe" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwir$6" resolve="getAnnotationContainment" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx_xz2" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx_C8l" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiski$2VO" role="jymVt">
       <property role="TrG5h" value="listMpsInternalFeatures" />
       <node concept="3Tmbuc" id="5JNiski$2VU" role="1B3o_S" />
@@ -2321,6 +2354,50 @@
     </node>
     <node concept="2tJIrI" id="7weWCFlmZps" role="jymVt" />
     <node concept="2tJIrI" id="5M8g5cSYLiu" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqx$xY7" role="jymVt">
+      <property role="TrG5h" value="listLcLanguages" />
+      <node concept="3Tm1VV" id="7OJcYqx$xY8" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqx$xY9" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqx$xYa" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx$xYi" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqx$xYj" role="3clF47">
+        <node concept="3cpWs8" id="7OJcYqx$Hf7" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqx$Hf8" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="_YKpA" id="7OJcYqx$z_H" role="1tU5fm">
+              <node concept="3uibUv" id="7OJcYqx$z_K" role="_ZDj9">
+                <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+              </node>
+            </node>
+            <node concept="3nyPlj" id="7OJcYqx$Hf9" role="33vP2m">
+              <ref role="37wK5l" node="7OJcYqwXqX5" resolve="listLcLanguages" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqx$QyW" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqx$U9Q" role="3clFbG">
+            <node concept="37vLTw" id="7OJcYqx$QyU" role="2Oq$k0">
+              <ref role="3cqZAo" node="7OJcYqx$Hf8" resolve="result" />
+            </node>
+            <node concept="TSZUe" id="7OJcYqx$Xam" role="2OqNvi">
+              <node concept="1rXfSq" id="7OJcYqx_0hU" role="25WWJ7">
+                <ref role="37wK5l" node="7OJcYqwv4t2" resolve="getStructureLanguage" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqx$xYl" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqx$Hfa" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqx$Hf8" resolve="result" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="3clFb_" id="5M8g5cSYOn5" role="jymVt">
       <property role="TrG5h" value="listSLanguages" />
       <node concept="3Tm1VV" id="5M8g5cSYOnd" role="1B3o_S" />
@@ -2486,6 +2563,47 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7weWCFln0QZ" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxzJ_1" role="jymVt">
+      <property role="TrG5h" value="listMpsInternalClassifier" />
+      <node concept="3Tm1VV" id="7OJcYqxzJ_2" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqxzJ_3" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqxzJ_4" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxzJ_c" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqxzJ_d" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqxzQG9" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqxzQG3" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqxzTks" role="2ShVmc">
+              <node concept="3uibUv" id="7OJcYqxzYG0" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx$4zE" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx$8Pa" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwirzY" resolve="getAnnotation" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx$dSX" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwv4ta" resolve="getClassifier" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx$jLY" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwv4ti" resolve="getConcept" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx$piX" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwv4tq" resolve="getInterface" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx$uEK" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwir$e" resolve="getINamed" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="3clFb_" id="7weWCFln2o1" role="jymVt">
       <property role="TrG5h" value="listMpsInternalClassifiers" />
       <node concept="3Tm1VV" id="7weWCFlqObT" role="1B3o_S" />
@@ -7270,7 +7388,7 @@
       <node concept="P$JXv" id="7OJcYqxpSwt" role="lGtFl">
         <node concept="TZ5HA" id="7OJcYqxqloi" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqxqloj" role="1dT_Ay">
-            <property role="1dT_AB" value="lc: io.lionweb.mps.specific.lang.MPS-specific annotations.VirtualPackage" />
+            <property role="1dT_AB" value="lc: io.lionweb.mps.m3.builtin.Built-in DataTypes.INamed.name" />
           </node>
         </node>
         <node concept="TZ5HA" id="7OJcYqxqlok" role="TZ5H$">
@@ -7301,7 +7419,7 @@
         </node>
         <node concept="TZ5HA" id="7OJcYqxqloo" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqxqlop" role="1dT_Ay">
-            <property role="1dT_AB" value="lcKey: VirtualPackage" />
+            <property role="1dT_AB" value="lcKey: LionCore-builtins-INamed-name" />
           </node>
         </node>
         <node concept="TZ5HA" id="7OJcYqxqloq" role="TZ5H$">
@@ -7311,12 +7429,12 @@
         </node>
         <node concept="TZ5HA" id="7OJcYqxqlos" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqxqlot" role="1dT_Ay">
-            <property role="1dT_AB" value="lcProp: io.lionweb.mps.m3.builtin.Built-in DataTypes.INamed.name" />
+            <property role="1dT_AB" value="lcAnnotation: io.lionweb.mps.specific.lang.MPS-specific annotations.VirtualPackage" />
           </node>
         </node>
         <node concept="TZ5HA" id="7OJcYqxqlou" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqxqlov" role="1dT_Ay">
-            <property role="1dT_AB" value="lcPropKey: LionCore-builtins-INamed-name" />
+            <property role="1dT_AB" value="lcAnnotationKey: VirtualPackage" />
           </node>
         </node>
       </node>
@@ -7439,7 +7557,7 @@
       <node concept="P$JXv" id="7OJcYqxpTFc" role="lGtFl">
         <node concept="TZ5HA" id="7OJcYqxqibc" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqxqibd" role="1dT_Ay">
-            <property role="1dT_AB" value="lc: io.lionweb.mps.specific.lang.MPS-specific annotations.ShortDescription" />
+            <property role="1dT_AB" value="lc: io.lionweb.mps.specific.lang.MPS-specific annotations.ShortDescription.description" />
           </node>
         </node>
         <node concept="TZ5HA" id="7OJcYqxqibe" role="TZ5H$">
@@ -7470,7 +7588,7 @@
         </node>
         <node concept="TZ5HA" id="7OJcYqxqibi" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqxqibj" role="1dT_Ay">
-            <property role="1dT_AB" value="lcKey: ShortDescription" />
+            <property role="1dT_AB" value="lcKey: ShortDescription-description" />
           </node>
         </node>
         <node concept="TZ5HA" id="7OJcYqxqibk" role="TZ5H$">
@@ -7480,12 +7598,12 @@
         </node>
         <node concept="TZ5HA" id="7OJcYqxqlbo" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqxqlbp" role="1dT_Ay">
-            <property role="1dT_AB" value="lcProp: io.lionweb.mps.specific.lang.MPS-specific annotations.ShortDescription.description" />
+            <property role="1dT_AB" value="lcAnnotation: io.lionweb.mps.specific.lang.MPS-specific annotations.ShortDescription" />
           </node>
         </node>
         <node concept="TZ5HA" id="7OJcYqxqlhO" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqxqlhP" role="1dT_Ay">
-            <property role="1dT_AB" value="lcPropKey: ShortDescription-description" />
+            <property role="1dT_AB" value="lcAnnotationKey: ShortDescription" />
           </node>
         </node>
       </node>
@@ -12012,6 +12130,14 @@
       <node concept="3Tqbb2" id="5JNiski3jVl" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
       </node>
+      <node concept="P$JXv" id="7OJcYqxEQZu" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxEQZv" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxEQZw" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxEQZx" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVm" role="jymVt">
       <property role="TrG5h" value="mpsStringType" />
@@ -12019,6 +12145,14 @@
       <node concept="3Tm1VV" id="5JNiski3jVo" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiski3jVp" role="3clF45">
         <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqxERxj" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxERxk" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxERxl" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxERxm" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVq" role="jymVt">
@@ -12028,18 +12162,42 @@
       <node concept="3uibUv" id="5JNiski3jVt" role="3clF45">
         <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
       </node>
+      <node concept="P$JXv" id="7OJcYqxES3o" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxES3p" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxES3q" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxES3r" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVu" role="jymVt">
       <property role="TrG5h" value="keyStringType" />
       <node concept="3clFbS" id="5JNiski3jVv" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jVw" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jVx" role="3clF45" />
+      <node concept="P$JXv" id="7OJcYqxES_H" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxES_I" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxES_J" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxES_K" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVy" role="jymVt">
       <property role="TrG5h" value="idStringType" />
       <node concept="3clFbS" id="5JNiski3jVz" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jV$" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jV_" role="3clF45" />
+      <node concept="P$JXv" id="7OJcYqxET8i" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxET8j" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxET8k" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxET8l" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jVA" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwQm1t" role="jymVt">
@@ -16070,8 +16228,8 @@
     <node concept="3Tm1VV" id="7OJcYqwnwCj" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqwnwCk" role="1zkMxy">
       <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
-      <node concept="3Tqbb2" id="7OJcYqwnwCl" role="11_B2D">
-        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
+      <node concept="3Tqbb2" id="7OJcYqx_Hfc" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
       </node>
       <node concept="3Tqbb2" id="7OJcYqwnwCm" role="11_B2D">
         <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
@@ -16081,15 +16239,15 @@
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqwpbTN" role="jymVt">
-      <property role="TrG5h" value="lcProp" />
+      <property role="TrG5h" value="lcAnnotation" />
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqwpbTO" role="1B3o_S" />
       <node concept="3Tqbb2" id="7OJcYqwpbTQ" role="1tU5fm">
-        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqwyo$l" role="jymVt">
-      <property role="TrG5h" value="lcPropKey" />
+      <property role="TrG5h" value="lcAnnotationKey" />
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqwyoo7" role="1B3o_S" />
       <node concept="17QB3L" id="7OJcYqwyo$5" role="1tU5fm" />
@@ -16101,7 +16259,7 @@
         <node concept="XkiVB" id="7OJcYqwnwCs" role="3cqZAp">
           <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
           <node concept="37vLTw" id="7OJcYqwnwCt" role="37wK5m">
-            <ref role="3cqZAo" node="7OJcYqwnwCC" resolve="lc" />
+            <ref role="3cqZAo" node="7OJcYqwp9Gu" resolve="lcProp" />
           </node>
           <node concept="37vLTw" id="7OJcYqwnwCu" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqwnwCE" resolve="mpsProp" />
@@ -16125,14 +16283,14 @@
             <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
             <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
             <node concept="37vLTw" id="7OJcYqwnwC_" role="37wK5m">
-              <ref role="3cqZAo" node="7OJcYqwnwCC" resolve="lc" />
+              <ref role="3cqZAo" node="7OJcYqwp9Gu" resolve="lcProp" />
             </node>
           </node>
           <node concept="2YIFZM" id="7OJcYqwPrVA" role="37wK5m">
             <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
             <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
             <node concept="37vLTw" id="7OJcYqwnwCB" role="37wK5m">
-              <ref role="3cqZAo" node="7OJcYqwnwCC" resolve="lc" />
+              <ref role="3cqZAo" node="7OJcYqwp9Gu" resolve="lcProp" />
             </node>
           </node>
         </node>
@@ -16141,11 +16299,11 @@
             <node concept="2OqwBi" id="7OJcYqwpdj3" role="37vLTJ">
               <node concept="Xjq3P" id="7OJcYqwpdr4" role="2Oq$k0" />
               <node concept="2OwXpG" id="7OJcYqwpdj6" role="2OqNvi">
-                <ref role="2Oxat5" node="7OJcYqwpbTN" resolve="lcProp" />
+                <ref role="2Oxat5" node="7OJcYqwpbTN" resolve="lcAnnotation" />
               </node>
             </node>
             <node concept="37vLTw" id="7OJcYqwpbTX" role="37vLTx">
-              <ref role="3cqZAo" node="7OJcYqwp9Gu" resolve="lcProp" />
+              <ref role="3cqZAo" node="7OJcYqwnwCC" resolve="lcAnnotation" />
             </node>
           </node>
         </node>
@@ -16154,21 +16312,21 @@
             <node concept="2OqwBi" id="7OJcYqwypaz" role="37vLTJ">
               <node concept="Xjq3P" id="7OJcYqwyoMR" role="2Oq$k0" />
               <node concept="2OwXpG" id="7OJcYqwypeV" role="2OqNvi">
-                <ref role="2Oxat5" node="7OJcYqwyo$l" resolve="lcPropKey" />
+                <ref role="2Oxat5" node="7OJcYqwyo$l" resolve="lcAnnotationKey" />
               </node>
             </node>
             <node concept="2YIFZM" id="7OJcYqwPrVB" role="37vLTx">
               <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
               <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
               <node concept="37vLTw" id="7OJcYqwypS9" role="37wK5m">
-                <ref role="3cqZAo" node="7OJcYqwp9Gu" resolve="lcProp" />
+                <ref role="3cqZAo" node="7OJcYqwnwCC" resolve="lcAnnotation" />
               </node>
             </node>
           </node>
         </node>
       </node>
       <node concept="37vLTG" id="7OJcYqwnwCC" role="3clF46">
-        <property role="TrG5h" value="lc" />
+        <property role="TrG5h" value="lcAnnotation" />
         <node concept="3Tqbb2" id="7OJcYqwnwCD" role="1tU5fm">
           <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
         </node>
@@ -16208,7 +16366,7 @@
       <property role="TrG5h" value="getLc" />
       <node concept="3Tm1VV" id="7OJcYqwOF7M" role="1B3o_S" />
       <node concept="3Tqbb2" id="7OJcYqwOF7N" role="3clF45">
-        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
+        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
       </node>
       <node concept="2AHcQZ" id="7OJcYqwOF7O" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
@@ -16261,9 +16419,9 @@
       </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwpe0k" role="jymVt">
-      <property role="TrG5h" value="getLcProp" />
+      <property role="TrG5h" value="getLcAnnotation" />
       <node concept="3Tqbb2" id="7OJcYqwpe0l" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwpe0m" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwpe0n" role="3clF47">
@@ -16271,7 +16429,7 @@
           <node concept="2OqwBi" id="7OJcYqwpe0h" role="3clFbG">
             <node concept="Xjq3P" id="7OJcYqwpe0i" role="2Oq$k0" />
             <node concept="2OwXpG" id="7OJcYqwpe0j" role="2OqNvi">
-              <ref role="2Oxat5" node="7OJcYqwpbTN" resolve="lcProp" />
+              <ref role="2Oxat5" node="7OJcYqwpbTN" resolve="lcAnnotation" />
             </node>
           </node>
         </node>
@@ -16281,7 +16439,7 @@
       </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwysbK" role="jymVt">
-      <property role="TrG5h" value="getLcPropKey" />
+      <property role="TrG5h" value="getLcAnnotationKey" />
       <node concept="17QB3L" id="7OJcYqwysbL" role="3clF45" />
       <node concept="3Tm1VV" id="7OJcYqwysbM" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwysbN" role="3clF47">
@@ -16289,13 +16447,25 @@
           <node concept="2OqwBi" id="7OJcYqwysbH" role="3clFbG">
             <node concept="Xjq3P" id="7OJcYqwysbI" role="2Oq$k0" />
             <node concept="2OwXpG" id="7OJcYqwysbJ" role="2OqNvi">
-              <ref role="2Oxat5" node="7OJcYqwyo$l" resolve="lcPropKey" />
+              <ref role="2Oxat5" node="7OJcYqwyo$l" resolve="lcAnnotationKey" />
             </node>
           </node>
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqwOMGE" role="2AJF6D">
         <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+    <node concept="3uibUv" id="7OJcYqx_G_k" role="EKbjA">
+      <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqx_HDU" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+      </node>
+      <node concept="3Tqbb2" id="7OJcYqx_HDV" role="11_B2D">
+        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+      </node>
+      <node concept="3uibUv" id="7OJcYqx_HDW" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
       </node>
     </node>
   </node>

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -36,6 +36,7 @@
     <import index="4xw4" ref="r:23ccdcd2-ac4f-4247-aad5-4d197fcb7e18(io.lionweb.mps.specific.lang)" />
     <import index="i2js" ref="r:8a5810a5-6291-48f8-84a1-e0b9d037018c(io.lionweb.mps.m3.core)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
+    <import index="6peh" ref="r:677983a1-6578-432d-8175-68c906e0375c(io.lionweb.mps.json)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -235,6 +236,7 @@
         <property id="5858074156537516431" name="text" index="x79VB" />
       </concept>
       <concept id="6832197706140518104" name="jetbrains.mps.baseLanguage.javadoc.structure.DocMethodParameterReference" flags="ng" index="zr_55" />
+      <concept id="6832197706140518107" name="jetbrains.mps.baseLanguage.javadoc.structure.DocTypeParameterReference" flags="ng" index="zr_56" />
       <concept id="6832197706140518103" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseParameterReference" flags="ng" index="zr_5a">
         <reference id="6832197706140518108" name="param" index="zr_51" />
       </concept>
@@ -249,6 +251,9 @@
       </concept>
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="2217234381367190443" name="jetbrains.mps.baseLanguage.javadoc.structure.SeeBlockDocTag" flags="ng" index="VUp57">
+        <child id="2217234381367190458" name="reference" index="VUp5m" />
       </concept>
       <concept id="2217234381367188008" name="jetbrains.mps.baseLanguage.javadoc.structure.FieldDocReference" flags="ng" index="VUqz4" />
       <concept id="2217234381367049075" name="jetbrains.mps.baseLanguage.javadoc.structure.CodeInlineDocTag" flags="ng" index="VVOAv">
@@ -9375,6 +9380,10 @@
   <node concept="3HP615" id="7OJcYqvKf0O">
     <property role="TrG5h" value="IKeyedStaple" />
     <property role="3GE5qa" value="staple" />
+    <node concept="15s5l7" id="alE3w2lAUd" role="lGtFl">
+      <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;reference scopes (reference scopes)&quot;;FLAVOUR_MESSAGE=&quot;The reference  JsonStaple (classifier) is out of search scope&quot;;FLAVOUR_NODE_FEATURE=&quot;classifier&quot;;FLAVOUR_RULE_ID=&quot;[r:28bcf003-0004-46b6-9fe7-2093e7fb1368(jetbrains.mps.baseLanguage.javadoc.constraints)/6836281137582713718]&quot;;" />
+      <property role="huDt6" value="The reference  JsonStaple (classifier) is out of search scope" />
+    </node>
     <node concept="3clFb_" id="7OJcYqvKhKf" role="jymVt">
       <property role="TrG5h" value="getLc" />
       <node concept="3clFbS" id="7OJcYqvKhKi" role="3clF47" />
@@ -9460,11 +9469,55 @@
     <node concept="16euLQ" id="7OJcYqvKhss" role="16eVyc">
       <property role="TrG5h" value="SLANG" />
     </node>
+    <node concept="3UR2Jj" id="alE3w2ldo0" role="lGtFl">
+      <node concept="TZ5HA" id="alE3w2ldo1" role="TZ5H$">
+        <node concept="1dT_AC" id="alE3w2ldo2" role="1dT_Ay">
+          <property role="1dT_AB" value="Staples[1] together representations of the same thing in different representations." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="alE3w2ldq1" role="TZ5H$">
+        <node concept="1dT_AC" id="alE3w2ldq2" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="alE3w2ldMn" role="TZ5H$">
+        <node concept="1dT_AC" id="alE3w2ldMo" role="1dT_Ay">
+          <property role="1dT_AB" value="[1] &quot;Staples&quot; as in a stapler holding together a stack of paper." />
+        </node>
+      </node>
+      <node concept="TUZQ0" id="alE3w2ldo3" role="3nqlJM">
+        <property role="TUZQ4" value="LionCore as instances of &lt;tt&gt;io.lionweb.mps.m3&lt;/tt&gt;" />
+        <node concept="zr_56" id="alE3w2ldo5" role="zr_5Q">
+          <ref role="zr_51" node="7OJcYqvKf2B" resolve="LC" />
+        </node>
+      </node>
+      <node concept="TUZQ0" id="alE3w2ldo6" role="3nqlJM">
+        <property role="TUZQ4" value="MPS as instances of &lt;tt&gt;jetbrains.mps.lang.structure&lt;/tt&gt;" />
+        <node concept="zr_56" id="alE3w2ldo8" role="zr_5Q">
+          <ref role="zr_51" node="7OJcYqvKgVK" resolve="MPS" />
+        </node>
+      </node>
+      <node concept="TUZQ0" id="alE3w2ldo9" role="3nqlJM">
+        <property role="TUZQ4" value="SLanguage as instances of &lt;tt&gt;org.jetbrains.mps.openapi.language&lt;/tt&gt;" />
+        <node concept="zr_56" id="alE3w2ldob" role="zr_5Q">
+          <ref role="zr_51" node="7OJcYqvKhss" resolve="SLANG" />
+        </node>
+      </node>
+      <node concept="VUp57" id="alE3w2lfs$" role="3nqlJM">
+        <node concept="VXe08" id="alE3w2lgP0" role="VUp5m">
+          <ref role="VXe09" to="6peh:7OJcYqxTPY1" resolve="JsonStaple" />
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="312cEu" id="7OJcYqvKk3R">
     <property role="3GE5qa" value="staple" />
     <property role="TrG5h" value="AKeyedStaple" />
     <property role="1sVAO0" value="true" />
+    <node concept="15s5l7" id="alE3w2lAnA" role="lGtFl">
+      <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: The type (instance of TypeVariableReference) is not a valid substitute for the bounded parameter LC&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6871159928248660343]&quot;;" />
+      <property role="huDt6" value="Error: The type (instance of TypeVariableReference) is not a valid substitute for the bounded parameter LC" />
+    </node>
     <node concept="3Tm1VV" id="7OJcYqvKk3S" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqvKk$F" role="EKbjA">
       <ref role="3uigEE" node="7OJcYqvKf0O" resolve="IKeyedStaple" />
@@ -11567,6 +11620,10 @@
   <node concept="3HP615" id="7OJcYqwYeSL">
     <property role="3GE5qa" value="staple" />
     <property role="TrG5h" value="IClassifierStaple" />
+    <node concept="15s5l7" id="alE3w2lAJH" role="lGtFl">
+      <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: The type (instance of TypeVariableReference) is not a valid substitute for the bounded parameter LC&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6871159928248660343]&quot;;" />
+      <property role="huDt6" value="Error: The type (instance of TypeVariableReference) is not a valid substitute for the bounded parameter LC" />
+    </node>
     <node concept="3Tm1VV" id="7OJcYqwYeSM" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqwYfpt" role="3HQHJm">
       <ref role="3uigEE" node="7OJcYqvKf0O" resolve="IKeyedStaple" />
@@ -11602,6 +11659,10 @@
   <node concept="3HP615" id="7OJcYqx0lp$">
     <property role="3GE5qa" value="staple" />
     <property role="TrG5h" value="IPrimitiveTypeStaple" />
+    <node concept="15s5l7" id="alE3w2lAZ2" role="lGtFl">
+      <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: The type (instance of TypeVariableReference) is not a valid substitute for the bounded parameter MPS&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6871159928248660343]&quot;;" />
+      <property role="huDt6" value="Error: The type (instance of TypeVariableReference) is not a valid substitute for the bounded parameter MPS" />
+    </node>
     <node concept="3clFb_" id="7OJcYq_mkbH" role="jymVt">
       <property role="TrG5h" value="getMpsPropId" />
       <node concept="3clFbS" id="7OJcYq_mkbK" role="3clF47" />
@@ -11631,6 +11692,10 @@
   <node concept="3HP615" id="7OJcYqx2vhv">
     <property role="3GE5qa" value="staple" />
     <property role="TrG5h" value="IFeatureStaple" />
+    <node concept="15s5l7" id="alE3w2lAL3" role="lGtFl">
+      <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: The type (instance of TypeVariableReference) is not a valid substitute for the bounded parameter LC&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6871159928248660343]&quot;;" />
+      <property role="huDt6" value="Error: The type (instance of TypeVariableReference) is not a valid substitute for the bounded parameter LC" />
+    </node>
     <node concept="3Tm1VV" id="7OJcYqx2vhw" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqx2vQ1" role="3HQHJm">
       <ref role="3uigEE" node="7OJcYqvKf0O" resolve="IKeyedStaple" />

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -44,14 +44,10 @@
         <child id="1224071154656" name="expression" index="0kSFX" />
       </concept>
       <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
-      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
-        <child id="1082485599096" name="statements" index="9aQI4" />
-      </concept>
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
-      <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
@@ -368,13 +364,6 @@
         <property id="8575328350543493365" name="message" index="huDt6" />
         <property id="2423417345669755629" name="filter" index="1eyWvh" />
       </concept>
-      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
-        <property id="709746936026609031" name="linkId" index="3V$3ak" />
-        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
-      </concept>
-      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
-        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
-      </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
       <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
@@ -409,14 +398,9 @@
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
-      <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
-      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
-        <child id="1225711182005" name="list" index="1y566C" />
-        <child id="1225711191269" name="index" index="1y58nS" />
-      </concept>
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
@@ -3006,91 +2990,6 @@
             </node>
           </node>
         </node>
-        <node concept="3SKdUt" id="3M8YG$9E2rI" role="3cqZAp">
-          <node concept="1PaTwC" id="3M8YG$9E2rJ" role="1aUNEU">
-            <node concept="3oM_SD" id="3M8YG$9E3_h" role="1PaTwD">
-              <property role="3oM_SC" value="TODO:" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E3_q" role="1PaTwD">
-              <property role="3oM_SC" value="Check" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E3_t" role="1PaTwD">
-              <property role="3oM_SC" value="if" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E3_x" role="1PaTwD">
-              <property role="3oM_SC" value="this" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E3_A" role="1PaTwD">
-              <property role="3oM_SC" value="is" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E3_G" role="1PaTwD">
-              <property role="3oM_SC" value="really" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E3_N" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E3_V" role="1PaTwD">
-              <property role="3oM_SC" value="place" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E3A4" role="1PaTwD">
-              <property role="3oM_SC" value="to" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E3Ae" role="1PaTwD">
-              <property role="3oM_SC" value="do" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E3Ap" role="1PaTwD">
-              <property role="3oM_SC" value="this" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E3A_" role="1PaTwD">
-              <property role="3oM_SC" value="mapping" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="3M8YG$9CZoS" role="3cqZAp">
-          <node concept="3cpWsn" id="3M8YG$9CZoT" role="3cpWs9">
-            <property role="TrG5h" value="coreLanguage" />
-            <node concept="17QB3L" id="3M8YG$9CXEs" role="1tU5fm" />
-            <node concept="1rXfSq" id="3M8YG$9CZoU" role="33vP2m">
-              <ref role="37wK5l" node="3M8YG$9CnuQ" resolve="mapCoreLanguageKey" />
-              <node concept="2OqwBi" id="3M8YG$9CZoV" role="37wK5m">
-                <node concept="2OqwBi" id="3M8YG$9CZoW" role="2Oq$k0">
-                  <node concept="37vLTw" id="3M8YG$9CZoX" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5AGBwuFFZd4" resolve="converter" />
-                  </node>
-                  <node concept="liA8E" id="3M8YG$9CZoY" role="2OqNvi">
-                    <ref role="37wK5l" node="39$JcGGnELF" resolve="toSLanguageId" />
-                    <node concept="37vLTw" id="3M8YG$9CZoZ" role="37wK5m">
-                      <ref role="3cqZAo" node="6fYiNFavjXc" resolve="sLanguage" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="liA8E" id="3M8YG$9CZp0" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SLanguageId.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="6Z_tmAe8zMm" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbJ" id="3M8YG$9BBYZ" role="8Wnug">
-            <node concept="3clFbS" id="3M8YG$9BBZ0" role="3clFbx">
-              <node concept="3cpWs6" id="3M8YG$9BBZ1" role="3cqZAp">
-                <node concept="37vLTw" id="3M8YG$9DjBY" role="3cqZAk">
-                  <ref role="3cqZAo" node="3M8YG$9CZoT" resolve="coreLanguage" />
-                </node>
-              </node>
-            </node>
-            <node concept="3y3z36" id="3M8YG$9DcOW" role="3clFbw">
-              <node concept="10Nm6u" id="3M8YG$9DfI4" role="3uHU7w" />
-              <node concept="37vLTw" id="3M8YG$9Dbmf" role="3uHU7B">
-                <ref role="3cqZAo" node="3M8YG$9CZoT" resolve="coreLanguage" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5AGBwuFGqaB" role="3cqZAp" />
         <node concept="3cpWs8" id="6fYiNFaHv6B" role="3cqZAp">
           <node concept="3cpWsn" id="6fYiNFaHv6C" role="3cpWs9">
             <property role="TrG5h" value="structure" />
@@ -3188,103 +3087,6 @@
         </node>
       </node>
       <node concept="3clFbS" id="5M3rB6_W0yE" role="3clF47">
-        <node concept="3cpWs8" id="4oHUzWXH90y" role="3cqZAp">
-          <node concept="3cpWsn" id="4oHUzWXH90z" role="3cpWs9">
-            <property role="TrG5h" value="converter" />
-            <node concept="3uibUv" id="4oHUzWXH90$" role="1tU5fm">
-              <ref role="3uigEE" node="39$JcGGnjRO" resolve="MpsLanguageConverter" />
-            </node>
-            <node concept="2YIFZM" id="68Be_yKnMF" role="33vP2m">
-              <ref role="37wK5l" node="39$JcGGnzni" resolve="getInstance" />
-              <ref role="1Pybhc" node="39$JcGGnjRO" resolve="MpsLanguageConverter" />
-            </node>
-          </node>
-        </node>
-        <node concept="3SKdUt" id="3M8YG$9E6ec" role="3cqZAp">
-          <node concept="1PaTwC" id="3M8YG$9E6ed" role="1aUNEU">
-            <node concept="3oM_SD" id="3M8YG$9E6ee" role="1PaTwD">
-              <property role="3oM_SC" value="TODO:" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E6ef" role="1PaTwD">
-              <property role="3oM_SC" value="Check" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E6eg" role="1PaTwD">
-              <property role="3oM_SC" value="if" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E6eh" role="1PaTwD">
-              <property role="3oM_SC" value="this" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E6ei" role="1PaTwD">
-              <property role="3oM_SC" value="is" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E6ej" role="1PaTwD">
-              <property role="3oM_SC" value="really" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E6ek" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E6el" role="1PaTwD">
-              <property role="3oM_SC" value="place" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E6em" role="1PaTwD">
-              <property role="3oM_SC" value="to" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E6en" role="1PaTwD">
-              <property role="3oM_SC" value="do" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E6eo" role="1PaTwD">
-              <property role="3oM_SC" value="this" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9E6ep" role="1PaTwD">
-              <property role="3oM_SC" value="mapping" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="3M8YG$9DkOD" role="3cqZAp">
-          <node concept="3cpWsn" id="3M8YG$9DkOE" role="3cpWs9">
-            <property role="TrG5h" value="coreLanguage" />
-            <node concept="17QB3L" id="3M8YG$9DkOF" role="1tU5fm" />
-            <node concept="1rXfSq" id="3M8YG$9DkOG" role="33vP2m">
-              <ref role="37wK5l" node="3M8YG$9CnuQ" resolve="mapCoreLanguageKey" />
-              <node concept="2OqwBi" id="3M8YG$9DkOH" role="37wK5m">
-                <node concept="2OqwBi" id="3M8YG$9DkOI" role="2Oq$k0">
-                  <node concept="37vLTw" id="3M8YG$9DkOJ" role="2Oq$k0">
-                    <ref role="3cqZAo" node="4oHUzWXH90z" resolve="converter" />
-                  </node>
-                  <node concept="liA8E" id="3M8YG$9DkOK" role="2OqNvi">
-                    <ref role="37wK5l" node="5M3rB6Alcru" resolve="toSLanguageId" />
-                    <node concept="37vLTw" id="3M8YG$9DkOL" role="37wK5m">
-                      <ref role="3cqZAo" node="5M3rB6_W0z7" resolve="structure" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="liA8E" id="3M8YG$9DkOM" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SLanguageId.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="6Z_tmAe8AmP" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbJ" id="3M8YG$9DkON" role="8Wnug">
-            <node concept="3clFbS" id="3M8YG$9DkOO" role="3clFbx">
-              <node concept="3cpWs6" id="3M8YG$9DkOP" role="3cqZAp">
-                <node concept="37vLTw" id="3M8YG$9DkOQ" role="3cqZAk">
-                  <ref role="3cqZAo" node="3M8YG$9DkOE" resolve="coreLanguage" />
-                </node>
-              </node>
-            </node>
-            <node concept="3y3z36" id="3M8YG$9DkOR" role="3clFbw">
-              <node concept="10Nm6u" id="3M8YG$9DkOS" role="3uHU7w" />
-              <node concept="37vLTw" id="3M8YG$9DkOT" role="3uHU7B">
-                <ref role="3cqZAo" node="3M8YG$9DkOE" resolve="coreLanguage" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="4oHUzWXGOeA" role="3cqZAp" />
         <node concept="3cpWs8" id="5M3rB6_W0yF" role="3cqZAp">
           <node concept="3cpWsn" id="5M3rB6_W0yG" role="3cpWs9">
             <property role="TrG5h" value="rootNodes" />
@@ -3387,90 +3189,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="3M8YG$9ChhL" role="jymVt" />
-    <node concept="3clFb_" id="3M8YG$9CnuQ" role="jymVt">
-      <property role="TrG5h" value="mapCoreLanguageKey" />
-      <node concept="3clFbS" id="3M8YG$9CnuT" role="3clF47">
-        <node concept="3cpWs8" id="7OJcYq$oexp" role="3cqZAp">
-          <node concept="3cpWsn" id="7OJcYq$oexq" role="3cpWs9">
-            <property role="TrG5h" value="staple" />
-            <node concept="3uibUv" id="7OJcYq$o1GQ" role="1tU5fm">
-              <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
-            </node>
-            <node concept="2OqwBi" id="7OJcYq$oexr" role="33vP2m">
-              <node concept="2OqwBi" id="7OJcYq$oexs" role="2Oq$k0">
-                <node concept="37vLTw" id="7OJcYq$oext" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
-                </node>
-                <node concept="liA8E" id="7OJcYq$oexu" role="2OqNvi">
-                  <ref role="37wK5l" node="7OJcYqwXhGH" resolve="listLcLanguages" />
-                </node>
-              </node>
-              <node concept="1z4cxt" id="7OJcYq$oexv" role="2OqNvi">
-                <node concept="1bVj0M" id="7OJcYq$oexw" role="23t8la">
-                  <node concept="3clFbS" id="7OJcYq$oexx" role="1bW5cS">
-                    <node concept="3clFbF" id="7OJcYq$oexy" role="3cqZAp">
-                      <node concept="17R0WA" id="7OJcYq$oexz" role="3clFbG">
-                        <node concept="37vLTw" id="7OJcYq$oex$" role="3uHU7w">
-                          <ref role="3cqZAo" node="3M8YG$9Cqto" resolve="languageId" />
-                        </node>
-                        <node concept="2OqwBi" id="7OJcYq$oex_" role="3uHU7B">
-                          <node concept="37vLTw" id="7OJcYq$oexA" role="2Oq$k0">
-                            <ref role="3cqZAo" node="7OJcYq$oexC" resolve="it" />
-                          </node>
-                          <node concept="liA8E" id="7OJcYq$oexB" role="2OqNvi">
-                            <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="Rh6nW" id="7OJcYq$oexC" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="7OJcYq$oexD" role="1tU5fm" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="7OJcYq$ok0I" role="3cqZAp">
-          <node concept="3clFbS" id="7OJcYq$ok0K" role="3clFbx">
-            <node concept="3cpWs6" id="7OJcYq$os8$" role="3cqZAp">
-              <node concept="2OqwBi" id="7OJcYqzdYsT" role="3cqZAk">
-                <node concept="37vLTw" id="7OJcYq$oexE" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7OJcYq$oexq" resolve="staple" />
-                </node>
-                <node concept="liA8E" id="7OJcYqze1Y_" role="2OqNvi">
-                  <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3y3z36" id="7OJcYq$oopA" role="3clFbw">
-            <node concept="10Nm6u" id="7OJcYq$opvL" role="3uHU7w" />
-            <node concept="37vLTw" id="7OJcYq$olwk" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYq$oexq" resolve="staple" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs6" id="7OJcYq$o_md" role="3cqZAp">
-          <node concept="10Nm6u" id="7OJcYq$o_nk" role="3cqZAk" />
-        </node>
-      </node>
-      <node concept="3Tm6S6" id="3M8YG$9CknW" role="1B3o_S" />
-      <node concept="17QB3L" id="3M8YG$9CnfR" role="3clF45" />
-      <node concept="37vLTG" id="3M8YG$9Cqto" role="3clF46">
-        <property role="TrG5h" value="languageId" />
-        <node concept="17QB3L" id="3M8YG$9Cqtn" role="1tU5fm" />
-        <node concept="2AHcQZ" id="3M8YG$9CsCI" role="2AJF6D">
-          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="3M8YG$9CtdC" role="2AJF6D">
-        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="6fYiNFaHcWT" role="jymVt" />
     <node concept="3clFb_" id="6fYiNFaH3n7" role="jymVt">
       <property role="TrG5h" value="findKeyFromAttribute" />
       <node concept="3clFbS" id="6fYiNFaH3n8" role="3clF47">
@@ -4025,235 +3743,6 @@
     <node concept="3clFb_" id="5M3rB6_WjPt" role="jymVt">
       <property role="TrG5h" value="findKeyFromAttribute" />
       <node concept="3clFbS" id="5M3rB6_WjPu" role="3clF47">
-        <node concept="3SKdUt" id="3M8YG$9HqYG" role="3cqZAp">
-          <node concept="1PaTwC" id="3M8YG$9HqYH" role="1aUNEU">
-            <node concept="3oM_SD" id="3M8YG$9Htxg" role="1PaTwD">
-              <property role="3oM_SC" value="TODO:" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9Htxi" role="1PaTwD">
-              <property role="3oM_SC" value="Check" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9Htxl" role="1PaTwD">
-              <property role="3oM_SC" value="if" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9Htxp" role="1PaTwD">
-              <property role="3oM_SC" value="this" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9Htxu" role="1PaTwD">
-              <property role="3oM_SC" value="should" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9Htx$" role="1PaTwD">
-              <property role="3oM_SC" value="be" />
-            </node>
-            <node concept="3oM_SD" id="3M8YG$9HtxF" role="1PaTwD">
-              <property role="3oM_SC" value="here" />
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="3M8YG$9HtxN" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="1_3QMa" id="3M8YG$9F9R5" role="8Wnug">
-            <node concept="2OqwBi" id="3M8YG$9Fdyv" role="1_3QMn">
-              <node concept="37vLTw" id="3M8YG$9FcsL" role="2Oq$k0">
-                <ref role="3cqZAo" node="5M3rB6_WjPA" resolve="element" />
-              </node>
-              <node concept="2yIwOk" id="3M8YG$9Fgnn" role="2OqNvi" />
-            </node>
-            <node concept="1_3QMl" id="3M8YG$9FhFw" role="1_3QMm">
-              <node concept="3gn64h" id="3M8YG$9FhFx" role="3Kbmr1">
-                <ref role="3gnhBz" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-              </node>
-              <node concept="3clFbS" id="3M8YG$9FhFy" role="3Kbo56">
-                <node concept="9aQIb" id="3M8YG$9FOLj" role="3cqZAp">
-                  <node concept="3clFbS" id="3M8YG$9FOLl" role="9aQI4">
-                    <node concept="3cpWs8" id="3M8YG$9FEdy" role="3cqZAp">
-                      <node concept="3cpWsn" id="3M8YG$9FEdz" role="3cpWs9">
-                        <property role="TrG5h" value="index" />
-                        <node concept="10Oyi0" id="3M8YG$9FEd$" role="1tU5fm" />
-                        <node concept="2OqwBi" id="3M8YG$9FEd_" role="33vP2m">
-                          <node concept="2OqwBi" id="3M8YG$9FEdA" role="2Oq$k0">
-                            <node concept="37vLTw" id="3M8YG$9FEdB" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
-                            </node>
-                            <node concept="liA8E" id="3M8YG$9FEdC" role="2OqNvi">
-                              <ref role="37wK5l" node="5JNiski3jZ$" resolve="listMpsClassifiers" />
-                            </node>
-                          </node>
-                          <node concept="2WmjW8" id="3M8YG$9FEdD" role="2OqNvi">
-                            <node concept="1PxgMI" id="3M8YG$9FEdE" role="25WWJ7">
-                              <node concept="chp4Y" id="3M8YG$9FEdF" role="3oSUPX">
-                                <ref role="cht4Q" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                              </node>
-                              <node concept="37vLTw" id="3M8YG$9FEdG" role="1m5AlR">
-                                <ref role="3cqZAo" node="5M3rB6_WjPA" resolve="element" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbJ" id="3M8YG$9FEdl" role="3cqZAp">
-                      <node concept="3clFbS" id="3M8YG$9FEdm" role="3clFbx">
-                        <node concept="3cpWs6" id="3M8YG$9FEdn" role="3cqZAp">
-                          <node concept="1y4W85" id="3M8YG$9FEdp" role="3cqZAk">
-                            <node concept="37vLTw" id="3M8YG$9FEdq" role="1y58nS">
-                              <ref role="3cqZAo" node="3M8YG$9FEdz" resolve="index" />
-                            </node>
-                            <node concept="2OqwBi" id="3M8YG$9FEdr" role="1y566C">
-                              <node concept="37vLTw" id="3M8YG$9FEds" role="2Oq$k0">
-                                <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
-                              </node>
-                              <node concept="liA8E" id="3M8YG$9FEdt" role="2OqNvi">
-                                <ref role="37wK5l" node="5JNiski3jZU" resolve="listKeyClassifiers" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2d3UOw" id="3M8YG$9FEdv" role="3clFbw">
-                        <node concept="3cmrfG" id="3M8YG$9FEdw" role="3uHU7w">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="37vLTw" id="3M8YG$9FEdx" role="3uHU7B">
-                          <ref role="3cqZAo" node="3M8YG$9FEdz" resolve="index" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1_3QMl" id="3M8YG$9FAcX" role="1_3QMm">
-              <node concept="3gn64h" id="3M8YG$9FAcZ" role="3Kbmr1">
-                <ref role="3gnhBz" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-              </node>
-              <node concept="3clFbS" id="3M8YG$9FAd1" role="3Kbo56">
-                <node concept="9aQIb" id="3M8YG$9FUcz" role="3cqZAp">
-                  <node concept="3clFbS" id="3M8YG$9FUc$" role="9aQI4">
-                    <node concept="3cpWs8" id="3M8YG$9Flqn" role="3cqZAp">
-                      <node concept="3cpWsn" id="3M8YG$9Flqo" role="3cpWs9">
-                        <property role="TrG5h" value="index" />
-                        <node concept="10Oyi0" id="3M8YG$9Flqp" role="1tU5fm" />
-                        <node concept="2OqwBi" id="3M8YG$9Flqq" role="33vP2m">
-                          <node concept="2OqwBi" id="3M8YG$9Flqr" role="2Oq$k0">
-                            <node concept="37vLTw" id="3M8YG$9Flqs" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
-                            </node>
-                            <node concept="liA8E" id="3M8YG$9Flqt" role="2OqNvi">
-                              <ref role="37wK5l" node="5JNiski3k0r" resolve="listMpsProperties" />
-                            </node>
-                          </node>
-                          <node concept="2WmjW8" id="3M8YG$9Flqu" role="2OqNvi">
-                            <node concept="1PxgMI" id="3M8YG$9Ft8T" role="25WWJ7">
-                              <node concept="chp4Y" id="3M8YG$9FvLx" role="3oSUPX">
-                                <ref role="cht4Q" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-                              </node>
-                              <node concept="37vLTw" id="3M8YG$9Flqx" role="1m5AlR">
-                                <ref role="3cqZAo" node="5M3rB6_WjPA" resolve="element" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbJ" id="3M8YG$9Flqy" role="3cqZAp">
-                      <node concept="3clFbS" id="3M8YG$9Flqz" role="3clFbx">
-                        <node concept="3cpWs6" id="3M8YG$9Flq$" role="3cqZAp">
-                          <node concept="1y4W85" id="3M8YG$9FlqA" role="3cqZAk">
-                            <node concept="37vLTw" id="3M8YG$9FlqB" role="1y58nS">
-                              <ref role="3cqZAo" node="3M8YG$9Flqo" resolve="index" />
-                            </node>
-                            <node concept="2OqwBi" id="3M8YG$9FlqC" role="1y566C">
-                              <node concept="37vLTw" id="3M8YG$9FlqD" role="2Oq$k0">
-                                <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
-                              </node>
-                              <node concept="liA8E" id="3M8YG$9FlqE" role="2OqNvi">
-                                <ref role="37wK5l" node="5JNiski3k0L" resolve="listKeyProperties" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2d3UOw" id="3M8YG$9FlqG" role="3clFbw">
-                        <node concept="3cmrfG" id="3M8YG$9FlqH" role="3uHU7w">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="37vLTw" id="3M8YG$9FlqI" role="3uHU7B">
-                          <ref role="3cqZAo" node="3M8YG$9Flqo" resolve="index" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1_3QMl" id="3M8YG$9Gfz4" role="1_3QMm">
-              <node concept="3gn64h" id="3M8YG$9Gfz6" role="3Kbmr1">
-                <ref role="3gnhBz" to="tpce:fKAxPRU" resolve="DataTypeDeclaration" />
-              </node>
-              <node concept="3clFbS" id="3M8YG$9Gfz8" role="3Kbo56">
-                <node concept="9aQIb" id="3M8YG$9Gk_K" role="3cqZAp">
-                  <node concept="3clFbS" id="3M8YG$9Gk_L" role="9aQI4">
-                    <node concept="3cpWs8" id="3M8YG$9Gk_M" role="3cqZAp">
-                      <node concept="3cpWsn" id="3M8YG$9Gk_N" role="3cpWs9">
-                        <property role="TrG5h" value="index" />
-                        <node concept="10Oyi0" id="3M8YG$9Gk_O" role="1tU5fm" />
-                        <node concept="2OqwBi" id="3M8YG$9Gk_P" role="33vP2m">
-                          <node concept="2OqwBi" id="3M8YG$9Gk_Q" role="2Oq$k0">
-                            <node concept="37vLTw" id="3M8YG$9Gk_R" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
-                            </node>
-                            <node concept="liA8E" id="3M8YG$9Gk_S" role="2OqNvi">
-                              <ref role="37wK5l" node="5JNiski3k1h" resolve="listMpsPrimitiveTypes" />
-                            </node>
-                          </node>
-                          <node concept="2WmjW8" id="3M8YG$9Gk_T" role="2OqNvi">
-                            <node concept="1PxgMI" id="3M8YG$9Gk_U" role="25WWJ7">
-                              <node concept="chp4Y" id="3M8YG$9Gk_V" role="3oSUPX">
-                                <ref role="cht4Q" to="tpce:fKAxPRU" resolve="DataTypeDeclaration" />
-                              </node>
-                              <node concept="37vLTw" id="3M8YG$9Gk_W" role="1m5AlR">
-                                <ref role="3cqZAo" node="5M3rB6_WjPA" resolve="element" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbJ" id="3M8YG$9Gk_X" role="3cqZAp">
-                      <node concept="3clFbS" id="3M8YG$9Gk_Y" role="3clFbx">
-                        <node concept="3cpWs6" id="3M8YG$9Gk_Z" role="3cqZAp">
-                          <node concept="1y4W85" id="3M8YG$9GkA1" role="3cqZAk">
-                            <node concept="37vLTw" id="3M8YG$9GkA2" role="1y58nS">
-                              <ref role="3cqZAo" node="3M8YG$9Gk_N" resolve="index" />
-                            </node>
-                            <node concept="2OqwBi" id="3M8YG$9GkA3" role="1y566C">
-                              <node concept="37vLTw" id="3M8YG$9GkA4" role="2Oq$k0">
-                                <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
-                              </node>
-                              <node concept="liA8E" id="3M8YG$9GkA5" role="2OqNvi">
-                                <ref role="37wK5l" node="5JNiski3k1B" resolve="listKeyPrimitiveTypes" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2d3UOw" id="3M8YG$9GkA7" role="3clFbw">
-                        <node concept="3cmrfG" id="3M8YG$9GkA8" role="3uHU7w">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="37vLTw" id="3M8YG$9GkA9" role="3uHU7B">
-                          <ref role="3cqZAo" node="3M8YG$9Gk_N" resolve="index" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3cpWs6" id="5M3rB6_WjPv" role="3cqZAp">
           <node concept="1rXfSq" id="5M3rB6_WjPw" role="3cqZAk">
             <ref role="37wK5l" node="5M3rB6_WF0q" resolve="findKeyFromNode" />
@@ -4281,16 +3770,6 @@
         <node concept="TZ5HA" id="3M8YG$9ELoF" role="TZ5H$">
           <node concept="1dT_AC" id="3M8YG$9ELoG" role="1dT_Ay">
             <property role="1dT_AB" value="Retrieves a custom LionWeb key from `element` via `LionWebEntityKey`." />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="3M8YG$9ELoH" role="TZ5H$">
-          <node concept="1dT_AC" id="3M8YG$9ELoI" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="3M8YG$9ELoS" role="TZ5H$">
-          <node concept="1dT_AC" id="3M8YG$9ELoT" role="1dT_Ay">
-            <property role="1dT_AB" value="TODO: Transparently maps LionCore entity keys." />
           </node>
         </node>
         <node concept="TUZQ0" id="3M8YG$9EINf" role="3nqlJM">

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -6448,6 +6448,11 @@
             <property role="1dT_AB" value="mpsId: e92f782f-6faf-41c2-bf76-2b1a350c0516" />
           </node>
         </node>
+        <node concept="TZ5HA" id="7OJcYq_lvRM" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYq_lvRN" role="1dT_Ay">
+            <property role="1dT_AB" value="  encoded: ZTkyZjc4MmYtNmZhZi00MWMyLWJmNzYtMmIxYTM1MGMwNTE2" />
+          </node>
+        </node>
         <node concept="TZ5HA" id="7OJcYqwUzrq" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqwUzrr" role="1dT_Ay">
             <property role="1dT_AB" value="mpsVersion: 0" />
@@ -6519,6 +6524,11 @@
         <node concept="TZ5HA" id="7OJcYqxqCb3" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqxqCb4" role="1dT_Ay">
             <property role="1dT_AB" value="mpsId: c72da2b9-7cce-4447-8389-f407dc1158b7" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYq_lvTW" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYq_lvTX" role="1dT_Ay">
+            <property role="1dT_AB" value="  encoded: YzcyZGEyYjktN2NjZS00NDQ3LTgzODktZjQwN2RjMTE1OGI3" />
           </node>
         </node>
         <node concept="TZ5HA" id="7OJcYqxqCb5" role="TZ5H$">
@@ -9258,6 +9268,11 @@
             <property role="1dT_AB" value="mpsId: 01cf0d82-8d29-4fc4-be96-28abaf4ad33d" />
           </node>
         </node>
+        <node concept="TZ5HA" id="7OJcYq_luuH" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYq_luuI" role="1dT_Ay">
+            <property role="1dT_AB" value="  encoded: MDFjZjBkODItOGQyOS00ZmM0LWJlOTYtMjhhYmFmNGFkMzNk" />
+          </node>
+        </node>
         <node concept="TZ5HA" id="7OJcYqwQWC5" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqwQWC6" role="1dT_Ay">
             <property role="1dT_AB" value="mpsVersion: 0" />
@@ -9325,6 +9340,11 @@
         <node concept="TZ5HA" id="7OJcYqwUkXy" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqwUkXz" role="1dT_Ay">
             <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYq_ltOW" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYq_ltOX" role="1dT_Ay">
+            <property role="1dT_AB" value="  encoded: Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj" />
           </node>
         </node>
         <node concept="TZ5HA" id="7OJcYqwUkX$" role="TZ5H$">
@@ -9395,6 +9415,11 @@
             <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
           </node>
         </node>
+        <node concept="TZ5HA" id="7OJcYq_luzo" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYq_luzp" role="1dT_Ay">
+            <property role="1dT_AB" value="  encoded: Y2VhYjUxOTUtMjVlYS00ZjIyLTliOTItMTAzYjk1Y2E4YzBj" />
+          </node>
+        </node>
         <node concept="TZ5HA" id="7OJcYqxK_p$" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqxK_p_" role="1dT_Ay">
             <property role="1dT_AB" value="mpsVersion: 2" />
@@ -9462,6 +9487,11 @@
         <node concept="TZ5HA" id="7OJcYqwUnHG" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqwUnHH" role="1dT_Ay">
             <property role="1dT_AB" value="mpsId: 411e5b27-8a76-482e-8af8-1704262b4468" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYq_lveE" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYq_lveF" role="1dT_Ay">
+            <property role="1dT_AB" value="  encoded: NDExZTViMjctOGE3Ni00ODJlLThhZjgtMTcwNDI2MmI0NDY4" />
           </node>
         </node>
         <node concept="TZ5HA" id="7OJcYqwUnHI" role="TZ5H$">

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -282,6 +282,9 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
       <concept id="4497478346159780083" name="jetbrains.mps.lang.smodel.structure.LanguageRefExpression" flags="ng" index="pHN19">
         <child id="3542851458883491298" name="languageId" index="2V$M_3" />
       </concept>
@@ -313,6 +316,7 @@
         <property id="3542851458883439831" name="namespace" index="2V$B1Q" />
         <property id="3542851458883439832" name="languageId" index="2V$B1T" />
       </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="2644386474302386080" name="jetbrains.mps.lang.smodel.structure.PropertyIdRefExpression" flags="nn" index="355D3s">
         <reference id="2644386474302386081" name="conceptDeclaration" index="355D3t" />
         <reference id="2644386474302386082" name="propertyDeclaration" index="355D3u" />
@@ -324,6 +328,9 @@
         <reference id="1154546997487" name="concept" index="3gnhBz" />
       </concept>
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
       <concept id="5944356402132808749" name="jetbrains.mps.lang.smodel.structure.ConceptSwitchStatement" flags="nn" index="1_3QMa">
         <child id="5944356402132808753" name="case" index="1_3QMm" />
         <child id="5944356402132808752" name="expression" index="1_3QMn" />
@@ -8240,11 +8247,24 @@
         </node>
       </node>
       <node concept="3clFbS" id="5JNiskisDQX" role="3clF47">
+        <node concept="3cpWs8" id="7OJcYq_s8jw" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_s8jx" role="3cpWs9">
+            <property role="TrG5h" value="listMpsInternalFeatures" />
+            <node concept="_YKpA" id="7OJcYq_s6Mk" role="1tU5fm">
+              <node concept="3uibUv" id="7OJcYq_s6Mn" role="_ZDj9">
+                <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
+              </node>
+            </node>
+            <node concept="1rXfSq" id="7OJcYq_s8jy" role="33vP2m">
+              <ref role="37wK5l" node="7OJcYqx2F8j" resolve="listMpsInternalFeatures" />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="7OJcYqx6YcN" role="3cqZAp">
           <node concept="2OqwBi" id="7OJcYqx6YcO" role="3clFbG">
             <node concept="2OqwBi" id="7OJcYqx6YcP" role="2Oq$k0">
-              <node concept="1rXfSq" id="7OJcYqx6YcQ" role="2Oq$k0">
-                <ref role="37wK5l" node="7OJcYqx2F8j" resolve="listMpsInternalFeatures" />
+              <node concept="37vLTw" id="7OJcYq_s8jz" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYq_s8jx" resolve="listMpsInternalFeatures" />
               </node>
               <node concept="3$u5V9" id="7OJcYqx6YcR" role="2OqNvi">
                 <node concept="1bVj0M" id="7OJcYqx6YcS" role="23t8la">
@@ -8297,11 +8317,24 @@
         </node>
       </node>
       <node concept="3clFbS" id="5JNiskisDRe" role="3clF47">
+        <node concept="3cpWs8" id="7OJcYq_sb1G" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_sb1H" role="3cpWs9">
+            <property role="TrG5h" value="listMpsInternalFeatures" />
+            <node concept="_YKpA" id="7OJcYq_sa5f" role="1tU5fm">
+              <node concept="3uibUv" id="7OJcYq_sa5i" role="_ZDj9">
+                <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
+              </node>
+            </node>
+            <node concept="1rXfSq" id="7OJcYq_sb1I" role="33vP2m">
+              <ref role="37wK5l" node="7OJcYqx2F8j" resolve="listMpsInternalFeatures" />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="5JNiskizHvL" role="3cqZAp">
           <node concept="2OqwBi" id="5JNiskizLC2" role="3clFbG">
             <node concept="2OqwBi" id="7OJcYqx6sn6" role="2Oq$k0">
-              <node concept="1rXfSq" id="5JNiskizHvJ" role="2Oq$k0">
-                <ref role="37wK5l" node="7OJcYqx2F8j" resolve="listMpsInternalFeatures" />
+              <node concept="37vLTw" id="7OJcYq_sb1J" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYq_sb1H" resolve="listMpsInternalFeatures" />
               </node>
               <node concept="3$u5V9" id="7OJcYqx6y4M" role="2OqNvi">
                 <node concept="1bVj0M" id="7OJcYqx6y4O" role="23t8la">
@@ -9923,6 +9956,15 @@
         <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
     </node>
+    <node concept="3clFb_" id="7OJcYq_s$7A" role="jymVt">
+      <property role="TrG5h" value="getLcLanguageKey" />
+      <node concept="3clFbS" id="7OJcYq_s$7D" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYq_s$7E" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYq_syTs" role="3clF45" />
+      <node concept="2AHcQZ" id="7OJcYq_s_6d" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+    </node>
     <node concept="3Tm1VV" id="7OJcYqvKf0P" role="1B3o_S" />
     <node concept="16euLQ" id="7OJcYqvKf2B" role="16eVyc">
       <property role="TrG5h" value="LC" />
@@ -9999,6 +10041,13 @@
       <node concept="3Tm6S6" id="7OJcYqvKvHu" role="1B3o_S" />
       <node concept="17QB3L" id="7OJcYqvKvHw" role="1tU5fm" />
     </node>
+    <node concept="312cEg" id="7OJcYq_sAXe" role="jymVt">
+      <property role="TrG5h" value="lcLanguageKey" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYq_sAXf" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYq_sAXh" role="1tU5fm" />
+    </node>
+    <node concept="2tJIrI" id="7OJcYq_sC1m" role="jymVt" />
     <node concept="3clFbW" id="7OJcYqvKqOn" role="jymVt">
       <node concept="3cqZAl" id="7OJcYqvKqOo" role="3clF45" />
       <node concept="3Tm1VV" id="7OJcYqvKqOp" role="1B3o_S" />
@@ -10081,6 +10130,19 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbF" id="7OJcYq_sAXi" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYq_sAXk" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYq_sBla" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYq_sBtE" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYq_sBld" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYq_sAXe" resolve="lcLanguageKey" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7OJcYq_sAXo" role="37vLTx">
+              <ref role="3cqZAo" node="7OJcYq_sA5K" resolve="lcLanguageKey" />
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="37vLTG" id="7OJcYqvKqXW" role="3clF46">
         <property role="TrG5h" value="lc" />
@@ -10127,6 +10189,13 @@
         <property role="TrG5h" value="lcKey" />
         <node concept="17QB3L" id="7OJcYqvKuwW" role="1tU5fm" />
         <node concept="2AHcQZ" id="7OJcYqwLNwE" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYq_sA5K" role="3clF46">
+        <property role="TrG5h" value="lcLanguageKey" />
+        <node concept="17QB3L" id="7OJcYq_sAy7" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7OJcYq_sAJj" role="2AJF6D">
           <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
         </node>
       </node>
@@ -10259,6 +10328,24 @@
     </node>
     <node concept="16euLQ" id="7OJcYqvKyqZ" role="16eVyc">
       <property role="TrG5h" value="SLANG" />
+    </node>
+    <node concept="3clFb_" id="7OJcYq_sCwa" role="jymVt">
+      <property role="TrG5h" value="getLcLanguageKey" />
+      <node concept="3Tm1VV" id="7OJcYq_sCwc" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYq_sCwd" role="3clF45" />
+      <node concept="2AHcQZ" id="7OJcYq_sCwe" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="7OJcYq_sCwf" role="3clF47">
+        <node concept="3clFbF" id="7OJcYq_sDB$" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYq_sDBx" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYq_sAXe" resolve="lcLanguageKey" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYq_sCwg" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="2YIFZL" id="5M3rB6_QlA6" role="jymVt">
       <property role="TrG5h" value="extractKey" />
@@ -10433,6 +10520,22 @@
               <ref role="3cqZAo" node="7OJcYqvKXdF" resolve="lc" />
             </node>
           </node>
+          <node concept="2YIFZM" id="7OJcYq_sIM3" role="37wK5m">
+            <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
+            <node concept="2OqwBi" id="7OJcYq_sIM4" role="37wK5m">
+              <node concept="37vLTw" id="7OJcYq_sIM5" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYqvKXdF" resolve="lc" />
+              </node>
+              <node concept="2Xjw5R" id="7OJcYq_sIM6" role="2OqNvi">
+                <node concept="1xMEDy" id="7OJcYq_sIM7" role="1xVPHs">
+                  <node concept="chp4Y" id="7OJcYq_sIM8" role="ri$Ld">
+                    <ref role="cht4Q" to="h3y3:2ju2syjkngz" resolve="Language" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
       <node concept="37vLTG" id="7OJcYqvKXdF" role="3clF46">
@@ -10538,6 +10641,22 @@
             <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqvLIAw" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqvLcd3" resolve="lc" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYq_sNdg" role="37wK5m">
+            <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
+            <node concept="2OqwBi" id="7OJcYq_sNdh" role="37wK5m">
+              <node concept="37vLTw" id="7OJcYq_sNdi" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYqvLcd3" resolve="lc" />
+              </node>
+              <node concept="2Xjw5R" id="7OJcYq_sNdj" role="2OqNvi">
+                <node concept="1xMEDy" id="7OJcYq_sNdk" role="1xVPHs">
+                  <node concept="chp4Y" id="7OJcYq_sNdl" role="ri$Ld">
+                    <ref role="cht4Q" to="h3y3:2ju2syjkngz" resolve="Language" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -10723,6 +10842,9 @@
             <ref role="3cqZAo" node="7OJcYqvMRoN" resolve="lcId" />
           </node>
           <node concept="37vLTw" id="7OJcYqxRknX" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvMRoP" resolve="lcKey" />
+          </node>
+          <node concept="37vLTw" id="7OJcYq_sMfc" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqvMRoP" resolve="lcKey" />
           </node>
         </node>
@@ -10988,6 +11110,22 @@
               <ref role="3cqZAo" node="7OJcYqvQc4_" resolve="lc" />
             </node>
           </node>
+          <node concept="2YIFZM" id="7OJcYq_sKwL" role="37wK5m">
+            <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
+            <node concept="2OqwBi" id="7OJcYq_sKwM" role="37wK5m">
+              <node concept="37vLTw" id="7OJcYq_sKwN" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYqvQc4_" resolve="lc" />
+              </node>
+              <node concept="2Xjw5R" id="7OJcYq_sKwO" role="2OqNvi">
+                <node concept="1xMEDy" id="7OJcYq_sKwP" role="1xVPHs">
+                  <node concept="chp4Y" id="7OJcYq_sKwQ" role="ri$Ld">
+                    <ref role="cht4Q" to="h3y3:2ju2syjkngz" resolve="Language" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
       <node concept="37vLTG" id="7OJcYqvQc4_" role="3clF46">
@@ -11088,6 +11226,22 @@
               <ref role="3cqZAo" node="7OJcYqvRxYM" resolve="lc" />
             </node>
           </node>
+          <node concept="2YIFZM" id="7OJcYq_sNsm" role="37wK5m">
+            <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
+            <node concept="2OqwBi" id="7OJcYq_sNsn" role="37wK5m">
+              <node concept="37vLTw" id="7OJcYq_sNso" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYqvRxYM" resolve="lc" />
+              </node>
+              <node concept="2Xjw5R" id="7OJcYq_sNsp" role="2OqNvi">
+                <node concept="1xMEDy" id="7OJcYq_sNsq" role="1xVPHs">
+                  <node concept="chp4Y" id="7OJcYq_sNsr" role="ri$Ld">
+                    <ref role="cht4Q" to="h3y3:2ju2syjkngz" resolve="Language" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
       <node concept="37vLTG" id="7OJcYqvRxYM" role="3clF46">
@@ -11177,6 +11331,22 @@
             <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqvXZ9g" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqvXZ9h" resolve="lc" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYq_sLcT" role="37wK5m">
+            <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
+            <node concept="2OqwBi" id="7OJcYq_sLcU" role="37wK5m">
+              <node concept="37vLTw" id="7OJcYq_sLcV" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYqvXZ9h" resolve="lc" />
+              </node>
+              <node concept="2Xjw5R" id="7OJcYq_sLcW" role="2OqNvi">
+                <node concept="1xMEDy" id="7OJcYq_sLcX" role="1xVPHs">
+                  <node concept="chp4Y" id="7OJcYq_sLcY" role="ri$Ld">
+                    <ref role="cht4Q" to="h3y3:2ju2syjkngz" resolve="Language" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -11340,6 +11510,22 @@
             <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqw2rzb" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqw2rzc" resolve="lc" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYq_sJyM" role="37wK5m">
+            <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
+            <node concept="2OqwBi" id="7OJcYq_sJyN" role="37wK5m">
+              <node concept="37vLTw" id="7OJcYq_sJyO" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYqw2rzc" resolve="lc" />
+              </node>
+              <node concept="2Xjw5R" id="7OJcYq_sJyP" role="2OqNvi">
+                <node concept="1xMEDy" id="7OJcYq_sJyQ" role="1xVPHs">
+                  <node concept="chp4Y" id="7OJcYq_sJyR" role="ri$Ld">
+                    <ref role="cht4Q" to="h3y3:2ju2syjkngz" resolve="Language" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -11542,6 +11728,22 @@
             <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqwnwCB" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqwp9Gu" resolve="lcProp" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYq_sHYV" role="37wK5m">
+            <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
+            <node concept="2OqwBi" id="7OJcYq_sHYW" role="37wK5m">
+              <node concept="37vLTw" id="7OJcYq_sHYX" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYqwp9Gu" resolve="lcProp" />
+              </node>
+              <node concept="2Xjw5R" id="7OJcYq_sHYY" role="2OqNvi">
+                <node concept="1xMEDy" id="7OJcYq_sHYZ" role="1xVPHs">
+                  <node concept="chp4Y" id="7OJcYq_sHZ0" role="ri$Ld">
+                    <ref role="cht4Q" to="h3y3:2ju2syjkngz" resolve="Language" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -11766,6 +11968,22 @@
             <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqwqLms" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqwqLmz" resolve="lc" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYq_sFCn" role="37wK5m">
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
+            <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
+            <node concept="2OqwBi" id="7OJcYq_sGfV" role="37wK5m">
+              <node concept="37vLTw" id="7OJcYq_sG08" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYqwqLmz" resolve="lc" />
+              </node>
+              <node concept="2Xjw5R" id="7OJcYq_sGUl" role="2OqNvi">
+                <node concept="1xMEDy" id="7OJcYq_sGUn" role="1xVPHs">
+                  <node concept="chp4Y" id="7OJcYq_sHlI" role="ri$Ld">
+                    <ref role="cht4Q" to="h3y3:2ju2syjkngz" resolve="Language" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -33,8 +33,9 @@
     <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" />
     <import index="pjrh" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter(MPS.Core/)" />
-    <import index="4xw4" ref="r:23ccdcd2-ac4f-4247-aad5-4d197fcb7e18(io.lionweb.mps.specific.lang)" implicit="true" />
+    <import index="4xw4" ref="r:23ccdcd2-ac4f-4247-aad5-4d197fcb7e18(io.lionweb.mps.specific.lang)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -51,6 +52,7 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
@@ -100,6 +102,7 @@
       </concept>
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <property id="1075300953594" name="abstractClass" index="1sVAO0" />
         <child id="1095933932569" name="implementedInterface" index="EKbjA" />
         <child id="1165602531693" name="superclass" index="1zkMxy" />
       </concept>
@@ -108,6 +111,15 @@
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1068431790191" name="jetbrains.mps.baseLanguage.structure.Expression" flags="nn" index="33vP2n" />
+      <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ">
+        <child id="1214996921760" name="bound" index="3ztrMU" />
+      </concept>
+      <concept id="1109279851642" name="jetbrains.mps.baseLanguage.structure.GenericDeclaration" flags="ng" index="16eOlS">
+        <child id="1109279881614" name="typeVariableDeclaration" index="16eVyc" />
+      </concept>
+      <concept id="1109283449304" name="jetbrains.mps.baseLanguage.structure.TypeVariableReference" flags="in" index="16syzq">
+        <reference id="1109283546497" name="typeVariableDeclaration" index="16sUi3" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -206,7 +218,14 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1178893518978" name="jetbrains.mps.baseLanguage.structure.ThisConstructorInvocation" flags="nn" index="1VxSAg" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
       <concept id="2546654756694997551" name="jetbrains.mps.baseLanguage.javadoc.structure.LinkInlineDocTag" flags="ng" index="92FcH">
@@ -235,6 +254,9 @@
       </concept>
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8465538089690331492" name="jetbrains.mps.baseLanguage.javadoc.structure.DeprecatedBlockDocTag" flags="ng" index="TZ5HI">
+        <child id="2667874559098216723" name="text" index="3HnX3l" />
       </concept>
       <concept id="2217234381367188008" name="jetbrains.mps.baseLanguage.javadoc.structure.FieldDocReference" flags="ng" index="VUqz4" />
       <concept id="2217234381367049075" name="jetbrains.mps.baseLanguage.javadoc.structure.CodeInlineDocTag" flags="ng" index="VVOAv">
@@ -377,6 +399,9 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
         <child id="1176906787974" name="rightExpression" index="576Qk" />
       </concept>
@@ -399,6 +424,7 @@
         <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="4611582986551314327" name="jetbrains.mps.baseLanguage.collections.structure.OfTypeOperation" flags="nn" index="UnYns">
@@ -412,6 +438,7 @@
         <child id="1225711182005" name="list" index="1y566C" />
         <child id="1225711191269" name="index" index="1y58nS" />
       </concept>
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
       <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
@@ -419,6 +446,78 @@
   </registry>
   <node concept="312cEu" id="DUXtGZOlwJ">
     <property role="TrG5h" value="LionCoreConstants" />
+    <node concept="312cEg" id="7OJcYqwumEM" role="jymVt">
+      <property role="TrG5h" value="VIRTUAL_PACKAGE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqwumEK" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqwumEL" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqwusrr" role="jymVt">
+      <property role="TrG5h" value="SHORT_DESCRIPTION" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqwusrp" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqwusrq" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqwuwts" role="jymVt">
+      <property role="TrG5h" value="STRUCTURE_LANGUAGE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqwuwtq" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqwuwtr" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqwuG9p" role="jymVt">
+      <property role="TrG5h" value="CLASSIFIER" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqwuG9n" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqwuG9o" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqwuLVt" role="jymVt">
+      <property role="TrG5h" value="CONCEPT" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqwuLVr" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqwuLVs" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqwuQlg" role="jymVt">
+      <property role="TrG5h" value="INTERFACE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqwuQle" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqwuQlf" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqwuUL4" role="jymVt">
+      <property role="TrG5h" value="CONCEPT_ALIAS" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqwuUL2" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqwuUL3" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqwuZhZ" role="jymVt">
+      <property role="TrG5h" value="CONCEPT_SHORT_DESCRIPTION" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqwuZhX" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqwuZhY" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqwWzAg" role="jymVt">
+      <property role="TrG5h" value="SPECIFIC_LANGUAGE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqwWzAe" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqwWzAf" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      </node>
+    </node>
     <node concept="3clFbW" id="DUXtGZOlxP" role="jymVt">
       <node concept="37vLTG" id="DUXtGZOlyn" role="3clF46">
         <property role="TrG5h" value="repository" />
@@ -439,6 +538,24 @@
           </node>
         </node>
         <node concept="3clFbH" id="5JNiskiqve6" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYqwsfwB" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwsfwC" role="3cpWs9">
+            <property role="TrG5h" value="coreLanguageId" />
+            <node concept="3uibUv" id="7OJcYqwsfwD" role="1tU5fm">
+              <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+            </node>
+            <node concept="2YIFZM" id="7OJcYqwsfwE" role="33vP2m">
+              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
+              <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
+              <node concept="pHN19" id="7OJcYqwsfwF" role="37wK5m">
+                <node concept="2V$Bhx" id="7OJcYqwsfwG" role="2V$M_3">
+                  <property role="2V$B1T" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
+                  <property role="2V$B1Q" value="jetbrains.mps.lang.core" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="5JNiskiqTF1" role="3cqZAp">
           <node concept="3cpWsn" id="5JNiskiqTF2" role="3cpWs9">
             <property role="TrG5h" value="coreLangHighBits" />
@@ -446,7 +563,7 @@
             <node concept="3cpWsb" id="5JNiskiqTF3" role="1tU5fm" />
             <node concept="2OqwBi" id="5JNiskiqTF4" role="33vP2m">
               <node concept="37vLTw" id="5JNiskiqTF5" role="2Oq$k0">
-                <ref role="3cqZAo" node="5AGBwuFFuSI" resolve="SLANG_CORE_LANGUAGE_ID" />
+                <ref role="3cqZAo" node="7OJcYqwsfwC" resolve="coreLanguageId" />
               </node>
               <node concept="liA8E" id="5JNiskiqTF6" role="2OqNvi">
                 <ref role="37wK5l" to="e8bb:~SLanguageId.getHighBits()" resolve="getHighBits" />
@@ -461,7 +578,7 @@
             <node concept="3cpWsb" id="5JNiskiqTF9" role="1tU5fm" />
             <node concept="2OqwBi" id="5JNiskiqTFa" role="33vP2m">
               <node concept="37vLTw" id="5JNiskiqTFb" role="2Oq$k0">
-                <ref role="3cqZAo" node="5AGBwuFFuSI" resolve="SLANG_CORE_LANGUAGE_ID" />
+                <ref role="3cqZAo" node="7OJcYqwsfwC" resolve="coreLanguageId" />
               </node>
               <node concept="liA8E" id="5JNiskiqTFc" role="2OqNvi">
                 <ref role="37wK5l" to="e8bb:~SLanguageId.getLowBits()" resolve="getLowBits" />
@@ -470,475 +587,912 @@
           </node>
         </node>
         <node concept="3clFbH" id="5JNiskiqTwm" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiskiLd$U" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiLd$V" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiLd$W" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskiKYx9" resolve="SLANG_SPECIFIC_LANGUAGE" />
-            </node>
-            <node concept="pHN19" id="5JNiskiLd$X" role="37vLTx">
-              <node concept="2V$Bhx" id="5JNiskiLken" role="2V$M_3">
-                <property role="2V$B1T" value="e92f782f-6faf-41c2-bf76-2b1a350c0516" />
-                <property role="2V$B1Q" value="io.lionweb.mps.specific" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiskiLd$Z" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiLd_0" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiskiLd_1" role="37vLTx">
-              <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
-              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-              <node concept="37vLTw" id="5JNiskiLd_2" role="37wK5m">
+        <node concept="1X3_iC" id="7OJcYqwsbri" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiLd$U" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiLd$V" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiLd$W" role="37vLTJ">
                 <ref role="3cqZAo" node="5JNiskiKYx9" resolve="SLANG_SPECIFIC_LANGUAGE" />
               </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiLd_3" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskiKYx0" resolve="SLANG_SPECIFIC_LANGUAGE_ID" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiskiLd_i" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiLd_j" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiLd_k" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskiKYxi" resolve="KEY_SPECIFIC_LANGUAGE" />
-            </node>
-            <node concept="Xl_RD" id="5JNiskiLd_l" role="37vLTx">
-              <property role="Xl_RC" value="io-lionweb-mps-specific" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiskiLd_m" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiLd_n" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiLd_o" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskiKYxr" resolve="ID_SPECIFIC_LANGUAGE" />
-            </node>
-            <node concept="2OqwBi" id="5JNiskiLd_p" role="37vLTx">
-              <node concept="37vLTw" id="5JNiskiLd_q" role="2Oq$k0">
-                <ref role="3cqZAo" node="5JNiskiKYx9" resolve="SLANG_SPECIFIC_LANGUAGE" />
-              </node>
-              <node concept="liA8E" id="5JNiskiLd_r" role="2OqNvi">
-                <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+              <node concept="pHN19" id="5JNiskiLd$X" role="37vLTx">
+                <node concept="2V$Bhx" id="5JNiskiLken" role="2V$M_3">
+                  <property role="2V$B1T" value="e92f782f-6faf-41c2-bf76-2b1a350c0516" />
+                  <property role="2V$B1Q" value="io.lionweb.mps.specific" />
+                </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiskiLd_s" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiLd_t" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiLd_v" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskiKYx$" resolve="VERSION_SPECIFIC_LANGUAGE" />
-            </node>
-            <node concept="2YIFZM" id="5JNiskiLIv8" role="37vLTx">
-              <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
-              <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
-              <node concept="2YIFZM" id="5JNiskiLD74" role="37wK5m">
-                <ref role="1Pybhc" node="6jTTMHD72IS" resolve="MpsLanguageUtil" />
-                <ref role="37wK5l" node="6jTTMHD72KX" resolve="getLanguageVersion" />
-                <node concept="37vLTw" id="5JNiskiLDWr" role="37wK5m">
+        <node concept="1X3_iC" id="7OJcYqwsbrj" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiLd$Z" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiLd_0" role="3clFbG">
+              <node concept="2YIFZM" id="5JNiskiLd_1" role="37vLTx">
+                <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
+                <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
+                <node concept="37vLTw" id="5JNiskiLd_2" role="37wK5m">
                   <ref role="3cqZAo" node="5JNiskiKYx9" resolve="SLANG_SPECIFIC_LANGUAGE" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiLd_3" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskiKYx0" resolve="SLANG_SPECIFIC_LANGUAGE_ID" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwsbrk" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiLd_i" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiLd_j" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiLd_k" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskiKYxi" resolve="KEY_SPECIFIC_LANGUAGE" />
+              </node>
+              <node concept="Xl_RD" id="5JNiskiLd_l" role="37vLTx">
+                <property role="Xl_RC" value="io-lionweb-mps-specific" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwsbrl" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiLd_m" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiLd_n" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiLd_o" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskiKYxr" resolve="ID_SPECIFIC_LANGUAGE" />
+              </node>
+              <node concept="2OqwBi" id="5JNiskiLd_p" role="37vLTx">
+                <node concept="37vLTw" id="5JNiskiLd_q" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5JNiskiKYx9" resolve="SLANG_SPECIFIC_LANGUAGE" />
+                </node>
+                <node concept="liA8E" id="5JNiskiLd_r" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwsbrm" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiLd_s" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiLd_t" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiLd_v" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskiKYx$" resolve="VERSION_SPECIFIC_LANGUAGE" />
+              </node>
+              <node concept="2YIFZM" id="5JNiskiLIv8" role="37vLTx">
+                <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
+                <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
+                <node concept="2YIFZM" id="5JNiskiLD74" role="37wK5m">
+                  <ref role="1Pybhc" node="6jTTMHD72IS" resolve="MpsLanguageUtil" />
+                  <ref role="37wK5l" node="6jTTMHD72KX" resolve="getLanguageVersion" />
+                  <node concept="37vLTw" id="5JNiskiLDWr" role="37wK5m">
+                    <ref role="3cqZAo" node="5JNiskiKYx9" resolve="SLANG_SPECIFIC_LANGUAGE" />
+                  </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="5JNiskiLcO1" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiskiqveL" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiqveM" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqveN" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskiq_M0" resolve="LC_VIRTUAL_PACKAGE_ANNOTATION" />
+        <node concept="3cpWs8" id="7OJcYqw9N$4" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqw9N$5" role="3cpWs9">
+            <property role="TrG5h" value="attributeLc" />
+            <node concept="3Tqbb2" id="7OJcYqw9LCp" role="1tU5fm">
+              <ref role="ehGHo" to="h3y3:2ju2syjkngz" resolve="Language" />
             </node>
-            <node concept="2OqwBi" id="5JNiskiqveO" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiskiqveP" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiskiqveQ" role="2tJFKM">
+            <node concept="2OqwBi" id="7OJcYqw9N$6" role="33vP2m">
+              <node concept="2tJFMh" id="7OJcYqw9N$7" role="2Oq$k0">
+                <node concept="ZC_QK" id="7OJcYqw9N$8" role="2tJFKM">
                   <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
-                  <node concept="ZC_QK" id="5JNiskiqveR" role="2aWVGa">
-                    <ref role="2aWVGs" to="4xw4:5JNiskir1qK" resolve="VirtualPackage" />
-                  </node>
                 </node>
               </node>
-              <node concept="Vyspw" id="5JNiskiqveT" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiskiqveU" role="Vysub">
+              <node concept="Vyspw" id="7OJcYqw9N$9" role="2OqNvi">
+                <node concept="37vLTw" id="7OJcYqw9N$a" role="Vysub">
                   <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiskiqveV" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiqveW" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiskiqveX" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiskiqveY" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiskiqveZ" role="2tJFKM">
+        <node concept="3clFbF" id="7OJcYqwWzAz" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqwWzA$" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqwWzA_" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqwWzAA" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqwWzAB" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqwWzAg" resolve="SPECIFIC_LANGUAGE" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqwWzAC" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqwWzAD" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvMRo3" resolve="LanguageKeyedMapping" />
+                <node concept="pHN19" id="7OJcYqwWzAE" role="37wK5m">
+                  <node concept="2V$Bhx" id="7OJcYqwWzAF" role="2V$M_3">
+                    <property role="2V$B1T" value="e92f782f-6faf-41c2-bf76-2b1a350c0516" />
+                    <property role="2V$B1Q" value="io.lionweb.mps.specific" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqwWzAG" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqwWzAH" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqw9N$5" resolve="attributeLc" />
+                  </node>
+                  <node concept="3TrcHB" id="7OJcYqwWzAI" role="2OqNvi">
+                    <ref role="3TsBF5" to="h3y3:2chztJeDvZC" resolve="version" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqwWzAJ" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqwWzAK" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqw9N$5" resolve="attributeLc" />
+                  </node>
+                  <node concept="3TrcHB" id="7OJcYqwWzAL" role="2OqNvi">
+                    <ref role="3TsBF5" to="h3y3:2ju2syjkkk9" resolve="key" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqwWzAM" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqwWzAN" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqw9N$5" resolve="attributeLc" />
+                  </node>
+                  <node concept="3TrcHB" id="7OJcYqwWzAO" role="2OqNvi">
+                    <ref role="3TsBF5" to="h3y3:2ju2syjkkk9" resolve="key" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqwVLdv" role="3cqZAp" />
+        <node concept="1X3_iC" id="7OJcYqwspqa" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiqveL" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiqveM" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqveN" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskiq_M0" resolve="LC_VIRTUAL_PACKAGE_ANNOTATION" />
+              </node>
+              <node concept="2OqwBi" id="5JNiskiqveO" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiskiqveP" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiskiqveQ" role="2tJFKM">
+                    <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
+                    <node concept="ZC_QK" id="5JNiskiqveR" role="2aWVGa">
+                      <ref role="2aWVGs" to="4xw4:5JNiskir1qK" resolve="VirtualPackage" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiskiqveT" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiskiqveU" role="Vysub">
+                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwspqb" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiqveV" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiqveW" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiskiqveX" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiskiqveY" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiskiqveZ" role="2tJFKM">
+                    <ref role="2aWVGs" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                    <node concept="ZC_QK" id="5JNiskiqvf0" role="2aWVGa">
+                      <ref role="2aWVGs" to="tpck:hnGE5uv" resolve="virtualPackage" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiskiqvf1" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiskiqvf2" role="Vysub">
+                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqvf3" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskiq_M9" resolve="MPS_VIRTUAL_PACKAGE_PROPERTY" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwspqc" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiqvf4" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiqvf5" role="3clFbG">
+              <node concept="2YIFZM" id="5JNiskiqvf6" role="37vLTx">
+                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
+                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                <node concept="37vLTw" id="5JNiskiqvf7" role="37wK5m">
+                  <ref role="3cqZAo" node="5JNiskiqTF2" resolve="coreLangHighBits" />
+                </node>
+                <node concept="37vLTw" id="5JNiskiqvf8" role="37wK5m">
+                  <ref role="3cqZAo" node="5JNiskiqTF8" resolve="coreLangLowBits" />
+                </node>
+                <node concept="2YIFZM" id="5JNiskiqvf9" role="37wK5m">
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <node concept="2OqwBi" id="5JNiskiqvfa" role="37wK5m">
+                    <node concept="37vLTw" id="5JNiskiqvfb" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
+                    </node>
+                    <node concept="3TrcHB" id="5JNiskiqvfc" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="5JNiskiqvfd" role="37wK5m">
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <node concept="2OqwBi" id="5JNiskiqvfe" role="37wK5m">
+                    <node concept="37vLTw" id="5JNiskiqvff" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5JNiskiq_M9" resolve="MPS_VIRTUAL_PACKAGE_PROPERTY" />
+                    </node>
+                    <node concept="3TrcHB" id="5JNiskiqvfg" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5JNiskiqvfh" role="37wK5m">
+                  <node concept="37vLTw" id="5JNiskiqvfi" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5JNiskiq_M9" resolve="MPS_VIRTUAL_PACKAGE_PROPERTY" />
+                  </node>
+                  <node concept="3TrcHB" id="5JNiskiqvfj" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqvfk" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskiq_Mi" resolve="SLANG_VIRTUAL_PACKAGE_PROPERTY" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwspqd" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiqvfl" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiqvfm" role="3clFbG">
+              <node concept="2YIFZM" id="7OJcYqwPrVe" role="37vLTx">
+                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+                <node concept="37vLTw" id="5JNiskiqvfo" role="37wK5m">
+                  <ref role="3cqZAo" node="5JNiskiq_M0" resolve="LC_VIRTUAL_PACKAGE_ANNOTATION" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqvfp" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskiq_Mr" resolve="KEY_VIRTUAL_PACKAGE_ANNOTATION" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwspqe" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiqvfq" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiqvfr" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqvfs" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskiq_M$" resolve="ID_VIRTUAL_PACKAGE_PROPERTY" />
+              </node>
+              <node concept="2OqwBi" id="5JNiskiqvft" role="37vLTx">
+                <node concept="2YIFZM" id="5JNiskiqvfu" role="2Oq$k0">
+                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getPropId(org.jetbrains.mps.openapi.model.SNode)" resolve="getPropId" />
+                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+                  <node concept="37vLTw" id="5JNiskiqvfv" role="37wK5m">
+                    <ref role="3cqZAo" node="5JNiskiq_M9" resolve="MPS_VIRTUAL_PACKAGE_PROPERTY" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5JNiskiqvfw" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SPropertyId.toString()" resolve="toString" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwspqf" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbH" id="5JNiskirCzz" role="8Wnug" />
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwspqg" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskirDae" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskirDVC" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskirEvM" role="37vLTx">
+                <ref role="3cqZAo" node="5AGBwuFJEKi" resolve="LC_NAME_PROPERTY" />
+              </node>
+              <node concept="37vLTw" id="5JNiskirDac" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskirrGQ" resolve="LC_VIRTUAL_PACKAGE_NAME_PROPERTY" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwspqh" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskirFu0" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskirGhZ" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskirGWw" role="37vLTx">
+                <ref role="3cqZAo" node="5M3rB6_PC4J" resolve="KEY_NAME_PROPERTY" />
+              </node>
+              <node concept="37vLTw" id="5JNiskirFtY" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskirATB" resolve="KEY_VIRTUAL_PACKAGE_NAME_PROPERTY" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqwnyFp" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYqwstkt" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwstku" role="3cpWs9">
+            <property role="TrG5h" value="mpsVirtualPackageProp" />
+            <node concept="3Tqbb2" id="7OJcYqwssaH" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqwstkv" role="33vP2m">
+              <node concept="2tJFMh" id="7OJcYqwstkw" role="2Oq$k0">
+                <node concept="ZC_QK" id="7OJcYqwstkx" role="2tJFKM">
                   <ref role="2aWVGs" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                  <node concept="ZC_QK" id="5JNiskiqvf0" role="2aWVGa">
+                  <node concept="ZC_QK" id="7OJcYqwstky" role="2aWVGa">
                     <ref role="2aWVGs" to="tpck:hnGE5uv" resolve="virtualPackage" />
                   </node>
                 </node>
               </node>
-              <node concept="Vyspw" id="5JNiskiqvf1" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiskiqvf2" role="Vysub">
-                  <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqvf3" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskiq_M9" resolve="MPS_VIRTUAL_PACKAGE_PROPERTY" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiskiqvf4" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiqvf5" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiskiqvf6" role="37vLTx">
-              <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
-              <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-              <node concept="37vLTw" id="5JNiskiqvf7" role="37wK5m">
-                <ref role="3cqZAo" node="5JNiskiqTF2" resolve="coreLangHighBits" />
-              </node>
-              <node concept="37vLTw" id="5JNiskiqvf8" role="37wK5m">
-                <ref role="3cqZAo" node="5JNiskiqTF8" resolve="coreLangLowBits" />
-              </node>
-              <node concept="2YIFZM" id="5JNiskiqvf9" role="37wK5m">
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <node concept="2OqwBi" id="5JNiskiqvfa" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiskiqvfb" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
-                  </node>
-                  <node concept="3TrcHB" id="5JNiskiqvfc" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2YIFZM" id="5JNiskiqvfd" role="37wK5m">
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <node concept="2OqwBi" id="5JNiskiqvfe" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiskiqvff" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5JNiskiq_M9" resolve="MPS_VIRTUAL_PACKAGE_PROPERTY" />
-                  </node>
-                  <node concept="3TrcHB" id="5JNiskiqvfg" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="5JNiskiqvfh" role="37wK5m">
-                <node concept="37vLTw" id="5JNiskiqvfi" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5JNiskiq_M9" resolve="MPS_VIRTUAL_PACKAGE_PROPERTY" />
-                </node>
-                <node concept="3TrcHB" id="5JNiskiqvfj" role="2OqNvi">
-                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqvfk" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskiq_Mi" resolve="SLANG_VIRTUAL_PACKAGE_PROPERTY" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiskiqvfl" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiqvfm" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiskiqvfn" role="37vLTx">
-              <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-              <node concept="37vLTw" id="5JNiskiqvfo" role="37wK5m">
-                <ref role="3cqZAo" node="5JNiskiq_M0" resolve="LC_VIRTUAL_PACKAGE_ANNOTATION" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqvfp" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskiq_Mr" resolve="KEY_VIRTUAL_PACKAGE_ANNOTATION" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiskiqvfq" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiqvfr" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqvfs" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskiq_M$" resolve="ID_VIRTUAL_PACKAGE_PROPERTY" />
-            </node>
-            <node concept="2OqwBi" id="5JNiskiqvft" role="37vLTx">
-              <node concept="2YIFZM" id="5JNiskiqvfu" role="2Oq$k0">
-                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getPropId(org.jetbrains.mps.openapi.model.SNode)" resolve="getPropId" />
-                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                <node concept="37vLTw" id="5JNiskiqvfv" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiskiq_M9" resolve="MPS_VIRTUAL_PACKAGE_PROPERTY" />
-                </node>
-              </node>
-              <node concept="liA8E" id="5JNiskiqvfw" role="2OqNvi">
-                <ref role="37wK5l" to="e8bb:~SPropertyId.toString()" resolve="toString" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5JNiskirCzz" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiskirDae" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskirDVC" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskirEvM" role="37vLTx">
-              <ref role="3cqZAo" node="5AGBwuFJEKi" resolve="LC_NAME_PROPERTY" />
-            </node>
-            <node concept="37vLTw" id="5JNiskirDac" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskirrGQ" resolve="LC_VIRTUAL_PACKAGE_NAME_PROPERTY" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiskirFu0" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskirGhZ" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskirGWw" role="37vLTx">
-              <ref role="3cqZAo" node="5M3rB6_PC4J" resolve="KEY_NAME_PROPERTY" />
-            </node>
-            <node concept="37vLTw" id="5JNiskirFtY" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskirATB" resolve="KEY_VIRTUAL_PACKAGE_NAME_PROPERTY" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5JNiskiqvea" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiskiqUBL" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiqUBM" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqUBN" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskiqAL0" resolve="LC_SHORT_DESCRIPTION_ANNOTATION" />
-            </node>
-            <node concept="2OqwBi" id="5JNiskiqUBO" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiskiqUBP" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiskiqUBQ" role="2tJFKM">
-                  <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
-                  <node concept="ZC_QK" id="5JNiskiqUBR" role="2aWVGa">
-                    <ref role="2aWVGs" to="4xw4:5JNiskir1qS" resolve="ShortDescription" />
-                  </node>
-                </node>
-              </node>
-              <node concept="Vyspw" id="5JNiskiqUBT" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiskiqUBU" role="Vysub">
+              <node concept="Vyspw" id="7OJcYqwstkz" role="2OqNvi">
+                <node concept="37vLTw" id="7OJcYqwstk$" role="Vysub">
                   <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiskiqUBC" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiqUBD" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiskiqUBE" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiskiqUBF" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiskiqUBG" role="2tJFKM">
-                  <ref role="2aWVGs" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                  <node concept="ZC_QK" id="5JNiskiqUBH" role="2aWVGa">
-                    <ref role="2aWVGs" to="tpck:gOOYnlO" resolve="shortDescription" />
-                  </node>
-                </node>
-              </node>
-              <node concept="Vyspw" id="5JNiskiqUBI" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiskiqUBJ" role="Vysub">
-                  <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
-                </node>
-              </node>
+        <node concept="3cpWs8" id="7OJcYqwsPL0" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwsPL1" role="3cpWs9">
+            <property role="TrG5h" value="mpsNode" />
+            <node concept="3Tqbb2" id="7OJcYqwsOFh" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
             </node>
-            <node concept="37vLTw" id="5JNiskiqUBK" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskiqAL9" resolve="MPS_SHORT_DESCRIPTION_PROPERTY" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiskiqUBn" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiqUBo" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiskiqUBp" role="37vLTx">
-              <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
-              <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-              <node concept="37vLTw" id="5JNiskiqUBq" role="37wK5m">
-                <ref role="3cqZAo" node="5JNiskiqTF2" resolve="coreLangHighBits" />
+            <node concept="2OqwBi" id="7OJcYqwsPL2" role="33vP2m">
+              <node concept="1rXfSq" id="7OJcYqwsPL3" role="2Oq$k0">
+                <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
               </node>
-              <node concept="37vLTw" id="5JNiskiqUBr" role="37wK5m">
-                <ref role="3cqZAo" node="5JNiskiqTF8" resolve="coreLangLowBits" />
-              </node>
-              <node concept="2YIFZM" id="5JNiskiqUBs" role="37wK5m">
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <node concept="2OqwBi" id="5JNiskiqUBt" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiskiqUBu" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
-                  </node>
-                  <node concept="3TrcHB" id="5JNiskiqUBv" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2YIFZM" id="5JNiskiqUBw" role="37wK5m">
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <node concept="2OqwBi" id="5JNiskiqUBx" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiskiqUBy" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5JNiskiqAL9" resolve="MPS_SHORT_DESCRIPTION_PROPERTY" />
-                  </node>
-                  <node concept="3TrcHB" id="5JNiskiqUBz" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="5JNiskiqUB$" role="37wK5m">
-                <node concept="37vLTw" id="5JNiskiqUB_" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5JNiskiqAL9" resolve="MPS_SHORT_DESCRIPTION_PROPERTY" />
-                </node>
-                <node concept="3TrcHB" id="5JNiskiqUBA" role="2OqNvi">
-                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqUBB" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskiqALi" resolve="SLANG_SHORT_DESCRIPTION_PROPERTY" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiskiqUBi" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiqUBj" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiskiqUBk" role="37vLTx">
-              <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-              <node concept="37vLTw" id="5JNiskiqUBl" role="37wK5m">
-                <ref role="3cqZAo" node="5JNiskiqAL0" resolve="LC_SHORT_DESCRIPTION_ANNOTATION" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqUBm" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskiqALr" resolve="KEY_SHORT_DESCRIPTION_ANNOTATION" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiskiqUBb" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiqUBc" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqUBd" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskiqAL$" resolve="ID_SHORT_DESCRIPTION_PROPERTY" />
-            </node>
-            <node concept="2OqwBi" id="5JNiskiqUBe" role="37vLTx">
-              <node concept="2YIFZM" id="5JNiskiqUBf" role="2Oq$k0">
-                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getPropId(org.jetbrains.mps.openapi.model.SNode)" resolve="getPropId" />
-                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                <node concept="37vLTw" id="5JNiskiqUBg" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiskiqAL9" resolve="MPS_SHORT_DESCRIPTION_PROPERTY" />
-                </node>
-              </node>
-              <node concept="liA8E" id="5JNiskiqUBh" role="2OqNvi">
-                <ref role="37wK5l" to="e8bb:~SPropertyId.toString()" resolve="toString" />
+              <node concept="liA8E" id="7OJcYqwsPL4" role="2OqNvi">
+                <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="5JNiskiqUBa" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiskirIur" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskirIXA" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskirIup" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskirxyP" resolve="LC_SHORT_DESCRIPTION_DESCRIPTION_PROPERTY" />
+        <node concept="3clFbF" id="7OJcYqwumFi" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqwumFj" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqwumFk" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqwumFl" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqwumFm" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqwumEM" resolve="VIRTUAL_PACKAGE" />
+              </node>
             </node>
-            <node concept="2OqwBi" id="5JNiskirJE0" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiskirJE1" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiskirJE2" role="2tJFKM">
-                  <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
-                  <node concept="ZC_QK" id="5JNiskirJE3" role="2aWVGa">
-                    <ref role="2aWVGs" to="4xw4:5JNiskir1qS" resolve="ShortDescription" />
-                    <node concept="ZC_QK" id="5JNiskirKgZ" role="2aWVGa">
-                      <ref role="2aWVGs" to="4xw4:5JNiskir1qZ" resolve="description" />
+            <node concept="2ShNRf" id="7OJcYqwumFn" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqwumFo" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqwnwCo" resolve="AnnotationPropertyKeyedMapping" />
+                <node concept="2OqwBi" id="7OJcYqwumFp" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqwumFq" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqwumFr" role="2tJFKM">
+                      <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
+                      <node concept="ZC_QK" id="7OJcYqwumFs" role="2aWVGa">
+                        <ref role="2aWVGs" to="4xw4:5JNiskir1qK" resolve="VirtualPackage" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqwumFt" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqwumFu" role="Vysub">
+                      <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqwumFv" role="37wK5m">
+                  <node concept="1rXfSq" id="7OJcYqwumFw" role="2Oq$k0">
+                    <ref role="37wK5l" node="7OJcYqwir$m" resolve="getINamedName" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYqwumFx" role="2OqNvi">
+                    <ref role="37wK5l" node="7OJcYqvKqcL" resolve="getLc" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="7OJcYqwumFy" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqwstku" resolve="mpsVirtualPackageProp" />
+                </node>
+                <node concept="2YIFZM" id="7OJcYqwumFz" role="37wK5m">
+                  <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
+                  <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                  <node concept="37vLTw" id="7OJcYqwumF$" role="37wK5m">
+                    <ref role="3cqZAo" node="5JNiskiqTF2" resolve="coreLangHighBits" />
+                  </node>
+                  <node concept="37vLTw" id="7OJcYqwumF_" role="37wK5m">
+                    <ref role="3cqZAo" node="5JNiskiqTF8" resolve="coreLangLowBits" />
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYqwumFA" role="37wK5m">
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <node concept="2OqwBi" id="7OJcYqwumFB" role="37wK5m">
+                      <node concept="37vLTw" id="7OJcYqwumFC" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwsPL1" resolve="mpsNode" />
+                      </node>
+                      <node concept="3TrcHB" id="7OJcYqwumFD" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYqwumFE" role="37wK5m">
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <node concept="2OqwBi" id="7OJcYqwumFF" role="37wK5m">
+                      <node concept="37vLTw" id="7OJcYqwumFG" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwstku" resolve="mpsVirtualPackageProp" />
+                      </node>
+                      <node concept="3TrcHB" id="7OJcYqwumFH" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqwumFI" role="37wK5m">
+                    <node concept="37vLTw" id="7OJcYqwumFJ" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYqwstku" resolve="mpsVirtualPackageProp" />
+                    </node>
+                    <node concept="3TrcHB" id="7OJcYqwumFK" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="Vyspw" id="5JNiskirJE4" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiskirJE5" role="Vysub">
-                  <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5JNiskiqvea" role="3cqZAp" />
+        <node concept="1X3_iC" id="7OJcYqwsC4F" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiqUBL" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiqUBM" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqUBN" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskiqAL0" resolve="LC_SHORT_DESCRIPTION_ANNOTATION" />
+              </node>
+              <node concept="2OqwBi" id="5JNiskiqUBO" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiskiqUBP" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiskiqUBQ" role="2tJFKM">
+                    <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
+                    <node concept="ZC_QK" id="5JNiskiqUBR" role="2aWVGa">
+                      <ref role="2aWVGs" to="4xw4:5JNiskir1qS" resolve="ShortDescription" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiskiqUBT" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiskiqUBU" role="Vysub">
+                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                  </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiskirLBn" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskirMdt" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskirLBl" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskirzDP" resolve="KEY_SHORT_DESCRIPTION_DESCRIPTION_PROPERTY" />
+        <node concept="1X3_iC" id="7OJcYqwsC4G" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiqUBC" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiqUBD" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiskiqUBE" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiskiqUBF" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiskiqUBG" role="2tJFKM">
+                    <ref role="2aWVGs" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                    <node concept="ZC_QK" id="5JNiskiqUBH" role="2aWVGa">
+                      <ref role="2aWVGs" to="tpck:gOOYnlO" resolve="shortDescription" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiskiqUBI" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiskiqUBJ" role="Vysub">
+                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqUBK" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskiqAL9" resolve="MPS_SHORT_DESCRIPTION_PROPERTY" />
+              </node>
             </node>
-            <node concept="2YIFZM" id="5JNiskirMKQ" role="37vLTx">
-              <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-              <node concept="37vLTw" id="5JNiskirMKR" role="37wK5m">
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwsC4H" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiqUBn" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiqUBo" role="3clFbG">
+              <node concept="2YIFZM" id="5JNiskiqUBp" role="37vLTx">
+                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
+                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                <node concept="37vLTw" id="5JNiskiqUBq" role="37wK5m">
+                  <ref role="3cqZAo" node="5JNiskiqTF2" resolve="coreLangHighBits" />
+                </node>
+                <node concept="37vLTw" id="5JNiskiqUBr" role="37wK5m">
+                  <ref role="3cqZAo" node="5JNiskiqTF8" resolve="coreLangLowBits" />
+                </node>
+                <node concept="2YIFZM" id="5JNiskiqUBs" role="37wK5m">
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <node concept="2OqwBi" id="5JNiskiqUBt" role="37wK5m">
+                    <node concept="37vLTw" id="5JNiskiqUBu" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
+                    </node>
+                    <node concept="3TrcHB" id="5JNiskiqUBv" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="5JNiskiqUBw" role="37wK5m">
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <node concept="2OqwBi" id="5JNiskiqUBx" role="37wK5m">
+                    <node concept="37vLTw" id="5JNiskiqUBy" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5JNiskiqAL9" resolve="MPS_SHORT_DESCRIPTION_PROPERTY" />
+                    </node>
+                    <node concept="3TrcHB" id="5JNiskiqUBz" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5JNiskiqUB$" role="37wK5m">
+                  <node concept="37vLTw" id="5JNiskiqUB_" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5JNiskiqAL9" resolve="MPS_SHORT_DESCRIPTION_PROPERTY" />
+                  </node>
+                  <node concept="3TrcHB" id="5JNiskiqUBA" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqUBB" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskiqALi" resolve="SLANG_SHORT_DESCRIPTION_PROPERTY" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwsC4I" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiqUBi" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiqUBj" role="3clFbG">
+              <node concept="2YIFZM" id="7OJcYqwPrVf" role="37vLTx">
+                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+                <node concept="37vLTw" id="5JNiskiqUBl" role="37wK5m">
+                  <ref role="3cqZAo" node="5JNiskiqAL0" resolve="LC_SHORT_DESCRIPTION_ANNOTATION" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqUBm" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskiqALr" resolve="KEY_SHORT_DESCRIPTION_ANNOTATION" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwsC4J" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiqUBb" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiqUBc" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqUBd" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskiqAL$" resolve="ID_SHORT_DESCRIPTION_PROPERTY" />
+              </node>
+              <node concept="2OqwBi" id="5JNiskiqUBe" role="37vLTx">
+                <node concept="2YIFZM" id="5JNiskiqUBf" role="2Oq$k0">
+                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getPropId(org.jetbrains.mps.openapi.model.SNode)" resolve="getPropId" />
+                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+                  <node concept="37vLTw" id="5JNiskiqUBg" role="37wK5m">
+                    <ref role="3cqZAo" node="5JNiskiqAL9" resolve="MPS_SHORT_DESCRIPTION_PROPERTY" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5JNiskiqUBh" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SPropertyId.toString()" resolve="toString" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwsC4K" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbH" id="5JNiskiqUBa" role="8Wnug" />
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwsC4L" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskirIur" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskirIXA" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskirIup" role="37vLTJ">
                 <ref role="3cqZAo" node="5JNiskirxyP" resolve="LC_SHORT_DESCRIPTION_DESCRIPTION_PROPERTY" />
+              </node>
+              <node concept="2OqwBi" id="5JNiskirJE0" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiskirJE1" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiskirJE2" role="2tJFKM">
+                    <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
+                    <node concept="ZC_QK" id="5JNiskirJE3" role="2aWVGa">
+                      <ref role="2aWVGs" to="4xw4:5JNiskir1qS" resolve="ShortDescription" />
+                      <node concept="ZC_QK" id="5JNiskirKgZ" role="2aWVGa">
+                        <ref role="2aWVGs" to="4xw4:5JNiskir1qZ" resolve="description" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiskirJE4" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiskirJE5" role="Vysub">
+                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwsC4M" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskirLBn" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskirMdt" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskirLBl" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskirzDP" resolve="KEY_SHORT_DESCRIPTION_DESCRIPTION_PROPERTY" />
+              </node>
+              <node concept="2YIFZM" id="7OJcYqwPrVg" role="37vLTx">
+                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+                <node concept="37vLTw" id="5JNiskirMKR" role="37wK5m">
+                  <ref role="3cqZAo" node="5JNiskirxyP" resolve="LC_SHORT_DESCRIPTION_DESCRIPTION_PROPERTY" />
+                </node>
               </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="34Q84zNOgJd" role="3cqZAp" />
-        <node concept="3clFbF" id="34Q84zNQalK" role="3cqZAp">
-          <node concept="37vLTI" id="34Q84zNQalL" role="3clFbG">
-            <node concept="37vLTw" id="34Q84zNQalM" role="37vLTJ">
-              <ref role="3cqZAo" node="34Q84zNPNje" resolve="SLANG_STRUCTURE_LANGUAGE" />
+        <node concept="3cpWs8" id="7OJcYqwsFRR" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwsFRS" role="3cpWs9">
+            <property role="TrG5h" value="mpsShortDescriptionProp" />
+            <node concept="3Tqbb2" id="7OJcYqwsEIk" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
             </node>
-            <node concept="pHN19" id="34Q84zNQalN" role="37vLTx">
-              <node concept="2V$Bhx" id="34Q84zNQhza" role="2V$M_3">
-                <property role="2V$B1T" value="c72da2b9-7cce-4447-8389-f407dc1158b7" />
-                <property role="2V$B1Q" value="jetbrains.mps.lang.structure" />
+            <node concept="2OqwBi" id="7OJcYqwsFRT" role="33vP2m">
+              <node concept="2tJFMh" id="7OJcYqwsFRU" role="2Oq$k0">
+                <node concept="ZC_QK" id="7OJcYqwsFRV" role="2tJFKM">
+                  <ref role="2aWVGs" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                  <node concept="ZC_QK" id="7OJcYqwsFRW" role="2aWVGa">
+                    <ref role="2aWVGs" to="tpck:gOOYnlO" resolve="shortDescription" />
+                  </node>
+                </node>
+              </node>
+              <node concept="Vyspw" id="7OJcYqwsFRX" role="2OqNvi">
+                <node concept="37vLTw" id="7OJcYqwsFRY" role="Vysub">
+                  <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="34Q84zNQalP" role="3cqZAp">
-          <node concept="37vLTI" id="34Q84zNQalQ" role="3clFbG">
-            <node concept="2YIFZM" id="34Q84zNQalR" role="37vLTx">
-              <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
-              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-              <node concept="37vLTw" id="34Q84zNQalS" role="37wK5m">
+        <node concept="3clFbF" id="7OJcYqwusrZ" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqwuss0" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqwuss1" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqwuss2" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqwuss3" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqwusrr" resolve="SHORT_DESCRIPTION" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqwuss4" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqwuss5" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqwnwCo" resolve="AnnotationPropertyKeyedMapping" />
+                <node concept="2OqwBi" id="7OJcYqwuss6" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqwuss7" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqwuss8" role="2tJFKM">
+                      <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
+                      <node concept="ZC_QK" id="7OJcYqwuss9" role="2aWVGa">
+                        <ref role="2aWVGs" to="4xw4:5JNiskir1qS" resolve="ShortDescription" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqwussa" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqwussb" role="Vysub">
+                      <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqwussc" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqwussd" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqwusse" role="2tJFKM">
+                      <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
+                      <node concept="ZC_QK" id="7OJcYqwussf" role="2aWVGa">
+                        <ref role="2aWVGs" to="4xw4:5JNiskir1qS" resolve="ShortDescription" />
+                        <node concept="ZC_QK" id="7OJcYqwussg" role="2aWVGa">
+                          <ref role="2aWVGs" to="4xw4:5JNiskir1qZ" resolve="description" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqwussh" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqwussi" role="Vysub">
+                      <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="7OJcYqwussj" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqwsFRS" resolve="mpsShortDescriptionProp" />
+                </node>
+                <node concept="2YIFZM" id="7OJcYqwussk" role="37wK5m">
+                  <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                  <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
+                  <node concept="37vLTw" id="7OJcYqwussl" role="37wK5m">
+                    <ref role="3cqZAo" node="5JNiskiqTF2" resolve="coreLangHighBits" />
+                  </node>
+                  <node concept="37vLTw" id="7OJcYqwussm" role="37wK5m">
+                    <ref role="3cqZAo" node="5JNiskiqTF8" resolve="coreLangLowBits" />
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYqwussn" role="37wK5m">
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <node concept="2OqwBi" id="7OJcYqwusso" role="37wK5m">
+                      <node concept="37vLTw" id="7OJcYqwussp" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwsPL1" resolve="mpsNode" />
+                      </node>
+                      <node concept="3TrcHB" id="7OJcYqwussq" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYqwussr" role="37wK5m">
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <node concept="2OqwBi" id="7OJcYqwusss" role="37wK5m">
+                      <node concept="37vLTw" id="7OJcYqwusst" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwsFRS" resolve="mpsShortDescriptionProp" />
+                      </node>
+                      <node concept="3TrcHB" id="7OJcYqwussu" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqwussv" role="37wK5m">
+                    <node concept="37vLTw" id="7OJcYqwussw" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYqwsFRS" resolve="mpsShortDescriptionProp" />
+                    </node>
+                    <node concept="3TrcHB" id="7OJcYqwussx" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqwpPmO" role="3cqZAp" />
+        <node concept="1X3_iC" id="7OJcYqwsXHV" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="34Q84zNQalK" role="8Wnug">
+            <node concept="37vLTI" id="34Q84zNQalL" role="3clFbG">
+              <node concept="37vLTw" id="34Q84zNQalM" role="37vLTJ">
                 <ref role="3cqZAo" node="34Q84zNPNje" resolve="SLANG_STRUCTURE_LANGUAGE" />
               </node>
-            </node>
-            <node concept="37vLTw" id="34Q84zNQalT" role="37vLTJ">
-              <ref role="3cqZAo" node="34Q84zNPKIX" resolve="SLANG_STRUCTURE_LANGUAGE_ID" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="34Q84zNQalU" role="3cqZAp">
-          <node concept="37vLTI" id="34Q84zNQalV" role="3clFbG">
-            <node concept="37vLTw" id="34Q84zNQalW" role="37vLTJ">
-              <ref role="3cqZAo" node="34Q84zNPOE1" resolve="KEY_STRUCTURE_LANGUAGE" />
-            </node>
-            <node concept="2YIFZM" id="5M8g5cT0H0_" role="37vLTx">
-              <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-              <node concept="37vLTw" id="5M8g5cT0H0A" role="37wK5m">
-                <ref role="3cqZAo" node="5JNiskiqAL0" resolve="LC_SHORT_DESCRIPTION_ANNOTATION" />
+              <node concept="pHN19" id="34Q84zNQalN" role="37vLTx">
+                <node concept="2V$Bhx" id="34Q84zNQhza" role="2V$M_3">
+                  <property role="2V$B1T" value="c72da2b9-7cce-4447-8389-f407dc1158b7" />
+                  <property role="2V$B1Q" value="jetbrains.mps.lang.structure" />
+                </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="34Q84zNQalY" role="3cqZAp">
-          <node concept="37vLTI" id="34Q84zNQalZ" role="3clFbG">
-            <node concept="37vLTw" id="34Q84zNQam0" role="37vLTJ">
-              <ref role="3cqZAo" node="34Q84zNPQ8E" resolve="ID_STRUCTURE_LANGUAGE" />
-            </node>
-            <node concept="2OqwBi" id="34Q84zNQam1" role="37vLTx">
-              <node concept="37vLTw" id="34Q84zNQam2" role="2Oq$k0">
-                <ref role="3cqZAo" node="34Q84zNPNje" resolve="SLANG_STRUCTURE_LANGUAGE" />
-              </node>
-              <node concept="liA8E" id="34Q84zNQam3" role="2OqNvi">
-                <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="34Q84zNQam4" role="3cqZAp">
-          <node concept="37vLTI" id="34Q84zNQam5" role="3clFbG">
-            <node concept="37vLTw" id="34Q84zNQam6" role="37vLTJ">
-              <ref role="3cqZAo" node="34Q84zNPRvz" resolve="VERSION_STRUCTURE_LANGUAGE" />
-            </node>
-            <node concept="2YIFZM" id="34Q84zNQam7" role="37vLTx">
-              <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
-              <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
-              <node concept="2YIFZM" id="34Q84zNQam8" role="37wK5m">
-                <ref role="1Pybhc" node="6jTTMHD72IS" resolve="MpsLanguageUtil" />
-                <ref role="37wK5l" node="6jTTMHD72KX" resolve="getLanguageVersion" />
-                <node concept="37vLTw" id="34Q84zNQam9" role="37wK5m">
+        <node concept="1X3_iC" id="7OJcYqwsXHW" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="34Q84zNQalP" role="8Wnug">
+            <node concept="37vLTI" id="34Q84zNQalQ" role="3clFbG">
+              <node concept="2YIFZM" id="34Q84zNQalR" role="37vLTx">
+                <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
+                <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
+                <node concept="37vLTw" id="34Q84zNQalS" role="37wK5m">
                   <ref role="3cqZAo" node="34Q84zNPNje" resolve="SLANG_STRUCTURE_LANGUAGE" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="34Q84zNQalT" role="37vLTJ">
+                <ref role="3cqZAo" node="34Q84zNPKIX" resolve="SLANG_STRUCTURE_LANGUAGE_ID" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwsXHX" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="34Q84zNQalU" role="8Wnug">
+            <node concept="37vLTI" id="34Q84zNQalV" role="3clFbG">
+              <node concept="37vLTw" id="34Q84zNQalW" role="37vLTJ">
+                <ref role="3cqZAo" node="34Q84zNPOE1" resolve="KEY_STRUCTURE_LANGUAGE" />
+              </node>
+              <node concept="2YIFZM" id="7OJcYqwPrVh" role="37vLTx">
+                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+                <node concept="37vLTw" id="5M8g5cT0H0A" role="37wK5m">
+                  <ref role="3cqZAo" node="5JNiskiqAL0" resolve="LC_SHORT_DESCRIPTION_ANNOTATION" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwsXHY" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="34Q84zNQalY" role="8Wnug">
+            <node concept="37vLTI" id="34Q84zNQalZ" role="3clFbG">
+              <node concept="37vLTw" id="34Q84zNQam0" role="37vLTJ">
+                <ref role="3cqZAo" node="34Q84zNPQ8E" resolve="ID_STRUCTURE_LANGUAGE" />
+              </node>
+              <node concept="2OqwBi" id="34Q84zNQam1" role="37vLTx">
+                <node concept="37vLTw" id="34Q84zNQam2" role="2Oq$k0">
+                  <ref role="3cqZAo" node="34Q84zNPNje" resolve="SLANG_STRUCTURE_LANGUAGE" />
+                </node>
+                <node concept="liA8E" id="34Q84zNQam3" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwsXHZ" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="34Q84zNQam4" role="8Wnug">
+            <node concept="37vLTI" id="34Q84zNQam5" role="3clFbG">
+              <node concept="37vLTw" id="34Q84zNQam6" role="37vLTJ">
+                <ref role="3cqZAo" node="34Q84zNPRvz" resolve="VERSION_STRUCTURE_LANGUAGE" />
+              </node>
+              <node concept="2YIFZM" id="34Q84zNQam7" role="37vLTx">
+                <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
+                <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
+                <node concept="2YIFZM" id="34Q84zNQam8" role="37wK5m">
+                  <ref role="1Pybhc" node="6jTTMHD72IS" resolve="MpsLanguageUtil" />
+                  <ref role="37wK5l" node="6jTTMHD72KX" resolve="getLanguageVersion" />
+                  <node concept="37vLTw" id="34Q84zNQam9" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNPNje" resolve="SLANG_STRUCTURE_LANGUAGE" />
+                  </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="34Q84zNQ9lf" role="3cqZAp" />
+        <node concept="3clFbF" id="7OJcYqwuwtA" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqwuwtB" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqwuwtC" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqwuwtD" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqwuwtE" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqwuwts" resolve="STRUCTURE_LANGUAGE" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqwuwtF" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqwuwtG" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqwqm3V" resolve="LanguageKeyedMapping" />
+                <node concept="pHN19" id="7OJcYqwuwtH" role="37wK5m">
+                  <node concept="2V$Bhx" id="7OJcYqwuwtI" role="2V$M_3">
+                    <property role="2V$B1T" value="c72da2b9-7cce-4447-8389-f407dc1158b7" />
+                    <property role="2V$B1Q" value="jetbrains.mps.lang.structure" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqwq5xZ" role="3cqZAp" />
         <node concept="3cpWs8" id="34Q84zNQETC" role="3cqZAp">
           <node concept="3cpWsn" id="34Q84zNQETD" role="3cpWs9">
             <property role="TrG5h" value="structureLangHighBits" />
             <property role="3TUv4t" value="true" />
             <node concept="3cpWsb" id="34Q84zNQETE" role="1tU5fm" />
             <node concept="2OqwBi" id="34Q84zNQETF" role="33vP2m">
-              <node concept="37vLTw" id="34Q84zNQETG" role="2Oq$k0">
-                <ref role="3cqZAo" node="34Q84zNPKIX" resolve="SLANG_STRUCTURE_LANGUAGE_ID" />
+              <node concept="2OqwBi" id="7OJcYqwu_ME" role="2Oq$k0">
+                <node concept="37vLTw" id="34Q84zNQETG" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7OJcYqwuwts" resolve="STRUCTURE_LANGUAGE" />
+                </node>
+                <node concept="liA8E" id="7OJcYqwuB3$" role="2OqNvi">
+                  <ref role="37wK5l" node="7OJcYqw7aei" resolve="getSlangId" />
+                </node>
               </node>
               <node concept="liA8E" id="34Q84zNQETH" role="2OqNvi">
                 <ref role="37wK5l" to="e8bb:~SLanguageId.getHighBits()" resolve="getHighBits" />
@@ -952,349 +1506,792 @@
             <property role="3TUv4t" value="true" />
             <node concept="3cpWsb" id="34Q84zNQETK" role="1tU5fm" />
             <node concept="2OqwBi" id="34Q84zNQETL" role="33vP2m">
-              <node concept="37vLTw" id="34Q84zNQETM" role="2Oq$k0">
-                <ref role="3cqZAo" node="34Q84zNPKIX" resolve="SLANG_STRUCTURE_LANGUAGE_ID" />
-              </node>
               <node concept="liA8E" id="34Q84zNQETN" role="2OqNvi">
                 <ref role="37wK5l" to="e8bb:~SLanguageId.getLowBits()" resolve="getLowBits" />
+              </node>
+              <node concept="2OqwBi" id="7OJcYqwuDAW" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYqwuDAX" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7OJcYqwuwts" resolve="STRUCTURE_LANGUAGE" />
+                </node>
+                <node concept="liA8E" id="7OJcYqwuDAY" role="2OqNvi">
+                  <ref role="37wK5l" node="7OJcYqw7aei" resolve="getSlangId" />
+                </node>
               </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="34Q84zNQEPO" role="3cqZAp" />
-        <node concept="3clFbF" id="34Q84zNOhCM" role="3cqZAp">
-          <node concept="37vLTI" id="34Q84zNOiG9" role="3clFbG">
-            <node concept="2OqwBi" id="34Q84zNOmSj" role="37vLTx">
-              <node concept="2tJFMh" id="34Q84zNOjEG" role="2Oq$k0">
-                <node concept="ZC_QK" id="34Q84zNOkwm" role="2tJFKM">
-                  <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
-                  <node concept="ZC_QK" id="34Q84zNOlm5" role="2aWVGa">
-                    <ref role="2aWVGs" to="4xw4:34Q84zMNsGk" resolve="ConceptDescription" />
+        <node concept="1X3_iC" id="7OJcYqwt1nW" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="34Q84zNOhCM" role="8Wnug">
+            <node concept="37vLTI" id="34Q84zNOiG9" role="3clFbG">
+              <node concept="2OqwBi" id="34Q84zNOmSj" role="37vLTx">
+                <node concept="2tJFMh" id="34Q84zNOjEG" role="2Oq$k0">
+                  <node concept="ZC_QK" id="34Q84zNOkwm" role="2tJFKM">
+                    <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
+                    <node concept="ZC_QK" id="34Q84zNOlm5" role="2aWVGa">
+                      <ref role="2aWVGs" to="4xw4:34Q84zMNsGk" resolve="ConceptDescription" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Vyspw" id="34Q84zNOo1s" role="2OqNvi">
+                  <node concept="37vLTw" id="34Q84zNOoK9" role="Vysub">
+                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
                   </node>
                 </node>
               </node>
-              <node concept="Vyspw" id="34Q84zNOo1s" role="2OqNvi">
-                <node concept="37vLTw" id="34Q84zNOoK9" role="Vysub">
-                  <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="34Q84zNOhCK" role="37vLTJ">
-              <ref role="3cqZAo" node="34Q84zNNvVS" resolve="LC_CONCEPT_DESCRIPTION_ANNOTATION" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="34Q84zNRqnP" role="3cqZAp">
-          <node concept="37vLTI" id="34Q84zNRrsU" role="3clFbG">
-            <node concept="37vLTw" id="34Q84zNRqnN" role="37vLTJ">
-              <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
-            </node>
-            <node concept="2OqwBi" id="34Q84zNRv_k" role="37vLTx">
-              <node concept="2tJFMh" id="34Q84zNRv_l" role="2Oq$k0">
-                <node concept="ZC_QK" id="34Q84zNRv_m" role="2tJFKM">
-                  <ref role="2aWVGs" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                </node>
-              </node>
-              <node concept="Vyspw" id="34Q84zNRv_n" role="2OqNvi">
-                <node concept="37vLTw" id="34Q84zNRv_o" role="Vysub">
-                  <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
-                </node>
+              <node concept="37vLTw" id="34Q84zNOhCK" role="37vLTJ">
+                <ref role="3cqZAo" node="34Q84zNNvVS" resolve="LC_CONCEPT_DESCRIPTION_ANNOTATION" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="7weWCFlnuRC" role="3cqZAp">
-          <node concept="37vLTI" id="7weWCFlnwgk" role="3clFbG">
-            <node concept="2YIFZM" id="7weWCFlnY$f" role="37vLTx">
-              <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-              <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
-              <node concept="37vLTw" id="7weWCFlnY$g" role="37wK5m">
-                <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+        <node concept="1X3_iC" id="7OJcYqwt1nX" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="34Q84zNRqnP" role="8Wnug">
+            <node concept="37vLTI" id="34Q84zNRrsU" role="3clFbG">
+              <node concept="37vLTw" id="34Q84zNRqnN" role="37vLTJ">
+                <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
               </node>
-              <node concept="37vLTw" id="7weWCFlo0Q3" role="37wK5m">
-                <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+              <node concept="2OqwBi" id="34Q84zNRv_k" role="37vLTx">
+                <node concept="2tJFMh" id="34Q84zNRv_l" role="2Oq$k0">
+                  <node concept="ZC_QK" id="34Q84zNRv_m" role="2tJFKM">
+                    <ref role="2aWVGs" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                  </node>
+                </node>
+                <node concept="Vyspw" id="34Q84zNRv_n" role="2OqNvi">
+                  <node concept="37vLTw" id="34Q84zNRv_o" role="Vysub">
+                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                  </node>
+                </node>
               </node>
-              <node concept="2YIFZM" id="7weWCFlo4mC" role="37wK5m">
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <node concept="2OqwBi" id="7weWCFlo6pf" role="37wK5m">
-                  <node concept="37vLTw" id="7weWCFlo5rf" role="2Oq$k0">
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwt1nY" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="7weWCFlnuRC" role="8Wnug">
+            <node concept="37vLTI" id="7weWCFlnwgk" role="3clFbG">
+              <node concept="2YIFZM" id="7weWCFlnY$f" role="37vLTx">
+                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
+                <node concept="37vLTw" id="7weWCFlnY$g" role="37wK5m">
+                  <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+                </node>
+                <node concept="37vLTw" id="7weWCFlo0Q3" role="37wK5m">
+                  <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+                </node>
+                <node concept="2YIFZM" id="7weWCFlo4mC" role="37wK5m">
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <node concept="2OqwBi" id="7weWCFlo6pf" role="37wK5m">
+                    <node concept="37vLTw" id="7weWCFlo5rf" role="2Oq$k0">
+                      <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
+                    </node>
+                    <node concept="3TrcHB" id="7weWCFlo898" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7weWCFlobCi" role="37wK5m">
+                  <node concept="37vLTw" id="7weWCFloahn" role="2Oq$k0">
                     <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
                   </node>
-                  <node concept="3TrcHB" id="7weWCFlo898" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                  <node concept="3TrcHB" id="7weWCFlod5n" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                   </node>
                 </node>
               </node>
-              <node concept="2OqwBi" id="7weWCFlobCi" role="37wK5m">
-                <node concept="37vLTw" id="7weWCFloahn" role="2Oq$k0">
-                  <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
-                </node>
-                <node concept="3TrcHB" id="7weWCFlod5n" role="2OqNvi">
-                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                </node>
+              <node concept="37vLTw" id="7weWCFlnuRA" role="37vLTJ">
+                <ref role="3cqZAo" node="7weWCFlnksG" resolve="SLANG_ABSTRACT_CONCEPT_CONCEPT" />
               </node>
-            </node>
-            <node concept="37vLTw" id="7weWCFlnuRA" role="37vLTJ">
-              <ref role="3cqZAo" node="7weWCFlnksG" resolve="SLANG_ABSTRACT_CONCEPT_CONCEPT" />
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="7weWCFloe7n" role="3cqZAp" />
-        <node concept="3clFbF" id="5M8g5cSBlZU" role="3cqZAp">
-          <node concept="37vLTI" id="5M8g5cSBlZV" role="3clFbG">
-            <node concept="37vLTw" id="5M8g5cSBlZW" role="37vLTJ">
-              <ref role="3cqZAo" node="5M8g5cSB02I" resolve="MPS_CONCEPT_DECLARATION_CONCEPT" />
+        <node concept="3cpWs8" id="7OJcYqwt4hL" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwt4hM" role="3cpWs9">
+            <property role="TrG5h" value="mpsClassifier" />
+            <node concept="3Tqbb2" id="7OJcYqwt3hh" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
             </node>
-            <node concept="2OqwBi" id="5M8g5cSBlZX" role="37vLTx">
-              <node concept="2tJFMh" id="5M8g5cSBlZY" role="2Oq$k0">
-                <node concept="ZC_QK" id="5M8g5cSBlZZ" role="2tJFKM">
-                  <ref role="2aWVGs" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+            <node concept="2OqwBi" id="7OJcYqwt4hN" role="33vP2m">
+              <node concept="2tJFMh" id="7OJcYqwt4hO" role="2Oq$k0">
+                <node concept="ZC_QK" id="7OJcYqwt4hP" role="2tJFKM">
+                  <ref role="2aWVGs" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
                 </node>
               </node>
-              <node concept="Vyspw" id="5M8g5cSBm00" role="2OqNvi">
-                <node concept="37vLTw" id="5M8g5cSBm01" role="Vysub">
+              <node concept="Vyspw" id="7OJcYqwt4hQ" role="2OqNvi">
+                <node concept="37vLTw" id="7OJcYqwt4hR" role="Vysub">
                   <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5M8g5cSBlZH" role="3cqZAp">
-          <node concept="37vLTI" id="5M8g5cSBlZI" role="3clFbG">
-            <node concept="2YIFZM" id="5M8g5cSBlZJ" role="37vLTx">
-              <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-              <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
-              <node concept="37vLTw" id="5M8g5cSBlZK" role="37wK5m">
-                <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+        <node concept="3clFbF" id="7OJcYqwuG9M" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqwuG9N" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqwuG9O" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqwuG9P" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqwuG9Q" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqwuG9p" resolve="CLASSIFIER" />
               </node>
-              <node concept="37vLTw" id="5M8g5cSBlZL" role="37wK5m">
-                <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
-              </node>
-              <node concept="2YIFZM" id="5M8g5cSBlZM" role="37wK5m">
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <node concept="2OqwBi" id="5M8g5cSBlZN" role="37wK5m">
-                  <node concept="37vLTw" id="5M8g5cSBlZO" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5M8g5cSB02I" resolve="MPS_CONCEPT_DECLARATION_CONCEPT" />
+            </node>
+            <node concept="2ShNRf" id="7OJcYqwuG9R" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqwuG9S" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqwqLmd" resolve="AnnotationConceptKeyedMapping" />
+                <node concept="2OqwBi" id="7OJcYqwuG9T" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqwuG9U" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqwuG9V" role="2tJFKM">
+                      <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
+                      <node concept="ZC_QK" id="7OJcYqwuG9W" role="2aWVGa">
+                        <ref role="2aWVGs" to="4xw4:34Q84zMNsGk" resolve="ConceptDescription" />
+                      </node>
+                    </node>
                   </node>
-                  <node concept="3TrcHB" id="5M8g5cSBlZP" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                  <node concept="Vyspw" id="7OJcYqwuG9X" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqwuG9Y" role="Vysub">
+                      <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                    </node>
                   </node>
                 </node>
-              </node>
-              <node concept="2OqwBi" id="5M8g5cSBlZQ" role="37wK5m">
-                <node concept="37vLTw" id="5M8g5cSBlZR" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5M8g5cSB02I" resolve="MPS_CONCEPT_DECLARATION_CONCEPT" />
+                <node concept="37vLTw" id="7OJcYqwuG9Z" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqwt4hM" resolve="mpsClassifier" />
                 </node>
-                <node concept="3TrcHB" id="5M8g5cSBlZS" role="2OqNvi">
-                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                <node concept="2YIFZM" id="7OJcYqwuGa0" role="37wK5m">
+                  <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
+                  <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                  <node concept="37vLTw" id="7OJcYqwuGa1" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+                  </node>
+                  <node concept="37vLTw" id="7OJcYqwuGa2" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYqwuGa3" role="37wK5m">
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <node concept="2OqwBi" id="7OJcYqwuGa4" role="37wK5m">
+                      <node concept="37vLTw" id="7OJcYqwuGa5" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwt4hM" resolve="mpsClassifier" />
+                      </node>
+                      <node concept="3TrcHB" id="7OJcYqwuGa6" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqwuGa7" role="37wK5m">
+                    <node concept="37vLTw" id="7OJcYqwuGa8" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYqwt4hM" resolve="mpsClassifier" />
+                    </node>
+                    <node concept="3TrcHB" id="7OJcYqwuGa9" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
-            <node concept="37vLTw" id="5M8g5cSBlZT" role="37vLTJ">
-              <ref role="3cqZAo" node="5M8g5cSB02$" resolve="SLANG_CONCEPT_CONCEPT" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqwqY8j" role="3cqZAp" />
+        <node concept="1X3_iC" id="7OJcYqwtcQ8" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5M8g5cSBlZU" role="8Wnug">
+            <node concept="37vLTI" id="5M8g5cSBlZV" role="3clFbG">
+              <node concept="37vLTw" id="5M8g5cSBlZW" role="37vLTJ">
+                <ref role="3cqZAo" node="5M8g5cSB02I" resolve="MPS_CONCEPT_DECLARATION_CONCEPT" />
+              </node>
+              <node concept="2OqwBi" id="5M8g5cSBlZX" role="37vLTx">
+                <node concept="2tJFMh" id="5M8g5cSBlZY" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5M8g5cSBlZZ" role="2tJFKM">
+                    <ref role="2aWVGs" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5M8g5cSBm00" role="2OqNvi">
+                  <node concept="37vLTw" id="5M8g5cSBm01" role="Vysub">
+                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwtcQ9" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5M8g5cSBlZH" role="8Wnug">
+            <node concept="37vLTI" id="5M8g5cSBlZI" role="3clFbG">
+              <node concept="2YIFZM" id="5M8g5cSBlZJ" role="37vLTx">
+                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
+                <node concept="37vLTw" id="5M8g5cSBlZK" role="37wK5m">
+                  <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+                </node>
+                <node concept="37vLTw" id="5M8g5cSBlZL" role="37wK5m">
+                  <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+                </node>
+                <node concept="2YIFZM" id="5M8g5cSBlZM" role="37wK5m">
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <node concept="2OqwBi" id="5M8g5cSBlZN" role="37wK5m">
+                    <node concept="37vLTw" id="5M8g5cSBlZO" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5M8g5cSB02I" resolve="MPS_CONCEPT_DECLARATION_CONCEPT" />
+                    </node>
+                    <node concept="3TrcHB" id="5M8g5cSBlZP" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5M8g5cSBlZQ" role="37wK5m">
+                  <node concept="37vLTw" id="5M8g5cSBlZR" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5M8g5cSB02I" resolve="MPS_CONCEPT_DECLARATION_CONCEPT" />
+                  </node>
+                  <node concept="3TrcHB" id="5M8g5cSBlZS" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5M8g5cSBlZT" role="37vLTJ">
+                <ref role="3cqZAo" node="5M8g5cSB02$" resolve="SLANG_CONCEPT_CONCEPT" />
+              </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="5M8g5cSBlZG" role="3cqZAp" />
-        <node concept="3clFbF" id="5M8g5cSBug_" role="3cqZAp">
-          <node concept="37vLTI" id="5M8g5cSBugA" role="3clFbG">
-            <node concept="37vLTw" id="5M8g5cSBugB" role="37vLTJ">
-              <ref role="3cqZAo" node="5M8g5cSAY3o" resolve="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
+        <node concept="3cpWs8" id="7OJcYqwtwQE" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwtwQF" role="3cpWs9">
+            <property role="TrG5h" value="mpsConcept" />
+            <node concept="3Tqbb2" id="7OJcYqwtvW_" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
             </node>
-            <node concept="2OqwBi" id="5M8g5cSBugC" role="37vLTx">
-              <node concept="2tJFMh" id="5M8g5cSBugD" role="2Oq$k0">
-                <node concept="ZC_QK" id="5M8g5cSBugE" role="2tJFKM">
-                  <ref role="2aWVGs" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
+            <node concept="2OqwBi" id="7OJcYqwtwQG" role="33vP2m">
+              <node concept="2tJFMh" id="7OJcYqwtwQH" role="2Oq$k0">
+                <node concept="ZC_QK" id="7OJcYqwtwQI" role="2tJFKM">
+                  <ref role="2aWVGs" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
                 </node>
               </node>
-              <node concept="Vyspw" id="5M8g5cSBugF" role="2OqNvi">
-                <node concept="37vLTw" id="5M8g5cSBugG" role="Vysub">
+              <node concept="Vyspw" id="7OJcYqwtwQJ" role="2OqNvi">
+                <node concept="37vLTw" id="7OJcYqwtwQK" role="Vysub">
                   <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5M8g5cSBugo" role="3cqZAp">
-          <node concept="37vLTI" id="5M8g5cSBugp" role="3clFbG">
-            <node concept="2YIFZM" id="5M8g5cSBugq" role="37vLTx">
-              <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-              <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
-              <node concept="37vLTw" id="5M8g5cSBugr" role="37wK5m">
-                <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+        <node concept="3clFbF" id="7OJcYqwuLVL" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqwuLVM" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqwuLVN" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqwuLVO" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqwuLVP" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqwuLVt" resolve="CONCEPT" />
               </node>
-              <node concept="37vLTw" id="5M8g5cSBugs" role="37wK5m">
-                <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
-              </node>
-              <node concept="2YIFZM" id="5M8g5cSBugt" role="37wK5m">
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <node concept="2OqwBi" id="5M8g5cSBugu" role="37wK5m">
-                  <node concept="37vLTw" id="5M8g5cSBugv" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5M8g5cSAY3o" resolve="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
-                  </node>
-                  <node concept="3TrcHB" id="5M8g5cSBugw" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
-                  </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqwuLVQ" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqwuLVR" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptKeyedMapping" />
+                <node concept="10Nm6u" id="7OJcYqwuLVS" role="37wK5m" />
+                <node concept="37vLTw" id="7OJcYqwuLVT" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqwtwQF" resolve="mpsConcept" />
                 </node>
-              </node>
-              <node concept="2OqwBi" id="5M8g5cSBugx" role="37wK5m">
-                <node concept="37vLTw" id="5M8g5cSBugy" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5M8g5cSAY3o" resolve="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
-                </node>
-                <node concept="3TrcHB" id="5M8g5cSBugz" role="2OqNvi">
-                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                <node concept="2YIFZM" id="7OJcYqwuLVU" role="37wK5m">
+                  <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                  <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
+                  <node concept="37vLTw" id="7OJcYqwuLVV" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+                  </node>
+                  <node concept="37vLTw" id="7OJcYqwuLVW" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYqwuLVX" role="37wK5m">
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <node concept="2OqwBi" id="7OJcYqwuLVY" role="37wK5m">
+                      <node concept="37vLTw" id="7OJcYqwuLVZ" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwtwQF" resolve="mpsConcept" />
+                      </node>
+                      <node concept="3TrcHB" id="7OJcYqwuLW0" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqwuLW1" role="37wK5m">
+                    <node concept="37vLTw" id="7OJcYqwuLW2" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYqwtwQF" resolve="mpsConcept" />
+                    </node>
+                    <node concept="3TrcHB" id="7OJcYqwuLW3" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
-            <node concept="37vLTw" id="5M8g5cSBug$" role="37vLTJ">
-              <ref role="3cqZAo" node="5M8g5cSAY3e" resolve="SLANG_INTERFACE_CONCEPT_CONCEPT" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqwrbLp" role="3cqZAp" />
+        <node concept="1X3_iC" id="7OJcYqwtEip" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5M8g5cSBug_" role="8Wnug">
+            <node concept="37vLTI" id="5M8g5cSBugA" role="3clFbG">
+              <node concept="37vLTw" id="5M8g5cSBugB" role="37vLTJ">
+                <ref role="3cqZAo" node="5M8g5cSAY3o" resolve="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
+              </node>
+              <node concept="2OqwBi" id="5M8g5cSBugC" role="37vLTx">
+                <node concept="2tJFMh" id="5M8g5cSBugD" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5M8g5cSBugE" role="2tJFKM">
+                    <ref role="2aWVGs" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5M8g5cSBugF" role="2OqNvi">
+                  <node concept="37vLTw" id="5M8g5cSBugG" role="Vysub">
+                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwtEiq" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5M8g5cSBugo" role="8Wnug">
+            <node concept="37vLTI" id="5M8g5cSBugp" role="3clFbG">
+              <node concept="2YIFZM" id="5M8g5cSBugq" role="37vLTx">
+                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
+                <node concept="37vLTw" id="5M8g5cSBugr" role="37wK5m">
+                  <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+                </node>
+                <node concept="37vLTw" id="5M8g5cSBugs" role="37wK5m">
+                  <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+                </node>
+                <node concept="2YIFZM" id="5M8g5cSBugt" role="37wK5m">
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <node concept="2OqwBi" id="5M8g5cSBugu" role="37wK5m">
+                    <node concept="37vLTw" id="5M8g5cSBugv" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5M8g5cSAY3o" resolve="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
+                    </node>
+                    <node concept="3TrcHB" id="5M8g5cSBugw" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5M8g5cSBugx" role="37wK5m">
+                  <node concept="37vLTw" id="5M8g5cSBugy" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5M8g5cSAY3o" resolve="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
+                  </node>
+                  <node concept="3TrcHB" id="5M8g5cSBugz" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5M8g5cSBug$" role="37vLTJ">
+                <ref role="3cqZAo" node="5M8g5cSAY3e" resolve="SLANG_INTERFACE_CONCEPT_CONCEPT" />
+              </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="5M8g5cSBugn" role="3cqZAp" />
-        <node concept="3clFbF" id="34Q84zNOpJK" role="3cqZAp">
-          <node concept="37vLTI" id="34Q84zNOpJL" role="3clFbG">
-            <node concept="2OqwBi" id="34Q84zNOpJM" role="37vLTx">
-              <node concept="2tJFMh" id="34Q84zNOpJN" role="2Oq$k0">
-                <node concept="ZC_QK" id="34Q84zNOpJO" role="2tJFKM">
-                  <ref role="2aWVGs" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                  <node concept="ZC_QK" id="34Q84zNOpJP" role="2aWVGa">
-                    <ref role="2aWVGs" to="tpce:4qF2Hm2r7ja" resolve="conceptAlias" />
-                  </node>
+        <node concept="3cpWs8" id="7OJcYqwtH6Q" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwtH6R" role="3cpWs9">
+            <property role="TrG5h" value="mpsInterface" />
+            <node concept="3Tqbb2" id="7OJcYqwtG62" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqwtH6S" role="33vP2m">
+              <node concept="2tJFMh" id="7OJcYqwtH6T" role="2Oq$k0">
+                <node concept="ZC_QK" id="7OJcYqwtH6U" role="2tJFKM">
+                  <ref role="2aWVGs" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
                 </node>
               </node>
-              <node concept="Vyspw" id="34Q84zNOpJQ" role="2OqNvi">
-                <node concept="37vLTw" id="34Q84zNOpJR" role="Vysub">
+              <node concept="Vyspw" id="7OJcYqwtH6V" role="2OqNvi">
+                <node concept="37vLTw" id="7OJcYqwtH6W" role="Vysub">
                   <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
                 </node>
               </node>
             </node>
-            <node concept="37vLTw" id="34Q84zNOpJS" role="37vLTJ">
-              <ref role="3cqZAo" node="34Q84zNNvW1" resolve="MPS_CONCEPT_ALIAS_PROPERTY" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqwuQl$" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqwuQl_" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqwuQlA" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqwuQlB" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqwuQlC" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqwuQlg" resolve="INTERFACE" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqwuQlD" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqwuQlE" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptKeyedMapping" />
+                <node concept="10Nm6u" id="7OJcYqwuQlF" role="37wK5m" />
+                <node concept="37vLTw" id="7OJcYqwuQlG" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqwtH6R" resolve="mpsInterface" />
+                </node>
+                <node concept="2YIFZM" id="7OJcYqwuQlH" role="37wK5m">
+                  <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                  <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
+                  <node concept="37vLTw" id="7OJcYqwuQlI" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+                  </node>
+                  <node concept="37vLTw" id="7OJcYqwuQlJ" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYqwuQlK" role="37wK5m">
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <node concept="2OqwBi" id="7OJcYqwuQlL" role="37wK5m">
+                      <node concept="37vLTw" id="7OJcYqwuQlM" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwtH6R" resolve="mpsInterface" />
+                      </node>
+                      <node concept="3TrcHB" id="7OJcYqwuQlN" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqwuQlO" role="37wK5m">
+                    <node concept="37vLTw" id="7OJcYqwuQlP" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYqwtH6R" resolve="mpsInterface" />
+                    </node>
+                    <node concept="3TrcHB" id="7OJcYqwuQlQ" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="34Q84zNOpJT" role="3cqZAp">
-          <node concept="37vLTI" id="34Q84zNOpJU" role="3clFbG">
-            <node concept="2YIFZM" id="34Q84zNOpJV" role="37vLTx">
-              <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
-              <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-              <node concept="37vLTw" id="34Q84zNOpJW" role="37wK5m">
-                <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
-              </node>
-              <node concept="37vLTw" id="34Q84zNOpJX" role="37wK5m">
-                <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
-              </node>
-              <node concept="2YIFZM" id="34Q84zNOpJY" role="37wK5m">
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <node concept="2OqwBi" id="34Q84zNOpJZ" role="37wK5m">
-                  <node concept="37vLTw" id="34Q84zNOpK0" role="2Oq$k0">
-                    <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
+        <node concept="3clFbH" id="7OJcYqwrsVZ" role="3cqZAp" />
+        <node concept="1X3_iC" id="7OJcYqwtOYf" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="34Q84zNOpJK" role="8Wnug">
+            <node concept="37vLTI" id="34Q84zNOpJL" role="3clFbG">
+              <node concept="2OqwBi" id="34Q84zNOpJM" role="37vLTx">
+                <node concept="2tJFMh" id="34Q84zNOpJN" role="2Oq$k0">
+                  <node concept="ZC_QK" id="34Q84zNOpJO" role="2tJFKM">
+                    <ref role="2aWVGs" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                    <node concept="ZC_QK" id="34Q84zNOpJP" role="2aWVGa">
+                      <ref role="2aWVGs" to="tpce:4qF2Hm2r7ja" resolve="conceptAlias" />
+                    </node>
                   </node>
-                  <node concept="3TrcHB" id="34Q84zNOpK1" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                </node>
+                <node concept="Vyspw" id="34Q84zNOpJQ" role="2OqNvi">
+                  <node concept="37vLTw" id="34Q84zNOpJR" role="Vysub">
+                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
                   </node>
                 </node>
               </node>
-              <node concept="2YIFZM" id="34Q84zNOpK2" role="37wK5m">
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <node concept="2OqwBi" id="34Q84zNOpK3" role="37wK5m">
-                  <node concept="37vLTw" id="34Q84zNOpK4" role="2Oq$k0">
-                    <ref role="3cqZAo" node="34Q84zNNvW1" resolve="MPS_CONCEPT_ALIAS_PROPERTY" />
-                  </node>
-                  <node concept="3TrcHB" id="34Q84zNOpK5" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="34Q84zNOpK6" role="37wK5m">
-                <node concept="37vLTw" id="34Q84zNOpK7" role="2Oq$k0">
-                  <ref role="3cqZAo" node="34Q84zNNvW1" resolve="MPS_CONCEPT_ALIAS_PROPERTY" />
-                </node>
-                <node concept="3TrcHB" id="34Q84zNOpK8" role="2OqNvi">
-                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                </node>
+              <node concept="37vLTw" id="34Q84zNOpJS" role="37vLTJ">
+                <ref role="3cqZAo" node="34Q84zNNvW1" resolve="MPS_CONCEPT_ALIAS_PROPERTY" />
               </node>
             </node>
-            <node concept="37vLTw" id="34Q84zNOpK9" role="37vLTJ">
-              <ref role="3cqZAo" node="34Q84zNNvWa" resolve="SLANG_CONCEPT_ALIAS_PROPERTY" />
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwtOYg" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="34Q84zNOpJT" role="8Wnug">
+            <node concept="37vLTI" id="34Q84zNOpJU" role="3clFbG">
+              <node concept="2YIFZM" id="34Q84zNOpJV" role="37vLTx">
+                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
+                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                <node concept="37vLTw" id="34Q84zNOpJW" role="37wK5m">
+                  <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+                </node>
+                <node concept="37vLTw" id="34Q84zNOpJX" role="37wK5m">
+                  <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+                </node>
+                <node concept="2YIFZM" id="34Q84zNOpJY" role="37wK5m">
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <node concept="2OqwBi" id="34Q84zNOpJZ" role="37wK5m">
+                    <node concept="37vLTw" id="34Q84zNOpK0" role="2Oq$k0">
+                      <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
+                    </node>
+                    <node concept="3TrcHB" id="34Q84zNOpK1" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="34Q84zNOpK2" role="37wK5m">
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <node concept="2OqwBi" id="34Q84zNOpK3" role="37wK5m">
+                    <node concept="37vLTw" id="34Q84zNOpK4" role="2Oq$k0">
+                      <ref role="3cqZAo" node="34Q84zNNvW1" resolve="MPS_CONCEPT_ALIAS_PROPERTY" />
+                    </node>
+                    <node concept="3TrcHB" id="34Q84zNOpK5" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="34Q84zNOpK6" role="37wK5m">
+                  <node concept="37vLTw" id="34Q84zNOpK7" role="2Oq$k0">
+                    <ref role="3cqZAo" node="34Q84zNNvW1" resolve="MPS_CONCEPT_ALIAS_PROPERTY" />
+                  </node>
+                  <node concept="3TrcHB" id="34Q84zNOpK8" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="34Q84zNOpK9" role="37vLTJ">
+                <ref role="3cqZAo" node="34Q84zNNvWa" resolve="SLANG_CONCEPT_ALIAS_PROPERTY" />
+              </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="34Q84zNOpH1" role="3cqZAp" />
-        <node concept="3clFbF" id="34Q84zNRLkB" role="3cqZAp">
-          <node concept="37vLTI" id="34Q84zNRLkC" role="3clFbG">
-            <node concept="2OqwBi" id="34Q84zNRLkD" role="37vLTx">
-              <node concept="2tJFMh" id="34Q84zNRLkE" role="2Oq$k0">
-                <node concept="ZC_QK" id="34Q84zNRLkF" role="2tJFKM">
+        <node concept="3cpWs8" id="7OJcYqwtTqJ" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwtTqK" role="3cpWs9">
+            <property role="TrG5h" value="mpsConceptAliasProp" />
+            <node concept="3Tqbb2" id="7OJcYqwtSdZ" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqwtTqL" role="33vP2m">
+              <node concept="2tJFMh" id="7OJcYqwtTqM" role="2Oq$k0">
+                <node concept="ZC_QK" id="7OJcYqwtTqN" role="2tJFKM">
                   <ref role="2aWVGs" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                  <node concept="ZC_QK" id="34Q84zNRLkG" role="2aWVGa">
-                    <ref role="2aWVGs" to="tpce:40UcGlRaVSw" resolve="conceptShortDescription" />
+                  <node concept="ZC_QK" id="7OJcYqwtTqO" role="2aWVGa">
+                    <ref role="2aWVGs" to="tpce:4qF2Hm2r7ja" resolve="conceptAlias" />
                   </node>
                 </node>
               </node>
-              <node concept="Vyspw" id="34Q84zNRLkH" role="2OqNvi">
-                <node concept="37vLTw" id="34Q84zNRLkI" role="Vysub">
+              <node concept="Vyspw" id="7OJcYqwtTqP" role="2OqNvi">
+                <node concept="37vLTw" id="7OJcYqwtTqQ" role="Vysub">
                   <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
                 </node>
               </node>
             </node>
-            <node concept="37vLTw" id="34Q84zNRLkJ" role="37vLTJ">
-              <ref role="3cqZAo" node="34Q84zNO3Ig" resolve="MPS_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqwuULs" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqwuULt" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqwuULu" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqwuULv" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqwuULw" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqwuUL4" resolve="CONCEPT_ALIAS" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqwuULx" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqwuULy" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvRxYF" resolve="PropertyKeyMapping" />
+                <node concept="10Nm6u" id="7OJcYqwuULz" role="37wK5m" />
+                <node concept="37vLTw" id="7OJcYqwuUL$" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqwtTqK" resolve="mpsConceptAliasProp" />
+                </node>
+                <node concept="2YIFZM" id="7OJcYqwuUL_" role="37wK5m">
+                  <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
+                  <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                  <node concept="37vLTw" id="7OJcYqwuULA" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+                  </node>
+                  <node concept="37vLTw" id="7OJcYqwuULB" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYqwuULC" role="37wK5m">
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <node concept="2OqwBi" id="7OJcYqwuULD" role="37wK5m">
+                      <node concept="37vLTw" id="7OJcYqwuULE" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwt4hM" resolve="mpsClassifier" />
+                      </node>
+                      <node concept="3TrcHB" id="7OJcYqwuULF" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYqwuULG" role="37wK5m">
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <node concept="2OqwBi" id="7OJcYqwuULH" role="37wK5m">
+                      <node concept="37vLTw" id="7OJcYqwuULI" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwtTqK" resolve="mpsConceptAliasProp" />
+                      </node>
+                      <node concept="3TrcHB" id="7OJcYqwuULJ" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqwuULK" role="37wK5m">
+                    <node concept="37vLTw" id="7OJcYqwuULL" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYqwtTqK" resolve="mpsConceptAliasProp" />
+                    </node>
+                    <node concept="3TrcHB" id="7OJcYqwuULM" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="34Q84zNRLkm" role="3cqZAp">
-          <node concept="37vLTI" id="34Q84zNRLkn" role="3clFbG">
-            <node concept="2YIFZM" id="34Q84zNRLko" role="37vLTx">
-              <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
-              <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-              <node concept="37vLTw" id="34Q84zNRLkp" role="37wK5m">
-                <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
-              </node>
-              <node concept="37vLTw" id="34Q84zNRLkq" role="37wK5m">
-                <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
-              </node>
-              <node concept="2YIFZM" id="34Q84zNRLkr" role="37wK5m">
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <node concept="2OqwBi" id="34Q84zNRLks" role="37wK5m">
-                  <node concept="37vLTw" id="34Q84zNRLkt" role="2Oq$k0">
-                    <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
+        <node concept="3clFbH" id="7OJcYqwrH7_" role="3cqZAp" />
+        <node concept="1X3_iC" id="7OJcYqwu3cE" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="34Q84zNRLkB" role="8Wnug">
+            <node concept="37vLTI" id="34Q84zNRLkC" role="3clFbG">
+              <node concept="2OqwBi" id="34Q84zNRLkD" role="37vLTx">
+                <node concept="2tJFMh" id="34Q84zNRLkE" role="2Oq$k0">
+                  <node concept="ZC_QK" id="34Q84zNRLkF" role="2tJFKM">
+                    <ref role="2aWVGs" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                    <node concept="ZC_QK" id="34Q84zNRLkG" role="2aWVGa">
+                      <ref role="2aWVGs" to="tpce:40UcGlRaVSw" resolve="conceptShortDescription" />
+                    </node>
                   </node>
-                  <node concept="3TrcHB" id="34Q84zNRLku" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                </node>
+                <node concept="Vyspw" id="34Q84zNRLkH" role="2OqNvi">
+                  <node concept="37vLTw" id="34Q84zNRLkI" role="Vysub">
+                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
                   </node>
                 </node>
               </node>
-              <node concept="2YIFZM" id="34Q84zNRLkv" role="37wK5m">
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <node concept="2OqwBi" id="34Q84zNRLkw" role="37wK5m">
-                  <node concept="37vLTw" id="34Q84zNRLkx" role="2Oq$k0">
+              <node concept="37vLTw" id="34Q84zNRLkJ" role="37vLTJ">
+                <ref role="3cqZAo" node="34Q84zNO3Ig" resolve="MPS_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwu3cF" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="34Q84zNRLkm" role="8Wnug">
+            <node concept="37vLTI" id="34Q84zNRLkn" role="3clFbG">
+              <node concept="2YIFZM" id="34Q84zNRLko" role="37vLTx">
+                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
+                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                <node concept="37vLTw" id="34Q84zNRLkp" role="37wK5m">
+                  <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+                </node>
+                <node concept="37vLTw" id="34Q84zNRLkq" role="37wK5m">
+                  <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+                </node>
+                <node concept="2YIFZM" id="34Q84zNRLkr" role="37wK5m">
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <node concept="2OqwBi" id="34Q84zNRLks" role="37wK5m">
+                    <node concept="37vLTw" id="34Q84zNRLkt" role="2Oq$k0">
+                      <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
+                    </node>
+                    <node concept="3TrcHB" id="34Q84zNRLku" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="34Q84zNRLkv" role="37wK5m">
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <node concept="2OqwBi" id="34Q84zNRLkw" role="37wK5m">
+                    <node concept="37vLTw" id="34Q84zNRLkx" role="2Oq$k0">
+                      <ref role="3cqZAo" node="34Q84zNO3Ig" resolve="MPS_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
+                    </node>
+                    <node concept="3TrcHB" id="34Q84zNRLky" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="34Q84zNRLkz" role="37wK5m">
+                  <node concept="37vLTw" id="34Q84zNRLk$" role="2Oq$k0">
                     <ref role="3cqZAo" node="34Q84zNO3Ig" resolve="MPS_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
                   </node>
-                  <node concept="3TrcHB" id="34Q84zNRLky" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
+                  <node concept="3TrcHB" id="34Q84zNRLk_" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                   </node>
                 </node>
               </node>
-              <node concept="2OqwBi" id="34Q84zNRLkz" role="37wK5m">
-                <node concept="37vLTw" id="34Q84zNRLk$" role="2Oq$k0">
-                  <ref role="3cqZAo" node="34Q84zNO3Ig" resolve="MPS_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
+              <node concept="37vLTw" id="34Q84zNRLkA" role="37vLTJ">
+                <ref role="3cqZAo" node="34Q84zNO3I7" resolve="SLANG_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqwrXbJ" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYqwu7gu" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwu7gv" role="3cpWs9">
+            <property role="TrG5h" value="mpsConceptShortDescriptionProp" />
+            <node concept="3Tqbb2" id="7OJcYqwu6c0" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqwu7gw" role="33vP2m">
+              <node concept="2tJFMh" id="7OJcYqwu7gx" role="2Oq$k0">
+                <node concept="ZC_QK" id="7OJcYqwu7gy" role="2tJFKM">
+                  <ref role="2aWVGs" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                  <node concept="ZC_QK" id="7OJcYqwu7gz" role="2aWVGa">
+                    <ref role="2aWVGs" to="tpce:40UcGlRaVSw" resolve="conceptShortDescription" />
+                  </node>
                 </node>
-                <node concept="3TrcHB" id="34Q84zNRLk_" role="2OqNvi">
-                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+              <node concept="Vyspw" id="7OJcYqwu7g$" role="2OqNvi">
+                <node concept="37vLTw" id="7OJcYqwu7g_" role="Vysub">
+                  <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
                 </node>
               </node>
             </node>
-            <node concept="37vLTw" id="34Q84zNRLkA" role="37vLTJ">
-              <ref role="3cqZAo" node="34Q84zNO3I7" resolve="SLANG_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqwuZin" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqwuZio" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqwuZip" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqwuZiq" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqwuZir" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqwuZhZ" resolve="CONCEPT_SHORT_DESCRIPTION" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqwuZis" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqwuZit" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvRxYF" resolve="PropertyKeyMapping" />
+                <node concept="10Nm6u" id="7OJcYqwuZiu" role="37wK5m" />
+                <node concept="37vLTw" id="7OJcYqwuZiv" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqwu7gv" resolve="mpsConceptShortDescriptionProp" />
+                </node>
+                <node concept="2YIFZM" id="7OJcYqwuZiw" role="37wK5m">
+                  <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                  <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
+                  <node concept="37vLTw" id="7OJcYqwuZix" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+                  </node>
+                  <node concept="37vLTw" id="7OJcYqwuZiy" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYqwuZiz" role="37wK5m">
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <node concept="2OqwBi" id="7OJcYqwuZi$" role="37wK5m">
+                      <node concept="37vLTw" id="7OJcYqwuZi_" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwt4hM" resolve="mpsClassifier" />
+                      </node>
+                      <node concept="3TrcHB" id="7OJcYqwuZiA" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYqwuZiB" role="37wK5m">
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <node concept="2OqwBi" id="7OJcYqwuZiC" role="37wK5m">
+                      <node concept="37vLTw" id="7OJcYqwuZiD" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwu7gv" resolve="mpsConceptShortDescriptionProp" />
+                      </node>
+                      <node concept="3TrcHB" id="7OJcYqwuZiE" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqwuZiF" role="37wK5m">
+                    <node concept="37vLTw" id="7OJcYqwuZiG" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYqwu7gv" resolve="mpsConceptShortDescriptionProp" />
+                    </node>
+                    <node concept="3TrcHB" id="7OJcYqwuZiH" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1315,20 +2312,29 @@
     <node concept="3uibUv" id="5JNiskhZoZC" role="1zkMxy">
       <ref role="3uigEE" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
     </node>
-    <node concept="312cEg" id="5JNiskiq_M0" role="jymVt">
-      <property role="TrG5h" value="LC_VIRTUAL_PACKAGE_ANNOTATION" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskiq_M1" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskiq_M2" role="1tU5fm">
-        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
+    <node concept="1X3_iC" id="7OJcYqwvQgW" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskiq_M0" role="8Wnug">
+        <property role="TrG5h" value="LC_VIRTUAL_PACKAGE_ANNOTATION" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskiq_M1" role="1B3o_S" />
+        <node concept="3Tqbb2" id="5JNiskiq_M2" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiq_M3" role="jymVt">
       <property role="TrG5h" value="lcVirtualPackageAnnotation" />
       <node concept="3clFbS" id="5JNiskiq_M4" role="3clF47">
         <node concept="3clFbF" id="5JNiskiq_M5" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskiq_M6" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskiq_M0" resolve="LC_VIRTUAL_PACKAGE_ANNOTATION" />
+          <node concept="2OqwBi" id="7OJcYqwxLzI" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwxITp" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwxOfe" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwOF7L" resolve="getLc" />
+            </node>
           </node>
         </node>
       </node>
@@ -1337,20 +2343,29 @@
         <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
       </node>
     </node>
-    <node concept="312cEg" id="5JNiskiq_M9" role="jymVt">
-      <property role="TrG5h" value="MPS_VIRTUAL_PACKAGE_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskiq_Ma" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskiq_Mb" role="1tU5fm">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+    <node concept="1X3_iC" id="7OJcYqwvSs5" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskiq_M9" role="8Wnug">
+        <property role="TrG5h" value="MPS_VIRTUAL_PACKAGE_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskiq_Ma" role="1B3o_S" />
+        <node concept="3Tqbb2" id="5JNiskiq_Mb" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiq_Mc" role="jymVt">
       <property role="TrG5h" value="mpsVirtualPackageProperty" />
       <node concept="3clFbS" id="5JNiskiq_Md" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiq_Me" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskiq_Mf" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskiq_M9" resolve="MPS_VIRTUAL_PACKAGE_PROPERTY" />
+        <node concept="3clFbF" id="7OJcYqwxQG6" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwxQG7" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwxQG8" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwxQG9" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
+            </node>
           </node>
         </node>
       </node>
@@ -1359,20 +2374,29 @@
         <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
       </node>
     </node>
-    <node concept="312cEg" id="5JNiskiq_Mi" role="jymVt">
-      <property role="TrG5h" value="SLANG_VIRTUAL_PACKAGE_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskiq_Mj" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskiq_Mk" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+    <node concept="1X3_iC" id="7OJcYqwvWr6" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskiq_Mi" role="8Wnug">
+        <property role="TrG5h" value="SLANG_VIRTUAL_PACKAGE_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskiq_Mj" role="1B3o_S" />
+        <node concept="3uibUv" id="5JNiskiq_Mk" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiq_Ml" role="jymVt">
       <property role="TrG5h" value="slangVirtualPackageProperty" />
       <node concept="3clFbS" id="5JNiskiq_Mm" role="3clF47">
         <node concept="3clFbF" id="5JNiskiq_Mn" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskiq_Mo" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskiq_Mi" resolve="SLANG_VIRTUAL_PACKAGE_PROPERTY" />
+          <node concept="2OqwBi" id="7OJcYqwy1Oa" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwy1Ob" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwy1Oc" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+            </node>
           </node>
         </node>
       </node>
@@ -1381,36 +2405,54 @@
         <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
       </node>
     </node>
-    <node concept="312cEg" id="5JNiskiq_Mr" role="jymVt">
-      <property role="TrG5h" value="KEY_VIRTUAL_PACKAGE_ANNOTATION" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskiq_Ms" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiq_Mt" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqww0_s" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskiq_Mr" role="8Wnug">
+        <property role="TrG5h" value="KEY_VIRTUAL_PACKAGE_ANNOTATION" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskiq_Ms" role="1B3o_S" />
+        <node concept="17QB3L" id="5JNiskiq_Mt" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskiq_Mu" role="jymVt">
       <property role="TrG5h" value="keyVirtualPackageAnnotation" />
       <node concept="3clFbS" id="5JNiskiq_Mv" role="3clF47">
         <node concept="3clFbF" id="5JNiskiq_Mw" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskiq_Mx" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskiq_Mr" resolve="KEY_VIRTUAL_PACKAGE_ANNOTATION" />
+          <node concept="2OqwBi" id="7OJcYqwy6Je" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwy6Jf" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwy6Jg" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwOF81" resolve="getLcKey" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskiq_My" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskiq_Mz" role="3clF45" />
     </node>
-    <node concept="312cEg" id="5JNiskiq_M$" role="jymVt">
-      <property role="TrG5h" value="ID_VIRTUAL_PACKAGE_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskiq_M_" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiq_MA" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqww3ei" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskiq_M$" role="8Wnug">
+        <property role="TrG5h" value="ID_VIRTUAL_PACKAGE_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskiq_M_" role="1B3o_S" />
+        <node concept="17QB3L" id="5JNiskiq_MA" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskiq_MB" role="jymVt">
       <property role="TrG5h" value="idVirtualPackageProperty" />
       <node concept="3clFbS" id="5JNiskiq_MC" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiq_MD" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskiq_ME" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskiq_M$" resolve="ID_VIRTUAL_PACKAGE_PROPERTY" />
+        <node concept="3clFbF" id="7OJcYqwybNk" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwybNl" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwybNm" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwybNn" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
+            </node>
           </node>
         </node>
       </node>
@@ -1418,20 +2460,29 @@
       <node concept="17QB3L" id="5JNiskiq_MG" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5JNiskirocj" role="jymVt" />
-    <node concept="312cEg" id="5JNiskirrGQ" role="jymVt">
-      <property role="TrG5h" value="LC_VIRTUAL_PACKAGE_NAME_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskirrGR" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskirrGS" role="1tU5fm">
-        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+    <node concept="1X3_iC" id="7OJcYqww5SI" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskirrGQ" role="8Wnug">
+        <property role="TrG5h" value="LC_VIRTUAL_PACKAGE_NAME_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskirrGR" role="1B3o_S" />
+        <node concept="3Tqbb2" id="5JNiskirrGS" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiroj0" role="jymVt">
       <property role="TrG5h" value="lcVirtualPackage_NameProperty" />
       <node concept="3clFbS" id="5JNiskiroj1" role="3clF47">
-        <node concept="3clFbF" id="5JNiskirwTh" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskirwTg" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskirrGQ" resolve="LC_VIRTUAL_PACKAGE_NAME_PROPERTY" />
+        <node concept="3clFbF" id="7OJcYqwyhwv" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwyhww" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwyhwx" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwyhwy" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwpe0k" resolve="getLcProp" />
+            </node>
           </node>
         </node>
       </node>
@@ -1440,18 +2491,27 @@
         <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
       </node>
     </node>
-    <node concept="312cEg" id="5JNiskirATB" role="jymVt">
-      <property role="TrG5h" value="KEY_VIRTUAL_PACKAGE_NAME_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskirA5G" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskirAGG" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqww9S2" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskirATB" role="8Wnug">
+        <property role="TrG5h" value="KEY_VIRTUAL_PACKAGE_NAME_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskirA5G" role="1B3o_S" />
+        <node concept="17QB3L" id="5JNiskirAGG" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskiroj4" role="jymVt">
       <property role="TrG5h" value="keyVirtualPackage_NameProperty" />
       <node concept="3clFbS" id="5JNiskiroj5" role="3clF47">
         <node concept="3clFbF" id="5JNiskirBN7" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskirBN6" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskirATB" resolve="KEY_VIRTUAL_PACKAGE_NAME_PROPERTY" />
+          <node concept="2OqwBi" id="7OJcYqwyxU8" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwyvml" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwyzPh" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwysbK" resolve="getLcPropKey" />
+            </node>
           </node>
         </node>
       </node>
@@ -1460,20 +2520,29 @@
     </node>
     <node concept="2tJIrI" id="5JNiskirofD" role="jymVt" />
     <node concept="2tJIrI" id="5JNiskiqAo0" role="jymVt" />
-    <node concept="312cEg" id="5JNiskiqAL0" role="jymVt">
-      <property role="TrG5h" value="LC_SHORT_DESCRIPTION_ANNOTATION" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskiqAL1" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskiqAL2" role="1tU5fm">
-        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
+    <node concept="1X3_iC" id="7OJcYqwwc$_" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskiqAL0" role="8Wnug">
+        <property role="TrG5h" value="LC_SHORT_DESCRIPTION_ANNOTATION" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskiqAL1" role="1B3o_S" />
+        <node concept="3Tqbb2" id="5JNiskiqAL2" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiqAL3" role="jymVt">
       <property role="TrG5h" value="lcShortDescriptionAnnotation" />
       <node concept="3clFbS" id="5JNiskiqAL4" role="3clF47">
         <node concept="3clFbF" id="5JNiskiqAL5" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskiqAL6" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskiqAL0" resolve="LC_SHORT_DESCRIPTION_ANNOTATION" />
+          <node concept="2OqwBi" id="7OJcYqwyCPK" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwyAfy" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwyFja" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwOF7L" resolve="getLc" />
+            </node>
           </node>
         </node>
       </node>
@@ -1482,20 +2551,29 @@
         <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
       </node>
     </node>
-    <node concept="312cEg" id="5JNiskiqAL9" role="jymVt">
-      <property role="TrG5h" value="MPS_SHORT_DESCRIPTION_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskiqALa" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskiqALb" role="1tU5fm">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+    <node concept="1X3_iC" id="7OJcYqwwffh" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskiqAL9" role="8Wnug">
+        <property role="TrG5h" value="MPS_SHORT_DESCRIPTION_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskiqALa" role="1B3o_S" />
+        <node concept="3Tqbb2" id="5JNiskiqALb" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiqALc" role="jymVt">
       <property role="TrG5h" value="mpsShortDescriptionProperty" />
       <node concept="3clFbS" id="5JNiskiqALd" role="3clF47">
         <node concept="3clFbF" id="5JNiskiqALe" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskiqALf" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskiqAL9" resolve="MPS_SHORT_DESCRIPTION_PROPERTY" />
+          <node concept="2OqwBi" id="7OJcYqwyHJT" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwyHJU" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwyHJV" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
+            </node>
           </node>
         </node>
       </node>
@@ -1504,20 +2582,29 @@
         <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
       </node>
     </node>
-    <node concept="312cEg" id="5JNiskiqALi" role="jymVt">
-      <property role="TrG5h" value="SLANG_SHORT_DESCRIPTION_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskiqALj" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskiqALk" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+    <node concept="1X3_iC" id="7OJcYqwwjgv" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskiqALi" role="8Wnug">
+        <property role="TrG5h" value="SLANG_SHORT_DESCRIPTION_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskiqALj" role="1B3o_S" />
+        <node concept="3uibUv" id="5JNiskiqALk" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiqALl" role="jymVt">
       <property role="TrG5h" value="slangShortDescriptionProperty" />
       <node concept="3clFbS" id="5JNiskiqALm" role="3clF47">
         <node concept="3clFbF" id="5JNiskiqALn" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskiqALo" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskiqALi" resolve="SLANG_SHORT_DESCRIPTION_PROPERTY" />
+          <node concept="2OqwBi" id="7OJcYqwyMRf" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwyMRg" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwyMRh" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+            </node>
           </node>
         </node>
       </node>
@@ -1526,36 +2613,54 @@
         <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
       </node>
     </node>
-    <node concept="312cEg" id="5JNiskiqALr" role="jymVt">
-      <property role="TrG5h" value="KEY_SHORT_DESCRIPTION_ANNOTATION" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskiqALs" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiqALt" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwwnoS" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskiqALr" role="8Wnug">
+        <property role="TrG5h" value="KEY_SHORT_DESCRIPTION_ANNOTATION" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskiqALs" role="1B3o_S" />
+        <node concept="17QB3L" id="5JNiskiqALt" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskiqALu" role="jymVt">
       <property role="TrG5h" value="keyShortDescriptionAnnotation" />
       <node concept="3clFbS" id="5JNiskiqALv" role="3clF47">
         <node concept="3clFbF" id="5JNiskiqALw" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskiqALx" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskiqALr" resolve="KEY_SHORT_DESCRIPTION_ANNOTATION" />
+          <node concept="2OqwBi" id="7OJcYqwyRuv" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwyRuw" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwyRux" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwOF81" resolve="getLcKey" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskiqALy" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskiqALz" role="3clF45" />
     </node>
-    <node concept="312cEg" id="5JNiskiqAL$" role="jymVt">
-      <property role="TrG5h" value="ID_SHORT_DESCRIPTION_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskiqAL_" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiqALA" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwwq1N" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskiqAL$" role="8Wnug">
+        <property role="TrG5h" value="ID_SHORT_DESCRIPTION_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskiqAL_" role="1B3o_S" />
+        <node concept="17QB3L" id="5JNiskiqALA" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskiqALB" role="jymVt">
       <property role="TrG5h" value="idShortDescriptionProperty" />
       <node concept="3clFbS" id="5JNiskiqALC" role="3clF47">
         <node concept="3clFbF" id="5JNiskiqALD" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskiqALE" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskiqAL$" resolve="ID_SHORT_DESCRIPTION_PROPERTY" />
+          <node concept="2OqwBi" id="7OJcYqwyWxX" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwyWxY" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwyWxZ" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwOF7T" resolve="getLcId" />
+            </node>
           </node>
         </node>
       </node>
@@ -1563,20 +2668,29 @@
       <node concept="17QB3L" id="5JNiskiqALG" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5JNiskiqApF" role="jymVt" />
-    <node concept="312cEg" id="5JNiskirxyP" role="jymVt">
-      <property role="TrG5h" value="LC_SHORT_DESCRIPTION_DESCRIPTION_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskirxyQ" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskirxyR" role="1tU5fm">
-        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+    <node concept="1X3_iC" id="7OJcYqwwsG$" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskirxyP" role="8Wnug">
+        <property role="TrG5h" value="LC_SHORT_DESCRIPTION_DESCRIPTION_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskirxyQ" role="1B3o_S" />
+        <node concept="3Tqbb2" id="5JNiskirxyR" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiroSo" role="jymVt">
       <property role="TrG5h" value="lcShortDescription_DescriptionProperty" />
       <node concept="3clFbS" id="5JNiskiroSp" role="3clF47">
         <node concept="3clFbF" id="5JNiskirz2b" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskirz2a" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskirxyP" resolve="LC_SHORT_DESCRIPTION_DESCRIPTION_PROPERTY" />
+          <node concept="2OqwBi" id="7OJcYqwz1K6" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwz1K7" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwz1K8" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwpe0k" resolve="getLcProp" />
+            </node>
           </node>
         </node>
       </node>
@@ -1585,18 +2699,27 @@
         <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
       </node>
     </node>
-    <node concept="312cEg" id="5JNiskirzDP" role="jymVt">
-      <property role="TrG5h" value="KEY_SHORT_DESCRIPTION_DESCRIPTION_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskirzDQ" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskirzDR" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwwwDX" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskirzDP" role="8Wnug">
+        <property role="TrG5h" value="KEY_SHORT_DESCRIPTION_DESCRIPTION_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskirzDQ" role="1B3o_S" />
+        <node concept="17QB3L" id="5JNiskirzDR" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskiroSs" role="jymVt">
       <property role="TrG5h" value="keyShortDescription_DescriptionProperty" />
       <node concept="3clFbS" id="5JNiskiroSt" role="3clF47">
         <node concept="3clFbF" id="5JNiskir$Wq" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskir$Wp" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskirzDP" resolve="KEY_SHORT_DESCRIPTION_DESCRIPTION_PROPERTY" />
+          <node concept="2OqwBi" id="7OJcYqwz6o$" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwz6o_" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwz6oA" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwysbK" resolve="getLcPropKey" />
+            </node>
           </node>
         </node>
       </node>
@@ -1604,20 +2727,29 @@
       <node concept="17QB3L" id="5JNiskiroSv" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5JNiskiroOS" role="jymVt" />
-    <node concept="312cEg" id="5JNiskiKYx0" role="jymVt">
-      <property role="TrG5h" value="SLANG_SPECIFIC_LANGUAGE_ID" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskiKYx1" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskiKYx2" role="1tU5fm">
-        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+    <node concept="1X3_iC" id="7OJcYqwwzkK" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskiKYx0" role="8Wnug">
+        <property role="TrG5h" value="SLANG_SPECIFIC_LANGUAGE_ID" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskiKYx1" role="1B3o_S" />
+        <node concept="3uibUv" id="5JNiskiKYx2" role="1tU5fm">
+          <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiKYx3" role="jymVt">
       <property role="TrG5h" value="slangSpecificLanguageId" />
       <node concept="3clFbS" id="5JNiskiKYx4" role="3clF47">
         <node concept="3clFbF" id="5JNiskiKYx5" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskiKYx6" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskiKYx0" resolve="SLANG_SPECIFIC_LANGUAGE_ID" />
+          <node concept="2OqwBi" id="7OJcYqwzfwE" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwzblh" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwWDfJ" resolve="getSpecificLanguage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwzjLh" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqw7aei" resolve="getSlangId" />
+            </node>
           </node>
         </node>
       </node>
@@ -1626,20 +2758,29 @@
         <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
       </node>
     </node>
-    <node concept="312cEg" id="5JNiskiKYx9" role="jymVt">
-      <property role="TrG5h" value="SLANG_SPECIFIC_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskiKYxa" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskiKYxb" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+    <node concept="1X3_iC" id="7OJcYqwwBpW" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskiKYx9" role="8Wnug">
+        <property role="TrG5h" value="SLANG_SPECIFIC_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskiKYxa" role="1B3o_S" />
+        <node concept="3uibUv" id="5JNiskiKYxb" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiKYxc" role="jymVt">
       <property role="TrG5h" value="slangSpecificLanguage" />
       <node concept="3clFbS" id="5JNiskiKYxd" role="3clF47">
         <node concept="3clFbF" id="5JNiskiKYxe" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskiKYxf" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskiKYx9" resolve="SLANG_SPECIFIC_LANGUAGE" />
+          <node concept="2OqwBi" id="7OJcYqwzoWl" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwzoWm" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwWDfJ" resolve="getSpecificLanguage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwzoWn" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0Q9" resolve="getSlang" />
+            </node>
           </node>
         </node>
       </node>
@@ -1648,54 +2789,81 @@
         <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
       </node>
     </node>
-    <node concept="312cEg" id="5JNiskiKYxi" role="jymVt">
-      <property role="TrG5h" value="KEY_SPECIFIC_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskiKYxj" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiKYxk" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwwFMO" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskiKYxi" role="8Wnug">
+        <property role="TrG5h" value="KEY_SPECIFIC_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskiKYxj" role="1B3o_S" />
+        <node concept="17QB3L" id="5JNiskiKYxk" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskiKYxl" role="jymVt">
       <property role="TrG5h" value="keySpecificLanguage" />
       <node concept="3clFbS" id="5JNiskiKYxm" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiKYxn" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskiKYxo" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskiKYxi" resolve="KEY_SPECIFIC_LANGUAGE" />
+        <node concept="3clFbF" id="7OJcYqwzvGm" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwzvGn" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwzvGo" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwWDfJ" resolve="getSpecificLanguage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwzvGp" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0QD" resolve="getLcKey" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskiKYxp" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskiKYxq" role="3clF45" />
     </node>
-    <node concept="312cEg" id="5JNiskiKYxr" role="jymVt">
-      <property role="TrG5h" value="ID_SPECIFIC_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskiKYxs" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiKYxt" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwwIpL" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskiKYxr" role="8Wnug">
+        <property role="TrG5h" value="ID_SPECIFIC_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskiKYxs" role="1B3o_S" />
+        <node concept="17QB3L" id="5JNiskiKYxt" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskiKYxu" role="jymVt">
       <property role="TrG5h" value="idSpecificLanguage" />
       <node concept="3clFbS" id="5JNiskiKYxv" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiKYxw" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskiKYxx" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskiKYxr" resolve="ID_SPECIFIC_LANGUAGE" />
+        <node concept="3clFbF" id="7OJcYqwzAvY" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwzAvZ" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwzAw0" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwWDfJ" resolve="getSpecificLanguage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwzAw1" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0Qx" resolve="getLcId" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskiKYxy" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskiKYxz" role="3clF45" />
     </node>
-    <node concept="312cEg" id="5JNiskiKYx$" role="jymVt">
-      <property role="TrG5h" value="VERSION_SPECIFIC_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskiKYx_" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiKYxA" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwwL4B" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskiKYx$" role="8Wnug">
+        <property role="TrG5h" value="VERSION_SPECIFIC_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskiKYx_" role="1B3o_S" />
+        <node concept="17QB3L" id="5JNiskiKYxA" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskiKYxB" role="jymVt">
       <property role="TrG5h" value="versionSpecificLanguage" />
       <node concept="3clFbS" id="5JNiskiKYxC" role="3clF47">
         <node concept="3clFbF" id="5JNiskiKYxD" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskiKYxE" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskiKYx$" resolve="VERSION_SPECIFIC_LANGUAGE" />
+          <node concept="2OqwBi" id="7OJcYqwzHXH" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwzHXI" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwWDfJ" resolve="getSpecificLanguage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwzHXJ" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0Qp" resolve="getLcVersion" />
+            </node>
           </node>
         </node>
       </node>
@@ -1703,12 +2871,16 @@
       <node concept="17QB3L" id="5JNiskiKYxG" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5JNiskjpl83" role="jymVt" />
-    <node concept="312cEg" id="34Q84zNPKIX" role="jymVt">
-      <property role="TrG5h" value="SLANG_STRUCTURE_LANGUAGE_ID" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="34Q84zNPKIY" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNPKIZ" role="1tU5fm">
-        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+    <node concept="1X3_iC" id="7OJcYqwwNJw" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="34Q84zNPKIX" role="8Wnug">
+        <property role="TrG5h" value="SLANG_STRUCTURE_LANGUAGE_ID" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="34Q84zNPKIY" role="1B3o_S" />
+        <node concept="3uibUv" id="34Q84zNPKIZ" role="1tU5fm">
+          <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNPHRO" role="jymVt">
@@ -1719,8 +2891,13 @@
       </node>
       <node concept="3clFbS" id="34Q84zNPHS1" role="3clF47">
         <node concept="3clFbF" id="34Q84zNQ5BE" role="3cqZAp">
-          <node concept="37vLTw" id="34Q84zNQ5BB" role="3clFbG">
-            <ref role="3cqZAo" node="34Q84zNPKIX" resolve="SLANG_STRUCTURE_LANGUAGE_ID" />
+          <node concept="2OqwBi" id="7OJcYqwzOGS" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwzOGT" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4t2" resolve="getStructureLanguage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwzOGU" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqw7aei" resolve="getSlangId" />
+            </node>
           </node>
         </node>
       </node>
@@ -1728,12 +2905,16 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="312cEg" id="34Q84zNPNje" role="jymVt">
-      <property role="TrG5h" value="SLANG_STRUCTURE_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="34Q84zNPNjf" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNPNjg" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+    <node concept="1X3_iC" id="7OJcYqwwRQA" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="34Q84zNPNje" role="8Wnug">
+        <property role="TrG5h" value="SLANG_STRUCTURE_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="34Q84zNPNjf" role="1B3o_S" />
+        <node concept="3uibUv" id="34Q84zNPNjg" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNPHS5" role="jymVt">
@@ -1744,8 +2925,13 @@
       </node>
       <node concept="3clFbS" id="34Q84zNPHSi" role="3clF47">
         <node concept="3clFbF" id="34Q84zNQ3z6" role="3cqZAp">
-          <node concept="37vLTw" id="34Q84zNQ3z3" role="3clFbG">
-            <ref role="3cqZAo" node="34Q84zNPNje" resolve="SLANG_STRUCTURE_LANGUAGE" />
+          <node concept="2OqwBi" id="7OJcYqwzVq9" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwzVqa" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4t2" resolve="getStructureLanguage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwzVqb" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0Q9" resolve="getSlang" />
+            </node>
           </node>
         </node>
       </node>
@@ -1753,20 +2939,29 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="312cEg" id="34Q84zNPOE1" role="jymVt">
-      <property role="TrG5h" value="KEY_STRUCTURE_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="34Q84zNPOE2" role="1B3o_S" />
-      <node concept="17QB3L" id="34Q84zNPOE3" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwwWfM" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="34Q84zNPOE1" role="8Wnug">
+        <property role="TrG5h" value="KEY_STRUCTURE_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="34Q84zNPOE2" role="1B3o_S" />
+        <node concept="17QB3L" id="34Q84zNPOE3" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="34Q84zNPHSm" role="jymVt">
       <property role="TrG5h" value="keyStructureLanguage" />
       <node concept="3Tm1VV" id="34Q84zNPHSo" role="1B3o_S" />
       <node concept="17QB3L" id="34Q84zNPHSp" role="3clF45" />
       <node concept="3clFbS" id="34Q84zNPHSu" role="3clF47">
-        <node concept="3clFbF" id="34Q84zNQ16D" role="3cqZAp">
-          <node concept="37vLTw" id="34Q84zNQ16A" role="3clFbG">
-            <ref role="3cqZAo" node="34Q84zNPOE1" resolve="KEY_STRUCTURE_LANGUAGE" />
+        <node concept="3clFbF" id="7OJcYqw$03f" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqw$03h" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqw$03i" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4t2" resolve="getStructureLanguage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw$03j" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0QD" resolve="getLcKey" />
+            </node>
           </node>
         </node>
       </node>
@@ -1774,20 +2969,29 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="312cEg" id="34Q84zNPQ8E" role="jymVt">
-      <property role="TrG5h" value="ID_STRUCTURE_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="34Q84zNPQ8F" role="1B3o_S" />
-      <node concept="17QB3L" id="34Q84zNPQ8G" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwwYSS" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="34Q84zNPQ8E" role="8Wnug">
+        <property role="TrG5h" value="ID_STRUCTURE_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="34Q84zNPQ8F" role="1B3o_S" />
+        <node concept="17QB3L" id="34Q84zNPQ8G" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="34Q84zNPHSy" role="jymVt">
       <property role="TrG5h" value="idStructureLanguage" />
       <node concept="3Tm1VV" id="34Q84zNPHS$" role="1B3o_S" />
       <node concept="17QB3L" id="34Q84zNPHS_" role="3clF45" />
       <node concept="3clFbS" id="34Q84zNPHSE" role="3clF47">
-        <node concept="3clFbF" id="34Q84zNPYL3" role="3cqZAp">
-          <node concept="37vLTw" id="34Q84zNPYL0" role="3clFbG">
-            <ref role="3cqZAo" node="34Q84zNPQ8E" resolve="ID_STRUCTURE_LANGUAGE" />
+        <node concept="3clFbF" id="7OJcYqw$58w" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqw$58y" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqw$58z" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4t2" resolve="getStructureLanguage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw$58$" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0Qx" resolve="getLcId" />
+            </node>
           </node>
         </node>
       </node>
@@ -1795,20 +2999,29 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="312cEg" id="34Q84zNPRvz" role="jymVt">
-      <property role="TrG5h" value="VERSION_STRUCTURE_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="34Q84zNPRv$" role="1B3o_S" />
-      <node concept="17QB3L" id="34Q84zNPRv_" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwx1zQ" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="34Q84zNPRvz" role="8Wnug">
+        <property role="TrG5h" value="VERSION_STRUCTURE_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="34Q84zNPRv$" role="1B3o_S" />
+        <node concept="17QB3L" id="34Q84zNPRv_" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="34Q84zNPHSI" role="jymVt">
       <property role="TrG5h" value="versionStructureLanguage" />
       <node concept="3Tm1VV" id="34Q84zNPHSK" role="1B3o_S" />
       <node concept="17QB3L" id="34Q84zNPHSL" role="3clF45" />
       <node concept="3clFbS" id="34Q84zNPHSQ" role="3clF47">
-        <node concept="3clFbF" id="34Q84zNPWtZ" role="3cqZAp">
-          <node concept="37vLTw" id="34Q84zNPWtW" role="3clFbG">
-            <ref role="3cqZAo" node="34Q84zNPRvz" resolve="VERSION_STRUCTURE_LANGUAGE" />
+        <node concept="3clFbF" id="7OJcYqw$b0Z" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqw$b11" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqw$b12" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4t2" resolve="getStructureLanguage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw$b13" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0Qp" resolve="getLcVersion" />
+            </node>
           </node>
         </node>
       </node>
@@ -1818,12 +3031,16 @@
     </node>
     <node concept="2tJIrI" id="34Q84zNNuO4" role="jymVt" />
     <node concept="2tJIrI" id="34Q84zNR0So" role="jymVt" />
-    <node concept="312cEg" id="34Q84zNRm0K" role="jymVt">
-      <property role="TrG5h" value="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="34Q84zNRm0L" role="1B3o_S" />
-      <node concept="3Tqbb2" id="34Q84zNRm0M" role="1tU5fm">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+    <node concept="1X3_iC" id="7OJcYqwx3Fu" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="34Q84zNRm0K" role="8Wnug">
+        <property role="TrG5h" value="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="34Q84zNRm0L" role="1B3o_S" />
+        <node concept="3Tqbb2" id="34Q84zNRm0M" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNR2iW" role="jymVt">
@@ -1834,8 +3051,13 @@
       </node>
       <node concept="3clFbS" id="34Q84zNR2j1" role="3clF47">
         <node concept="3clFbF" id="34Q84zNRRuc" role="3cqZAp">
-          <node concept="37vLTw" id="34Q84zNRRub" role="3clFbG">
-            <ref role="3cqZAo" node="34Q84zNRm0K" resolve="MPS_ABSTRACT_CONCEPT_DECLARATION_CONCEPT" />
+          <node concept="2OqwBi" id="7OJcYqw$iYn" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqw$gbt" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4ta" resolve="getClassifier" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw$lUK" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
+            </node>
           </node>
         </node>
       </node>
@@ -1843,12 +3065,16 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="312cEg" id="7weWCFlnksG" role="jymVt">
-      <property role="TrG5h" value="SLANG_ABSTRACT_CONCEPT_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="7weWCFlnhL_" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlnjU3" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+    <node concept="1X3_iC" id="7OJcYqwx7GT" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="7weWCFlnksG" role="8Wnug">
+        <property role="TrG5h" value="SLANG_ABSTRACT_CONCEPT_CONCEPT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="7weWCFlnhL_" role="1B3o_S" />
+        <node concept="3uibUv" id="7weWCFlnjU3" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="7weWCFlnoxb" role="jymVt">
@@ -1859,8 +3085,13 @@
       </node>
       <node concept="3clFbS" id="7weWCFlnoxg" role="3clF47">
         <node concept="3clFbF" id="7weWCFlntkN" role="3cqZAp">
-          <node concept="37vLTw" id="7weWCFlntkK" role="3clFbG">
-            <ref role="3cqZAo" node="7weWCFlnksG" resolve="SLANG_ABSTRACT_CONCEPT_CONCEPT" />
+          <node concept="2OqwBi" id="7OJcYqw$oxR" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqw$oxS" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4ta" resolve="getClassifier" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw$oxT" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+            </node>
           </node>
         </node>
       </node>
@@ -1869,12 +3100,16 @@
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNS0hq" role="jymVt" />
-    <node concept="312cEg" id="5M8g5cSB02I" role="jymVt">
-      <property role="TrG5h" value="MPS_CONCEPT_DECLARATION_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5M8g5cSB02J" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5M8g5cSB02K" role="1tU5fm">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+    <node concept="1X3_iC" id="7OJcYqwxbR0" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5M8g5cSB02I" role="8Wnug">
+        <property role="TrG5h" value="MPS_CONCEPT_DECLARATION_CONCEPT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5M8g5cSB02J" role="1B3o_S" />
+        <node concept="3Tqbb2" id="5M8g5cSB02K" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5M8g5cSB02B" role="jymVt">
@@ -1885,8 +3120,13 @@
       </node>
       <node concept="3clFbS" id="5M8g5cSB02E" role="3clF47">
         <node concept="3clFbF" id="5M8g5cSB02F" role="3cqZAp">
-          <node concept="37vLTw" id="5M8g5cSB02G" role="3clFbG">
-            <ref role="3cqZAo" node="5M8g5cSB02I" resolve="MPS_CONCEPT_DECLARATION_CONCEPT" />
+          <node concept="2OqwBi" id="7OJcYqw$x4T" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqw$uic" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4ti" resolve="getConcept" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw$zwT" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
+            </node>
           </node>
         </node>
       </node>
@@ -1894,12 +3134,16 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="312cEg" id="5M8g5cSB02$" role="jymVt">
-      <property role="TrG5h" value="SLANG_CONCEPT_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5M8g5cSB02_" role="1B3o_S" />
-      <node concept="3uibUv" id="5M8g5cSB02A" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+    <node concept="1X3_iC" id="7OJcYqwxfON" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5M8g5cSB02$" role="8Wnug">
+        <property role="TrG5h" value="SLANG_CONCEPT_CONCEPT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5M8g5cSB02_" role="1B3o_S" />
+        <node concept="3uibUv" id="5M8g5cSB02A" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5M8g5cSB02t" role="jymVt">
@@ -1909,9 +3153,14 @@
         <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
       </node>
       <node concept="3clFbS" id="5M8g5cSB02w" role="3clF47">
-        <node concept="3clFbF" id="5M8g5cSB02x" role="3cqZAp">
-          <node concept="37vLTw" id="5M8g5cSB02y" role="3clFbG">
-            <ref role="3cqZAo" node="5M8g5cSB02$" resolve="SLANG_CONCEPT_CONCEPT" />
+        <node concept="3clFbF" id="7OJcYqw$Ab4" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqw$Ab5" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqw$Ab6" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4ti" resolve="getConcept" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw$Ab7" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+            </node>
           </node>
         </node>
       </node>
@@ -1920,12 +3169,16 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5M8g5cSB02s" role="jymVt" />
-    <node concept="312cEg" id="5M8g5cSAY3o" role="jymVt">
-      <property role="TrG5h" value="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5M8g5cSAY3p" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5M8g5cSAY3q" role="1tU5fm">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+    <node concept="1X3_iC" id="7OJcYqwxjOf" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5M8g5cSAY3o" role="8Wnug">
+        <property role="TrG5h" value="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5M8g5cSAY3p" role="1B3o_S" />
+        <node concept="3Tqbb2" id="5M8g5cSAY3q" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5M8g5cSAY3h" role="jymVt">
@@ -1936,8 +3189,13 @@
       </node>
       <node concept="3clFbS" id="5M8g5cSAY3k" role="3clF47">
         <node concept="3clFbF" id="5M8g5cSAY3l" role="3cqZAp">
-          <node concept="37vLTw" id="5M8g5cSAY3m" role="3clFbG">
-            <ref role="3cqZAo" node="5M8g5cSAY3o" resolve="MPS_INTERFACE_CONCEPT_DECLARATION_CONCEPT" />
+          <node concept="2OqwBi" id="7OJcYqw$FP$" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqw$FP_" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4tq" resolve="getInterface" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw$FPA" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
+            </node>
           </node>
         </node>
       </node>
@@ -1945,12 +3203,16 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="312cEg" id="5M8g5cSAY3e" role="jymVt">
-      <property role="TrG5h" value="SLANG_INTERFACE_CONCEPT_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5M8g5cSAY3f" role="1B3o_S" />
-      <node concept="3uibUv" id="5M8g5cSAY3g" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+    <node concept="1X3_iC" id="7OJcYqwxnPL" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5M8g5cSAY3e" role="8Wnug">
+        <property role="TrG5h" value="SLANG_INTERFACE_CONCEPT_CONCEPT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5M8g5cSAY3f" role="1B3o_S" />
+        <node concept="3uibUv" id="5M8g5cSAY3g" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5M8g5cSAY37" role="jymVt">
@@ -1961,8 +3223,13 @@
       </node>
       <node concept="3clFbS" id="5M8g5cSAY3a" role="3clF47">
         <node concept="3clFbF" id="5M8g5cSAY3b" role="3cqZAp">
-          <node concept="37vLTw" id="5M8g5cSAY3c" role="3clFbG">
-            <ref role="3cqZAo" node="5M8g5cSAY3e" resolve="SLANG_INTERFACE_CONCEPT_CONCEPT" />
+          <node concept="2OqwBi" id="7OJcYqw$MEN" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqw$MEO" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4tq" resolve="getInterface" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw$MEP" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+            </node>
           </node>
         </node>
       </node>
@@ -1971,12 +3238,16 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5M8g5cSAY36" role="jymVt" />
-    <node concept="312cEg" id="34Q84zNNvW1" role="jymVt">
-      <property role="TrG5h" value="MPS_CONCEPT_ALIAS_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="34Q84zNNvW2" role="1B3o_S" />
-      <node concept="3Tqbb2" id="34Q84zNNvW3" role="1tU5fm">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+    <node concept="1X3_iC" id="7OJcYqwxrRi" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="34Q84zNNvW1" role="8Wnug">
+        <property role="TrG5h" value="MPS_CONCEPT_ALIAS_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="34Q84zNNvW2" role="1B3o_S" />
+        <node concept="3Tqbb2" id="34Q84zNNvW3" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNR2j3" role="jymVt">
@@ -1986,9 +3257,14 @@
         <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
       </node>
       <node concept="3clFbS" id="34Q84zNR2j8" role="3clF47">
-        <node concept="3clFbF" id="34Q84zNR9eI" role="3cqZAp">
-          <node concept="37vLTw" id="34Q84zNR9eH" role="3clFbG">
-            <ref role="3cqZAo" node="34Q84zNNvW1" resolve="MPS_CONCEPT_ALIAS_PROPERTY" />
+        <node concept="3clFbF" id="7OJcYqw_1Cw" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqw_4v6" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqw_1Ct" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4ty" resolve="getConceptAlias" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw_7cM" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
+            </node>
           </node>
         </node>
       </node>
@@ -1996,20 +3272,29 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="312cEg" id="34Q84zNNvWa" role="jymVt">
-      <property role="TrG5h" value="SLANG_CONCEPT_ALIAS_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="34Q84zNNvWb" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNNvWc" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+    <node concept="1X3_iC" id="7OJcYqwxvSP" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="34Q84zNNvWa" role="8Wnug">
+        <property role="TrG5h" value="SLANG_CONCEPT_ALIAS_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="34Q84zNNvWb" role="1B3o_S" />
+        <node concept="3uibUv" id="34Q84zNNvWc" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNNvWd" role="jymVt">
       <property role="TrG5h" value="slangConceptAliasProperty" />
       <node concept="3clFbS" id="34Q84zNNvWe" role="3clF47">
         <node concept="3clFbF" id="34Q84zNNvWf" role="3cqZAp">
-          <node concept="37vLTw" id="34Q84zNNvWg" role="3clFbG">
-            <ref role="3cqZAo" node="34Q84zNNvWa" resolve="SLANG_CONCEPT_ALIAS_PROPERTY" />
+          <node concept="2OqwBi" id="7OJcYqw_9Nj" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqw_9Nk" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4ty" resolve="getConceptAlias" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw_9Nl" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+            </node>
           </node>
         </node>
       </node>
@@ -2019,12 +3304,16 @@
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNS8TW" role="jymVt" />
-    <node concept="312cEg" id="34Q84zNO3Ig" role="jymVt">
-      <property role="TrG5h" value="MPS_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="34Q84zNO3Ih" role="1B3o_S" />
-      <node concept="3Tqbb2" id="34Q84zNO3Ii" role="1tU5fm">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+    <node concept="1X3_iC" id="7OJcYqwx$3n" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="34Q84zNO3Ig" role="8Wnug">
+        <property role="TrG5h" value="MPS_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="34Q84zNO3Ih" role="1B3o_S" />
+        <node concept="3Tqbb2" id="34Q84zNO3Ii" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNR2ja" role="jymVt">
@@ -2035,8 +3324,13 @@
       </node>
       <node concept="3clFbS" id="34Q84zNR2jf" role="3clF47">
         <node concept="3clFbF" id="34Q84zNRgiP" role="3cqZAp">
-          <node concept="37vLTw" id="34Q84zNRgiO" role="3clFbG">
-            <ref role="3cqZAo" node="34Q84zNO3Ig" resolve="MPS_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
+          <node concept="2OqwBi" id="7OJcYqw_ild" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqw_fwL" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4tE" resolve="getConceptShortDescription" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw_lfy" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
+            </node>
           </node>
         </node>
       </node>
@@ -2044,20 +3338,29 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="312cEg" id="34Q84zNO3I7" role="jymVt">
-      <property role="TrG5h" value="SLANG_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="34Q84zNO3I8" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNO3I9" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+    <node concept="1X3_iC" id="7OJcYqwxC4q" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="34Q84zNO3I7" role="8Wnug">
+        <property role="TrG5h" value="SLANG_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="34Q84zNO3I8" role="1B3o_S" />
+        <node concept="3uibUv" id="34Q84zNO3I9" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNO3I1" role="jymVt">
       <property role="TrG5h" value="slangConceptShortDescriptionProperty" />
       <node concept="3clFbS" id="34Q84zNO3I2" role="3clF47">
         <node concept="3clFbF" id="34Q84zNO3I3" role="3cqZAp">
-          <node concept="37vLTw" id="34Q84zNO3I4" role="3clFbG">
-            <ref role="3cqZAo" node="34Q84zNO3I7" resolve="SLANG_CONCEPT_SHORT_DESCRIPTION_PROPERTY" />
+          <node concept="2OqwBi" id="7OJcYqw_nKB" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqw_nKC" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4tE" resolve="getConceptShortDescription" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw_nKD" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+            </node>
           </node>
         </node>
       </node>
@@ -2067,20 +3370,29 @@
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNSe_t" role="jymVt" />
-    <node concept="312cEg" id="34Q84zNNvVS" role="jymVt">
-      <property role="TrG5h" value="LC_CONCEPT_DESCRIPTION_ANNOTATION" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="34Q84zNNvVT" role="1B3o_S" />
-      <node concept="3Tqbb2" id="34Q84zNNvVU" role="1tU5fm">
-        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
+    <node concept="1X3_iC" id="7OJcYqwxGdq" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="34Q84zNNvVS" role="8Wnug">
+        <property role="TrG5h" value="LC_CONCEPT_DESCRIPTION_ANNOTATION" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="34Q84zNNvVT" role="1B3o_S" />
+        <node concept="3Tqbb2" id="34Q84zNNvVU" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNNvVV" role="jymVt">
       <property role="TrG5h" value="lcConceptDescriptionAnnotation" />
       <node concept="3clFbS" id="34Q84zNNvVW" role="3clF47">
         <node concept="3clFbF" id="34Q84zNNvVX" role="3cqZAp">
-          <node concept="37vLTw" id="34Q84zNNvVY" role="3clFbG">
-            <ref role="3cqZAo" node="34Q84zNNvVS" resolve="LC_CONCEPT_DESCRIPTION_ANNOTATION" />
+          <node concept="2OqwBi" id="7OJcYqw_vPO" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqw_tob" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw_ymv" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwOF7L" resolve="getLc" />
+            </node>
           </node>
         </node>
       </node>
@@ -2148,7 +3460,7 @@
     <node concept="2tJIrI" id="5JNiski$9iK" role="jymVt" />
     <node concept="3clFb_" id="5JNiski$2W4" role="jymVt">
       <property role="TrG5h" value="listSLanguageInternalFeatures" />
-      <node concept="3Tmbuc" id="5JNiski$2Wb" role="1B3o_S" />
+      <node concept="3Tm1VV" id="6Z_tmAehb3w" role="1B3o_S" />
       <node concept="_YKpA" id="5JNiski$2Wc" role="3clF45">
         <node concept="3uibUv" id="5JNiski$2Wd" role="_ZDj9">
           <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
@@ -2185,7 +3497,7 @@
     <node concept="2tJIrI" id="5JNiski$ePF" role="jymVt" />
     <node concept="3clFb_" id="5JNiski$2Wr" role="jymVt">
       <property role="TrG5h" value="listSClassifierInternalFeatureIds" />
-      <node concept="3Tmbuc" id="5JNiski$2Wy" role="1B3o_S" />
+      <node concept="3Tm1VV" id="6Z_tmAeh92R" role="1B3o_S" />
       <node concept="_YKpA" id="5JNiski$2Wz" role="3clF45">
         <node concept="17QB3L" id="5JNiski$2W$" role="_ZDj9" />
       </node>
@@ -2433,6 +3745,9 @@
               <node concept="1rXfSq" id="5M8g5cSBOLL" role="HW$Y0">
                 <ref role="37wK5l" node="5M8g5cSAY3h" resolve="mpsInterfaceConceptDeclarationConcept" />
               </node>
+              <node concept="1rXfSq" id="6Z_tmAehXHe" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhqBwd" resolve="mpsINamedInterface" />
+              </node>
               <node concept="3Tqbb2" id="7weWCFln6BG" role="HW$YZ">
                 <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
               </node>
@@ -2471,6 +3786,9 @@
               <node concept="1rXfSq" id="5M8g5cSBHN5" role="HW$Y0">
                 <ref role="37wK5l" node="5M8g5cSAY37" resolve="slangInterfaceConceptConcept" />
               </node>
+              <node concept="1rXfSq" id="6Z_tmAei1N5" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhqBw9" resolve="slangINamedInterface" />
+              </node>
               <node concept="3uibUv" id="7weWCFlnaje" role="HW$YZ">
                 <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
               </node>
@@ -2479,6 +3797,199 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7weWCFln2oC" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvGEcS" role="jymVt">
+      <property role="TrG5h" value="listSLanguageInternalClassifierLanguageKeys" />
+      <node concept="3Tm1VV" id="7OJcYqvGEcU" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqvGEcV" role="3clF45">
+        <node concept="17QB3L" id="7OJcYqvGEcW" role="_ZDj9" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqvGEcZ" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvGJm$" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqvGJm_" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqvGJmA" role="2ShVmc">
+              <node concept="1rXfSq" id="7OJcYqvGO4Q" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqvGVEr" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhqTR7" resolve="keyM3Language" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqvGY0t" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhqTR7" resolve="keyM3Language" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqvH0nA" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhqTR7" resolve="keyM3Language" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqvH2_K" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhqTR7" resolve="keyM3Language" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqvH703" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
+              </node>
+              <node concept="17QB3L" id="7OJcYqvGQZB" role="HW$YZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqvGEd0" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwv4sM" role="jymVt">
+      <property role="TrG5h" value="getVirtualPackage" />
+      <node concept="3uibUv" id="7OJcYqwv4sN" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwv4sO" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwv4sP" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwv4sQ" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwv4sJ" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwv4sK" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwv4sL" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqwumEM" resolve="VIRTUAL_PACKAGE" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwv4sU" role="jymVt">
+      <property role="TrG5h" value="getShortDescription" />
+      <node concept="3uibUv" id="7OJcYqwv4sV" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwv4sW" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwv4sX" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwv4sY" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwv4sR" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwv4sS" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwv4sT" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqwusrr" resolve="SHORT_DESCRIPTION" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwv4t2" role="jymVt">
+      <property role="TrG5h" value="getStructureLanguage" />
+      <node concept="3uibUv" id="7OJcYqwv4t3" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwv4t4" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwv4t5" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwv4t6" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwv4sZ" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwv4t0" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwv4t1" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqwuwts" resolve="STRUCTURE_LANGUAGE" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwv4ta" role="jymVt">
+      <property role="TrG5h" value="getClassifier" />
+      <node concept="3uibUv" id="7OJcYqwv4tb" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwv4tc" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwv4td" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwv4te" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwv4t7" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwv4t8" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwv4t9" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqwuG9p" resolve="CLASSIFIER" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwv4ti" role="jymVt">
+      <property role="TrG5h" value="getConcept" />
+      <node concept="3uibUv" id="7OJcYqwv4tj" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwv4tk" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwv4tl" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwv4tm" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwv4tf" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwv4tg" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwv4th" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqwuLVt" resolve="CONCEPT" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwv4tq" role="jymVt">
+      <property role="TrG5h" value="getInterface" />
+      <node concept="3uibUv" id="7OJcYqwv4tr" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwv4ts" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwv4tt" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwv4tu" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwv4tn" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwv4to" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwv4tp" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqwuQlg" resolve="INTERFACE" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwv4ty" role="jymVt">
+      <property role="TrG5h" value="getConceptAlias" />
+      <node concept="3uibUv" id="7OJcYqwv4tz" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwv4t$" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwv4t_" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwv4tA" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwv4tv" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwv4tw" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwv4tx" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqwuUL4" resolve="CONCEPT_ALIAS" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwv4tE" role="jymVt">
+      <property role="TrG5h" value="getConceptShortDescription" />
+      <node concept="3uibUv" id="7OJcYqwv4tF" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwv4tG" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwv4tH" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwv4tI" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwv4tB" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwv4tC" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwv4tD" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqwuZhZ" resolve="CONCEPT_SHORT_DESCRIPTION" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwWDfJ" role="jymVt">
+      <property role="TrG5h" value="getSpecificLanguage" />
+      <node concept="3uibUv" id="7OJcYqwWDfK" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwWDfL" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwWDgf" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwWDgi" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwWKjn" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwWIZp" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwWN9B" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqwWzAg" resolve="SPECIFIC_LANGUAGE" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwWDgg" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -3783,18 +5294,41 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbJ" id="3M8YG$9BBYZ" role="3cqZAp">
-          <node concept="3clFbS" id="3M8YG$9BBZ0" role="3clFbx">
-            <node concept="3cpWs6" id="3M8YG$9BBZ1" role="3cqZAp">
-              <node concept="37vLTw" id="3M8YG$9DjBY" role="3cqZAk">
-                <ref role="3cqZAo" node="3M8YG$9CZoT" resolve="coreLanguage" />
+        <node concept="3clFbF" id="6Z_tmAe7l68" role="3cqZAp">
+          <node concept="2OqwBi" id="6Z_tmAe7l65" role="3clFbG">
+            <node concept="10M0yZ" id="6Z_tmAe7l66" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+            </node>
+            <node concept="liA8E" id="6Z_tmAe7l67" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="3cpWs3" id="6Z_tmAe7zE0" role="37wK5m">
+                <node concept="37vLTw" id="6Z_tmAe7_$q" role="3uHU7w">
+                  <ref role="3cqZAo" node="3M8YG$9CZoT" resolve="coreLanguage" />
+                </node>
+                <node concept="Xl_RD" id="6Z_tmAe7nMd" role="3uHU7B">
+                  <property role="Xl_RC" value="coreLanguage: " />
+                </node>
               </node>
             </node>
           </node>
-          <node concept="3y3z36" id="3M8YG$9DcOW" role="3clFbw">
-            <node concept="10Nm6u" id="3M8YG$9DfI4" role="3uHU7w" />
-            <node concept="37vLTw" id="3M8YG$9Dbmf" role="3uHU7B">
-              <ref role="3cqZAo" node="3M8YG$9CZoT" resolve="coreLanguage" />
+        </node>
+        <node concept="1X3_iC" id="6Z_tmAe8zMm" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbJ" id="3M8YG$9BBYZ" role="8Wnug">
+            <node concept="3clFbS" id="3M8YG$9BBZ0" role="3clFbx">
+              <node concept="3cpWs6" id="3M8YG$9BBZ1" role="3cqZAp">
+                <node concept="37vLTw" id="3M8YG$9DjBY" role="3cqZAk">
+                  <ref role="3cqZAo" node="3M8YG$9CZoT" resolve="coreLanguage" />
+                </node>
+              </node>
+            </node>
+            <node concept="3y3z36" id="3M8YG$9DcOW" role="3clFbw">
+              <node concept="10Nm6u" id="3M8YG$9DfI4" role="3uHU7w" />
+              <node concept="37vLTw" id="3M8YG$9Dbmf" role="3uHU7B">
+                <ref role="3cqZAo" node="3M8YG$9CZoT" resolve="coreLanguage" />
+              </node>
             </node>
           </node>
         </node>
@@ -3973,18 +5507,41 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbJ" id="3M8YG$9DkON" role="3cqZAp">
-          <node concept="3clFbS" id="3M8YG$9DkOO" role="3clFbx">
-            <node concept="3cpWs6" id="3M8YG$9DkOP" role="3cqZAp">
-              <node concept="37vLTw" id="3M8YG$9DkOQ" role="3cqZAk">
-                <ref role="3cqZAo" node="3M8YG$9DkOE" resolve="coreLanguage" />
+        <node concept="3clFbF" id="6Z_tmAe7LIe" role="3cqZAp">
+          <node concept="2OqwBi" id="6Z_tmAe7LIf" role="3clFbG">
+            <node concept="10M0yZ" id="6Z_tmAe7LIg" role="2Oq$k0">
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+            </node>
+            <node concept="liA8E" id="6Z_tmAe7LIh" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="3cpWs3" id="6Z_tmAe7LIi" role="37wK5m">
+                <node concept="37vLTw" id="6Z_tmAe7LIj" role="3uHU7w">
+                  <ref role="3cqZAo" node="3M8YG$9DkOE" resolve="coreLanguage" />
+                </node>
+                <node concept="Xl_RD" id="6Z_tmAe7LIk" role="3uHU7B">
+                  <property role="Xl_RC" value="coreLanguage2: " />
+                </node>
               </node>
             </node>
           </node>
-          <node concept="3y3z36" id="3M8YG$9DkOR" role="3clFbw">
-            <node concept="10Nm6u" id="3M8YG$9DkOS" role="3uHU7w" />
-            <node concept="37vLTw" id="3M8YG$9DkOT" role="3uHU7B">
-              <ref role="3cqZAo" node="3M8YG$9DkOE" resolve="coreLanguage" />
+        </node>
+        <node concept="1X3_iC" id="6Z_tmAe8AmP" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbJ" id="3M8YG$9DkON" role="8Wnug">
+            <node concept="3clFbS" id="3M8YG$9DkOO" role="3clFbx">
+              <node concept="3cpWs6" id="3M8YG$9DkOP" role="3cqZAp">
+                <node concept="37vLTw" id="3M8YG$9DkOQ" role="3cqZAk">
+                  <ref role="3cqZAo" node="3M8YG$9DkOE" resolve="coreLanguage" />
+                </node>
+              </node>
+            </node>
+            <node concept="3y3z36" id="3M8YG$9DkOR" role="3clFbw">
+              <node concept="10Nm6u" id="3M8YG$9DkOS" role="3uHU7w" />
+              <node concept="37vLTw" id="3M8YG$9DkOT" role="3uHU7B">
+                <ref role="3cqZAo" node="3M8YG$9DkOE" resolve="coreLanguage" />
+              </node>
             </node>
           </node>
         </node>
@@ -6936,6 +8493,139 @@
   </node>
   <node concept="3HP615" id="5JNiskhxHcX">
     <property role="TrG5h" value="ILionCoreConstants" />
+    <node concept="3clFb_" id="7OJcYqwQyzV" role="jymVt">
+      <property role="TrG5h" value="getVirtualPackage" />
+      <node concept="3uibUv" id="7OJcYqwQyzW" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwQyzX" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQyzY" role="3clF47" />
+    </node>
+    <node concept="3clFb_" id="7OJcYqwQy$4" role="jymVt">
+      <property role="TrG5h" value="getShortDescription" />
+      <node concept="3uibUv" id="7OJcYqwQy$5" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwQy$6" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQy$7" role="3clF47" />
+    </node>
+    <node concept="3clFb_" id="7OJcYqwQy$d" role="jymVt">
+      <property role="TrG5h" value="getStructureLanguage" />
+      <node concept="3uibUv" id="7OJcYqwQy$e" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwQy$f" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQy$g" role="3clF47" />
+    </node>
+    <node concept="3clFb_" id="7OJcYqwQy$m" role="jymVt">
+      <property role="TrG5h" value="getClassifier" />
+      <node concept="3uibUv" id="7OJcYqwQy$n" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwQy$o" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQy$p" role="3clF47" />
+    </node>
+    <node concept="3clFb_" id="7OJcYqwQy$v" role="jymVt">
+      <property role="TrG5h" value="getConcept" />
+      <node concept="3uibUv" id="7OJcYqwQy$w" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwQy$x" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQy$y" role="3clF47" />
+    </node>
+    <node concept="3clFb_" id="7OJcYqwQy$C" role="jymVt">
+      <property role="TrG5h" value="getInterface" />
+      <node concept="3uibUv" id="7OJcYqwQy$D" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwQy$E" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQy$F" role="3clF47" />
+    </node>
+    <node concept="3clFb_" id="7OJcYqwQy$L" role="jymVt">
+      <property role="TrG5h" value="getConceptAlias" />
+      <node concept="3uibUv" id="7OJcYqwQy$M" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwQy$N" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQy$O" role="3clF47" />
+    </node>
+    <node concept="3clFb_" id="7OJcYqwQy$U" role="jymVt">
+      <property role="TrG5h" value="getConceptShortDescription" />
+      <node concept="3uibUv" id="7OJcYqwQy$V" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwQy$W" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQy$X" role="3clF47" />
+    </node>
+    <node concept="3clFb_" id="7OJcYqwUzr1" role="jymVt">
+      <property role="TrG5h" value="getSpecificLanguage" />
+      <node concept="3uibUv" id="7OJcYqwUzr2" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwUzr3" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwUzr4" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqwUzr5" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwUzr6" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUzr7" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUzr8" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUzr9" role="1dT_Ay">
+            <property role="1dT_AB" value="io.io.lionweb.mps.specific as " />
+          </node>
+          <node concept="1dT_AA" id="7OJcYqwUzra" role="1dT_Ay">
+            <node concept="92FcH" id="7OJcYqwUzrb" role="qph3F">
+              <node concept="TZ5HA" id="7OJcYqwUzrc" role="2XjZqd" />
+              <node concept="VXe08" id="7OJcYqwUzrd" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SLanguage" resolve="SLanguage" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="7OJcYqwUzre" role="1dT_Ay" />
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUzrf" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUzrg" role="1dT_Ay">
+            <property role="1dT_AB" value="slangId: " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUzrh" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUzri" role="1dT_Ay">
+            <property role="1dT_AB" value="io.io.lionweb.mps.specific as " />
+          </node>
+          <node concept="1dT_AA" id="7OJcYqwUzrj" role="1dT_Ay">
+            <node concept="92FcH" id="7OJcYqwUzrk" role="qph3F">
+              <node concept="TZ5HA" id="7OJcYqwUzrl" role="2XjZqd" />
+              <node concept="VXe08" id="7OJcYqwUzrm" role="92FcQ">
+                <ref role="VXe09" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="7OJcYqwUzrn" role="1dT_Ay" />
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUzro" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUzrp" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: e92f782f-6faf-41c2-bf76-2b1a350c0516" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUzrq" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUzrr" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsVersion: 0" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUzrs" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUzrt" role="1dT_Ay">
+            <property role="1dT_AB" value="lcVersion: 0" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUzru" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUzrv" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: io-lionweb-mps-specific" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqwQyqk" role="jymVt" />
     <node concept="3clFb_" id="5JNiskipPo2" role="jymVt">
       <property role="TrG5h" value="lcVirtualPackageAnnotation" />
       <node concept="3clFbS" id="5JNiskipPo3" role="3clF47" />
@@ -7549,6 +9239,102 @@
   </node>
   <node concept="312cEu" id="5JNiskhYWOE">
     <property role="TrG5h" value="LionCoreConstants_2023_1" />
+    <node concept="312cEg" id="7OJcYqvS5bN" role="jymVt">
+      <property role="TrG5h" value="M3_LANGUAGE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvS5bL" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqvS5bM" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqvScQL" role="jymVt">
+      <property role="TrG5h" value="LIONCORE_BUILTINS" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvScQJ" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqvScQK" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqvSkE$" role="jymVt">
+      <property role="TrG5h" value="STRING" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvSkEy" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqvSkEz" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqvSsAf" role="jymVt">
+      <property role="TrG5h" value="BOOLEAN" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvSsAd" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqvSsAe" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqvSxpd" role="jymVt">
+      <property role="TrG5h" value="INTEGER" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvSxpb" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqvSxpc" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqvSGCF" role="jymVt">
+      <property role="TrG5h" value="JSON" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvSGCD" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqvSGCE" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqw2ryQ" resolve="ConstrainedPrimitiveTypeKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqvSOTI" role="jymVt">
+      <property role="TrG5h" value="NODE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvSOTG" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqvSOTH" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqvSX4c" role="jymVt">
+      <property role="TrG5h" value="ANNOTATION" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvSX4a" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqvSX4b" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqvT58p" role="jymVt">
+      <property role="TrG5h" value="ANNOTATION_CONTAINMENT" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvT58n" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqvT58o" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvQ8aH" resolve="ContainmentKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqvTdFq" role="jymVt">
+      <property role="TrG5h" value="INAMED" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvTdFo" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqvTdFp" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvXZ8V" resolve="InterfaceKeyedMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqvTlIS" role="jymVt">
+      <property role="TrG5h" value="NAME" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvTlIQ" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqvTlIR" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqw99Yc" role="jymVt">
+      <property role="TrG5h" value="ATTRIBUTE_LANGUAGE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqw99Ya" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqw99Yb" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      </node>
+    </node>
     <node concept="3clFbW" id="5JNiski3MAN" role="jymVt">
       <node concept="37vLTG" id="5JNiski3MAO" role="3clF46">
         <property role="TrG5h" value="repository" />
@@ -7563,30 +9349,56 @@
       <node concept="3Tm1VV" id="5JNiski3MAS" role="1B3o_S" />
       <node concept="3clFbS" id="5JNiski3MAT" role="3clF47">
         <node concept="3clFbH" id="5JNiski3MAU" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiski3MAV" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MAW" role="3clFbG">
-            <node concept="37vLTw" id="5JNiski3MAX" role="37vLTJ">
-              <ref role="3cqZAo" node="4R9posq8YbX" resolve="SLANG_M3_LANGUAGE" />
-            </node>
-            <node concept="pHN19" id="5JNiski3MAY" role="37vLTx">
-              <node concept="2V$Bhx" id="5JNiski3MAZ" role="2V$M_3">
-                <property role="2V$B1T" value="01cf0d82-8d29-4fc4-be96-28abaf4ad33d" />
-                <property role="2V$B1Q" value="io.lionweb.mps.m3" />
+        <node concept="1X3_iC" id="7OJcYqwaPSW" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MAV" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MAW" role="3clFbG">
+              <node concept="37vLTw" id="5JNiski3MAX" role="37vLTJ">
+                <ref role="3cqZAo" node="4R9posq8YbX" resolve="SLANG_M3_LANGUAGE" />
+              </node>
+              <node concept="pHN19" id="5JNiski3MAY" role="37vLTx">
+                <node concept="2V$Bhx" id="5JNiski3MAZ" role="2V$M_3">
+                  <property role="2V$B1T" value="01cf0d82-8d29-4fc4-be96-28abaf4ad33d" />
+                  <property role="2V$B1Q" value="io.lionweb.mps.m3" />
+                </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MB0" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MB1" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiski3MB2" role="37vLTx">
-              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-              <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
-              <node concept="37vLTw" id="5JNiski3MB3" role="37wK5m">
-                <ref role="3cqZAo" node="4R9posq8YbX" resolve="SLANG_M3_LANGUAGE" />
+        <node concept="1X3_iC" id="7OJcYqwaPSX" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MB0" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MB1" role="3clFbG">
+              <node concept="2YIFZM" id="5JNiski3MB2" role="37vLTx">
+                <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
+                <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
+                <node concept="37vLTw" id="5JNiski3MB3" role="37wK5m">
+                  <ref role="3cqZAo" node="4R9posq8YbX" resolve="SLANG_M3_LANGUAGE" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiski3MB4" role="37vLTJ">
+                <ref role="3cqZAo" node="5AGBwuFFqaM" resolve="SLANG_M3_LANGUAGE_ID" />
               </node>
             </node>
-            <node concept="37vLTw" id="5JNiski3MB4" role="37vLTJ">
-              <ref role="3cqZAo" node="5AGBwuFFqaM" resolve="SLANG_M3_LANGUAGE_ID" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7OJcYqwcE0M" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwcE0N" role="3cpWs9">
+            <property role="TrG5h" value="m3LanguageId" />
+            <node concept="3uibUv" id="7OJcYqwcC8z" role="1tU5fm">
+              <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+            </node>
+            <node concept="2YIFZM" id="7OJcYqwcE0P" role="33vP2m">
+              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
+              <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
+              <node concept="pHN19" id="7OJcYqwcNpB" role="37wK5m">
+                <node concept="2V$Bhx" id="7OJcYqwcNpC" role="2V$M_3">
+                  <property role="2V$B1T" value="01cf0d82-8d29-4fc4-be96-28abaf4ad33d" />
+                  <property role="2V$B1Q" value="io.lionweb.mps.m3" />
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -7630,7 +9442,7 @@
             </node>
           </node>
         </node>
-        <node concept="1X3_iC" id="5JNiski3MBj" role="lGtFl">
+        <node concept="1X3_iC" id="7OJcYqwaTGd" role="lGtFl">
           <property role="3V$3am" value="statement" />
           <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
           <node concept="3clFbF" id="5JNiski3MBk" role="8Wnug">
@@ -7670,80 +9482,174 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MBy" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MBz" role="3clFbG">
-            <node concept="37vLTw" id="5JNiski3MB$" role="37vLTJ">
-              <ref role="3cqZAo" node="5AGBwuFF_qd" resolve="KEY_M3_LANGUAGE" />
-            </node>
-            <node concept="Xl_RD" id="5JNiski3MB_" role="37vLTx">
-              <property role="Xl_RC" value="LionCore-M3" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MBA" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MBB" role="3clFbG">
-            <node concept="37vLTw" id="5JNiski3MBC" role="37vLTJ">
-              <ref role="3cqZAo" node="2mPmTXsy5za" resolve="ID_M3_LANGUAGE" />
-            </node>
-            <node concept="2OqwBi" id="5JNiski3MBD" role="37vLTx">
-              <node concept="37vLTw" id="5JNiski3MBE" role="2Oq$k0">
-                <ref role="3cqZAo" node="5AGBwuFFqaM" resolve="SLANG_M3_LANGUAGE_ID" />
+        <node concept="1X3_iC" id="7OJcYqwaTGe" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MBy" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MBz" role="3clFbG">
+              <node concept="37vLTw" id="5JNiski3MB$" role="37vLTJ">
+                <ref role="3cqZAo" node="5AGBwuFF_qd" resolve="KEY_M3_LANGUAGE" />
               </node>
-              <node concept="liA8E" id="5JNiski3MBF" role="2OqNvi">
-                <ref role="37wK5l" to="e8bb:~SLanguageId.toString()" resolve="toString" />
+              <node concept="Xl_RD" id="5JNiski3MB_" role="37vLTx">
+                <property role="Xl_RC" value="LionCore-M3" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MBG" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MBH" role="3clFbG">
-            <node concept="37vLTw" id="5JNiski3MBI" role="37vLTx">
-              <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
+        <node concept="1X3_iC" id="7OJcYqwaTGf" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MBA" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MBB" role="3clFbG">
+              <node concept="37vLTw" id="5JNiski3MBC" role="37vLTJ">
+                <ref role="3cqZAo" node="2mPmTXsy5za" resolve="ID_M3_LANGUAGE" />
+              </node>
+              <node concept="2OqwBi" id="5JNiski3MBD" role="37vLTx">
+                <node concept="37vLTw" id="5JNiski3MBE" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5AGBwuFFqaM" resolve="SLANG_M3_LANGUAGE_ID" />
+                </node>
+                <node concept="liA8E" id="5JNiski3MBF" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SLanguageId.toString()" resolve="toString" />
+                </node>
+              </node>
             </node>
-            <node concept="37vLTw" id="5JNiski3MBJ" role="37vLTJ">
-              <ref role="3cqZAo" node="1ryFPTS4XtL" resolve="VERSION_M3_LANGUAGE" />
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwaTGg" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MBG" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MBH" role="3clFbG">
+              <node concept="37vLTw" id="5JNiski3MBI" role="37vLTx">
+                <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
+              </node>
+              <node concept="37vLTw" id="5JNiski3MBJ" role="37vLTJ">
+                <ref role="3cqZAo" node="1ryFPTS4XtL" resolve="VERSION_M3_LANGUAGE" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqvS5c0" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvS5c1" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvS5c2" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvS5c3" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvS5c4" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvS5bN" resolve="M3_LANGUAGE" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqvS5c5" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqvS5c6" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvMRo3" resolve="LanguageKeyedMapping" />
+                <node concept="pHN19" id="7OJcYqvS5c7" role="37wK5m">
+                  <node concept="2V$Bhx" id="7OJcYqvS5c8" role="2V$M_3">
+                    <property role="2V$B1T" value="01cf0d82-8d29-4fc4-be96-28abaf4ad33d" />
+                    <property role="2V$B1Q" value="io.lionweb.mps.m3" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="7OJcYqvS5c9" role="37wK5m">
+                  <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
+                </node>
+                <node concept="Xl_RD" id="7OJcYqvS5ca" role="37wK5m">
+                  <property role="Xl_RC" value="LionCore-M3" />
+                </node>
+                <node concept="Xl_RD" id="7OJcYqvS5cb" role="37wK5m">
+                  <property role="Xl_RC" value="LionCore-M3" />
+                </node>
+              </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="5JNiski3MBK" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiski3MBL" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MBM" role="3clFbG">
-            <node concept="pHN19" id="5JNiski3MBN" role="37vLTx">
-              <node concept="2V$Bhx" id="5JNiski3MBO" role="2V$M_3">
-                <property role="2V$B1T" value="411e5b27-8a76-482e-8af8-1704262b4468" />
-                <property role="2V$B1Q" value="io.lionweb.mps.structure.attribute" />
+        <node concept="1X3_iC" id="7OJcYqwaXmA" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MBL" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MBM" role="3clFbG">
+              <node concept="pHN19" id="5JNiski3MBN" role="37vLTx">
+                <node concept="2V$Bhx" id="5JNiski3MBO" role="2V$M_3">
+                  <property role="2V$B1T" value="411e5b27-8a76-482e-8af8-1704262b4468" />
+                  <property role="2V$B1Q" value="io.lionweb.mps.structure.attribute" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiski3MBP" role="37vLTJ">
+                <ref role="3cqZAo" node="4WflrVaDO5l" resolve="SLANG_ATTRIBUTE_LANGUAGE" />
               </node>
             </node>
-            <node concept="37vLTw" id="5JNiski3MBP" role="37vLTJ">
-              <ref role="3cqZAo" node="4WflrVaDO5l" resolve="SLANG_ATTRIBUTE_LANGUAGE" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqw99Yp" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqw99Yq" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqw99Yr" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqw99Ys" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqw99Yt" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqw99Yc" resolve="ATTRIBUTE_LANGUAGE" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqw99Yu" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqw99Yv" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqwqm3V" resolve="LanguageKeyedMapping" />
+                <node concept="pHN19" id="7OJcYqw99Yw" role="37wK5m">
+                  <node concept="2V$Bhx" id="7OJcYqwUMaB" role="2V$M_3">
+                    <property role="2V$B1T" value="411e5b27-8a76-482e-8af8-1704262b4468" />
+                    <property role="2V$B1Q" value="io.lionweb.mps.structure.attribute" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="5JNiski3MBQ" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiski3MBR" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MBS" role="3clFbG">
-            <node concept="37vLTw" id="5JNiski3MBT" role="37vLTJ">
-              <ref role="3cqZAo" node="4R9posq8ZVS" resolve="SLANG_CORE_LANGUAGE" />
-            </node>
-            <node concept="pHN19" id="5JNiski3MBU" role="37vLTx">
-              <node concept="2V$Bhx" id="5JNiski3MBV" role="2V$M_3">
-                <property role="2V$B1T" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
-                <property role="2V$B1Q" value="jetbrains.mps.lang.core" />
+        <node concept="1X3_iC" id="7OJcYqwb0S7" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MBR" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MBS" role="3clFbG">
+              <node concept="37vLTw" id="5JNiski3MBT" role="37vLTJ">
+                <ref role="3cqZAo" node="4R9posq8ZVS" resolve="SLANG_CORE_LANGUAGE" />
+              </node>
+              <node concept="pHN19" id="5JNiski3MBU" role="37vLTx">
+                <node concept="2V$Bhx" id="5JNiski3MBV" role="2V$M_3">
+                  <property role="2V$B1T" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
+                  <property role="2V$B1Q" value="jetbrains.mps.lang.core" />
+                </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MBW" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MBX" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiski3MBY" role="37vLTx">
-              <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
-              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-              <node concept="37vLTw" id="5JNiski3MBZ" role="37wK5m">
-                <ref role="3cqZAo" node="4R9posq8ZVS" resolve="SLANG_CORE_LANGUAGE" />
+        <node concept="1X3_iC" id="7OJcYqwb0S8" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MBW" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MBX" role="3clFbG">
+              <node concept="2YIFZM" id="5JNiski3MBY" role="37vLTx">
+                <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
+                <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
+                <node concept="37vLTw" id="5JNiski3MBZ" role="37wK5m">
+                  <ref role="3cqZAo" node="4R9posq8ZVS" resolve="SLANG_CORE_LANGUAGE" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiski3MC0" role="37vLTJ">
+                <ref role="3cqZAo" node="5AGBwuFFuSI" resolve="SLANG_CORE_LANGUAGE_ID" />
               </node>
             </node>
-            <node concept="37vLTw" id="5JNiski3MC0" role="37vLTJ">
-              <ref role="3cqZAo" node="5AGBwuFFuSI" resolve="SLANG_CORE_LANGUAGE_ID" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7OJcYqwchFV" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwchFW" role="3cpWs9">
+            <property role="TrG5h" value="coreLanguageId" />
+            <property role="3TUv4t" value="true" />
+            <node concept="3uibUv" id="7OJcYqwcfHt" role="1tU5fm">
+              <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+            </node>
+            <node concept="2YIFZM" id="7OJcYqwchFY" role="33vP2m">
+              <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
+              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
+              <node concept="pHN19" id="7OJcYqwcqkx" role="37wK5m">
+                <node concept="2V$Bhx" id="7OJcYqwcqky" role="2V$M_3">
+                  <property role="2V$B1T" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
+                  <property role="2V$B1Q" value="jetbrains.mps.lang.core" />
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -7781,105 +9687,164 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MCe" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MCf" role="3clFbG">
-            <node concept="Xl_RD" id="5JNiski3MCg" role="37vLTx">
-              <property role="Xl_RC" value="LionCore-builtins" />
-            </node>
-            <node concept="37vLTw" id="5JNiski3MCh" role="37vLTJ">
-              <ref role="3cqZAo" node="5AGBwuFFBJV" resolve="KEY_BUILTIN_LANGUAGE" />
+        <node concept="1X3_iC" id="7OJcYqwb4uw" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MCe" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MCf" role="3clFbG">
+              <node concept="Xl_RD" id="5JNiski3MCg" role="37vLTx">
+                <property role="Xl_RC" value="LionCore-builtins" />
+              </node>
+              <node concept="37vLTw" id="5JNiski3MCh" role="37vLTJ">
+                <ref role="3cqZAo" node="5AGBwuFFBJV" resolve="KEY_BUILTIN_LANGUAGE" />
+              </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MCi" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MCj" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiski3MCk" role="37vLTx">
-              <node concept="37vLTw" id="5JNiski3MCl" role="2Oq$k0">
-                <ref role="3cqZAo" node="5AGBwuFFuSI" resolve="SLANG_CORE_LANGUAGE_ID" />
+        <node concept="1X3_iC" id="7OJcYqwb4ux" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MCi" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MCj" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiski3MCk" role="37vLTx">
+                <node concept="37vLTw" id="5JNiski3MCl" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5AGBwuFFuSI" resolve="SLANG_CORE_LANGUAGE_ID" />
+                </node>
+                <node concept="liA8E" id="5JNiski3MCm" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SLanguageId.toString()" resolve="toString" />
+                </node>
               </node>
-              <node concept="liA8E" id="5JNiski3MCm" role="2OqNvi">
-                <ref role="37wK5l" to="e8bb:~SLanguageId.toString()" resolve="toString" />
+              <node concept="37vLTw" id="5JNiski3MCn" role="37vLTJ">
+                <ref role="3cqZAo" node="2mPmTXsy76l" resolve="ID_BUILTIN_LANGUAGE" />
               </node>
-            </node>
-            <node concept="37vLTw" id="5JNiski3MCn" role="37vLTJ">
-              <ref role="3cqZAo" node="2mPmTXsy76l" resolve="ID_BUILTIN_LANGUAGE" />
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MCo" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MCp" role="3clFbG">
-            <node concept="37vLTw" id="5JNiski3MCq" role="37vLTJ">
-              <ref role="3cqZAo" node="1ryFPTS4Z8M" resolve="VERSION_BUILTIN_LANGUAGE" />
-            </node>
-            <node concept="37vLTw" id="5JNiski3MCr" role="37vLTx">
-              <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
+        <node concept="1X3_iC" id="7OJcYqwb4uy" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MCo" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MCp" role="3clFbG">
+              <node concept="37vLTw" id="5JNiski3MCq" role="37vLTJ">
+                <ref role="3cqZAo" node="1ryFPTS4Z8M" resolve="VERSION_BUILTIN_LANGUAGE" />
+              </node>
+              <node concept="37vLTw" id="5JNiski3MCr" role="37vLTx">
+                <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
+              </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="5JNiski3MCs" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiski3MCt" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MCu" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiski3MCv" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiski3MCw" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiski3MCx" role="2tJFKM">
-                  <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
-                  <node concept="ZC_QK" id="5JNiski3MCy" role="2aWVGa">
-                    <ref role="2aWVGs" to="2pzz:2ju2syjnJjX" resolve="String" />
+        <node concept="3clFbF" id="7OJcYqvScQY" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvScQZ" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvScR0" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvScR1" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvScR2" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvScQL" resolve="LIONCORE_BUILTINS" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqvScR3" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqvScR4" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvMRo3" resolve="LanguageKeyedMapping" />
+                <node concept="pHN19" id="7OJcYqvScR5" role="37wK5m">
+                  <node concept="2V$Bhx" id="7OJcYqvScR6" role="2V$M_3">
+                    <property role="2V$B1T" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
+                    <property role="2V$B1Q" value="jetbrains.mps.lang.core" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="7OJcYqvScR7" role="37wK5m">
+                  <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
+                </node>
+                <node concept="Xl_RD" id="7OJcYqvScR8" role="37wK5m">
+                  <property role="Xl_RC" value="LionCore-builtins" />
+                </node>
+                <node concept="Xl_RD" id="7OJcYqvScR9" role="37wK5m">
+                  <property role="Xl_RC" value="LionCore-builtins" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqvUqCi" role="3cqZAp" />
+        <node concept="1X3_iC" id="7OJcYqwb7WL" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MCt" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MCu" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiski3MCv" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiski3MCw" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiski3MCx" role="2tJFKM">
+                    <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
+                    <node concept="ZC_QK" id="5JNiski3MCy" role="2aWVGa">
+                      <ref role="2aWVGs" to="2pzz:2ju2syjnJjX" resolve="String" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiski3MCz" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiski3MC$" role="Vysub">
+                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
                   </node>
                 </node>
               </node>
-              <node concept="Vyspw" id="5JNiski3MCz" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiski3MC$" role="Vysub">
-                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqrD9" role="37vLTJ">
-              <ref role="3cqZAo" node="2ju2syjsm_6" resolve="LC_STRING_TYPE" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MCC" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MCD" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqrDa" role="37vLTJ">
-              <ref role="3cqZAo" node="DUXtH0nMqB" resolve="MPS_STRING_TYPE" />
-            </node>
-            <node concept="2OqwBi" id="5JNiski3MCH" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiski3MCI" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiski3MCJ" role="2tJFKM">
-                  <ref role="2aWVGs" to="tpck:fKAOsGN" resolve="string" />
-                </node>
-              </node>
-              <node concept="Vyspw" id="5JNiski3MCK" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiski3MCL" role="Vysub">
-                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MCM" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MCN" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqrDb" role="37vLTJ">
-              <ref role="3cqZAo" node="39$JcGGWFCK" resolve="SLANG_STRING_TYPE" />
-            </node>
-            <node concept="10M0yZ" id="5JNiski3MCR" role="37vLTx">
-              <ref role="3cqZAo" to="xx25:~SPrimitiveTypes.STRING" resolve="STRING" />
-              <ref role="1PxDUh" to="xx25:~SPrimitiveTypes" resolve="SPrimitiveTypes" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MCS" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MCT" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiski3MCU" role="37vLTx">
-              <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-              <node concept="37vLTw" id="5JNiski3MCV" role="37wK5m">
+              <node concept="37vLTw" id="5JNiskiqrD9" role="37vLTJ">
                 <ref role="3cqZAo" node="2ju2syjsm_6" resolve="LC_STRING_TYPE" />
               </node>
             </node>
-            <node concept="37vLTw" id="5JNiskiqrDc" role="37vLTJ">
-              <ref role="3cqZAo" node="5M3rB6_Plke" resolve="KEY_STRING_TYPE" />
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwb7WM" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MCC" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MCD" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqrDa" role="37vLTJ">
+                <ref role="3cqZAo" node="DUXtH0nMqB" resolve="MPS_STRING_TYPE" />
+              </node>
+              <node concept="2OqwBi" id="5JNiski3MCH" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiski3MCI" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiski3MCJ" role="2tJFKM">
+                    <ref role="2aWVGs" to="tpck:fKAOsGN" resolve="string" />
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiski3MCK" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiski3MCL" role="Vysub">
+                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwb7WN" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MCM" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MCN" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqrDb" role="37vLTJ">
+                <ref role="3cqZAo" node="39$JcGGWFCK" resolve="SLANG_STRING_TYPE" />
+              </node>
+              <node concept="10M0yZ" id="5JNiski3MCR" role="37vLTx">
+                <ref role="3cqZAo" to="xx25:~SPrimitiveTypes.STRING" resolve="STRING" />
+                <ref role="1PxDUh" to="xx25:~SPrimitiveTypes" resolve="SPrimitiveTypes" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwb7WO" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MCS" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MCT" role="3clFbG">
+              <node concept="2YIFZM" id="7OJcYqwPrVi" role="37vLTx">
+                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+                <node concept="37vLTw" id="5JNiski3MCV" role="37wK5m">
+                  <ref role="3cqZAo" node="2ju2syjsm_6" resolve="LC_STRING_TYPE" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrDc" role="37vLTJ">
+                <ref role="3cqZAo" node="5M3rB6_Plke" resolve="KEY_STRING_TYPE" />
+              </node>
             </node>
           </node>
         </node>
@@ -7902,89 +9867,156 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MD8" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MD9" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqrDe" role="37vLTJ">
-              <ref role="3cqZAo" node="2mPmTXsxVhr" resolve="ID_STRING_TYPE" />
-            </node>
-            <node concept="2OqwBi" id="5JNiski3MDd" role="37vLTx">
-              <node concept="2YIFZM" id="5JNiski3MDe" role="2Oq$k0">
-                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
-                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                <node concept="37vLTw" id="5JNiski3MDf" role="37wK5m">
-                  <ref role="3cqZAo" node="DUXtH0nMqB" resolve="MPS_STRING_TYPE" />
-                </node>
+        <node concept="1X3_iC" id="7OJcYqwbbIv" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MD8" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MD9" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqrDe" role="37vLTJ">
+                <ref role="3cqZAo" node="2mPmTXsxVhr" resolve="ID_STRING_TYPE" />
               </node>
-              <node concept="liA8E" id="5JNiski3MDg" role="2OqNvi">
-                <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
+              <node concept="2OqwBi" id="5JNiski3MDd" role="37vLTx">
+                <node concept="2YIFZM" id="5JNiski3MDe" role="2Oq$k0">
+                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
+                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+                  <node concept="37vLTw" id="5JNiski3MDf" role="37wK5m">
+                    <ref role="3cqZAo" node="DUXtH0nMqB" resolve="MPS_STRING_TYPE" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5JNiski3MDg" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
+                </node>
               </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="5JNiski3MDh" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiski3MDi" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MDj" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiski3MDk" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiski3MDl" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiski3MDm" role="2tJFKM">
-                  <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
-                  <node concept="ZC_QK" id="5JNiski3MDn" role="2aWVGa">
-                    <ref role="2aWVGs" to="2pzz:2ju2syjnJk2" resolve="Boolean" />
+        <node concept="3clFbF" id="7OJcYqvSkES" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvSkET" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvSkEU" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvSkEV" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvSkEW" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvSkE$" resolve="STRING" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqvSkEX" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqvSkEY" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvLccW" resolve="PrimitiveTypeKeyedMapping" />
+                <node concept="2OqwBi" id="7OJcYqvSkEZ" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqvSkF0" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqvSkF1" role="2tJFKM">
+                      <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
+                      <node concept="ZC_QK" id="7OJcYqvSkF2" role="2aWVGa">
+                        <ref role="2aWVGs" to="2pzz:2ju2syjnJjX" resolve="String" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqvSkF3" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqvSkF4" role="Vysub">
+                      <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqvSkF5" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqvSkF6" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqvSkF7" role="2tJFKM">
+                      <ref role="2aWVGs" to="tpck:fKAOsGN" resolve="string" />
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqvSkF8" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqvSkF9" role="Vysub">
+                      <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="10M0yZ" id="7OJcYqvSkFa" role="37wK5m">
+                  <ref role="1PxDUh" to="xx25:~SPrimitiveTypes" resolve="SPrimitiveTypes" />
+                  <ref role="3cqZAo" to="xx25:~SPrimitiveTypes.STRING" resolve="STRING" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqvUGns" role="3cqZAp" />
+        <node concept="1X3_iC" id="7OJcYqwbfjx" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MDi" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MDj" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiski3MDk" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiski3MDl" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiski3MDm" role="2tJFKM">
+                    <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
+                    <node concept="ZC_QK" id="5JNiski3MDn" role="2aWVGa">
+                      <ref role="2aWVGs" to="2pzz:2ju2syjnJk2" resolve="Boolean" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiski3MDo" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiski3MDp" role="Vysub">
+                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
                   </node>
                 </node>
               </node>
-              <node concept="Vyspw" id="5JNiski3MDo" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiski3MDp" role="Vysub">
-                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqrDf" role="37vLTJ">
-              <ref role="3cqZAo" node="2ju2syjsnG3" resolve="LC_BOOLEAN_TYPE" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MDt" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MDu" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqrDg" role="37vLTJ">
-              <ref role="3cqZAo" node="DUXtH0nRhx" resolve="MPS_BOOLEAN_TYPE" />
-            </node>
-            <node concept="2OqwBi" id="5JNiski3MDy" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiski3MDz" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiski3MD$" role="2tJFKM">
-                  <ref role="2aWVGs" to="tpck:fKAQMTB" resolve="boolean" />
-                </node>
-              </node>
-              <node concept="Vyspw" id="5JNiski3MD_" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiski3MDA" role="Vysub">
-                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MDB" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MDC" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqrDh" role="37vLTJ">
-              <ref role="3cqZAo" node="39$JcGGWAx4" resolve="SLANG_BOOLEAN_TYPE" />
-            </node>
-            <node concept="10M0yZ" id="5JNiski3MDG" role="37vLTx">
-              <ref role="1PxDUh" to="xx25:~SPrimitiveTypes" resolve="SPrimitiveTypes" />
-              <ref role="3cqZAo" to="xx25:~SPrimitiveTypes.BOOLEAN" resolve="BOOLEAN" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MDH" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MDI" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiski3MDJ" role="37vLTx">
-              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-              <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-              <node concept="37vLTw" id="5JNiski3MDK" role="37wK5m">
+              <node concept="37vLTw" id="5JNiskiqrDf" role="37vLTJ">
                 <ref role="3cqZAo" node="2ju2syjsnG3" resolve="LC_BOOLEAN_TYPE" />
               </node>
             </node>
-            <node concept="37vLTw" id="5JNiskiqrDi" role="37vLTJ">
-              <ref role="3cqZAo" node="5M3rB6_PmED" resolve="KEY_BOOLEAN_TYPE" />
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbfjy" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MDt" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MDu" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqrDg" role="37vLTJ">
+                <ref role="3cqZAo" node="DUXtH0nRhx" resolve="MPS_BOOLEAN_TYPE" />
+              </node>
+              <node concept="2OqwBi" id="5JNiski3MDy" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiski3MDz" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiski3MD$" role="2tJFKM">
+                    <ref role="2aWVGs" to="tpck:fKAQMTB" resolve="boolean" />
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiski3MD_" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiski3MDA" role="Vysub">
+                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbfjz" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MDB" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MDC" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqrDh" role="37vLTJ">
+                <ref role="3cqZAo" node="39$JcGGWAx4" resolve="SLANG_BOOLEAN_TYPE" />
+              </node>
+              <node concept="10M0yZ" id="5JNiski3MDG" role="37vLTx">
+                <ref role="1PxDUh" to="xx25:~SPrimitiveTypes" resolve="SPrimitiveTypes" />
+                <ref role="3cqZAo" to="xx25:~SPrimitiveTypes.BOOLEAN" resolve="BOOLEAN" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbfj$" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MDH" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MDI" role="3clFbG">
+              <node concept="2YIFZM" id="7OJcYqwPrVj" role="37vLTx">
+                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+                <node concept="37vLTw" id="5JNiski3MDK" role="37wK5m">
+                  <ref role="3cqZAo" node="2ju2syjsnG3" resolve="LC_BOOLEAN_TYPE" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrDi" role="37vLTJ">
+                <ref role="3cqZAo" node="5M3rB6_PmED" resolve="KEY_BOOLEAN_TYPE" />
+              </node>
             </node>
           </node>
         </node>
@@ -8007,89 +10039,156 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MDX" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MDY" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqrDk" role="37vLTJ">
-              <ref role="3cqZAo" node="2mPmTXsxWOq" resolve="ID_BOOLEAN_TYPE" />
-            </node>
-            <node concept="2OqwBi" id="5JNiski3ME2" role="37vLTx">
-              <node concept="2YIFZM" id="5JNiski3ME3" role="2Oq$k0">
-                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
-                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                <node concept="37vLTw" id="5JNiski3ME4" role="37wK5m">
-                  <ref role="3cqZAo" node="DUXtH0nRhx" resolve="MPS_BOOLEAN_TYPE" />
-                </node>
+        <node concept="1X3_iC" id="7OJcYqwbj1L" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MDX" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MDY" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqrDk" role="37vLTJ">
+                <ref role="3cqZAo" node="2mPmTXsxWOq" resolve="ID_BOOLEAN_TYPE" />
               </node>
-              <node concept="liA8E" id="5JNiski3ME5" role="2OqNvi">
-                <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
+              <node concept="2OqwBi" id="5JNiski3ME2" role="37vLTx">
+                <node concept="2YIFZM" id="5JNiski3ME3" role="2Oq$k0">
+                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
+                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+                  <node concept="37vLTw" id="5JNiski3ME4" role="37wK5m">
+                    <ref role="3cqZAo" node="DUXtH0nRhx" resolve="MPS_BOOLEAN_TYPE" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5JNiski3ME5" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
+                </node>
               </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="5JNiski3ME6" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiski3ME7" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3ME8" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiski3ME9" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiski3MEa" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiski3MEb" role="2tJFKM">
-                  <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
-                  <node concept="ZC_QK" id="5JNiski3MEc" role="2aWVGa">
-                    <ref role="2aWVGs" to="2pzz:48csSBPfMBo" resolve="Integer" />
+        <node concept="3clFbF" id="7OJcYqvSsAz" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvSsA$" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvSsA_" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvSsAA" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvSsAB" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvSsAf" resolve="BOOLEAN" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqvSsAC" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqvSsAD" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvLccW" resolve="PrimitiveTypeKeyedMapping" />
+                <node concept="2OqwBi" id="7OJcYqvSsAE" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqvSsAF" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqvSsAG" role="2tJFKM">
+                      <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
+                      <node concept="ZC_QK" id="7OJcYqvSsAH" role="2aWVGa">
+                        <ref role="2aWVGs" to="2pzz:2ju2syjnJk2" resolve="Boolean" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqvSsAI" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqvSsAJ" role="Vysub">
+                      <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqvSsAK" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqvSsAL" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqvSsAM" role="2tJFKM">
+                      <ref role="2aWVGs" to="tpck:fKAQMTB" resolve="boolean" />
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqvSsAN" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqvSsAO" role="Vysub">
+                      <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="10M0yZ" id="7OJcYqvSsAP" role="37wK5m">
+                  <ref role="3cqZAo" to="xx25:~SPrimitiveTypes.BOOLEAN" resolve="BOOLEAN" />
+                  <ref role="1PxDUh" to="xx25:~SPrimitiveTypes" resolve="SPrimitiveTypes" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqvVdoV" role="3cqZAp" />
+        <node concept="1X3_iC" id="7OJcYqwbmro" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3ME7" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3ME8" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiski3ME9" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiski3MEa" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiski3MEb" role="2tJFKM">
+                    <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
+                    <node concept="ZC_QK" id="5JNiski3MEc" role="2aWVGa">
+                      <ref role="2aWVGs" to="2pzz:48csSBPfMBo" resolve="Integer" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiski3MEd" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiski3MEe" role="Vysub">
+                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
                   </node>
                 </node>
               </node>
-              <node concept="Vyspw" id="5JNiski3MEd" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiski3MEe" role="Vysub">
-                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqrDl" role="37vLTJ">
-              <ref role="3cqZAo" node="48csSBPf4M9" resolve="LC_INTEGER_TYPE" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MEi" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MEj" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqrDm" role="37vLTJ">
-              <ref role="3cqZAo" node="48csSBPf4M6" resolve="MPS_INTEGER_TYPE" />
-            </node>
-            <node concept="2OqwBi" id="5JNiski3MEn" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiski3MEo" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiski3MEp" role="2tJFKM">
-                  <ref role="2aWVGs" to="tpck:fKAQMTA" resolve="integer" />
-                </node>
-              </node>
-              <node concept="Vyspw" id="5JNiski3MEq" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiski3MEr" role="Vysub">
-                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MEs" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MEt" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqrDn" role="37vLTJ">
-              <ref role="3cqZAo" node="39$JcGGWu$v" resolve="SLANG_INTEGER_TYPE" />
-            </node>
-            <node concept="10M0yZ" id="5JNiski3MEx" role="37vLTx">
-              <ref role="1PxDUh" to="xx25:~SPrimitiveTypes" resolve="SPrimitiveTypes" />
-              <ref role="3cqZAo" to="xx25:~SPrimitiveTypes.INTEGER" resolve="INTEGER" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MEy" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MEz" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiski3ME$" role="37vLTx">
-              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-              <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-              <node concept="37vLTw" id="5JNiski3ME_" role="37wK5m">
+              <node concept="37vLTw" id="5JNiskiqrDl" role="37vLTJ">
                 <ref role="3cqZAo" node="48csSBPf4M9" resolve="LC_INTEGER_TYPE" />
               </node>
             </node>
-            <node concept="37vLTw" id="5JNiskiqrDo" role="37vLTJ">
-              <ref role="3cqZAo" node="5M3rB6_Ppp8" resolve="KEY_INTEGER_TYPE" />
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbmrp" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MEi" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MEj" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqrDm" role="37vLTJ">
+                <ref role="3cqZAo" node="48csSBPf4M6" resolve="MPS_INTEGER_TYPE" />
+              </node>
+              <node concept="2OqwBi" id="5JNiski3MEn" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiski3MEo" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiski3MEp" role="2tJFKM">
+                    <ref role="2aWVGs" to="tpck:fKAQMTA" resolve="integer" />
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiski3MEq" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiski3MEr" role="Vysub">
+                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbmrq" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MEs" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MEt" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqrDn" role="37vLTJ">
+                <ref role="3cqZAo" node="39$JcGGWu$v" resolve="SLANG_INTEGER_TYPE" />
+              </node>
+              <node concept="10M0yZ" id="5JNiski3MEx" role="37vLTx">
+                <ref role="1PxDUh" to="xx25:~SPrimitiveTypes" resolve="SPrimitiveTypes" />
+                <ref role="3cqZAo" to="xx25:~SPrimitiveTypes.INTEGER" resolve="INTEGER" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbmrr" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MEy" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MEz" role="3clFbG">
+              <node concept="2YIFZM" id="7OJcYqwPrVk" role="37vLTx">
+                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+                <node concept="37vLTw" id="5JNiski3ME_" role="37wK5m">
+                  <ref role="3cqZAo" node="48csSBPf4M9" resolve="LC_INTEGER_TYPE" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrDo" role="37vLTJ">
+                <ref role="3cqZAo" node="5M3rB6_Ppp8" resolve="KEY_INTEGER_TYPE" />
+              </node>
             </node>
           </node>
         </node>
@@ -8112,125 +10211,192 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MEM" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MEN" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqrDq" role="37vLTJ">
-              <ref role="3cqZAo" node="2mPmTXsxYns" resolve="ID_INTEGER_TYPE" />
-            </node>
-            <node concept="2OqwBi" id="5JNiski3MER" role="37vLTx">
-              <node concept="2YIFZM" id="5JNiski3MES" role="2Oq$k0">
-                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
-                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                <node concept="37vLTw" id="5JNiski3MET" role="37wK5m">
-                  <ref role="3cqZAo" node="48csSBPf4M6" resolve="MPS_INTEGER_TYPE" />
-                </node>
+        <node concept="1X3_iC" id="7OJcYqwbq2s" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MEM" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MEN" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqrDq" role="37vLTJ">
+                <ref role="3cqZAo" node="2mPmTXsxYns" resolve="ID_INTEGER_TYPE" />
               </node>
-              <node concept="liA8E" id="5JNiski3MEU" role="2OqNvi">
-                <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
+              <node concept="2OqwBi" id="5JNiski3MER" role="37vLTx">
+                <node concept="2YIFZM" id="5JNiski3MES" role="2Oq$k0">
+                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
+                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+                  <node concept="37vLTw" id="5JNiski3MET" role="37wK5m">
+                    <ref role="3cqZAo" node="48csSBPf4M6" resolve="MPS_INTEGER_TYPE" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5JNiski3MEU" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
+                </node>
               </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="5JNiski3MEV" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiski3MEW" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MEX" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiski3MEY" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiski3MEZ" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiski3MF0" role="2tJFKM">
-                  <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
-                  <node concept="ZC_QK" id="5JNiski3MF1" role="2aWVGa">
-                    <ref role="2aWVGs" to="2pzz:39$JcGFBN1E" resolve="JSON" />
+        <node concept="3clFbF" id="7OJcYqvSxpx" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvSxpy" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvSxpz" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvSxp$" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvSxp_" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvSxpd" resolve="INTEGER" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqvSxpA" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqvSxpB" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvLccW" resolve="PrimitiveTypeKeyedMapping" />
+                <node concept="2OqwBi" id="7OJcYqvSxpC" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqvSxpD" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqvSxpE" role="2tJFKM">
+                      <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
+                      <node concept="ZC_QK" id="7OJcYqvSxpF" role="2aWVGa">
+                        <ref role="2aWVGs" to="2pzz:48csSBPfMBo" resolve="Integer" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqvSxpG" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqvSxpH" role="Vysub">
+                      <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                    </node>
                   </node>
                 </node>
-              </node>
-              <node concept="Vyspw" id="5JNiski3MF2" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiski3MF3" role="Vysub">
-                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqrDr" role="37vLTJ">
-              <ref role="3cqZAo" node="39$JcGFBNeh" resolve="LC_JSON_TYPE" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MF7" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MF8" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiski3MF9" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiski3MFa" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiski3MFb" role="2tJFKM">
-                  <ref role="2aWVGs" to="h3y3:39$JcGFBYkI" resolve="JSON" />
-                </node>
-              </node>
-              <node concept="Vyspw" id="5JNiski3MFc" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiski3MFd" role="Vysub">
-                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqrDs" role="37vLTJ">
-              <ref role="3cqZAo" node="39$JcGFBYPi" resolve="MPS_JSON_TYPE" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MFh" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MFi" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqrDt" role="37vLTJ">
-              <ref role="3cqZAo" node="39$JcGFCmtL" resolve="SLANG_JSON_TYPE" />
-            </node>
-            <node concept="2YIFZM" id="5JNiski3MFm" role="37vLTx">
-              <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConstrainedStringDataType(long,long,long,java.lang.String)" resolve="getConstrainedStringDataType" />
-              <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-              <node concept="2OqwBi" id="5JNiski3MFn" role="37wK5m">
-                <node concept="37vLTw" id="5JNiski3MFo" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5AGBwuFFqaM" resolve="SLANG_M3_LANGUAGE_ID" />
-                </node>
-                <node concept="liA8E" id="5JNiski3MFp" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SLanguageId.getHighBits()" resolve="getHighBits" />
-                </node>
-              </node>
-              <node concept="2OqwBi" id="5JNiski3MFq" role="37wK5m">
-                <node concept="37vLTw" id="5JNiski3MFr" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5AGBwuFFqaM" resolve="SLANG_M3_LANGUAGE_ID" />
-                </node>
-                <node concept="liA8E" id="5JNiski3MFs" role="2OqNvi">
-                  <ref role="37wK5l" to="e8bb:~SLanguageId.getLowBits()" resolve="getLowBits" />
-                </node>
-              </node>
-              <node concept="2YIFZM" id="5JNiski3MFt" role="37wK5m">
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <node concept="2OqwBi" id="5JNiski3MFu" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiski3MFv" role="2Oq$k0">
-                    <ref role="3cqZAo" node="39$JcGFBYPi" resolve="MPS_JSON_TYPE" />
+                <node concept="2OqwBi" id="7OJcYqvSxpI" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqvSxpJ" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqvSxpK" role="2tJFKM">
+                      <ref role="2aWVGs" to="tpck:fKAQMTA" resolve="integer" />
+                    </node>
                   </node>
-                  <node concept="3TrcHB" id="5JNiski3MFw" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:6Kv_6E714g3" resolve="datatypeId" />
+                  <node concept="Vyspw" id="7OJcYqvSxpL" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqvSxpM" role="Vysub">
+                      <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                    </node>
                   </node>
                 </node>
-              </node>
-              <node concept="2OqwBi" id="5JNiski3MFx" role="37wK5m">
-                <node concept="37vLTw" id="5JNiski3MFy" role="2Oq$k0">
-                  <ref role="3cqZAo" node="39$JcGFBYPi" resolve="MPS_JSON_TYPE" />
-                </node>
-                <node concept="3TrcHB" id="5JNiski3MFz" role="2OqNvi">
-                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                <node concept="10M0yZ" id="7OJcYqvSxpN" role="37wK5m">
+                  <ref role="3cqZAo" to="xx25:~SPrimitiveTypes.INTEGER" resolve="INTEGER" />
+                  <ref role="1PxDUh" to="xx25:~SPrimitiveTypes" resolve="SPrimitiveTypes" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MF$" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MF_" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiski3MFA" role="37vLTx">
-              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-              <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-              <node concept="37vLTw" id="5JNiski3MFB" role="37wK5m">
+        <node concept="3clFbH" id="7OJcYqvVA7e" role="3cqZAp" />
+        <node concept="1X3_iC" id="7OJcYqwbtqV" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MEW" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MEX" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiski3MEY" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiski3MEZ" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiski3MF0" role="2tJFKM">
+                    <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
+                    <node concept="ZC_QK" id="5JNiski3MF1" role="2aWVGa">
+                      <ref role="2aWVGs" to="2pzz:39$JcGFBN1E" resolve="JSON" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiski3MF2" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiski3MF3" role="Vysub">
+                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrDr" role="37vLTJ">
                 <ref role="3cqZAo" node="39$JcGFBNeh" resolve="LC_JSON_TYPE" />
               </node>
             </node>
-            <node concept="37vLTw" id="5JNiskiqrDu" role="37vLTJ">
-              <ref role="3cqZAo" node="5M3rB6_Psos" resolve="KEY_JSON_TYPE" />
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbtqW" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MF7" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MF8" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiski3MF9" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiski3MFa" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiski3MFb" role="2tJFKM">
+                    <ref role="2aWVGs" to="h3y3:39$JcGFBYkI" resolve="JSON" />
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiski3MFc" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiski3MFd" role="Vysub">
+                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrDs" role="37vLTJ">
+                <ref role="3cqZAo" node="39$JcGFBYPi" resolve="MPS_JSON_TYPE" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbtqX" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MFh" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MFi" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqrDt" role="37vLTJ">
+                <ref role="3cqZAo" node="39$JcGFCmtL" resolve="SLANG_JSON_TYPE" />
+              </node>
+              <node concept="2YIFZM" id="5JNiski3MFm" role="37vLTx">
+                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConstrainedStringDataType(long,long,long,java.lang.String)" resolve="getConstrainedStringDataType" />
+                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                <node concept="2OqwBi" id="5JNiski3MFn" role="37wK5m">
+                  <node concept="37vLTw" id="5JNiski3MFo" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5AGBwuFFqaM" resolve="SLANG_M3_LANGUAGE_ID" />
+                  </node>
+                  <node concept="liA8E" id="5JNiski3MFp" role="2OqNvi">
+                    <ref role="37wK5l" to="e8bb:~SLanguageId.getHighBits()" resolve="getHighBits" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5JNiski3MFq" role="37wK5m">
+                  <node concept="37vLTw" id="5JNiski3MFr" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5AGBwuFFqaM" resolve="SLANG_M3_LANGUAGE_ID" />
+                  </node>
+                  <node concept="liA8E" id="5JNiski3MFs" role="2OqNvi">
+                    <ref role="37wK5l" to="e8bb:~SLanguageId.getLowBits()" resolve="getLowBits" />
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="5JNiski3MFt" role="37wK5m">
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <node concept="2OqwBi" id="5JNiski3MFu" role="37wK5m">
+                    <node concept="37vLTw" id="5JNiski3MFv" role="2Oq$k0">
+                      <ref role="3cqZAo" node="39$JcGFBYPi" resolve="MPS_JSON_TYPE" />
+                    </node>
+                    <node concept="3TrcHB" id="5JNiski3MFw" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:6Kv_6E714g3" resolve="datatypeId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5JNiski3MFx" role="37wK5m">
+                  <node concept="37vLTw" id="5JNiski3MFy" role="2Oq$k0">
+                    <ref role="3cqZAo" node="39$JcGFBYPi" resolve="MPS_JSON_TYPE" />
+                  </node>
+                  <node concept="3TrcHB" id="5JNiski3MFz" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbtqY" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MF$" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MF_" role="3clFbG">
+              <node concept="2YIFZM" id="7OJcYqwPrVl" role="37vLTx">
+                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+                <node concept="37vLTw" id="5JNiski3MFB" role="37wK5m">
+                  <ref role="3cqZAo" node="39$JcGFBNeh" resolve="LC_JSON_TYPE" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrDu" role="37vLTJ">
+                <ref role="3cqZAo" node="5M3rB6_Psos" resolve="KEY_JSON_TYPE" />
+              </node>
             </node>
           </node>
         </node>
@@ -8253,67 +10419,30 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MFO" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MFP" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqrDw" role="37vLTJ">
-              <ref role="3cqZAo" node="2mPmTXsxZUx" resolve="ID_JSON_TYPE" />
-            </node>
-            <node concept="2OqwBi" id="5JNiski3MFT" role="37vLTx">
-              <node concept="2YIFZM" id="5JNiski3MFU" role="2Oq$k0">
-                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
-                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                <node concept="37vLTw" id="5JNiski3MFV" role="37wK5m">
-                  <ref role="3cqZAo" node="39$JcGFBYPi" resolve="MPS_JSON_TYPE" />
-                </node>
+        <node concept="1X3_iC" id="7OJcYqwbwSb" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MFO" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MFP" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqrDw" role="37vLTJ">
+                <ref role="3cqZAo" node="2mPmTXsxZUx" resolve="ID_JSON_TYPE" />
               </node>
-              <node concept="liA8E" id="5JNiski3MFW" role="2OqNvi">
-                <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
+              <node concept="2OqwBi" id="5JNiski3MFT" role="37vLTx">
+                <node concept="2YIFZM" id="5JNiski3MFU" role="2Oq$k0">
+                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
+                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+                  <node concept="37vLTw" id="5JNiski3MFV" role="37wK5m">
+                    <ref role="3cqZAo" node="39$JcGFBYPi" resolve="MPS_JSON_TYPE" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5JNiski3MFW" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
+                </node>
               </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="5JNiski3MFX" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiski3MFY" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MFZ" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiski3MG0" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiski3MG1" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiski3MG2" role="2tJFKM">
-                  <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
-                  <node concept="ZC_QK" id="5JNiski3MG3" role="2aWVGa">
-                    <ref role="2aWVGs" to="2pzz:39$JcGFBN1$" resolve="Node" />
-                  </node>
-                </node>
-              </node>
-              <node concept="Vyspw" id="5JNiski3MG4" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiski3MG5" role="Vysub">
-                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqrDx" role="37vLTJ">
-              <ref role="3cqZAo" node="39$JcGFBNUw" resolve="LC_NODE_CONCEPT" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MG9" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MGa" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiski3MGb" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiski3MGc" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiski3MGd" role="2tJFKM">
-                  <ref role="2aWVGs" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                </node>
-              </node>
-              <node concept="Vyspw" id="5JNiski3MGe" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiski3MGf" role="Vysub">
-                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqrDy" role="37vLTJ">
-              <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
-            </node>
-          </node>
-        </node>
         <node concept="3cpWs8" id="5JNiski3MGj" role="3cqZAp">
           <node concept="3cpWsn" id="5JNiski3MGk" role="3cpWs9">
             <property role="TrG5h" value="coreLangHighBits" />
@@ -8321,7 +10450,7 @@
             <node concept="3cpWsb" id="5JNiski3MGl" role="1tU5fm" />
             <node concept="2OqwBi" id="5JNiski3MGm" role="33vP2m">
               <node concept="37vLTw" id="5JNiski3MGn" role="2Oq$k0">
-                <ref role="3cqZAo" node="5AGBwuFFuSI" resolve="SLANG_CORE_LANGUAGE_ID" />
+                <ref role="3cqZAo" node="7OJcYqwchFW" resolve="coreLanguageId" />
               </node>
               <node concept="liA8E" id="5JNiski3MGo" role="2OqNvi">
                 <ref role="37wK5l" to="e8bb:~SLanguageId.getHighBits()" resolve="getHighBits" />
@@ -8336,7 +10465,7 @@
             <node concept="3cpWsb" id="5JNiski3MGr" role="1tU5fm" />
             <node concept="2OqwBi" id="5JNiski3MGs" role="33vP2m">
               <node concept="37vLTw" id="5JNiski3MGt" role="2Oq$k0">
-                <ref role="3cqZAo" node="5AGBwuFFuSI" resolve="SLANG_CORE_LANGUAGE_ID" />
+                <ref role="3cqZAo" node="7OJcYqwchFW" resolve="coreLanguageId" />
               </node>
               <node concept="liA8E" id="5JNiski3MGu" role="2OqNvi">
                 <ref role="37wK5l" to="e8bb:~SLanguageId.getLowBits()" resolve="getLowBits" />
@@ -8344,54 +10473,205 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MGv" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MGw" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiski3MGx" role="37vLTx">
-              <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
-              <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-              <node concept="37vLTw" id="5JNiski3MGy" role="37wK5m">
-                <ref role="3cqZAo" node="5JNiski3MGk" resolve="coreLangHighBits" />
-              </node>
-              <node concept="37vLTw" id="5JNiski3MGz" role="37wK5m">
-                <ref role="3cqZAo" node="5JNiski3MGq" resolve="coreLangLowBits" />
-              </node>
-              <node concept="2YIFZM" id="5JNiski3MG$" role="37wK5m">
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <node concept="2OqwBi" id="5JNiski3MG_" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiski3MGA" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
-                  </node>
-                  <node concept="3TrcHB" id="5JNiski3MGB" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
-                  </node>
+        <node concept="3cpWs8" id="7OJcYqwd3Yu" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwd3Yv" role="3cpWs9">
+            <property role="TrG5h" value="mpsJson" />
+            <node concept="2OqwBi" id="7OJcYqwdbF6" role="33vP2m">
+              <node concept="2tJFMh" id="7OJcYqwd3Yw" role="2Oq$k0">
+                <node concept="ZC_QK" id="7OJcYqwd3Yx" role="2tJFKM">
+                  <ref role="2aWVGs" to="h3y3:39$JcGFBYkI" resolve="JSON" />
                 </node>
               </node>
-              <node concept="2OqwBi" id="5JNiski3MGC" role="37wK5m">
-                <node concept="37vLTw" id="5JNiski3MGD" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
-                </node>
-                <node concept="3TrcHB" id="5JNiski3MGE" role="2OqNvi">
-                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              <node concept="Vyspw" id="7OJcYqwde3P" role="2OqNvi">
+                <node concept="37vLTw" id="7OJcYqwdgF6" role="Vysub">
+                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
                 </node>
               </node>
             </node>
-            <node concept="37vLTw" id="5JNiskiqrDz" role="37vLTJ">
-              <ref role="3cqZAo" node="39$JcGG9w_Q" resolve="SLANG_NODE_CONCEPT" />
+            <node concept="3Tqbb2" id="7OJcYqwdhs2" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:fKAz7CR" resolve="ConstrainedDataTypeDeclaration" />
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MGI" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MGJ" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiski3MGK" role="37vLTx">
-              <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-              <node concept="37vLTw" id="5JNiski3MGL" role="37wK5m">
+        <node concept="3clFbF" id="7OJcYqvSGDc" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvSGDd" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvSGDe" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvSGDf" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvSGDg" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvSGCF" resolve="JSON" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqvSGDh" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqvSGDi" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqw2ryW" resolve="ConstrainedPrimitiveTypeKeyedMapping" />
+                <node concept="2OqwBi" id="7OJcYqvSGDj" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqvSGDk" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqvSGDl" role="2tJFKM">
+                      <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
+                      <node concept="ZC_QK" id="7OJcYqvSGDm" role="2aWVGa">
+                        <ref role="2aWVGs" to="2pzz:39$JcGFBN1E" resolve="JSON" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqvSGDn" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqvSGDo" role="Vysub">
+                      <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="7OJcYqwd3Yy" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqwd3Yv" resolve="mpsJson" />
+                </node>
+                <node concept="2YIFZM" id="7OJcYqvSGDu" role="37wK5m">
+                  <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConstrainedStringDataType(long,long,long,java.lang.String)" resolve="getConstrainedStringDataType" />
+                  <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                  <node concept="2OqwBi" id="7OJcYqvSGDv" role="37wK5m">
+                    <node concept="37vLTw" id="7OJcYqvSGDw" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYqwcE0N" resolve="m3LanguageId" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqvSGDx" role="2OqNvi">
+                      <ref role="37wK5l" to="e8bb:~SLanguageId.getHighBits()" resolve="getHighBits" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqvSGDy" role="37wK5m">
+                    <node concept="37vLTw" id="7OJcYqvSGDz" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYqwcE0N" resolve="m3LanguageId" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYqvSGD$" role="2OqNvi">
+                      <ref role="37wK5l" to="e8bb:~SLanguageId.getLowBits()" resolve="getLowBits" />
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYqvSGD_" role="37wK5m">
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <node concept="2OqwBi" id="7OJcYqvSGDA" role="37wK5m">
+                      <node concept="37vLTw" id="7OJcYqvSGDB" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwd3Yv" resolve="mpsJson" />
+                      </node>
+                      <node concept="3TrcHB" id="7OJcYqvSGDC" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:6Kv_6E714g3" resolve="datatypeId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqvSGDD" role="37wK5m">
+                    <node concept="37vLTw" id="7OJcYqvSGDE" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYqwd3Yv" resolve="mpsJson" />
+                    </node>
+                    <node concept="3TrcHB" id="7OJcYqvSGDF" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqvW5v6" role="3cqZAp" />
+        <node concept="1X3_iC" id="7OJcYqwb$hr" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MFY" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MFZ" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiski3MG0" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiski3MG1" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiski3MG2" role="2tJFKM">
+                    <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
+                    <node concept="ZC_QK" id="5JNiski3MG3" role="2aWVGa">
+                      <ref role="2aWVGs" to="2pzz:39$JcGFBN1$" resolve="Node" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiski3MG4" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiski3MG5" role="Vysub">
+                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrDx" role="37vLTJ">
                 <ref role="3cqZAo" node="39$JcGFBNUw" resolve="LC_NODE_CONCEPT" />
               </node>
             </node>
-            <node concept="37vLTw" id="5JNiskiqrD$" role="37vLTJ">
-              <ref role="3cqZAo" node="5M3rB6_PuRS" resolve="KEY_NODE_CONCEPT" />
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwb$hs" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MG9" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MGa" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiski3MGb" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiski3MGc" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiski3MGd" role="2tJFKM">
+                    <ref role="2aWVGs" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiski3MGe" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiski3MGf" role="Vysub">
+                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrDy" role="37vLTJ">
+                <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbBx8" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MGv" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MGw" role="3clFbG">
+              <node concept="2YIFZM" id="5JNiski3MGx" role="37vLTx">
+                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
+                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                <node concept="37vLTw" id="5JNiski3MGy" role="37wK5m">
+                  <ref role="3cqZAo" node="5JNiski3MGk" resolve="coreLangHighBits" />
+                </node>
+                <node concept="37vLTw" id="5JNiski3MGz" role="37wK5m">
+                  <ref role="3cqZAo" node="5JNiski3MGq" resolve="coreLangLowBits" />
+                </node>
+                <node concept="2YIFZM" id="5JNiski3MG$" role="37wK5m">
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <node concept="2OqwBi" id="5JNiski3MG_" role="37wK5m">
+                    <node concept="37vLTw" id="5JNiski3MGA" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
+                    </node>
+                    <node concept="3TrcHB" id="5JNiski3MGB" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5JNiski3MGC" role="37wK5m">
+                  <node concept="37vLTw" id="5JNiski3MGD" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
+                  </node>
+                  <node concept="3TrcHB" id="5JNiski3MGE" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrDz" role="37vLTJ">
+                <ref role="3cqZAo" node="39$JcGG9w_Q" resolve="SLANG_NODE_CONCEPT" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbBx9" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MGI" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MGJ" role="3clFbG">
+              <node concept="2YIFZM" id="7OJcYqwPrVm" role="37vLTx">
+                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+                <node concept="37vLTw" id="5JNiski3MGL" role="37wK5m">
+                  <ref role="3cqZAo" node="39$JcGFBNUw" resolve="LC_NODE_CONCEPT" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrD$" role="37vLTJ">
+                <ref role="3cqZAo" node="5M3rB6_PuRS" resolve="KEY_NODE_CONCEPT" />
+              </node>
             </node>
           </node>
         </node>
@@ -8414,26 +10694,125 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MGY" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MGZ" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqrDA" role="37vLTJ">
-              <ref role="3cqZAo" node="2mPmTXsy1tD" resolve="ID_NODE_CONCEPT" />
-            </node>
-            <node concept="2OqwBi" id="5JNiski3MH3" role="37vLTx">
-              <node concept="2YIFZM" id="5JNiski3MH4" role="2Oq$k0">
-                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getConceptId(org.jetbrains.mps.openapi.model.SNode)" resolve="getConceptId" />
-                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                <node concept="37vLTw" id="5JNiski3MH5" role="37wK5m">
-                  <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
-                </node>
+        <node concept="1X3_iC" id="7OJcYqwbESv" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MGY" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MGZ" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqrDA" role="37vLTJ">
+                <ref role="3cqZAo" node="2mPmTXsy1tD" resolve="ID_NODE_CONCEPT" />
               </node>
-              <node concept="liA8E" id="5JNiski3MH6" role="2OqNvi">
-                <ref role="37wK5l" to="e8bb:~SConceptId.toString()" resolve="toString" />
+              <node concept="2OqwBi" id="5JNiski3MH3" role="37vLTx">
+                <node concept="2YIFZM" id="5JNiski3MH4" role="2Oq$k0">
+                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getConceptId(org.jetbrains.mps.openapi.model.SNode)" resolve="getConceptId" />
+                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+                  <node concept="37vLTw" id="5JNiski3MH5" role="37wK5m">
+                    <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5JNiski3MH6" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SConceptId.toString()" resolve="toString" />
+                </node>
               </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="5JNiski3MH7" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYqwdvVk" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwdvVl" role="3cpWs9">
+            <property role="TrG5h" value="mpsNode" />
+            <node concept="3Tqbb2" id="7OJcYqwdu1t" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqwdvVm" role="33vP2m">
+              <node concept="2tJFMh" id="7OJcYqwdvVn" role="2Oq$k0">
+                <node concept="ZC_QK" id="7OJcYqwdvVo" role="2tJFKM">
+                  <ref role="2aWVGs" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="7OJcYqwdvVp" role="2OqNvi">
+                <node concept="37vLTw" id="7OJcYqwdvVq" role="Vysub">
+                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7OJcYqwdP1E" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwdP1F" role="3cpWs9">
+            <property role="TrG5h" value="slangNode" />
+            <node concept="3uibUv" id="7OJcYqwdNp8" role="1tU5fm">
+              <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+            </node>
+            <node concept="2YIFZM" id="7OJcYqwdP1G" role="33vP2m">
+              <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
+              <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+              <node concept="37vLTw" id="7OJcYqwdP1H" role="37wK5m">
+                <ref role="3cqZAo" node="5JNiski3MGk" resolve="coreLangHighBits" />
+              </node>
+              <node concept="37vLTw" id="7OJcYqwdP1I" role="37wK5m">
+                <ref role="3cqZAo" node="5JNiski3MGq" resolve="coreLangLowBits" />
+              </node>
+              <node concept="2YIFZM" id="7OJcYqwdP1J" role="37wK5m">
+                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                <node concept="2OqwBi" id="7OJcYqwdP1K" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYqwdP1L" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqwdvVl" resolve="mpsNode" />
+                  </node>
+                  <node concept="3TrcHB" id="7OJcYqwdP1M" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7OJcYqwdP1N" role="37wK5m">
+                <node concept="37vLTw" id="7OJcYqwdP1O" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7OJcYqwdvVl" resolve="mpsNode" />
+                </node>
+                <node concept="3TrcHB" id="7OJcYqwdP1P" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqvSOUb" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvSOUc" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvSOUd" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvSOUe" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvSOUf" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvSOTI" resolve="NODE" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqvSOUg" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqvSOUh" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptKeyedMapping" />
+                <node concept="2OqwBi" id="7OJcYqvSOUi" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqvSOUj" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqvSOUk" role="2tJFKM">
+                      <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
+                      <node concept="ZC_QK" id="7OJcYqvSOUl" role="2aWVGa">
+                        <ref role="2aWVGs" to="2pzz:39$JcGFBN1$" resolve="Node" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqvSOUm" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqvSOUn" role="Vysub">
+                      <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="7OJcYqwdvVr" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqwdvVl" resolve="mpsNode" />
+                </node>
+                <node concept="37vLTw" id="7OJcYqwdP1Q" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqwdP1F" resolve="slangNode" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqvMjrl" role="3cqZAp" />
         <node concept="1X3_iC" id="5JNiski3MH8" role="lGtFl">
           <property role="3V$3am" value="statement" />
           <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
@@ -8458,59 +10837,67 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MHk" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MHl" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiski3MHm" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiski3MHn" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiski3MHo" role="2tJFKM">
-                  <ref role="2aWVGs" to="tpck:2ULFgo8_XDk" resolve="NodeAttribute" />
+        <node concept="1X3_iC" id="7OJcYqwbIh8" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MHk" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MHl" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiski3MHm" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiski3MHn" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiski3MHo" role="2tJFKM">
+                    <ref role="2aWVGs" to="tpck:2ULFgo8_XDk" resolve="NodeAttribute" />
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiski3MHp" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiski3MHq" role="Vysub">
+                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                  </node>
                 </node>
               </node>
-              <node concept="Vyspw" id="5JNiski3MHp" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiski3MHq" role="Vysub">
-                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                </node>
+              <node concept="37vLTw" id="5JNiskiqrDC" role="37vLTJ">
+                <ref role="3cqZAo" node="30uXOOfMilR" resolve="MPS_ANNOTATION_CONCEPT" />
               </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqrDC" role="37vLTJ">
-              <ref role="3cqZAo" node="30uXOOfMilR" resolve="MPS_ANNOTATION_CONCEPT" />
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MHu" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MHv" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiski3MHw" role="37vLTx">
-              <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-              <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
-              <node concept="37vLTw" id="5JNiski3MHx" role="37wK5m">
-                <ref role="3cqZAo" node="5JNiski3MGk" resolve="coreLangHighBits" />
-              </node>
-              <node concept="37vLTw" id="5JNiski3MHy" role="37wK5m">
-                <ref role="3cqZAo" node="5JNiski3MGq" resolve="coreLangLowBits" />
-              </node>
-              <node concept="2YIFZM" id="5JNiski3MHz" role="37wK5m">
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <node concept="2OqwBi" id="5JNiski3MH$" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiski3MH_" role="2Oq$k0">
+        <node concept="1X3_iC" id="7OJcYqwbIh9" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MHu" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MHv" role="3clFbG">
+              <node concept="2YIFZM" id="5JNiski3MHw" role="37vLTx">
+                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
+                <node concept="37vLTw" id="5JNiski3MHx" role="37wK5m">
+                  <ref role="3cqZAo" node="5JNiski3MGk" resolve="coreLangHighBits" />
+                </node>
+                <node concept="37vLTw" id="5JNiski3MHy" role="37wK5m">
+                  <ref role="3cqZAo" node="5JNiski3MGq" resolve="coreLangLowBits" />
+                </node>
+                <node concept="2YIFZM" id="5JNiski3MHz" role="37wK5m">
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <node concept="2OqwBi" id="5JNiski3MH$" role="37wK5m">
+                    <node concept="37vLTw" id="5JNiski3MH_" role="2Oq$k0">
+                      <ref role="3cqZAo" node="30uXOOfMilR" resolve="MPS_ANNOTATION_CONCEPT" />
+                    </node>
+                    <node concept="3TrcHB" id="5JNiski3MHA" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5JNiski3MHB" role="37wK5m">
+                  <node concept="37vLTw" id="5JNiski3MHC" role="2Oq$k0">
                     <ref role="3cqZAo" node="30uXOOfMilR" resolve="MPS_ANNOTATION_CONCEPT" />
                   </node>
-                  <node concept="3TrcHB" id="5JNiski3MHA" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                  <node concept="3TrcHB" id="5JNiski3MHD" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                   </node>
                 </node>
               </node>
-              <node concept="2OqwBi" id="5JNiski3MHB" role="37wK5m">
-                <node concept="37vLTw" id="5JNiski3MHC" role="2Oq$k0">
-                  <ref role="3cqZAo" node="30uXOOfMilR" resolve="MPS_ANNOTATION_CONCEPT" />
-                </node>
-                <node concept="3TrcHB" id="5JNiski3MHD" role="2OqNvi">
-                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                </node>
+              <node concept="37vLTw" id="5JNiskiqrDD" role="37vLTJ">
+                <ref role="3cqZAo" node="30uXOOfMilO" resolve="SLANG_ANNOTATION_CONCEPT" />
               </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqrDD" role="37vLTJ">
-              <ref role="3cqZAo" node="30uXOOfMilO" resolve="SLANG_ANNOTATION_CONCEPT" />
             </node>
           </node>
         </node>
@@ -8524,180 +10911,334 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MHO" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MHP" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqrDF" role="37vLTJ">
-              <ref role="3cqZAo" node="6Pr6izIcvKD" resolve="ID_ANNOTATION_CONCEPT" />
-            </node>
-            <node concept="2OqwBi" id="5JNiski3MHT" role="37vLTx">
-              <node concept="2YIFZM" id="5JNiski3MHU" role="2Oq$k0">
-                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getConceptId(org.jetbrains.mps.openapi.model.SNode)" resolve="getConceptId" />
-                <node concept="37vLTw" id="5JNiski3MHV" role="37wK5m">
-                  <ref role="3cqZAo" node="30uXOOfMilR" resolve="MPS_ANNOTATION_CONCEPT" />
-                </node>
+        <node concept="1X3_iC" id="7OJcYqwbLAv" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MHO" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MHP" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqrDF" role="37vLTJ">
+                <ref role="3cqZAo" node="6Pr6izIcvKD" resolve="ID_ANNOTATION_CONCEPT" />
               </node>
-              <node concept="liA8E" id="5JNiski3MHW" role="2OqNvi">
-                <ref role="37wK5l" to="e8bb:~SConceptId.toString()" resolve="toString" />
+              <node concept="2OqwBi" id="5JNiski3MHT" role="37vLTx">
+                <node concept="2YIFZM" id="5JNiski3MHU" role="2Oq$k0">
+                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getConceptId(org.jetbrains.mps.openapi.model.SNode)" resolve="getConceptId" />
+                  <node concept="37vLTw" id="5JNiski3MHV" role="37wK5m">
+                    <ref role="3cqZAo" node="30uXOOfMilR" resolve="MPS_ANNOTATION_CONCEPT" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5JNiski3MHW" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SConceptId.toString()" resolve="toString" />
+                </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MHX" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MHY" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiski3MHZ" role="37vLTx">
-              <node concept="2OqwBi" id="5JNiski3MI0" role="2Oq$k0">
-                <node concept="2OqwBi" id="5JNiski3MI1" role="2Oq$k0">
-                  <node concept="37vLTw" id="5JNiski3MI2" role="2Oq$k0">
-                    <ref role="3cqZAo" node="39$JcGG9w_Q" resolve="SLANG_NODE_CONCEPT" />
-                  </node>
-                  <node concept="liA8E" id="5JNiski3MI3" role="2OqNvi">
-                    <ref role="37wK5l" to="c17a:~SAbstractConcept.getContainmentLinks()" resolve="getContainmentLinks" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="5JNiski3MI4" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~Collection.iterator()" resolve="iterator" />
-                </node>
-              </node>
-              <node concept="liA8E" id="5JNiski3MI5" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-              </node>
+        <node concept="3clFbH" id="7OJcYqvPv4U" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYqwdEvZ" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwdEw0" role="3cpWs9">
+            <property role="TrG5h" value="mpsAnnotation" />
+            <node concept="3Tqbb2" id="7OJcYqwdCD6" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
             </node>
-            <node concept="37vLTw" id="5JNiskiqrDG" role="37vLTJ">
-              <ref role="3cqZAo" node="4WflrVajnwK" resolve="SLANG_ANNOTATION_CONTAINMENT" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiskiu6k7" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiuc64" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiskiuo8P" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiskiueD1" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiskiugYq" role="2tJFKM">
-                  <ref role="2aWVGs" to="tpck:gw2VY9q" resolve="BaseConcept" />
-                  <node concept="ZC_QK" id="5JNiskiujkr" role="2aWVGa">
-                    <ref role="2aWVGs" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
-                  </node>
+            <node concept="2OqwBi" id="7OJcYqwdEw1" role="33vP2m">
+              <node concept="2tJFMh" id="7OJcYqwdEw2" role="2Oq$k0">
+                <node concept="ZC_QK" id="7OJcYqwdEw3" role="2tJFKM">
+                  <ref role="2aWVGs" to="tpck:2ULFgo8_XDk" resolve="NodeAttribute" />
                 </node>
               </node>
-              <node concept="Vyspw" id="5JNiskiuprT" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiskiurNJ" role="Vysub">
+              <node concept="Vyspw" id="7OJcYqwdEw4" role="2OqNvi">
+                <node concept="37vLTw" id="7OJcYqwdEw5" role="Vysub">
                   <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
                 </node>
               </node>
             </node>
-            <node concept="37vLTw" id="5JNiskiu6k5" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskitK$o" resolve="MPS_ANNOTATION_CONTAINMENT" />
-            </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiskiyL18" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiskiyNCf" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiskiyYaD" role="37vLTx">
-              <node concept="2YIFZM" id="5JNiskiySZV" role="2Oq$k0">
-                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getLinkId(org.jetbrains.mps.openapi.model.SNode)" resolve="getLinkId" />
-                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                <node concept="37vLTw" id="5JNiskiyVqd" role="37wK5m">
-                  <ref role="3cqZAo" node="5JNiskitK$o" resolve="MPS_ANNOTATION_CONTAINMENT" />
+        <node concept="3clFbF" id="7OJcYqvSX4$" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvSX4_" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvSX4A" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvSX4B" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvSX4C" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvSX4c" resolve="ANNOTATION" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqvSX4D" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqvSX4E" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptKeyedMapping" />
+                <node concept="10Nm6u" id="7OJcYqvSX4F" role="37wK5m" />
+                <node concept="37vLTw" id="7OJcYqwdEw6" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqwdEw0" resolve="mpsAnnotation" />
                 </node>
-              </node>
-              <node concept="liA8E" id="5JNiskiz1gs" role="2OqNvi">
-                <ref role="37wK5l" to="e8bb:~SContainmentLinkId.toString()" resolve="toString" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiyL16" role="37vLTJ">
-              <ref role="3cqZAo" node="5JNiskiyDwd" resolve="ID_ANNOTATION_CONTAINMENT" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MIa" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MIb" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiski3MIc" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiski3MId" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiski3MIe" role="2tJFKM">
-                  <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
-                  <node concept="ZC_QK" id="5JNiski3MIf" role="2aWVGa">
-                    <ref role="2aWVGs" to="2pzz:6jTTMHCZNUU" resolve="INamed" />
+                <node concept="2YIFZM" id="7OJcYqvSX4L" role="37wK5m">
+                  <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                  <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
+                  <node concept="37vLTw" id="7OJcYqvSX4M" role="37wK5m">
+                    <ref role="3cqZAo" node="5JNiski3MGk" resolve="coreLangHighBits" />
+                  </node>
+                  <node concept="37vLTw" id="7OJcYqvSX4N" role="37wK5m">
+                    <ref role="3cqZAo" node="5JNiski3MGq" resolve="coreLangLowBits" />
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYqvSX4O" role="37wK5m">
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <node concept="2OqwBi" id="7OJcYqvSX4P" role="37wK5m">
+                      <node concept="37vLTw" id="7OJcYqvSX4Q" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwdEw0" resolve="mpsAnnotation" />
+                      </node>
+                      <node concept="3TrcHB" id="7OJcYqvSX4R" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqvSX4S" role="37wK5m">
+                    <node concept="37vLTw" id="7OJcYqvSX4T" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYqwdEw0" resolve="mpsAnnotation" />
+                    </node>
+                    <node concept="3TrcHB" id="7OJcYqvSX4U" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
                   </node>
                 </node>
               </node>
-              <node concept="Vyspw" id="5JNiski3MIg" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiski3MIh" role="Vysub">
-                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqrDH" role="37vLTJ">
-              <ref role="3cqZAo" node="6jTTMHCZPnj" resolve="LC_INAMED_INTERFACE" />
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MIl" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MIm" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiski3MIn" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiski3MIo" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiski3MIp" role="2tJFKM">
-                  <ref role="2aWVGs" to="tpck:h0TrEE$" resolve="INamedConcept" />
-                </node>
-              </node>
-              <node concept="Vyspw" id="5JNiski3MIq" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiski3MIr" role="Vysub">
-                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqrDI" role="37vLTJ">
-              <ref role="3cqZAo" node="6jTTMHCZPng" resolve="MPS_INAMED_INTERFACE" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MIv" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MIw" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiski3MIx" role="37vLTx">
-              <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getInterfaceConcept(long,long,long,java.lang.String)" resolve="getInterfaceConcept" />
-              <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-              <node concept="37vLTw" id="5JNiski3MIy" role="37wK5m">
-                <ref role="3cqZAo" node="5JNiski3MGk" resolve="coreLangHighBits" />
-              </node>
-              <node concept="37vLTw" id="5JNiski3MIz" role="37wK5m">
-                <ref role="3cqZAo" node="5JNiski3MGq" resolve="coreLangLowBits" />
-              </node>
-              <node concept="2YIFZM" id="5JNiski3MI$" role="37wK5m">
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <node concept="2OqwBi" id="5JNiski3MI_" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiski3MIA" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6jTTMHCZPng" resolve="MPS_INAMED_INTERFACE" />
+        <node concept="3clFbH" id="7OJcYqvPZ16" role="3cqZAp" />
+        <node concept="1X3_iC" id="7OJcYqwbOKP" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MHX" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MHY" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiski3MHZ" role="37vLTx">
+                <node concept="2OqwBi" id="5JNiski3MI0" role="2Oq$k0">
+                  <node concept="2OqwBi" id="5JNiski3MI1" role="2Oq$k0">
+                    <node concept="37vLTw" id="5JNiski3MI2" role="2Oq$k0">
+                      <ref role="3cqZAo" node="39$JcGG9w_Q" resolve="SLANG_NODE_CONCEPT" />
+                    </node>
+                    <node concept="liA8E" id="5JNiski3MI3" role="2OqNvi">
+                      <ref role="37wK5l" to="c17a:~SAbstractConcept.getContainmentLinks()" resolve="getContainmentLinks" />
+                    </node>
                   </node>
-                  <node concept="3TrcHB" id="5JNiski3MIB" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                  <node concept="liA8E" id="5JNiski3MI4" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Collection.iterator()" resolve="iterator" />
                   </node>
                 </node>
-              </node>
-              <node concept="2OqwBi" id="5JNiski3MIC" role="37wK5m">
-                <node concept="37vLTw" id="5JNiski3MID" role="2Oq$k0">
-                  <ref role="3cqZAo" node="6jTTMHCZPng" resolve="MPS_INAMED_INTERFACE" />
-                </node>
-                <node concept="3TrcHB" id="5JNiski3MIE" role="2OqNvi">
-                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                <node concept="liA8E" id="5JNiski3MI5" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
                 </node>
               </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqrDJ" role="37vLTJ">
-              <ref role="3cqZAo" node="6jTTMHCZPnd" resolve="SLANG_INAMED_INTERFACE" />
+              <node concept="37vLTw" id="5JNiskiqrDG" role="37vLTJ">
+                <ref role="3cqZAo" node="4WflrVajnwK" resolve="SLANG_ANNOTATION_CONTAINMENT" />
+              </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MII" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MIJ" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiski3MIK" role="37vLTx">
-              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-              <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-              <node concept="37vLTw" id="5JNiski3MIL" role="37wK5m">
+        <node concept="1X3_iC" id="7OJcYqwbOKQ" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiu6k7" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiuc64" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiskiuo8P" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiskiueD1" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiskiugYq" role="2tJFKM">
+                    <ref role="2aWVGs" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                    <node concept="ZC_QK" id="5JNiskiujkr" role="2aWVGa">
+                      <ref role="2aWVGs" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiskiuprT" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiskiurNJ" role="Vysub">
+                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiu6k5" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskitK$o" resolve="MPS_ANNOTATION_CONTAINMENT" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbOKR" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiskiyL18" role="8Wnug">
+            <node concept="37vLTI" id="5JNiskiyNCf" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiskiyYaD" role="37vLTx">
+                <node concept="2YIFZM" id="5JNiskiySZV" role="2Oq$k0">
+                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getLinkId(org.jetbrains.mps.openapi.model.SNode)" resolve="getLinkId" />
+                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+                  <node concept="37vLTw" id="5JNiskiyVqd" role="37wK5m">
+                    <ref role="3cqZAo" node="5JNiskitK$o" resolve="MPS_ANNOTATION_CONTAINMENT" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5JNiskiz1gs" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SContainmentLinkId.toString()" resolve="toString" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiyL16" role="37vLTJ">
+                <ref role="3cqZAo" node="5JNiskiyDwd" resolve="ID_ANNOTATION_CONTAINMENT" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqvQ20y" role="3cqZAp" />
+        <node concept="3clFbF" id="7OJcYqvT58J" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvT58K" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvT58L" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvT58M" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvT58N" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvT58p" resolve="ANNOTATION_CONTAINMENT" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqvT58O" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqvT58P" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvQc4u" resolve="ContainmentKeyedMapping" />
+                <node concept="10Nm6u" id="7OJcYqvT58Q" role="37wK5m" />
+                <node concept="2OqwBi" id="7OJcYqvT58R" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqvT58S" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqvT58T" role="2tJFKM">
+                      <ref role="2aWVGs" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                      <node concept="ZC_QK" id="7OJcYqvT58U" role="2aWVGa">
+                        <ref role="2aWVGs" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqvT58V" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqvT58W" role="Vysub">
+                      <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7OJcYqvT58X" role="37wK5m">
+                  <node concept="2OqwBi" id="7OJcYqvT58Y" role="2Oq$k0">
+                    <node concept="2OqwBi" id="7OJcYqvT58Z" role="2Oq$k0">
+                      <node concept="37vLTw" id="7OJcYqvT590" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwdP1F" resolve="slangNode" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYqvT591" role="2OqNvi">
+                        <ref role="37wK5l" to="c17a:~SAbstractConcept.getContainmentLinks()" resolve="getContainmentLinks" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="7OJcYqvT592" role="2OqNvi">
+                      <ref role="37wK5l" to="33ny:~Collection.iterator()" resolve="iterator" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="7OJcYqvT593" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqvQ55q" role="3cqZAp" />
+        <node concept="1X3_iC" id="7OJcYqwbRQB" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MIa" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MIb" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiski3MIc" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiski3MId" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiski3MIe" role="2tJFKM">
+                    <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
+                    <node concept="ZC_QK" id="5JNiski3MIf" role="2aWVGa">
+                      <ref role="2aWVGs" to="2pzz:6jTTMHCZNUU" resolve="INamed" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiski3MIg" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiski3MIh" role="Vysub">
+                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrDH" role="37vLTJ">
                 <ref role="3cqZAo" node="6jTTMHCZPnj" resolve="LC_INAMED_INTERFACE" />
               </node>
             </node>
-            <node concept="37vLTw" id="5JNiskiqrDK" role="37vLTJ">
-              <ref role="3cqZAo" node="5M3rB6_P$Vq" resolve="KEY_INAMED_INTERFACE" />
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbRQC" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MIl" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MIm" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiski3MIn" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiski3MIo" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiski3MIp" role="2tJFKM">
+                    <ref role="2aWVGs" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiski3MIq" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiski3MIr" role="Vysub">
+                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrDI" role="37vLTJ">
+                <ref role="3cqZAo" node="6jTTMHCZPng" resolve="MPS_INAMED_INTERFACE" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbRQD" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MIv" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MIw" role="3clFbG">
+              <node concept="2YIFZM" id="5JNiski3MIx" role="37vLTx">
+                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getInterfaceConcept(long,long,long,java.lang.String)" resolve="getInterfaceConcept" />
+                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                <node concept="37vLTw" id="5JNiski3MIy" role="37wK5m">
+                  <ref role="3cqZAo" node="5JNiski3MGk" resolve="coreLangHighBits" />
+                </node>
+                <node concept="37vLTw" id="5JNiski3MIz" role="37wK5m">
+                  <ref role="3cqZAo" node="5JNiski3MGq" resolve="coreLangLowBits" />
+                </node>
+                <node concept="2YIFZM" id="5JNiski3MI$" role="37wK5m">
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <node concept="2OqwBi" id="5JNiski3MI_" role="37wK5m">
+                    <node concept="37vLTw" id="5JNiski3MIA" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6jTTMHCZPng" resolve="MPS_INAMED_INTERFACE" />
+                    </node>
+                    <node concept="3TrcHB" id="5JNiski3MIB" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5JNiski3MIC" role="37wK5m">
+                  <node concept="37vLTw" id="5JNiski3MID" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6jTTMHCZPng" resolve="MPS_INAMED_INTERFACE" />
+                  </node>
+                  <node concept="3TrcHB" id="5JNiski3MIE" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrDJ" role="37vLTJ">
+                <ref role="3cqZAo" node="6jTTMHCZPnd" resolve="SLANG_INAMED_INTERFACE" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbRQE" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MII" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MIJ" role="3clFbG">
+              <node concept="2YIFZM" id="7OJcYqwPrVn" role="37vLTx">
+                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+                <node concept="37vLTw" id="5JNiski3MIL" role="37wK5m">
+                  <ref role="3cqZAo" node="6jTTMHCZPnj" resolve="LC_INAMED_INTERFACE" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrDK" role="37vLTJ">
+                <ref role="3cqZAo" node="5M3rB6_P$Vq" resolve="KEY_INAMED_INTERFACE" />
+              </node>
             </node>
           </node>
         </node>
@@ -8720,133 +11261,237 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MIY" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MIZ" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqrDM" role="37vLTJ">
-              <ref role="3cqZAo" node="2mPmTXsy2Sr" resolve="ID_INAMED_INTERFACE" />
-            </node>
-            <node concept="2OqwBi" id="5JNiski3MJ3" role="37vLTx">
-              <node concept="2YIFZM" id="5JNiski3MJ4" role="2Oq$k0">
-                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getConceptId(org.jetbrains.mps.openapi.model.SNode)" resolve="getConceptId" />
-                <node concept="37vLTw" id="5JNiski3MJ5" role="37wK5m">
-                  <ref role="3cqZAo" node="6jTTMHCZPng" resolve="MPS_INAMED_INTERFACE" />
-                </node>
+        <node concept="1X3_iC" id="7OJcYqwbUXd" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MIY" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MIZ" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqrDM" role="37vLTJ">
+                <ref role="3cqZAo" node="2mPmTXsy2Sr" resolve="ID_INAMED_INTERFACE" />
               </node>
-              <node concept="liA8E" id="5JNiski3MJ6" role="2OqNvi">
-                <ref role="37wK5l" to="e8bb:~SConceptId.toString()" resolve="toString" />
+              <node concept="2OqwBi" id="5JNiski3MJ3" role="37vLTx">
+                <node concept="2YIFZM" id="5JNiski3MJ4" role="2Oq$k0">
+                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getConceptId(org.jetbrains.mps.openapi.model.SNode)" resolve="getConceptId" />
+                  <node concept="37vLTw" id="5JNiski3MJ5" role="37wK5m">
+                    <ref role="3cqZAo" node="6jTTMHCZPng" resolve="MPS_INAMED_INTERFACE" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5JNiski3MJ6" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SConceptId.toString()" resolve="toString" />
+                </node>
               </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="5JNiski3MJ7" role="3cqZAp" />
-        <node concept="3clFbF" id="5JNiski3MJ8" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MJ9" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqrDN" role="37vLTJ">
-              <ref role="3cqZAo" node="5AGBwuFJEKi" resolve="LC_NAME_PROPERTY" />
+        <node concept="3cpWs8" id="7OJcYqwdWS4" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwdWS5" role="3cpWs9">
+            <property role="TrG5h" value="mpsINamed" />
+            <node concept="3Tqbb2" id="7OJcYqwdV3e" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
             </node>
-            <node concept="2OqwBi" id="5JNiski3MJd" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiski3MJe" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiski3MJf" role="2tJFKM">
-                  <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
-                  <node concept="ZC_QK" id="5JNiski3MJg" role="2aWVGa">
-                    <ref role="2aWVGs" to="2pzz:6jTTMHCZNUU" resolve="INamed" />
-                    <node concept="ZC_QK" id="5JNiski3MJh" role="2aWVGa">
-                      <ref role="2aWVGs" to="2pzz:6jTTMHCZNV2" resolve="name" />
+            <node concept="2OqwBi" id="7OJcYqwdWS6" role="33vP2m">
+              <node concept="2tJFMh" id="7OJcYqwdWS7" role="2Oq$k0">
+                <node concept="ZC_QK" id="7OJcYqwdWS8" role="2tJFKM">
+                  <ref role="2aWVGs" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="7OJcYqwdWS9" role="2OqNvi">
+                <node concept="37vLTw" id="7OJcYqwdWSa" role="Vysub">
+                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqvTdFR" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvTdFS" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvTdFT" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvTdFU" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvTdFV" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvTdFq" resolve="INAMED" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqvTdFW" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqvTdFX" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvXZ91" resolve="InterfaceKeyedMapping" />
+                <node concept="2OqwBi" id="7OJcYqvTdFY" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqvTdFZ" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqvTdG0" role="2tJFKM">
+                      <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
+                      <node concept="ZC_QK" id="7OJcYqvTdG1" role="2aWVGa">
+                        <ref role="2aWVGs" to="2pzz:6jTTMHCZNUU" resolve="INamed" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqvTdG2" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqvTdG3" role="Vysub">
+                      <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="7OJcYqwdWSb" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqwdWS5" resolve="mpsINamed" />
+                </node>
+                <node concept="2YIFZM" id="7OJcYqvTdG9" role="37wK5m">
+                  <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getInterfaceConcept(long,long,long,java.lang.String)" resolve="getInterfaceConcept" />
+                  <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                  <node concept="37vLTw" id="7OJcYqvTdGa" role="37wK5m">
+                    <ref role="3cqZAo" node="5JNiski3MGk" resolve="coreLangHighBits" />
+                  </node>
+                  <node concept="37vLTw" id="7OJcYqvTdGb" role="37wK5m">
+                    <ref role="3cqZAo" node="5JNiski3MGq" resolve="coreLangLowBits" />
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYqvTdGc" role="37wK5m">
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <node concept="2OqwBi" id="7OJcYqvTdGd" role="37wK5m">
+                      <node concept="37vLTw" id="7OJcYqvTdGe" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwdWS5" resolve="mpsINamed" />
+                      </node>
+                      <node concept="3TrcHB" id="7OJcYqvTdGf" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqvTdGg" role="37wK5m">
+                    <node concept="37vLTw" id="7OJcYqvTdGh" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYqwdWS5" resolve="mpsINamed" />
+                    </node>
+                    <node concept="3TrcHB" id="7OJcYqvTdGi" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="Vyspw" id="5JNiski3MJi" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiski3MJj" role="Vysub">
-                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                </node>
-              </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MJk" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MJl" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiski3MJm" role="37vLTx">
-              <node concept="2tJFMh" id="5JNiski3MJn" role="2Oq$k0">
-                <node concept="ZC_QK" id="5JNiski3MJo" role="2tJFKM">
-                  <ref role="2aWVGs" to="tpck:h0TrEE$" resolve="INamedConcept" />
-                  <node concept="ZC_QK" id="5JNiski3MJp" role="2aWVGa">
-                    <ref role="2aWVGs" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-              </node>
-              <node concept="Vyspw" id="5JNiski3MJq" role="2OqNvi">
-                <node concept="37vLTw" id="5JNiski3MJr" role="Vysub">
-                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqrDO" role="37vLTJ">
-              <ref role="3cqZAo" node="5AGBwuFJEKf" resolve="MPS_NAME_PROPERTY" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MJv" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MJw" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiski3MJx" role="37vLTx">
-              <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
-              <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
-              <node concept="37vLTw" id="5JNiski3MJy" role="37wK5m">
-                <ref role="3cqZAo" node="5JNiski3MGk" resolve="coreLangHighBits" />
-              </node>
-              <node concept="37vLTw" id="5JNiski3MJz" role="37wK5m">
-                <ref role="3cqZAo" node="5JNiski3MGq" resolve="coreLangLowBits" />
-              </node>
-              <node concept="2YIFZM" id="5JNiski3MJ$" role="37wK5m">
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <node concept="2OqwBi" id="5JNiski3MJ_" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiski3MJA" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6jTTMHCZPng" resolve="MPS_INAMED_INTERFACE" />
-                  </node>
-                  <node concept="3TrcHB" id="5JNiski3MJB" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2YIFZM" id="5JNiski3MJC" role="37wK5m">
-                <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
-                <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-                <node concept="2OqwBi" id="5JNiski3MJD" role="37wK5m">
-                  <node concept="37vLTw" id="5JNiski3MJE" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5AGBwuFJEKf" resolve="MPS_NAME_PROPERTY" />
-                  </node>
-                  <node concept="3TrcHB" id="5JNiski3MJF" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="5JNiski3MJG" role="37wK5m">
-                <node concept="37vLTw" id="5JNiski3MJH" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5AGBwuFJEKf" resolve="MPS_NAME_PROPERTY" />
-                </node>
-                <node concept="3TrcHB" id="5JNiski3MJI" role="2OqNvi">
-                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="5JNiskiqrDP" role="37vLTJ">
-              <ref role="3cqZAo" node="5AGBwuFJEKc" resolve="SLANG_NAME_PROPERTY" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5JNiski3MJM" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MJN" role="3clFbG">
-            <node concept="2YIFZM" id="5JNiski3MJO" role="37vLTx">
-              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
-              <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
-              <node concept="37vLTw" id="5JNiski3MJP" role="37wK5m">
+        <node concept="3clFbH" id="7OJcYqvQZmU" role="3cqZAp" />
+        <node concept="1X3_iC" id="7OJcYqwbXTI" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MJ8" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MJ9" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqrDN" role="37vLTJ">
                 <ref role="3cqZAo" node="5AGBwuFJEKi" resolve="LC_NAME_PROPERTY" />
               </node>
+              <node concept="2OqwBi" id="5JNiski3MJd" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiski3MJe" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiski3MJf" role="2tJFKM">
+                    <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
+                    <node concept="ZC_QK" id="5JNiski3MJg" role="2aWVGa">
+                      <ref role="2aWVGs" to="2pzz:6jTTMHCZNUU" resolve="INamed" />
+                      <node concept="ZC_QK" id="5JNiski3MJh" role="2aWVGa">
+                        <ref role="2aWVGs" to="2pzz:6jTTMHCZNV2" resolve="name" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiski3MJi" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiski3MJj" role="Vysub">
+                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                  </node>
+                </node>
+              </node>
             </node>
-            <node concept="37vLTw" id="5JNiskiqrDQ" role="37vLTJ">
-              <ref role="3cqZAo" node="5M3rB6_PC4J" resolve="KEY_NAME_PROPERTY" />
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbXTJ" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MJk" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MJl" role="3clFbG">
+              <node concept="2OqwBi" id="5JNiski3MJm" role="37vLTx">
+                <node concept="2tJFMh" id="5JNiski3MJn" role="2Oq$k0">
+                  <node concept="ZC_QK" id="5JNiski3MJo" role="2tJFKM">
+                    <ref role="2aWVGs" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                    <node concept="ZC_QK" id="5JNiski3MJp" role="2aWVGa">
+                      <ref role="2aWVGs" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Vyspw" id="5JNiski3MJq" role="2OqNvi">
+                  <node concept="37vLTw" id="5JNiski3MJr" role="Vysub">
+                    <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrDO" role="37vLTJ">
+                <ref role="3cqZAo" node="5AGBwuFJEKf" resolve="MPS_NAME_PROPERTY" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbXTK" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MJv" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MJw" role="3clFbG">
+              <node concept="2YIFZM" id="5JNiski3MJx" role="37vLTx">
+                <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
+                <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                <node concept="37vLTw" id="5JNiski3MJy" role="37wK5m">
+                  <ref role="3cqZAo" node="5JNiski3MGk" resolve="coreLangHighBits" />
+                </node>
+                <node concept="37vLTw" id="5JNiski3MJz" role="37wK5m">
+                  <ref role="3cqZAo" node="5JNiski3MGq" resolve="coreLangLowBits" />
+                </node>
+                <node concept="2YIFZM" id="5JNiski3MJ$" role="37wK5m">
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <node concept="2OqwBi" id="5JNiski3MJ_" role="37wK5m">
+                    <node concept="37vLTw" id="5JNiski3MJA" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6jTTMHCZPng" resolve="MPS_INAMED_INTERFACE" />
+                    </node>
+                    <node concept="3TrcHB" id="5JNiski3MJB" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="5JNiski3MJC" role="37wK5m">
+                  <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                  <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                  <node concept="2OqwBi" id="5JNiski3MJD" role="37wK5m">
+                    <node concept="37vLTw" id="5JNiski3MJE" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5AGBwuFJEKf" resolve="MPS_NAME_PROPERTY" />
+                    </node>
+                    <node concept="3TrcHB" id="5JNiski3MJF" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5JNiski3MJG" role="37wK5m">
+                  <node concept="37vLTw" id="5JNiski3MJH" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5AGBwuFJEKf" resolve="MPS_NAME_PROPERTY" />
+                  </node>
+                  <node concept="3TrcHB" id="5JNiski3MJI" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrDP" role="37vLTJ">
+                <ref role="3cqZAo" node="5AGBwuFJEKc" resolve="SLANG_NAME_PROPERTY" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="7OJcYqwbXTL" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MJM" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MJN" role="3clFbG">
+              <node concept="2YIFZM" id="7OJcYqwPrVo" role="37vLTx">
+                <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+                <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+                <node concept="37vLTw" id="5JNiski3MJP" role="37wK5m">
+                  <ref role="3cqZAo" node="5AGBwuFJEKi" resolve="LC_NAME_PROPERTY" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="5JNiskiqrDQ" role="37vLTJ">
+                <ref role="3cqZAo" node="5M3rB6_PC4J" resolve="KEY_NAME_PROPERTY" />
+              </node>
             </node>
           </node>
         </node>
@@ -8869,21 +11514,127 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5JNiski3MK2" role="3cqZAp">
-          <node concept="37vLTI" id="5JNiski3MK3" role="3clFbG">
-            <node concept="37vLTw" id="5JNiskiqrDS" role="37vLTJ">
-              <ref role="3cqZAo" node="2mPmTXsy402" resolve="ID_NAME_PROPERTY" />
-            </node>
-            <node concept="2OqwBi" id="5JNiski3MK7" role="37vLTx">
-              <node concept="2YIFZM" id="5JNiski3MK8" role="2Oq$k0">
-                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getPropId(org.jetbrains.mps.openapi.model.SNode)" resolve="getPropId" />
-                <node concept="37vLTw" id="5JNiski3MK9" role="37wK5m">
-                  <ref role="3cqZAo" node="5AGBwuFJEKf" resolve="MPS_NAME_PROPERTY" />
+        <node concept="1X3_iC" id="7OJcYqwc14a" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5JNiski3MK2" role="8Wnug">
+            <node concept="37vLTI" id="5JNiski3MK3" role="3clFbG">
+              <node concept="37vLTw" id="5JNiskiqrDS" role="37vLTJ">
+                <ref role="3cqZAo" node="2mPmTXsy402" resolve="ID_NAME_PROPERTY" />
+              </node>
+              <node concept="2OqwBi" id="5JNiski3MK7" role="37vLTx">
+                <node concept="2YIFZM" id="5JNiski3MK8" role="2Oq$k0">
+                  <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+                  <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getPropId(org.jetbrains.mps.openapi.model.SNode)" resolve="getPropId" />
+                  <node concept="37vLTw" id="5JNiski3MK9" role="37wK5m">
+                    <ref role="3cqZAo" node="5AGBwuFJEKf" resolve="MPS_NAME_PROPERTY" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5JNiski3MKa" role="2OqNvi">
+                  <ref role="37wK5l" to="e8bb:~SPropertyId.toString()" resolve="toString" />
                 </node>
               </node>
-              <node concept="liA8E" id="5JNiski3MKa" role="2OqNvi">
-                <ref role="37wK5l" to="e8bb:~SPropertyId.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYqvRmSH" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYqwebi5" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwebi6" role="3cpWs9">
+            <property role="TrG5h" value="mpsINamedName" />
+            <node concept="3Tqbb2" id="7OJcYqwe9y0" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqwebi7" role="33vP2m">
+              <node concept="2tJFMh" id="7OJcYqwebi8" role="2Oq$k0">
+                <node concept="ZC_QK" id="7OJcYqwebi9" role="2tJFKM">
+                  <ref role="2aWVGs" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                  <node concept="ZC_QK" id="7OJcYqwebia" role="2aWVGa">
+                    <ref role="2aWVGs" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+              <node concept="Vyspw" id="7OJcYqwebib" role="2OqNvi">
+                <node concept="37vLTw" id="7OJcYqwebic" role="Vysub">
+                  <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqvTlJr" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvTlJs" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvTlJt" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvTlJu" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvTlJv" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvTlIS" resolve="NAME" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7OJcYqvTlJw" role="37vLTx">
+              <node concept="1pGfFk" id="7OJcYqvTlJx" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvRxYF" resolve="PropertyKeyMapping" />
+                <node concept="2OqwBi" id="7OJcYqvTlJy" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqvTlJz" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqvTlJ$" role="2tJFKM">
+                      <ref role="2aWVGs" to="2pzz:2ju2syjnJjW" resolve="Built-in DataTypes" />
+                      <node concept="ZC_QK" id="7OJcYqvTlJ_" role="2aWVGa">
+                        <ref role="2aWVGs" to="2pzz:6jTTMHCZNUU" resolve="INamed" />
+                        <node concept="ZC_QK" id="7OJcYqvTlJA" role="2aWVGa">
+                          <ref role="2aWVGs" to="2pzz:6jTTMHCZNV2" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqvTlJB" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqvTlJC" role="Vysub">
+                      <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="7OJcYqwebid" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqwebi6" resolve="mpsINamedName" />
+                </node>
+                <node concept="2YIFZM" id="7OJcYqvTlJJ" role="37wK5m">
+                  <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
+                  <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                  <node concept="37vLTw" id="7OJcYqvTlJK" role="37wK5m">
+                    <ref role="3cqZAo" node="5JNiski3MGk" resolve="coreLangHighBits" />
+                  </node>
+                  <node concept="37vLTw" id="7OJcYqvTlJL" role="37wK5m">
+                    <ref role="3cqZAo" node="5JNiski3MGq" resolve="coreLangLowBits" />
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYqvTlJM" role="37wK5m">
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <node concept="2OqwBi" id="7OJcYqvTlJN" role="37wK5m">
+                      <node concept="37vLTw" id="7OJcYqvTlJO" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwdWS5" resolve="mpsINamed" />
+                      </node>
+                      <node concept="3TrcHB" id="7OJcYqvTlJP" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYqvTlJQ" role="37wK5m">
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <node concept="2OqwBi" id="7OJcYqvTlJR" role="37wK5m">
+                      <node concept="37vLTw" id="7OJcYqvTlJS" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqwebi6" resolve="mpsINamedName" />
+                      </node>
+                      <node concept="3TrcHB" id="7OJcYqvTlJT" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqvTlJU" role="37wK5m">
+                    <node concept="37vLTw" id="7OJcYqvTlJV" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYqwebi6" resolve="mpsINamedName" />
+                    </node>
+                    <node concept="3TrcHB" id="7OJcYqvTlJW" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -8894,7 +11645,7 @@
     <node concept="312cEg" id="3M8YG$9w5jG" role="jymVt">
       <property role="TrG5h" value="LION_CORE_VERSION" />
       <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwaxU" role="1B3o_S" />
+      <node concept="3Tm6S6" id="7OJcYqwc3NU" role="1B3o_S" />
       <node concept="17QB3L" id="3M8YG$9w5iY" role="1tU5fm" />
       <node concept="Xl_RD" id="3M8YG$9w78I" role="33vP2m">
         <property role="Xl_RC" value="2023.1" />
@@ -8913,20 +11664,29 @@
       <node concept="17QB3L" id="5JNiskhmwT4" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5JNiskhmsVz" role="jymVt" />
-    <node concept="312cEg" id="2ju2syjsm_6" role="jymVt">
-      <property role="TrG5h" value="LC_STRING_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tqbb2" id="2ju2syjsmuv" role="1tU5fm">
-        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+    <node concept="1X3_iC" id="7OJcYqweqfe" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="2ju2syjsm_6" role="8Wnug">
+        <property role="TrG5h" value="LC_STRING_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tqbb2" id="2ju2syjsmuv" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+        </node>
+        <node concept="3Tmbuc" id="5JNiskhwcR3" role="1B3o_S" />
       </node>
-      <node concept="3Tmbuc" id="5JNiskhwcR3" role="1B3o_S" />
     </node>
     <node concept="3clFb_" id="5JNiskhmCGz" role="jymVt">
       <property role="TrG5h" value="lcStringType" />
       <node concept="3clFbS" id="5JNiskhmCGA" role="3clF47">
         <node concept="3clFbF" id="5JNiskhmEGU" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhmEGT" role="3clFbG">
-            <ref role="3cqZAo" node="2ju2syjsm_6" resolve="LC_STRING_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqvYxMo" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwjJ_D" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzm" resolve="getString" />
+            </node>
+            <node concept="liA8E" id="7OJcYqvY_vW" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwP92e" resolve="getLc" />
+            </node>
           </node>
         </node>
       </node>
@@ -8935,20 +11695,29 @@
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
       </node>
     </node>
-    <node concept="312cEg" id="DUXtH0nMqB" role="jymVt">
-      <property role="TrG5h" value="MPS_STRING_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhweUV" role="1B3o_S" />
-      <node concept="3Tqbb2" id="DUXtH0nMqn" role="1tU5fm">
-        <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
+    <node concept="1X3_iC" id="7OJcYqweuur" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="DUXtH0nMqB" role="8Wnug">
+        <property role="TrG5h" value="MPS_STRING_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhweUV" role="1B3o_S" />
+        <node concept="3Tqbb2" id="DUXtH0nMqn" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhmKpL" role="jymVt">
       <property role="TrG5h" value="mpsStringType" />
       <node concept="3clFbS" id="5JNiskhmKpO" role="3clF47">
         <node concept="3clFbF" id="5JNiskhmMqw" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhmMqv" role="3clFbG">
-            <ref role="3cqZAo" node="DUXtH0nMqB" resolve="MPS_STRING_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqvYW1z" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqvZ0BD" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwjNua" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzm" resolve="getString" />
+            </node>
           </node>
         </node>
       </node>
@@ -8957,20 +11726,29 @@
         <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
       </node>
     </node>
-    <node concept="312cEg" id="39$JcGGWFCK" role="jymVt">
-      <property role="TrG5h" value="SLANG_STRING_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwgS5" role="1B3o_S" />
-      <node concept="3uibUv" id="39$JcGGWFCM" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+    <node concept="1X3_iC" id="7OJcYqweyHD" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="39$JcGGWFCK" role="8Wnug">
+        <property role="TrG5h" value="SLANG_STRING_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwgS5" role="1B3o_S" />
+        <node concept="3uibUv" id="39$JcGGWFCM" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhnnGw" role="jymVt">
       <property role="TrG5h" value="slangStringType" />
       <node concept="3clFbS" id="5JNiskhnnGx" role="3clF47">
         <node concept="3clFbF" id="5JNiskhnnGy" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhnnGz" role="3clFbG">
-            <ref role="3cqZAo" node="39$JcGGWFCK" resolve="SLANG_STRING_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqvZ7I4" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqvZctT" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwjRij" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzm" resolve="getString" />
+            </node>
           </node>
         </node>
       </node>
@@ -8979,36 +11757,54 @@
         <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
       </node>
     </node>
-    <node concept="312cEg" id="5M3rB6_Plke" role="jymVt">
-      <property role="TrG5h" value="KEY_STRING_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwiSe" role="1B3o_S" />
-      <node concept="17QB3L" id="5M3rB6_Pljn" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqweAV$" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5M3rB6_Plke" role="8Wnug">
+        <property role="TrG5h" value="KEY_STRING_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwiSe" role="1B3o_S" />
+        <node concept="17QB3L" id="5M3rB6_Pljn" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhntM$" role="jymVt">
       <property role="TrG5h" value="keyStringType" />
       <node concept="3clFbS" id="5JNiskhntM_" role="3clF47">
         <node concept="3clFbF" id="5JNiskhntMA" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhntMB" role="3clFbG">
-            <ref role="3cqZAo" node="5M3rB6_Plke" resolve="KEY_STRING_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqvZjLy" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqvZluh" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwP92u" resolve="getLcKey" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwjV5e" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzm" resolve="getString" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskhntMC" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhntMD" role="3clF45" />
     </node>
-    <node concept="312cEg" id="2mPmTXsxVhr" role="jymVt">
-      <property role="TrG5h" value="ID_STRING_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwkL5" role="1B3o_S" />
-      <node concept="17QB3L" id="2mPmTXsxVht" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqweJNK" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="2mPmTXsxVhr" role="8Wnug">
+        <property role="TrG5h" value="ID_STRING_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwkL5" role="1B3o_S" />
+        <node concept="17QB3L" id="2mPmTXsxVht" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhnzc0" role="jymVt">
       <property role="TrG5h" value="idStringType" />
       <node concept="3clFbS" id="5JNiskhnzc1" role="3clF47">
         <node concept="3clFbF" id="5JNiskhnzc2" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhnzc3" role="3clFbG">
-            <ref role="3cqZAo" node="2mPmTXsxVhr" resolve="ID_STRING_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqvZtGO" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqvZxHc" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwjYQV" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzm" resolve="getString" />
+            </node>
           </node>
         </node>
       </node>
@@ -9016,20 +11812,29 @@
       <node concept="17QB3L" id="5JNiskhnzc5" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="DUXtH0nOOu" role="jymVt" />
-    <node concept="312cEg" id="2ju2syjsnG3" role="jymVt">
-      <property role="TrG5h" value="LC_BOOLEAN_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tqbb2" id="2ju2syjsnG4" role="1tU5fm">
-        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+    <node concept="1X3_iC" id="7OJcYqweO31" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="2ju2syjsnG3" role="8Wnug">
+        <property role="TrG5h" value="LC_BOOLEAN_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tqbb2" id="2ju2syjsnG4" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+        </node>
+        <node concept="3Tmbuc" id="5JNiskhwn4Z" role="1B3o_S" />
       </node>
-      <node concept="3Tmbuc" id="5JNiskhwn4Z" role="1B3o_S" />
     </node>
     <node concept="3clFb_" id="5JNiskhnMfh" role="jymVt">
       <property role="TrG5h" value="lcBooleanType" />
       <node concept="3clFbS" id="5JNiskhnMfi" role="3clF47">
         <node concept="3clFbF" id="5JNiskhoAwc" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhoAwb" role="3clFbG">
-            <ref role="3cqZAo" node="2ju2syjsnG3" resolve="LC_BOOLEAN_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqvZCUf" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwk2HE" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzu" resolve="getBoolean" />
+            </node>
+            <node concept="liA8E" id="7OJcYqvZHFw" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwP92e" resolve="getLc" />
+            </node>
           </node>
         </node>
       </node>
@@ -9038,20 +11843,29 @@
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
       </node>
     </node>
-    <node concept="312cEg" id="DUXtH0nRhx" role="jymVt">
-      <property role="TrG5h" value="MPS_BOOLEAN_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwoXU" role="1B3o_S" />
-      <node concept="3Tqbb2" id="DUXtH0nRhz" role="1tU5fm">
-        <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
+    <node concept="1X3_iC" id="7OJcYqweSgZ" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="DUXtH0nRhx" role="8Wnug">
+        <property role="TrG5h" value="MPS_BOOLEAN_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwoXU" role="1B3o_S" />
+        <node concept="3Tqbb2" id="DUXtH0nRhz" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhnMfd" role="jymVt">
       <property role="TrG5h" value="mpsBooleanType" />
       <node concept="3clFbS" id="5JNiskhnMfe" role="3clF47">
         <node concept="3clFbF" id="5JNiskhoJ98" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhoJ97" role="3clFbG">
-            <ref role="3cqZAo" node="DUXtH0nRhx" resolve="MPS_BOOLEAN_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqvZOXp" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqvZTbY" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwk6$C" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzu" resolve="getBoolean" />
+            </node>
           </node>
         </node>
       </node>
@@ -9060,20 +11874,29 @@
         <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
       </node>
     </node>
-    <node concept="312cEg" id="39$JcGGWAx4" role="jymVt">
-      <property role="TrG5h" value="SLANG_BOOLEAN_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwqV6" role="1B3o_S" />
-      <node concept="3uibUv" id="39$JcGGWAx6" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+    <node concept="1X3_iC" id="7OJcYqweWwi" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="39$JcGGWAx4" role="8Wnug">
+        <property role="TrG5h" value="SLANG_BOOLEAN_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwqV6" role="1B3o_S" />
+        <node concept="3uibUv" id="39$JcGGWAx6" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhnMf9" role="jymVt">
       <property role="TrG5h" value="slangBooleanType" />
       <node concept="3clFbS" id="5JNiskhnMfa" role="3clF47">
         <node concept="3clFbF" id="5JNiskhoKSA" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhoKS_" role="3clFbG">
-            <ref role="3cqZAo" node="39$JcGGWAx4" resolve="SLANG_BOOLEAN_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqw01u9" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw067V" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwkaob" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzu" resolve="getBoolean" />
+            </node>
           </node>
         </node>
       </node>
@@ -9082,36 +11905,54 @@
         <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
       </node>
     </node>
-    <node concept="312cEg" id="5M3rB6_PmED" role="jymVt">
-      <property role="TrG5h" value="KEY_BOOLEAN_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwsNX" role="1B3o_S" />
-      <node concept="17QB3L" id="5M3rB6_PmEF" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwf0JA" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5M3rB6_PmED" role="8Wnug">
+        <property role="TrG5h" value="KEY_BOOLEAN_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwsNX" role="1B3o_S" />
+        <node concept="17QB3L" id="5M3rB6_PmEF" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhnMf5" role="jymVt">
       <property role="TrG5h" value="keyBooleanType" />
       <node concept="3clFbS" id="5JNiskhnMf6" role="3clF47">
         <node concept="3clFbF" id="5JNiskhoMBQ" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhoMBP" role="3clFbG">
-            <ref role="3cqZAo" node="5M3rB6_PmED" resolve="KEY_BOOLEAN_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqw0iD0" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw0noW" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwP92u" resolve="getLcKey" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwkeaw" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzu" resolve="getBoolean" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskhnMf7" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhnMf8" role="3clF45" />
     </node>
-    <node concept="312cEg" id="2mPmTXsxWOq" role="jymVt">
-      <property role="TrG5h" value="ID_BOOLEAN_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwuGO" role="1B3o_S" />
-      <node concept="17QB3L" id="2mPmTXsxWOs" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwf513" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="2mPmTXsxWOq" role="8Wnug">
+        <property role="TrG5h" value="ID_BOOLEAN_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwuGO" role="1B3o_S" />
+        <node concept="17QB3L" id="2mPmTXsxWOs" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhnMf1" role="jymVt">
       <property role="TrG5h" value="idBooleanType" />
       <node concept="3clFbS" id="5JNiskhnMf2" role="3clF47">
         <node concept="3clFbF" id="5JNiskhoOua" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhoOu9" role="3clFbG">
-            <ref role="3cqZAo" node="2mPmTXsxWOq" resolve="ID_BOOLEAN_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqw0uBc" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw0znP" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwkhLL" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzu" resolve="getBoolean" />
+            </node>
           </node>
         </node>
       </node>
@@ -9119,20 +11960,29 @@
       <node concept="17QB3L" id="5JNiskhnMf4" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="DUXtGZOqx1" role="jymVt" />
-    <node concept="312cEg" id="48csSBPf4M9" role="jymVt">
-      <property role="TrG5h" value="LC_INTEGER_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tqbb2" id="48csSBPf4Ma" role="1tU5fm">
-        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+    <node concept="1X3_iC" id="7OJcYqwf9f5" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="48csSBPf4M9" role="8Wnug">
+        <property role="TrG5h" value="LC_INTEGER_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tqbb2" id="48csSBPf4Ma" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+        </node>
+        <node concept="3Tmbuc" id="5JNiskhwwA3" role="1B3o_S" />
       </node>
-      <node concept="3Tmbuc" id="5JNiskhwwA3" role="1B3o_S" />
     </node>
     <node concept="3clFb_" id="5JNiskhnZtN" role="jymVt">
       <property role="TrG5h" value="lcIntegerType" />
       <node concept="3clFbS" id="5JNiskhnZtO" role="3clF47">
         <node concept="3clFbF" id="5JNiskhphv_" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhphv$" role="3clFbG">
-            <ref role="3cqZAo" node="48csSBPf4M9" resolve="LC_INTEGER_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqw0ETg" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwklHx" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzA" resolve="getInteger" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw0IXK" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwP92e" resolve="getLc" />
+            </node>
           </node>
         </node>
       </node>
@@ -9141,20 +11991,29 @@
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
       </node>
     </node>
-    <node concept="312cEg" id="48csSBPf4M6" role="jymVt">
-      <property role="TrG5h" value="MPS_INTEGER_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwy_S" role="1B3o_S" />
-      <node concept="3Tqbb2" id="48csSBPf4M8" role="1tU5fm">
-        <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
+    <node concept="1X3_iC" id="7OJcYqwfdt8" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="48csSBPf4M6" role="8Wnug">
+        <property role="TrG5h" value="MPS_INTEGER_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwy_S" role="1B3o_S" />
+        <node concept="3Tqbb2" id="48csSBPf4M8" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhnZtJ" role="jymVt">
       <property role="TrG5h" value="mpsIntegerType" />
       <node concept="3clFbS" id="5JNiskhnZtK" role="3clF47">
         <node concept="3clFbF" id="5JNiskhpjmd" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhpjmc" role="3clFbG">
-            <ref role="3cqZAo" node="48csSBPf4M6" resolve="MPS_INTEGER_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqw0Q8a" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw0Ud8" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwkpzT" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzA" resolve="getInteger" />
+            </node>
           </node>
         </node>
       </node>
@@ -9163,20 +12022,29 @@
         <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
       </node>
     </node>
-    <node concept="312cEg" id="39$JcGGWu$v" role="jymVt">
-      <property role="TrG5h" value="SLANG_INTEGER_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhw$uN" role="1B3o_S" />
-      <node concept="3uibUv" id="39$JcGGWu$x" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+    <node concept="1X3_iC" id="7OJcYqwfhFc" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="39$JcGGWu$v" role="8Wnug">
+        <property role="TrG5h" value="SLANG_INTEGER_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhw$uN" role="1B3o_S" />
+        <node concept="3uibUv" id="39$JcGGWu$x" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhnZtF" role="jymVt">
       <property role="TrG5h" value="slangIntegerType" />
       <node concept="3clFbS" id="5JNiskhnZtG" role="3clF47">
         <node concept="3clFbF" id="5JNiskhplww" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhplwv" role="3clFbG">
-            <ref role="3cqZAo" node="39$JcGGWu$v" resolve="SLANG_INTEGER_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqw10Uh" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw15JU" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwktoe" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzA" resolve="getInteger" />
+            </node>
           </node>
         </node>
       </node>
@@ -9185,36 +12053,54 @@
         <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
       </node>
     </node>
-    <node concept="312cEg" id="5M3rB6_Ppp8" role="jymVt">
-      <property role="TrG5h" value="KEY_INTEGER_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwAnE" role="1B3o_S" />
-      <node concept="17QB3L" id="5M3rB6_Pppa" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwflTh" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5M3rB6_Ppp8" role="8Wnug">
+        <property role="TrG5h" value="KEY_INTEGER_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwAnE" role="1B3o_S" />
+        <node concept="17QB3L" id="5M3rB6_Pppa" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhnZtB" role="jymVt">
       <property role="TrG5h" value="keyIntegerType" />
       <node concept="3clFbS" id="5JNiskhnZtC" role="3clF47">
         <node concept="3clFbF" id="5JNiskhpngy" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhpngx" role="3clFbG">
-            <ref role="3cqZAo" node="5M3rB6_Ppp8" resolve="KEY_INTEGER_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqw1d4p" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw1hUG" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwP92u" resolve="getLcKey" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwkxcH" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzA" resolve="getInteger" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskhnZtD" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhnZtE" role="3clF45" />
     </node>
-    <node concept="312cEg" id="2mPmTXsxYns" role="jymVt">
-      <property role="TrG5h" value="ID_INTEGER_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwC9f" role="1B3o_S" />
-      <node concept="17QB3L" id="2mPmTXsxYnu" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwfq7n" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="2mPmTXsxYns" role="8Wnug">
+        <property role="TrG5h" value="ID_INTEGER_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwC9f" role="1B3o_S" />
+        <node concept="17QB3L" id="2mPmTXsxYnu" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhnZtz" role="jymVt">
       <property role="TrG5h" value="idIntegerType" />
       <node concept="3clFbS" id="5JNiskhnZt$" role="3clF47">
         <node concept="3clFbF" id="5JNiskhpp5e" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhpp5d" role="3clFbG">
-            <ref role="3cqZAo" node="2mPmTXsxYns" resolve="ID_INTEGER_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqw1p4d" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw1qPp" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwk$x2" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzA" resolve="getInteger" />
+            </node>
           </node>
         </node>
       </node>
@@ -9222,20 +12108,29 @@
       <node concept="17QB3L" id="5JNiskhnZtA" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="48csSBPf4M5" role="jymVt" />
-    <node concept="312cEg" id="39$JcGFBNeh" role="jymVt">
-      <property role="TrG5h" value="LC_JSON_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tqbb2" id="39$JcGFBNei" role="1tU5fm">
-        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+    <node concept="1X3_iC" id="7OJcYqwfF9o" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="39$JcGFBNeh" role="8Wnug">
+        <property role="TrG5h" value="LC_JSON_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tqbb2" id="39$JcGFBNei" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+        </node>
+        <node concept="3Tmbuc" id="5JNiskhwE7P" role="1B3o_S" />
       </node>
-      <node concept="3Tmbuc" id="5JNiskhwE7P" role="1B3o_S" />
     </node>
     <node concept="3clFb_" id="5JNiskhoaPB" role="jymVt">
       <property role="TrG5h" value="lcJsonType" />
       <node concept="3clFbS" id="5JNiskhoaPC" role="3clF47">
         <node concept="3clFbF" id="5JNiskhpPFg" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhpPFf" role="3clFbG">
-            <ref role="3cqZAo" node="39$JcGFBNeh" resolve="LC_JSON_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqw1z4N" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwkCvK" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzI" resolve="getJson" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw1ATb" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwOOzI" resolve="getLc" />
+            </node>
           </node>
         </node>
       </node>
@@ -9244,20 +12139,29 @@
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
       </node>
     </node>
-    <node concept="312cEg" id="39$JcGFBYPi" role="jymVt">
-      <property role="TrG5h" value="MPS_JSON_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwG0K" role="1B3o_S" />
-      <node concept="3Tqbb2" id="39$JcGFBYPk" role="1tU5fm">
-        <ref role="ehGHo" to="tpce:fKAz7CR" resolve="ConstrainedDataTypeDeclaration" />
+    <node concept="1X3_iC" id="7OJcYqwfJoO" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="39$JcGFBYPi" role="8Wnug">
+        <property role="TrG5h" value="MPS_JSON_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwG0K" role="1B3o_S" />
+        <node concept="3Tqbb2" id="39$JcGFBYPk" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:fKAz7CR" resolve="ConstrainedDataTypeDeclaration" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhoaPz" role="jymVt">
       <property role="TrG5h" value="mpsJsonType" />
       <node concept="3clFbS" id="5JNiskhoaP$" role="3clF47">
         <node concept="3clFbF" id="5JNiskhpRku" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhpRkt" role="3clFbG">
-            <ref role="3cqZAo" node="39$JcGFBYPi" resolve="MPS_JSON_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqw20h_" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw20hB" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwkGHx" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzI" resolve="getJson" />
+            </node>
           </node>
         </node>
       </node>
@@ -9266,20 +12170,29 @@
         <ref role="ehGHo" to="tpce:fKAz7CR" resolve="ConstrainedDataTypeDeclaration" />
       </node>
     </node>
-    <node concept="312cEg" id="39$JcGFCmtL" role="jymVt">
-      <property role="TrG5h" value="SLANG_JSON_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwHV7" role="1B3o_S" />
-      <node concept="3uibUv" id="39$JcGFCmt_" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+    <node concept="1X3_iC" id="7OJcYqwfNFb" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="39$JcGFCmtL" role="8Wnug">
+        <property role="TrG5h" value="SLANG_JSON_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwHV7" role="1B3o_S" />
+        <node concept="3uibUv" id="39$JcGFCmt_" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhoaPv" role="jymVt">
       <property role="TrG5h" value="slangJsonType" />
       <node concept="3clFbS" id="5JNiskhoaPw" role="3clF47">
         <node concept="3clFbF" id="5JNiskhpT7y" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhpT7x" role="3clFbG">
-            <ref role="3cqZAo" node="39$JcGFCmtL" resolve="SLANG_JSON_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqw36$Z" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw3buS" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwkJZD" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzI" resolve="getJson" />
+            </node>
           </node>
         </node>
       </node>
@@ -9288,36 +12201,54 @@
         <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
       </node>
     </node>
-    <node concept="312cEg" id="5M3rB6_Psos" role="jymVt">
-      <property role="TrG5h" value="KEY_JSON_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwJOm" role="1B3o_S" />
-      <node concept="17QB3L" id="5M3rB6_Psou" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwfRUD" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5M3rB6_Psos" role="8Wnug">
+        <property role="TrG5h" value="KEY_JSON_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwJOm" role="1B3o_S" />
+        <node concept="17QB3L" id="5M3rB6_Psou" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhoaPr" role="jymVt">
       <property role="TrG5h" value="keyJsonType" />
       <node concept="3clFbS" id="5JNiskhoaPs" role="3clF47">
         <node concept="3clFbF" id="5JNiskhpV0v" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhpV0u" role="3clFbG">
-            <ref role="3cqZAo" node="5M3rB6_Psos" resolve="KEY_JSON_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqw3iMH" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw3m_i" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwOOzY" resolve="getLcKey" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwkNOU" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzI" resolve="getJson" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskhoaPt" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhoaPu" role="3clF45" />
     </node>
-    <node concept="312cEg" id="2mPmTXsxZUx" role="jymVt">
-      <property role="TrG5h" value="ID_JSON_TYPE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwLO7" role="1B3o_S" />
-      <node concept="17QB3L" id="2mPmTXsxZUz" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwfW8O" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="2mPmTXsxZUx" role="8Wnug">
+        <property role="TrG5h" value="ID_JSON_TYPE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwLO7" role="1B3o_S" />
+        <node concept="17QB3L" id="2mPmTXsxZUz" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhoaPn" role="jymVt">
       <property role="TrG5h" value="idJsonType" />
       <node concept="3clFbS" id="5JNiskhoaPo" role="3clF47">
         <node concept="3clFbF" id="5JNiskhpWNR" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhpWNQ" role="3clFbG">
-            <ref role="3cqZAo" node="2mPmTXsxZUx" resolve="ID_JSON_TYPE" />
+          <node concept="2OqwBi" id="7OJcYqw3tEr" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw3z0j" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwkRHc" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzI" resolve="getJson" />
+            </node>
           </node>
         </node>
       </node>
@@ -9325,20 +12256,29 @@
       <node concept="17QB3L" id="5JNiskhoaPq" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="39$JcGFBYDh" role="jymVt" />
-    <node concept="312cEg" id="39$JcGFBNUw" role="jymVt">
-      <property role="TrG5h" value="LC_NODE_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwNGY" role="1B3o_S" />
-      <node concept="3Tqbb2" id="39$JcGFBNUg" role="1tU5fm">
-        <ref role="ehGHo" to="h3y3:2ju2syjklrv" resolve="Concept" />
+    <node concept="1X3_iC" id="7OJcYqwg0Cb" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="39$JcGFBNUw" role="8Wnug">
+        <property role="TrG5h" value="LC_NODE_CONCEPT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwNGY" role="1B3o_S" />
+        <node concept="3Tqbb2" id="39$JcGFBNUg" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjklrv" resolve="Concept" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqgVp" role="jymVt">
       <property role="TrG5h" value="lcNodeConcept" />
       <node concept="3clFbS" id="5JNiskhqgVq" role="3clF47">
         <node concept="3clFbF" id="5JNiskhrp2b" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhrp2a" role="3clFbG">
-            <ref role="3cqZAo" node="39$JcGFBNUw" resolve="LC_NODE_CONCEPT" />
+          <node concept="2OqwBi" id="7OJcYqw3EnR" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwkVyW" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw3Jc$" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcL" resolve="getLc" />
+            </node>
           </node>
         </node>
       </node>
@@ -9347,20 +12287,29 @@
         <ref role="ehGHo" to="h3y3:2ju2syjklrv" resolve="Concept" />
       </node>
     </node>
-    <node concept="312cEg" id="3ePT3MaQsZ_" role="jymVt">
-      <property role="TrG5h" value="MPS_NODE_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwP_T" role="1B3o_S" />
-      <node concept="3Tqbb2" id="3ePT3MaQsZB" role="1tU5fm">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+    <node concept="1X3_iC" id="7OJcYqwg4Qo" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="3ePT3MaQsZ_" role="8Wnug">
+        <property role="TrG5h" value="MPS_NODE_CONCEPT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwP_T" role="1B3o_S" />
+        <node concept="3Tqbb2" id="3ePT3MaQsZB" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqgVl" role="jymVt">
       <property role="TrG5h" value="mpsNodeConcept" />
       <node concept="3clFbS" id="5JNiskhqgVm" role="3clF47">
         <node concept="3clFbF" id="5JNiskhrqP2" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhrqP1" role="3clFbG">
-            <ref role="3cqZAo" node="3ePT3MaQsZ_" resolve="MPS_NODE_CONCEPT" />
+          <node concept="2OqwBi" id="7OJcYqw3XKm" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw432f" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwkZsd" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
+            </node>
           </node>
         </node>
       </node>
@@ -9369,20 +12318,29 @@
         <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
       </node>
     </node>
-    <node concept="312cEg" id="39$JcGG9w_Q" role="jymVt">
-      <property role="TrG5h" value="SLANG_NODE_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwRnI" role="1B3o_S" />
-      <node concept="3uibUv" id="39$JcGG9x5k" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+    <node concept="1X3_iC" id="7OJcYqwg95U" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="39$JcGG9w_Q" role="8Wnug">
+        <property role="TrG5h" value="SLANG_NODE_CONCEPT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwRnI" role="1B3o_S" />
+        <node concept="3uibUv" id="39$JcGG9x5k" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqgVh" role="jymVt">
       <property role="TrG5h" value="slangNodeConcept" />
       <node concept="3clFbS" id="5JNiskhqgVi" role="3clF47">
         <node concept="3clFbF" id="5JNiskhrsEU" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhrsET" role="3clFbG">
-            <ref role="3cqZAo" node="39$JcGG9w_Q" resolve="SLANG_NODE_CONCEPT" />
+          <node concept="2OqwBi" id="7OJcYqw4kR2" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw4kR4" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwl3kZ" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
+            </node>
           </node>
         </node>
       </node>
@@ -9391,36 +12349,54 @@
         <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
       </node>
     </node>
-    <node concept="312cEg" id="5M3rB6_PuRS" role="jymVt">
-      <property role="TrG5h" value="KEY_NODE_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwTpu" role="1B3o_S" />
-      <node concept="17QB3L" id="5M3rB6_PuRU" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwgdr3" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5M3rB6_PuRS" role="8Wnug">
+        <property role="TrG5h" value="KEY_NODE_CONCEPT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwTpu" role="1B3o_S" />
+        <node concept="17QB3L" id="5M3rB6_PuRU" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqgVd" role="jymVt">
       <property role="TrG5h" value="keyNodeConcept" />
       <node concept="3clFbS" id="5JNiskhqgVe" role="3clF47">
         <node concept="3clFbF" id="5JNiskhruvC" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhruvB" role="3clFbG">
-            <ref role="3cqZAo" node="5M3rB6_PuRS" resolve="KEY_NODE_CONCEPT" />
+          <node concept="2OqwBi" id="7OJcYqw4ETM" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw4J4o" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwl6Ys" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskhqgVf" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhqgVg" role="3clF45" />
     </node>
-    <node concept="312cEg" id="2mPmTXsy1tD" role="jymVt">
-      <property role="TrG5h" value="ID_NODE_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwVil" role="1B3o_S" />
-      <node concept="17QB3L" id="2mPmTXsy1tF" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwghJm" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="2mPmTXsy1tD" role="8Wnug">
+        <property role="TrG5h" value="ID_NODE_CONCEPT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwVil" role="1B3o_S" />
+        <node concept="17QB3L" id="2mPmTXsy1tF" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqgV9" role="jymVt">
       <property role="TrG5h" value="idNodeConcept" />
       <node concept="3clFbS" id="5JNiskhqgVa" role="3clF47">
         <node concept="3clFbF" id="5JNiskhrwkS" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhrwkR" role="3clFbG">
-            <ref role="3cqZAo" node="2mPmTXsy1tD" resolve="ID_NODE_CONCEPT" />
+          <node concept="2OqwBi" id="7OJcYqw4QKz" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw4S_v" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwlaSS" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
+            </node>
           </node>
         </node>
       </node>
@@ -9428,20 +12404,29 @@
       <node concept="17QB3L" id="5JNiskhqgVc" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="6jTTMHCZQ3M" role="jymVt" />
-    <node concept="312cEg" id="30uXOOfMilR" role="jymVt">
-      <property role="TrG5h" value="MPS_ANNOTATION_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwXcB" role="1B3o_S" />
-      <node concept="3Tqbb2" id="30uXOOfMilT" role="1tU5fm">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+    <node concept="1X3_iC" id="7OJcYqwglZ0" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="30uXOOfMilR" role="8Wnug">
+        <property role="TrG5h" value="MPS_ANNOTATION_CONCEPT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwXcB" role="1B3o_S" />
+        <node concept="3Tqbb2" id="30uXOOfMilT" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqsXL" role="jymVt">
       <property role="TrG5h" value="mpsAnnotationConcept" />
       <node concept="3clFbS" id="5JNiskhqsXM" role="3clF47">
         <node concept="3clFbF" id="5JNiskhs9RS" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhs9RR" role="3clFbG">
-            <ref role="3cqZAo" node="30uXOOfMilR" resolve="MPS_ANNOTATION_CONCEPT" />
+          <node concept="2OqwBi" id="7OJcYqw54Qd" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwleRF" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzY" resolve="getAnnotation" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw59S2" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
+            </node>
           </node>
         </node>
       </node>
@@ -9450,20 +12435,29 @@
         <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
       </node>
     </node>
-    <node concept="312cEg" id="30uXOOfMilO" role="jymVt">
-      <property role="TrG5h" value="SLANG_ANNOTATION_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhwZcW" role="1B3o_S" />
-      <node concept="3uibUv" id="30uXOOfMilQ" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+    <node concept="1X3_iC" id="7OJcYqwgqeF" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="30uXOOfMilO" role="8Wnug">
+        <property role="TrG5h" value="SLANG_ANNOTATION_CONCEPT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhwZcW" role="1B3o_S" />
+        <node concept="3uibUv" id="30uXOOfMilQ" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqsXH" role="jymVt">
       <property role="TrG5h" value="slangAnnotationConcept" />
       <node concept="3clFbS" id="5JNiskhqsXI" role="3clF47">
         <node concept="3clFbF" id="5JNiskhsb_y" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhsb_x" role="3clFbG">
-            <ref role="3cqZAo" node="30uXOOfMilO" resolve="SLANG_ANNOTATION_CONCEPT" />
+          <node concept="2OqwBi" id="7OJcYqw5hu5" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw5myP" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwliL6" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzY" resolve="getAnnotation" />
+            </node>
           </node>
         </node>
       </node>
@@ -9472,38 +12466,56 @@
         <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
       </node>
     </node>
-    <node concept="312cEg" id="6Pr6izIcvKD" role="jymVt">
-      <property role="TrG5h" value="ID_ANNOTATION_CONCEPT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhx0Y$" role="1B3o_S" />
-      <node concept="17QB3L" id="6Pr6izIcvKF" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwguuj" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="6Pr6izIcvKD" role="8Wnug">
+        <property role="TrG5h" value="ID_ANNOTATION_CONCEPT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhx0Y$" role="1B3o_S" />
+        <node concept="17QB3L" id="6Pr6izIcvKF" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqsX_" role="jymVt">
       <property role="TrG5h" value="idAnnotationConcept" />
       <node concept="3clFbS" id="5JNiskhqsXA" role="3clF47">
         <node concept="3clFbF" id="5JNiskhsdte" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhsdtd" role="3clFbG">
-            <ref role="3cqZAo" node="6Pr6izIcvKD" resolve="ID_ANNOTATION_CONCEPT" />
+          <node concept="2OqwBi" id="7OJcYqw5u7Y" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw5yxY" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwlmFd" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirzY" resolve="getAnnotation" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskhqsXB" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhqsXC" role="3clF45" />
     </node>
-    <node concept="312cEg" id="4WflrVajnwK" role="jymVt">
-      <property role="TrG5h" value="SLANG_ANNOTATION_CONTAINMENT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhx2SJ" role="1B3o_S" />
-      <node concept="3uibUv" id="4WflrVajnv2" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+    <node concept="1X3_iC" id="7OJcYqwgyHZ" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="4WflrVajnwK" role="8Wnug">
+        <property role="TrG5h" value="SLANG_ANNOTATION_CONTAINMENT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhx2SJ" role="1B3o_S" />
+        <node concept="3uibUv" id="4WflrVajnv2" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhsfjt" role="jymVt">
       <property role="TrG5h" value="slangAnnotationContainment" />
       <node concept="3clFbS" id="5JNiskhsfju" role="3clF47">
         <node concept="3clFbF" id="5JNiskhsfjv" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhsfjw" role="3clFbG">
-            <ref role="3cqZAo" node="4WflrVajnwK" resolve="SLANG_ANNOTATION_CONTAINMENT" />
+          <node concept="2OqwBi" id="7OJcYqw5S4f" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwlqBn" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwir$6" resolve="getAnnotationContainment" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw5TUm" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+            </node>
           </node>
         </node>
       </node>
@@ -9512,20 +12524,29 @@
         <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
       </node>
     </node>
-    <node concept="312cEg" id="5JNiskitK$o" role="jymVt">
-      <property role="TrG5h" value="MPS_ANNOTATION_CONTAINMENT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskitK$p" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskitX4f" role="1tU5fm">
-        <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+    <node concept="1X3_iC" id="7OJcYqwgB0q" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskitK$o" role="8Wnug">
+        <property role="TrG5h" value="MPS_ANNOTATION_CONTAINMENT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskitK$p" role="1B3o_S" />
+        <node concept="3Tqbb2" id="5JNiskitX4f" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskitK$i" role="jymVt">
       <property role="TrG5h" value="mpsAnnotationContainment" />
       <node concept="3clFbS" id="5JNiskitK$j" role="3clF47">
-        <node concept="3clFbF" id="5JNiskitK$k" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskitK$l" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskitK$o" resolve="MPS_ANNOTATION_CONTAINMENT" />
+        <node concept="3clFbF" id="7OJcYqw6oBf" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqw6oBg" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw6oBi" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwluyo" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwir$6" resolve="getAnnotationContainment" />
+            </node>
           </node>
         </node>
       </node>
@@ -9534,11 +12555,15 @@
         <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
       </node>
     </node>
-    <node concept="312cEg" id="5JNiskiyDwd" role="jymVt">
-      <property role="TrG5h" value="ID_ANNOTATION_CONTAINMENT" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskiyyfS" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiyBVU" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwgFg9" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5JNiskiyDwd" role="8Wnug">
+        <property role="TrG5h" value="ID_ANNOTATION_CONTAINMENT" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskiyyfS" role="1B3o_S" />
+        <node concept="17QB3L" id="5JNiskiyBVU" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskiyneZ" role="jymVt">
       <property role="TrG5h" value="idAnnotationContainment" />
@@ -9546,8 +12571,13 @@
       <node concept="17QB3L" id="5JNiskiynf2" role="3clF45" />
       <node concept="3clFbS" id="5JNiskiynf3" role="3clF47">
         <node concept="3clFbF" id="5JNiskiyHyC" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskiyHyB" role="3clFbG">
-            <ref role="3cqZAo" node="5JNiskiyDwd" resolve="ID_ANNOTATION_CONTAINMENT" />
+          <node concept="2OqwBi" id="7OJcYqw6Cyx" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw6Cyz" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwlys5" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwir$6" resolve="getAnnotationContainment" />
+            </node>
           </node>
         </node>
       </node>
@@ -9556,20 +12586,29 @@
       </node>
     </node>
     <node concept="2tJIrI" id="30uXOOfMilH" role="jymVt" />
-    <node concept="312cEg" id="6jTTMHCZPnj" role="jymVt">
-      <property role="TrG5h" value="LC_INAMED_INTERFACE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhx4LY" role="1B3o_S" />
-      <node concept="3Tqbb2" id="6jTTMHCZPnl" role="1tU5fm">
-        <ref role="ehGHo" to="h3y3:2ju2syjklHQ" resolve="Interface" />
+    <node concept="1X3_iC" id="7OJcYqwgJvT" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="6jTTMHCZPnj" role="8Wnug">
+        <property role="TrG5h" value="LC_INAMED_INTERFACE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhx4LY" role="1B3o_S" />
+        <node concept="3Tqbb2" id="6jTTMHCZPnl" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjklHQ" resolve="Interface" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqBwh" role="jymVt">
       <property role="TrG5h" value="lcINamedInterface" />
       <node concept="3clFbS" id="5JNiskhqBwi" role="3clF47">
         <node concept="3clFbF" id="5JNiskhsT8h" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhsT8g" role="3clFbG">
-            <ref role="3cqZAo" node="6jTTMHCZPnj" resolve="LC_INAMED_INTERFACE" />
+          <node concept="2OqwBi" id="7OJcYqw6QLV" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwlAr7" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwir$e" resolve="getINamed" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw6VRP" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwOWjc" resolve="getLc" />
+            </node>
           </node>
         </node>
       </node>
@@ -9578,20 +12617,29 @@
         <ref role="ehGHo" to="h3y3:2ju2syjklHQ" resolve="Interface" />
       </node>
     </node>
-    <node concept="312cEg" id="6jTTMHCZPng" role="jymVt">
-      <property role="TrG5h" value="MPS_INAMED_INTERFACE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhx6LN" role="1B3o_S" />
-      <node concept="3Tqbb2" id="6jTTMHCZPni" role="1tU5fm">
-        <ref role="ehGHo" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
+    <node concept="1X3_iC" id="7OJcYqwgNJE" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="6jTTMHCZPng" role="8Wnug">
+        <property role="TrG5h" value="MPS_INAMED_INTERFACE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhx6LN" role="1B3o_S" />
+        <node concept="3Tqbb2" id="6jTTMHCZPni" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqBwd" role="jymVt">
       <property role="TrG5h" value="mpsINamedInterface" />
       <node concept="3clFbS" id="5JNiskhqBwe" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhsV5f" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhsV5e" role="3clFbG">
-            <ref role="3cqZAo" node="6jTTMHCZPng" resolve="MPS_INAMED_INTERFACE" />
+        <node concept="3clFbF" id="7OJcYqw70t6" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqw70t7" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw70t9" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwlEm6" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwir$e" resolve="getINamed" />
+            </node>
           </node>
         </node>
       </node>
@@ -9600,20 +12648,29 @@
         <ref role="ehGHo" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
       </node>
     </node>
-    <node concept="312cEg" id="6jTTMHCZPnd" role="jymVt">
-      <property role="TrG5h" value="SLANG_INAMED_INTERFACE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhx8EU" role="1B3o_S" />
-      <node concept="3uibUv" id="6jTTMHCZPnf" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SInterfaceConcept" resolve="SInterfaceConcept" />
+    <node concept="1X3_iC" id="7OJcYqwgRZs" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="6jTTMHCZPnd" role="8Wnug">
+        <property role="TrG5h" value="SLANG_INAMED_INTERFACE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhx8EU" role="1B3o_S" />
+        <node concept="3uibUv" id="6jTTMHCZPnf" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SInterfaceConcept" resolve="SInterfaceConcept" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqBw9" role="jymVt">
       <property role="TrG5h" value="slangINamedInterface" />
       <node concept="3clFbS" id="5JNiskhqBwa" role="3clF47">
         <node concept="3clFbF" id="5JNiskhsWV5" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhsWV4" role="3clFbG">
-            <ref role="3cqZAo" node="6jTTMHCZPnd" resolve="SLANG_INAMED_INTERFACE" />
+          <node concept="2OqwBi" id="7OJcYqvXMaC" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqvXQD$" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwlIdH" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwir$e" resolve="getINamed" />
+            </node>
           </node>
         </node>
       </node>
@@ -9622,36 +12679,54 @@
         <ref role="3uigEE" to="c17a:~SInterfaceConcept" resolve="SInterfaceConcept" />
       </node>
     </node>
-    <node concept="312cEg" id="5M3rB6_P$Vq" role="jymVt">
-      <property role="TrG5h" value="KEY_INAMED_INTERFACE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxasv" role="1B3o_S" />
-      <node concept="17QB3L" id="5M3rB6_P$Vs" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwgWfb" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5M3rB6_P$Vq" role="8Wnug">
+        <property role="TrG5h" value="KEY_INAMED_INTERFACE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxasv" role="1B3o_S" />
+        <node concept="17QB3L" id="5M3rB6_P$Vs" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqBw5" role="jymVt">
       <property role="TrG5h" value="keyINamedInterface" />
       <node concept="3clFbS" id="5JNiskhqBw6" role="3clF47">
         <node concept="3clFbF" id="5JNiskhsZ6k" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhsZ6j" role="3clFbG">
-            <ref role="3cqZAo" node="5M3rB6_P$Vq" resolve="KEY_INAMED_INTERFACE" />
+          <node concept="2OqwBi" id="7OJcYqvXAqX" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqvXFiv" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqwOWjs" resolve="getLcKey" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwlM1g" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwir$e" resolve="getINamed" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskhqBw7" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhqBw8" role="3clF45" />
     </node>
-    <node concept="312cEg" id="2mPmTXsy2Sr" role="jymVt">
-      <property role="TrG5h" value="ID_INAMED_INTERFACE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxclm" role="1B3o_S" />
-      <node concept="17QB3L" id="2mPmTXsy2St" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwh0wj" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="2mPmTXsy2Sr" role="8Wnug">
+        <property role="TrG5h" value="ID_INAMED_INTERFACE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxclm" role="1B3o_S" />
+        <node concept="17QB3L" id="2mPmTXsy2St" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqBw1" role="jymVt">
       <property role="TrG5h" value="idINamedInterface" />
       <node concept="3clFbS" id="5JNiskhqBw2" role="3clF47">
         <node concept="3clFbF" id="5JNiskht12d" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskht12c" role="3clFbG">
-            <ref role="3cqZAo" node="2mPmTXsy2Sr" resolve="ID_INAMED_INTERFACE" />
+          <node concept="2OqwBi" id="7OJcYqvXoTx" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqvXtKI" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwlPWC" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwir$e" resolve="getINamed" />
+            </node>
           </node>
         </node>
       </node>
@@ -9659,20 +12734,29 @@
       <node concept="17QB3L" id="5JNiskhqBw4" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5AGBwuFJGvp" role="jymVt" />
-    <node concept="312cEg" id="5AGBwuFJEKi" role="jymVt">
-      <property role="TrG5h" value="LC_NAME_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxeed" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5AGBwuFJEKk" role="1tU5fm">
-        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+    <node concept="1X3_iC" id="7OJcYqwh4Lw" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5AGBwuFJEKi" role="8Wnug">
+        <property role="TrG5h" value="LC_NAME_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxeed" role="1B3o_S" />
+        <node concept="3Tqbb2" id="5AGBwuFJEKk" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqJpu" role="jymVt">
       <property role="TrG5h" value="lcNameProperty" />
       <node concept="3clFbS" id="5JNiskhqJpv" role="3clF47">
         <node concept="3clFbF" id="5JNiskhtHQh" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhtHQg" role="3clFbG">
-            <ref role="3cqZAo" node="5AGBwuFJEKi" resolve="LC_NAME_PROPERTY" />
+          <node concept="2OqwBi" id="7OJcYqvXcyT" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwlTJI" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwir$m" resolve="getINamedName" />
+            </node>
+            <node concept="liA8E" id="7OJcYqvXh1H" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcL" resolve="getLc" />
+            </node>
           </node>
         </node>
       </node>
@@ -9681,20 +12765,29 @@
         <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
       </node>
     </node>
-    <node concept="312cEg" id="5AGBwuFJEKf" role="jymVt">
-      <property role="TrG5h" value="MPS_NAME_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxg8s" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5AGBwuFJEKh" role="1tU5fm">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+    <node concept="1X3_iC" id="7OJcYqwh91m" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5AGBwuFJEKf" role="8Wnug">
+        <property role="TrG5h" value="MPS_NAME_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxg8s" role="1B3o_S" />
+        <node concept="3Tqbb2" id="5AGBwuFJEKh" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqJpq" role="jymVt">
       <property role="TrG5h" value="mpsNameProperty" />
       <node concept="3clFbS" id="5JNiskhqJpr" role="3clF47">
         <node concept="3clFbF" id="5JNiskhtJI3" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhtJI2" role="3clFbG">
-            <ref role="3cqZAo" node="5AGBwuFJEKf" resolve="MPS_NAME_PROPERTY" />
+          <node concept="2OqwBi" id="7OJcYqvX1RD" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqvX5Oi" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwlXFr" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwir$m" resolve="getINamedName" />
+            </node>
           </node>
         </node>
       </node>
@@ -9703,20 +12796,29 @@
         <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
       </node>
     </node>
-    <node concept="312cEg" id="5AGBwuFJEKc" role="jymVt">
-      <property role="TrG5h" value="SLANG_NAME_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxi1R" role="1B3o_S" />
-      <node concept="3uibUv" id="5AGBwuFJEKe" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+    <node concept="1X3_iC" id="7OJcYqwhdix" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5AGBwuFJEKc" role="8Wnug">
+        <property role="TrG5h" value="SLANG_NAME_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxi1R" role="1B3o_S" />
+        <node concept="3uibUv" id="5AGBwuFJEKe" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqJpm" role="jymVt">
       <property role="TrG5h" value="slangNameProperty" />
       <node concept="3clFbS" id="5JNiskhqJpn" role="3clF47">
         <node concept="3clFbF" id="5JNiskhtL_3" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhtL_2" role="3clFbG">
-            <ref role="3cqZAo" node="5AGBwuFJEKc" resolve="SLANG_NAME_PROPERTY" />
+          <node concept="2OqwBi" id="7OJcYqvWPfy" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqvWTM1" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwm1_0" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwir$m" resolve="getINamedName" />
+            </node>
           </node>
         </node>
       </node>
@@ -9725,36 +12827,54 @@
         <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
       </node>
     </node>
-    <node concept="312cEg" id="5M3rB6_PC4J" role="jymVt">
-      <property role="TrG5h" value="KEY_NAME_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxjUI" role="1B3o_S" />
-      <node concept="17QB3L" id="5M3rB6_PC4L" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwhhFI" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5M3rB6_PC4J" role="8Wnug">
+        <property role="TrG5h" value="KEY_NAME_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxjUI" role="1B3o_S" />
+        <node concept="17QB3L" id="5M3rB6_PC4L" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqJpi" role="jymVt">
       <property role="TrG5h" value="keyNameProperty" />
       <node concept="3clFbS" id="5JNiskhqJpj" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhtNyJ" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhtNyI" role="3clFbG">
-            <ref role="3cqZAo" node="5M3rB6_PC4J" resolve="KEY_NAME_PROPERTY" />
+        <node concept="3clFbF" id="7OJcYqvWCO9" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqvWCOa" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqvWCOc" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwm5wU" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwir$m" resolve="getINamedName" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskhqJpk" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhqJpl" role="3clF45" />
     </node>
-    <node concept="312cEg" id="2mPmTXsy402" role="jymVt">
-      <property role="TrG5h" value="ID_NAME_PROPERTY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxlUv" role="1B3o_S" />
-      <node concept="17QB3L" id="2mPmTXsy404" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwhlVB" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="2mPmTXsy402" role="8Wnug">
+        <property role="TrG5h" value="ID_NAME_PROPERTY" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxlUv" role="1B3o_S" />
+        <node concept="17QB3L" id="2mPmTXsy404" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqJpe" role="jymVt">
       <property role="TrG5h" value="idNameProperty" />
       <node concept="3clFbS" id="5JNiskhqJpf" role="3clF47">
         <node concept="3clFbF" id="5JNiskhtPtj" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhtPti" role="3clFbG">
-            <ref role="3cqZAo" node="2mPmTXsy402" resolve="ID_NAME_PROPERTY" />
+          <node concept="2OqwBi" id="7OJcYqvWtzY" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqvWzas" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwm9d1" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwir$m" resolve="getINamedName" />
+            </node>
           </node>
         </node>
       </node>
@@ -9762,20 +12882,29 @@
       <node concept="17QB3L" id="5JNiskhqJph" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="39$JcGFBN$Q" role="jymVt" />
-    <node concept="312cEg" id="5AGBwuFFqaM" role="jymVt">
-      <property role="TrG5h" value="SLANG_M3_LANGUAGE_ID" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxnNm" role="1B3o_S" />
-      <node concept="3uibUv" id="39$JcGFEy9F" role="1tU5fm">
-        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+    <node concept="1X3_iC" id="7OJcYqwhqbx" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5AGBwuFFqaM" role="8Wnug">
+        <property role="TrG5h" value="SLANG_M3_LANGUAGE_ID" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxnNm" role="1B3o_S" />
+        <node concept="3uibUv" id="39$JcGFEy9F" role="1tU5fm">
+          <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqTRf" role="jymVt">
       <property role="TrG5h" value="slangM3LanguageId" />
       <node concept="3clFbS" id="5JNiskhqTRg" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhuxw$" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhuxwz" role="3clFbG">
-            <ref role="3cqZAo" node="5AGBwuFFqaM" resolve="SLANG_M3_LANGUAGE_ID" />
+        <node concept="3clFbF" id="7OJcYqvWiye" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqvWiyf" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwmdc4" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirz6" resolve="getM3" />
+            </node>
+            <node concept="liA8E" id="7OJcYqvWiyh" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqw7aei" resolve="getSlangId" />
+            </node>
           </node>
         </node>
       </node>
@@ -9784,20 +12913,29 @@
         <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
       </node>
     </node>
-    <node concept="312cEg" id="4R9posq8YbX" role="jymVt">
-      <property role="TrG5h" value="SLANG_M3_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxp$W" role="1B3o_S" />
-      <node concept="3uibUv" id="4R9posq8YbZ" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+    <node concept="1X3_iC" id="7OJcYqwhutM" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="4R9posq8YbX" role="8Wnug">
+        <property role="TrG5h" value="SLANG_M3_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxp$W" role="1B3o_S" />
+        <node concept="3uibUv" id="4R9posq8YbZ" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqTRb" role="jymVt">
       <property role="TrG5h" value="slangM3Language" />
       <node concept="3clFbS" id="5JNiskhqTRc" role="3clF47">
         <node concept="3clFbF" id="5JNiskhuzuI" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhuzuH" role="3clFbG">
-            <ref role="3cqZAo" node="4R9posq8YbX" resolve="SLANG_M3_LANGUAGE" />
+          <node concept="2OqwBi" id="7OJcYqvWb0a" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqvWej4" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0Q9" resolve="getSlang" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwmh6k" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirz6" resolve="getM3" />
+            </node>
           </node>
         </node>
       </node>
@@ -9806,54 +12944,81 @@
         <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
       </node>
     </node>
-    <node concept="312cEg" id="5AGBwuFF_qd" role="jymVt">
-      <property role="TrG5h" value="KEY_M3_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxrwm" role="1B3o_S" />
-      <node concept="17QB3L" id="5AGBwuFF_ps" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwhyIk" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5AGBwuFF_qd" role="8Wnug">
+        <property role="TrG5h" value="KEY_M3_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxrwm" role="1B3o_S" />
+        <node concept="17QB3L" id="5AGBwuFF_ps" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqTR7" role="jymVt">
       <property role="TrG5h" value="keyM3Language" />
       <node concept="3clFbS" id="5JNiskhqTR8" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhu_m8" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhu_m7" role="3clFbG">
-            <ref role="3cqZAo" node="5AGBwuFF_qd" resolve="KEY_M3_LANGUAGE" />
+        <node concept="3clFbF" id="7OJcYqw7pno" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqw7pnp" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw7pnr" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0QD" resolve="getLcKey" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwmkZn" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirz6" resolve="getM3" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskhqTR9" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhqTRa" role="3clF45" />
     </node>
-    <node concept="312cEg" id="2mPmTXsy5za" role="jymVt">
-      <property role="TrG5h" value="ID_M3_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxtqq" role="1B3o_S" />
-      <node concept="17QB3L" id="2mPmTXsy5zc" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwhBnH" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="2mPmTXsy5za" role="8Wnug">
+        <property role="TrG5h" value="ID_M3_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxtqq" role="1B3o_S" />
+        <node concept="17QB3L" id="2mPmTXsy5zc" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqTR3" role="jymVt">
       <property role="TrG5h" value="idM3Language" />
       <node concept="3clFbS" id="5JNiskhqTR4" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhuB6q" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhuB6p" role="3clFbG">
-            <ref role="3cqZAo" node="2mPmTXsy5za" resolve="ID_M3_LANGUAGE" />
+        <node concept="3clFbF" id="7OJcYqw7yPc" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqw7yPd" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw7yPf" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0Qh" resolve="getMpsId" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwmoWN" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirz6" resolve="getM3" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskhqTR5" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhqTR6" role="3clF45" />
     </node>
-    <node concept="312cEg" id="1ryFPTS4XtL" role="jymVt">
-      <property role="TrG5h" value="VERSION_M3_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxvja" role="1B3o_S" />
-      <node concept="17QB3L" id="1ryFPTS4Xtj" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwhFEo" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="1ryFPTS4XtL" role="8Wnug">
+        <property role="TrG5h" value="VERSION_M3_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxvja" role="1B3o_S" />
+        <node concept="17QB3L" id="1ryFPTS4Xtj" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhqTRj" role="jymVt">
       <property role="TrG5h" value="versionM3Language" />
       <node concept="3clFbS" id="5JNiskhqTRk" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhuD0I" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhuD0H" role="3clFbG">
-            <ref role="3cqZAo" node="1ryFPTS4XtL" resolve="VERSION_M3_LANGUAGE" />
+        <node concept="3clFbF" id="7OJcYqw7G8b" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqw7G8c" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw7G8e" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0Qp" resolve="getLcVersion" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwmsQa" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirz6" resolve="getM3" />
+            </node>
           </node>
         </node>
       </node>
@@ -9861,20 +13026,29 @@
       <node concept="17QB3L" id="5JNiskhuHOn" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5AGBwuFFBkK" role="jymVt" />
-    <node concept="312cEg" id="5AGBwuFFuSI" role="jymVt">
-      <property role="TrG5h" value="SLANG_CORE_LANGUAGE_ID" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxxci" role="1B3o_S" />
-      <node concept="3uibUv" id="39$JcGG9EyC" role="1tU5fm">
-        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+    <node concept="1X3_iC" id="7OJcYqwhJUn" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5AGBwuFFuSI" role="8Wnug">
+        <property role="TrG5h" value="SLANG_CORE_LANGUAGE_ID" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxxci" role="1B3o_S" />
+        <node concept="3uibUv" id="39$JcGG9EyC" role="1tU5fm">
+          <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhvkMR" role="jymVt">
       <property role="TrG5h" value="slangCoreLanguageId" />
       <node concept="3clFbS" id="5JNiskhvkMS" role="3clF47">
         <node concept="3clFbF" id="5JNiskhvkMT" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhvkMU" role="3clFbG">
-            <ref role="3cqZAo" node="5AGBwuFFuSI" resolve="SLANG_CORE_LANGUAGE_ID" />
+          <node concept="2OqwBi" id="7OJcYqw7Uk2" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwmwdG" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirze" resolve="getLioncoreBuiltins" />
+            </node>
+            <node concept="liA8E" id="7OJcYqw7Z2v" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqw7aei" resolve="getSlangId" />
+            </node>
           </node>
         </node>
       </node>
@@ -9883,20 +13057,29 @@
         <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
       </node>
     </node>
-    <node concept="312cEg" id="4R9posq8ZVS" role="jymVt">
-      <property role="TrG5h" value="SLANG_CORE_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxzc4" role="1B3o_S" />
-      <node concept="3uibUv" id="4R9posq8ZVU" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+    <node concept="1X3_iC" id="7OJcYqwhOeL" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="4R9posq8ZVS" role="8Wnug">
+        <property role="TrG5h" value="SLANG_CORE_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxzc4" role="1B3o_S" />
+        <node concept="3uibUv" id="4R9posq8ZVU" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhv7gW" role="jymVt">
       <property role="TrG5h" value="slangCoreLanguage" />
       <node concept="3clFbS" id="5JNiskhv7gX" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhv7gY" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhv7gZ" role="3clFbG">
-            <ref role="3cqZAo" node="4R9posq8ZVS" resolve="SLANG_CORE_LANGUAGE" />
+        <node concept="3clFbF" id="7OJcYqw83LK" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqw83LL" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw83LN" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0Q9" resolve="getSlang" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwm$bI" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirze" resolve="getLioncoreBuiltins" />
+            </node>
           </node>
         </node>
       </node>
@@ -9905,54 +13088,81 @@
         <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
       </node>
     </node>
-    <node concept="312cEg" id="5AGBwuFFBJV" role="jymVt">
-      <property role="TrG5h" value="KEY_BUILTIN_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhx_4S" role="1B3o_S" />
-      <node concept="17QB3L" id="5AGBwuFFBJX" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwhSwK" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="5AGBwuFFBJV" role="8Wnug">
+        <property role="TrG5h" value="KEY_BUILTIN_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhx_4S" role="1B3o_S" />
+        <node concept="17QB3L" id="5AGBwuFFBJX" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhv1Rx" role="jymVt">
       <property role="TrG5h" value="keyBuiltinLanguage" />
       <node concept="3clFbS" id="5JNiskhv1Ry" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhv1Rz" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhv1R$" role="3clFbG">
-            <ref role="3cqZAo" node="5AGBwuFFBJV" resolve="KEY_BUILTIN_LANGUAGE" />
+        <node concept="3clFbF" id="7OJcYqw8d2S" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqw8d2T" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw8d2V" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0QD" resolve="getLcKey" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwmBYp" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirze" resolve="getLioncoreBuiltins" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskhv1R_" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhv1RA" role="3clF45" />
     </node>
-    <node concept="312cEg" id="2mPmTXsy76l" role="jymVt">
-      <property role="TrG5h" value="ID_BUILTIN_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxBpl" role="1B3o_S" />
-      <node concept="17QB3L" id="2mPmTXsy76n" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwhWPX" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="2mPmTXsy76l" role="8Wnug">
+        <property role="TrG5h" value="ID_BUILTIN_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxBpl" role="1B3o_S" />
+        <node concept="17QB3L" id="2mPmTXsy76n" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhuV1t" role="jymVt">
       <property role="TrG5h" value="idBuiltinLanguage" />
       <node concept="3clFbS" id="5JNiskhuV1u" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhuV1v" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhuV1w" role="3clFbG">
-            <ref role="3cqZAo" node="2mPmTXsy76l" resolve="ID_BUILTIN_LANGUAGE" />
+        <node concept="3clFbF" id="7OJcYqw8mSI" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqw8mSJ" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw8mSL" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0Qx" resolve="getLcId" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwmFQa" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirze" resolve="getLioncoreBuiltins" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskhuV1x" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskhuV1y" role="3clF45" />
     </node>
-    <node concept="312cEg" id="1ryFPTS4Z8M" role="jymVt">
-      <property role="TrG5h" value="VERSION_BUILTIN_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxDl7" role="1B3o_S" />
-      <node concept="17QB3L" id="1ryFPTS4Z8O" role="1tU5fm" />
+    <node concept="1X3_iC" id="7OJcYqwi17l" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="1ryFPTS4Z8M" role="8Wnug">
+        <property role="TrG5h" value="VERSION_BUILTIN_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxDl7" role="1B3o_S" />
+        <node concept="17QB3L" id="1ryFPTS4Z8O" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="5JNiskhuLWh" role="jymVt">
       <property role="TrG5h" value="versionBuiltinLanguage" />
       <node concept="3clFbS" id="5JNiskhuLWi" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhuLWj" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhuLWk" role="3clFbG">
-            <ref role="3cqZAo" node="1ryFPTS4Z8M" resolve="VERSION_BUILTIN_LANGUAGE" />
+        <node concept="3clFbF" id="7OJcYqw8wi9" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqw8wia" role="3clFbG">
+            <node concept="liA8E" id="7OJcYqw8wic" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0Qp" resolve="getLcVersion" />
+            </node>
+            <node concept="1rXfSq" id="7OJcYqwmJKj" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwirze" resolve="getLioncoreBuiltins" />
+            </node>
           </node>
         </node>
       </node>
@@ -9960,26 +13170,65 @@
       <node concept="17QB3L" id="5JNiskhuLWm" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5AGBwuFFq4f" role="jymVt" />
-    <node concept="312cEg" id="4WflrVaDO5l" role="jymVt">
-      <property role="TrG5h" value="SLANG_ATTRIBUTE_LANGUAGE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tmbuc" id="5JNiskhxFfb" role="1B3o_S" />
-      <node concept="3uibUv" id="4WflrVaDNUB" role="1tU5fm">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+    <node concept="1X3_iC" id="7OJcYqwi5oH" role="lGtFl">
+      <property role="3V$3am" value="member" />
+      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971" />
+      <node concept="312cEg" id="4WflrVaDO5l" role="8Wnug">
+        <property role="TrG5h" value="SLANG_ATTRIBUTE_LANGUAGE" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tmbuc" id="5JNiskhxFfb" role="1B3o_S" />
+        <node concept="3uibUv" id="4WflrVaDNUB" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskhvXBZ" role="jymVt">
       <property role="TrG5h" value="slangAttributeLanguage" />
       <node concept="3clFbS" id="5JNiskhvXC0" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhvXC1" role="3cqZAp">
-          <node concept="37vLTw" id="5JNiskhvXC2" role="3clFbG">
-            <ref role="3cqZAo" node="4WflrVaDO5l" resolve="SLANG_ATTRIBUTE_LANGUAGE" />
+        <node concept="3clFbF" id="7OJcYqwaw$E" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwa$Iv" role="3clFbG">
+            <node concept="1rXfSq" id="7OJcYqwmNK1" role="2Oq$k0">
+              <ref role="37wK5l" node="7OJcYqwUZco" resolve="getAttributeLanguage" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwaDtk" role="2OqNvi">
+              <ref role="37wK5l" node="7OJcYqvN0Q9" resolve="getSlang" />
+            </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5JNiskhvXC3" role="1B3o_S" />
       <node concept="3uibUv" id="5JNiskhvXC4" role="3clF45">
         <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqwXwT1" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqwXqX5" role="jymVt">
+      <property role="TrG5h" value="listLcLanguages" />
+      <node concept="3Tm1VV" id="7OJcYqwXqX7" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqwXqX8" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqwXqX9" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqwXqXa" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwX_tX" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqwX_tV" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqwXDP5" role="2ShVmc">
+              <node concept="3uibUv" id="7OJcYqwXLtq" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqwXTIv" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwirz6" resolve="getM3" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqwY1OK" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwirze" resolve="getLioncoreBuiltins" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwXqXb" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3Cws" role="jymVt" />
@@ -10088,6 +13337,35 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskhYXcG" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqwYKHE" role="jymVt">
+      <property role="TrG5h" value="listClassifiers" />
+      <node concept="3Tm1VV" id="7OJcYqwYKHG" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqwYKHH" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqwYKHI" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqwYKHJ" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwYQMs" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqwYQMq" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqwYUtf" role="2ShVmc">
+              <node concept="3uibUv" id="7OJcYqwZ36x" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqwZbAD" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqwZiz4" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwir$e" resolve="getINamed" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwYKHK" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiskhYXcH" role="jymVt">
       <property role="TrG5h" value="listLcClassifiers" />
       <node concept="3clFbS" id="5JNiskhYXcI" role="3clF47">
@@ -10223,6 +13501,32 @@
     </node>
     <node concept="2tJIrI" id="5JNiskhYXe0" role="jymVt" />
     <node concept="2tJIrI" id="5JNiskhYXe1" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqwZBzt" role="jymVt">
+      <property role="TrG5h" value="listLcProperty" />
+      <node concept="3Tm1VV" id="7OJcYqwZBzv" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqwZBzw" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqwZBzx" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqwZBzy" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwZM4g" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqwZM4e" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqwZPSo" role="2ShVmc">
+              <node concept="3uibUv" id="7OJcYqwZYOw" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx07B6" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwir$m" resolve="getINamedName" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwZBzz" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiskhYXe2" role="jymVt">
       <property role="TrG5h" value="listLcProperties" />
       <node concept="3clFbS" id="5JNiskhYXe3" role="3clF47">
@@ -10342,6 +13646,42 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskhYXfg" role="jymVt" />
+    <node concept="2tJIrI" id="7OJcYqx0zJr" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqx0D9N" role="jymVt">
+      <property role="TrG5h" value="listLcPrimitiveType" />
+      <node concept="3Tm1VV" id="7OJcYqx0D9P" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqx0D9Q" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqx0D9R" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqx0D9S" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqx0JwY" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqx0JwW" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqx0NrY" role="2ShVmc">
+              <node concept="3uibUv" id="7OJcYqx0WB1" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx15UZ" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwirzu" resolve="getBoolean" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx1eRb" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwirzA" resolve="getInteger" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx1mbt" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwirzm" resolve="getString" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx1uo8" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwirzI" resolve="getJson" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx0D9T" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiskhYXfh" role="jymVt">
       <property role="TrG5h" value="listLcPrimitiveTypes" />
       <node concept="3clFbS" id="5JNiskhYXfi" role="3clF47">
@@ -10505,6 +13845,37 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="3clFb_" id="7OJcYqvG8kD" role="jymVt">
+      <property role="TrG5h" value="listSLanguagePrimitiveTypeLanguageKeys" />
+      <node concept="3Tm1VV" id="7OJcYqvG8kF" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqvG8kG" role="3clF45">
+        <node concept="17QB3L" id="7OJcYqvG8kH" role="_ZDj9" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqvG8kI" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvGdgt" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqvGdgu" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqvGdgv" role="2ShVmc">
+              <node concept="17QB3L" id="7OJcYqvGdgw" role="HW$YZ" />
+              <node concept="1rXfSq" id="7OJcYqvGn95" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqvGr7o" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqvGuDA" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqvGybO" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqvG8kJ" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="5JNiskhYXgI" role="jymVt" />
     <node concept="3clFb_" id="5JNiskhYXgJ" role="jymVt">
       <property role="TrG5h" value="isMpsInternalConcept" />
@@ -10523,9 +13894,6 @@
             <node concept="3clFbS" id="5JNiskhYXgR" role="3Kbo56">
               <node concept="3cpWs6" id="5JNiskhYXgS" role="3cqZAp">
                 <node concept="2OqwBi" id="5JNiskhYXgT" role="3cqZAk">
-                  <node concept="1rXfSq" id="5JNiskhYXgU" role="2Oq$k0">
-                    <ref role="37wK5l" node="5JNiskhYXhP" resolve="listMpsInternalClassifiers" />
-                  </node>
                   <node concept="3JPx81" id="5JNiskhYXgV" role="2OqNvi">
                     <node concept="1PxgMI" id="5JNiskhYXgW" role="25WWJ7">
                       <node concept="chp4Y" id="5JNiskhYXgX" role="3oSUPX">
@@ -10533,6 +13901,31 @@
                       </node>
                       <node concept="37vLTw" id="5JNiskhYXgY" role="1m5AlR">
                         <ref role="3cqZAo" node="5JNiskhYXh3" resolve="mpsConcept" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqx8EcH" role="2Oq$k0">
+                    <node concept="1rXfSq" id="7OJcYqx8EcI" role="2Oq$k0">
+                      <ref role="37wK5l" node="7OJcYqx1NIa" resolve="listMpsInternalClassifier" />
+                    </node>
+                    <node concept="3$u5V9" id="7OJcYqx8EcJ" role="2OqNvi">
+                      <node concept="1bVj0M" id="7OJcYqx8EcK" role="23t8la">
+                        <node concept="3clFbS" id="7OJcYqx8EcL" role="1bW5cS">
+                          <node concept="3clFbF" id="7OJcYqx8EcM" role="3cqZAp">
+                            <node concept="2OqwBi" id="7OJcYqx8EcN" role="3clFbG">
+                              <node concept="37vLTw" id="7OJcYqx8EcO" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7OJcYqx8EcQ" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="7OJcYqx8EcP" role="2OqNvi">
+                                <ref role="37wK5l" node="7OJcYqvKihR" resolve="getMps" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="7OJcYqx8EcQ" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="7OJcYqx8EcR" role="1tU5fm" />
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -10560,22 +13953,49 @@
     </node>
     <node concept="2tJIrI" id="5JNiskhYXhc" role="jymVt" />
     <node concept="3clFb_" id="5JNiskhYXhd" role="jymVt">
-      <property role="TrG5h" value="isMpsInternalConcept" />
+      <property role="TrG5h" value="isMpsInternalElement" />
       <node concept="3clFbS" id="5JNiskhYXhe" role="3clF47">
         <node concept="3clFbJ" id="5JNiskhYXhf" role="3cqZAp">
           <node concept="3clFbS" id="5JNiskhYXhg" role="3clFbx">
             <node concept="3cpWs6" id="5JNiskhYXhh" role="3cqZAp">
               <node concept="2OqwBi" id="5JNiskhYXhi" role="3cqZAk">
-                <node concept="1rXfSq" id="5JNiskhYXhj" role="2Oq$k0">
-                  <ref role="37wK5l" node="5JNiskhYXi3" resolve="listSLanguageInternalClassifiers" />
+                <node concept="2OqwBi" id="7OJcYqx7qdc" role="2Oq$k0">
+                  <node concept="1rXfSq" id="5JNiskhYXhj" role="2Oq$k0">
+                    <ref role="37wK5l" node="7OJcYqx1NIa" resolve="listMpsInternalClassifier" />
+                  </node>
+                  <node concept="3$u5V9" id="7OJcYqx7woy" role="2OqNvi">
+                    <node concept="1bVj0M" id="7OJcYqx7wo$" role="23t8la">
+                      <node concept="3clFbS" id="7OJcYqx7wo_" role="1bW5cS">
+                        <node concept="3clFbF" id="7OJcYqx7_tA" role="3cqZAp">
+                          <node concept="10QFUN" id="7OJcYqxc7a3" role="3clFbG">
+                            <node concept="2OqwBi" id="7OJcYqxc7a0" role="10QFUP">
+                              <node concept="37vLTw" id="7OJcYqxc7a1" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7OJcYqx7woA" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="7OJcYqxc7a2" role="2OqNvi">
+                                <ref role="37wK5l" node="7OJcYqvKizN" resolve="getSlang" />
+                              </node>
+                            </node>
+                            <node concept="3uibUv" id="7OJcYqxccnd" role="10QFUM">
+                              <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="7OJcYqx7woA" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7OJcYqx7woB" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
                 <node concept="3JPx81" id="5JNiskhYXhk" role="2OqNvi">
-                  <node concept="0kSF2" id="5JNiskhYXhl" role="25WWJ7">
-                    <node concept="3uibUv" id="5JNiskhYXhm" role="0kSFW">
-                      <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-                    </node>
-                    <node concept="37vLTw" id="5JNiskhYXhn" role="0kSFX">
+                  <node concept="10QFUN" id="6Z_tmAefksy" role="25WWJ7">
+                    <node concept="37vLTw" id="6Z_tmAefksx" role="10QFUP">
                       <ref role="3cqZAo" node="5JNiskhYXhv" resolve="element" />
+                    </node>
+                    <node concept="3uibUv" id="6Z_tmAefo9Z" role="10QFUM">
+                      <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
                     </node>
                   </node>
                 </node>
@@ -10587,6 +14007,120 @@
               <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
             </node>
             <node concept="37vLTw" id="5JNiskhYXhq" role="2ZW6bz">
+              <ref role="3cqZAo" node="5JNiskhYXhv" resolve="element" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6Z_tmAee6sb" role="3cqZAp">
+          <node concept="3clFbS" id="6Z_tmAee6sd" role="3clFbx">
+            <node concept="3cpWs6" id="6Z_tmAeekkg" role="3cqZAp">
+              <node concept="2OqwBi" id="6Z_tmAeerUd" role="3cqZAk">
+                <node concept="2OqwBi" id="7OJcYqx7S50" role="2Oq$k0">
+                  <node concept="1rXfSq" id="6Z_tmAeenH6" role="2Oq$k0">
+                    <ref role="37wK5l" node="7OJcYqx0D9N" resolve="listLcPrimitiveType" />
+                  </node>
+                  <node concept="3$u5V9" id="7OJcYqx7XOy" role="2OqNvi">
+                    <node concept="1bVj0M" id="7OJcYqx7XO$" role="23t8la">
+                      <node concept="3clFbS" id="7OJcYqx7XO_" role="1bW5cS">
+                        <node concept="3clFbF" id="7OJcYqx82WL" role="3cqZAp">
+                          <node concept="10QFUN" id="7OJcYqxchzk" role="3clFbG">
+                            <node concept="2OqwBi" id="7OJcYqxchzh" role="10QFUP">
+                              <node concept="37vLTw" id="7OJcYqxchzi" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7OJcYqx7XOA" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="7OJcYqxchzj" role="2OqNvi">
+                                <ref role="37wK5l" node="7OJcYqvKizN" resolve="getSlang" />
+                              </node>
+                            </node>
+                            <node concept="3uibUv" id="7OJcYqxcmK$" role="10QFUM">
+                              <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="7OJcYqx7XOA" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7OJcYqx7XOB" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3JPx81" id="6Z_tmAeewCL" role="2OqNvi">
+                  <node concept="10QFUN" id="6Z_tmAefv4U" role="25WWJ7">
+                    <node concept="37vLTw" id="6Z_tmAefv4T" role="10QFUP">
+                      <ref role="3cqZAo" node="5JNiskhYXhv" resolve="element" />
+                    </node>
+                    <node concept="3uibUv" id="6Z_tmAefyuf" role="10QFUM">
+                      <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2ZW3vV" id="6Z_tmAeedi4" role="3clFbw">
+            <node concept="3uibUv" id="6Z_tmAeegPJ" role="2ZW6by">
+              <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+            </node>
+            <node concept="37vLTw" id="6Z_tmAee9GV" role="2ZW6bz">
+              <ref role="3cqZAo" node="5JNiskhYXhv" resolve="element" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6Z_tmAefDau" role="3cqZAp">
+          <node concept="3clFbS" id="6Z_tmAefDaw" role="3clFbx">
+            <node concept="3cpWs6" id="6Z_tmAefR8O" role="3cqZAp">
+              <node concept="2OqwBi" id="6Z_tmAegjuh" role="3cqZAk">
+                <node concept="2OqwBi" id="7OJcYqx8jtI" role="2Oq$k0">
+                  <node concept="1rXfSq" id="6Z_tmAefXg3" role="2Oq$k0">
+                    <ref role="37wK5l" node="7OJcYqx2F8j" resolve="listMpsInternalFeature" />
+                  </node>
+                  <node concept="3$u5V9" id="7OJcYqx8or$" role="2OqNvi">
+                    <node concept="1bVj0M" id="7OJcYqx8orA" role="23t8la">
+                      <node concept="3clFbS" id="7OJcYqx8orB" role="1bW5cS">
+                        <node concept="3clFbF" id="7OJcYqx8sKv" role="3cqZAp">
+                          <node concept="10QFUN" id="7OJcYqxcrXu" role="3clFbG">
+                            <node concept="2OqwBi" id="7OJcYqxcrXr" role="10QFUP">
+                              <node concept="37vLTw" id="7OJcYqxcrXs" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7OJcYqx8orC" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="7OJcYqxcrXt" role="2OqNvi">
+                                <ref role="37wK5l" node="7OJcYqvKizN" resolve="getSlang" />
+                              </node>
+                            </node>
+                            <node concept="3uibUv" id="7OJcYqxcxc8" role="10QFUM">
+                              <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="7OJcYqx8orC" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7OJcYqx8orD" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3JPx81" id="6Z_tmAegoe$" role="2OqNvi">
+                  <node concept="1eOMI4" id="6Z_tmAeg8n1" role="25WWJ7">
+                    <node concept="10QFUN" id="6Z_tmAeg8n0" role="1eOMHV">
+                      <node concept="37vLTw" id="6Z_tmAeg8mZ" role="10QFUP">
+                        <ref role="3cqZAo" node="5JNiskhYXhv" resolve="element" />
+                      </node>
+                      <node concept="3uibUv" id="6Z_tmAegbWN" role="10QFUM">
+                        <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2ZW3vV" id="6Z_tmAefK3D" role="3clFbw">
+            <node concept="3uibUv" id="6Z_tmAefNy9" role="2ZW6by">
+              <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
+            </node>
+            <node concept="37vLTw" id="6Z_tmAefGFD" role="2ZW6bz">
               <ref role="3cqZAo" node="5JNiskhYXhv" resolve="element" />
             </node>
           </node>
@@ -10625,13 +14159,40 @@
         </node>
       </node>
       <node concept="3clFbS" id="5JNiskisDQX" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiznGr" role="3cqZAp">
-          <node concept="2OqwBi" id="5JNiskizr$X" role="3clFbG">
-            <node concept="1rXfSq" id="5JNiskiznGp" role="2Oq$k0">
-              <ref role="37wK5l" node="5JNiskix7ir" resolve="listSLanguageInternalFeatures" />
+        <node concept="3clFbF" id="7OJcYqx6YcN" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqx6YcO" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqx6YcP" role="2Oq$k0">
+              <node concept="1rXfSq" id="7OJcYqx6YcQ" role="2Oq$k0">
+                <ref role="37wK5l" node="7OJcYqx2F8j" resolve="listMpsInternalFeature" />
+              </node>
+              <node concept="3$u5V9" id="7OJcYqx6YcR" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYqx6YcS" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYqx6YcT" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYqx6YcU" role="3cqZAp">
+                      <node concept="10QFUN" id="7OJcYqxcIG_" role="3clFbG">
+                        <node concept="2OqwBi" id="7OJcYqxcIGy" role="10QFUP">
+                          <node concept="37vLTw" id="7OJcYqxcIGz" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqx6Yd0" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqxcIG$" role="2OqNvi">
+                            <ref role="37wK5l" node="7OJcYqvKizN" resolve="getSlang" />
+                          </node>
+                        </node>
+                        <node concept="3uibUv" id="7OJcYqxcNGh" role="10QFUM">
+                          <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYqx6Yd0" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYqx6Yd1" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
             </node>
-            <node concept="3JPx81" id="5JNiskizvDR" role="2OqNvi">
-              <node concept="37vLTw" id="5JNiskizzmC" role="25WWJ7">
+            <node concept="3JPx81" id="7OJcYqx6Yd2" role="2OqNvi">
+              <node concept="37vLTw" id="7OJcYqx6Yd3" role="25WWJ7">
                 <ref role="3cqZAo" node="5JNiskisDQO" resolve="feature" />
               </node>
             </node>
@@ -10657,8 +14218,33 @@
       <node concept="3clFbS" id="5JNiskisDRe" role="3clF47">
         <node concept="3clFbF" id="5JNiskizHvL" role="3cqZAp">
           <node concept="2OqwBi" id="5JNiskizLC2" role="3clFbG">
-            <node concept="1rXfSq" id="5JNiskizHvJ" role="2Oq$k0">
-              <ref role="37wK5l" node="5JNiskix7id" resolve="listMpsInternalFeatures" />
+            <node concept="2OqwBi" id="7OJcYqx6sn6" role="2Oq$k0">
+              <node concept="1rXfSq" id="5JNiskizHvJ" role="2Oq$k0">
+                <ref role="37wK5l" node="7OJcYqx2F8j" resolve="listMpsInternalFeature" />
+              </node>
+              <node concept="3$u5V9" id="7OJcYqx6y4M" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYqx6y4O" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYqx6y4P" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYqx6B8g" role="3cqZAp">
+                      <node concept="10QFUN" id="7OJcYqx6O0B" role="3clFbG">
+                        <node concept="2OqwBi" id="7OJcYqx6O0$" role="10QFUP">
+                          <node concept="37vLTw" id="7OJcYqx6O0_" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqx6y4Q" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqx6O0A" role="2OqNvi">
+                            <ref role="37wK5l" node="7OJcYqvKihR" resolve="getMps" />
+                          </node>
+                        </node>
+                        <node concept="3Tqbb2" id="7OJcYqx6TfZ" role="10QFUM" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYqx6y4Q" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYqx6y4R" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
             </node>
             <node concept="3JPx81" id="5JNiskizQwd" role="2OqNvi">
               <node concept="37vLTw" id="5JNiskizTRt" role="25WWJ7">
@@ -10678,8 +14264,13 @@
       <node concept="3clFbS" id="5JNiskhYXhE" role="3clF47">
         <node concept="3clFbF" id="5JNiskhYXhF" role="3cqZAp">
           <node concept="17R0WA" id="5JNiskhYXhG" role="3clFbG">
-            <node concept="1rXfSq" id="5JNiskhYXhH" role="3uHU7w">
-              <ref role="37wK5l" node="5JNiskhsfjt" resolve="slangAnnotationContainment" />
+            <node concept="2OqwBi" id="7OJcYqx6bkf" role="3uHU7w">
+              <node concept="1rXfSq" id="7OJcYqx662a" role="2Oq$k0">
+                <ref role="37wK5l" node="7OJcYqwir$6" resolve="getAnnotationContainment" />
+              </node>
+              <node concept="liA8E" id="7OJcYqx6gPy" role="2OqNvi">
+                <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+              </node>
             </node>
             <node concept="37vLTw" id="5JNiskhYXhI" role="3uHU7B">
               <ref role="3cqZAo" node="5JNiskhYXhL" resolve="containment" />
@@ -10700,6 +14291,35 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskhYXhO" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqx1NIa" role="jymVt">
+      <property role="TrG5h" value="listMpsInternalClassifier" />
+      <node concept="3Tm1VV" id="7OJcYqx1NIc" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqx1NId" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqx1NIe" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqx1NIf" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqx1Uh6" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqx1Uh4" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqx1YAc" role="2ShVmc">
+              <node concept="3uibUv" id="7OJcYqx288_" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx2htG" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx2qFs" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwirzY" resolve="getAnnotation" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx1NIg" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiskhYXhP" role="jymVt">
       <property role="TrG5h" value="listMpsInternalClassifiers" />
       <node concept="3clFbS" id="5JNiskhYXhQ" role="3clF47">
@@ -10781,6 +14401,31 @@
         </node>
       </node>
     </node>
+    <node concept="3clFb_" id="7OJcYqvHsZE" role="jymVt">
+      <property role="TrG5h" value="listSLanguageInternalClassifierLanguageKeys" />
+      <node concept="3Tm1VV" id="7OJcYqvHsZG" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqvHsZH" role="3clF45">
+        <node concept="17QB3L" id="7OJcYqvHsZI" role="_ZDj9" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqvHsZJ" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvHy52" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqvHy50" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqvH_BY" role="2ShVmc">
+              <node concept="17QB3L" id="7OJcYqvHGxI" role="HW$YZ" />
+              <node concept="1rXfSq" id="7OJcYqvHNaL" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqvHUaA" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhqTR7" resolve="keyM3Language" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqvHsZK" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiskhYXin" role="jymVt">
       <property role="TrG5h" value="listSClassifierInternalIds" />
       <node concept="3clFbS" id="5JNiskhYXio" role="3clF47">
@@ -10825,6 +14470,32 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskixn4F" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqx2F8j" role="jymVt">
+      <property role="TrG5h" value="listMpsInternalFeature" />
+      <node concept="3Tm1VV" id="7OJcYqx2F8l" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqx2F8m" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqx2F8n" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqx2F8o" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqx2QyC" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqx2QyA" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqx2UOb" role="2ShVmc">
+              <node concept="3uibUv" id="7OJcYqx33I5" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqx3dhF" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwir$6" resolve="getAnnotationContainment" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx2F8p" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiskix7id" role="jymVt">
       <property role="TrG5h" value="listMpsInternalFeatures" />
       <node concept="3clFbS" id="5JNiskix7ie" role="3clF47">
@@ -10867,7 +14538,7 @@
           </node>
         </node>
       </node>
-      <node concept="3Tmbuc" id="5JNiskixywt" role="1B3o_S" />
+      <node concept="3Tm1VV" id="6Z_tmAegC7g" role="1B3o_S" />
       <node concept="_YKpA" id="5JNiskix7i$" role="3clF45">
         <node concept="3uibUv" id="5JNiskix7i_" role="_ZDj9">
           <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
@@ -10909,7 +14580,7 @@
           </node>
         </node>
       </node>
-      <node concept="3Tmbuc" id="5JNiskiz6YG" role="1B3o_S" />
+      <node concept="3Tm1VV" id="6Z_tmAegSM$" role="1B3o_S" />
       <node concept="_YKpA" id="5JNiskix7iS" role="3clF45">
         <node concept="17QB3L" id="5JNiskix7iT" role="_ZDj9" />
       </node>
@@ -10933,6 +14604,28 @@
         <node concept="x79VA" id="5JNiskix7j2" role="3nqlJM">
           <property role="x79VB" value="All MPS concept features that need special treatment in LionWeb." />
         </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvFAaf" role="jymVt">
+      <property role="TrG5h" value="listSClassifierInternalFeatureLanguageKeys" />
+      <node concept="3Tm1VV" id="7OJcYqvFAah" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqvFAai" role="3clF45">
+        <node concept="17QB3L" id="7OJcYqvFAaj" role="_ZDj9" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqvFAak" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvFFc0" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqvFFbY" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqvFKXm" role="2ShVmc">
+              <node concept="17QB3L" id="7OJcYqvFQyl" role="HW$YZ" />
+              <node concept="1rXfSq" id="7OJcYqvFXag" role="HW$Y0">
+                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqvFAal" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskixnqO" role="jymVt" />
@@ -10985,66 +14678,216 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5M3rB6_QhP3" role="jymVt" />
-    <node concept="2YIFZL" id="5M3rB6_QlA6" role="jymVt">
-      <property role="TrG5h" value="extractKey" />
-      <node concept="3clFbS" id="5M3rB6_QlAc" role="3clF47">
-        <node concept="3cpWs8" id="2M_CqyUJRdD" role="3cqZAp">
-          <node concept="3cpWsn" id="2M_CqyUJRdE" role="3cpWs9">
-            <property role="TrG5h" value="node" />
-            <node concept="3uibUv" id="2M_CqyUJRdF" role="1tU5fm">
-              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
-            </node>
-            <node concept="37vLTw" id="2M_CqyUJSIU" role="33vP2m">
-              <ref role="3cqZAo" node="5M3rB6_QlAa" resolve="keyed" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs6" id="5M3rB6_QlAd" role="3cqZAp">
-          <node concept="2YIFZM" id="5M3rB6Bhih1" role="3cqZAk">
-            <ref role="37wK5l" to="33ny:~Objects.requireNonNull(java.lang.Object,java.lang.String)" resolve="requireNonNull" />
-            <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
-            <node concept="2OqwBi" id="2M_CqyUJVzp" role="37wK5m">
-              <node concept="37vLTw" id="2M_CqyUJUxY" role="2Oq$k0">
-                <ref role="3cqZAo" node="2M_CqyUJRdE" resolve="node" />
-              </node>
-              <node concept="liA8E" id="2M_CqyUJWnI" role="2OqNvi">
-                <ref role="37wK5l" to="mhbf:~SNode.getProperty(org.jetbrains.mps.openapi.language.SProperty)" resolve="getProperty" />
-                <node concept="355D3s" id="2M_CqyUJYAI" role="37wK5m">
-                  <ref role="355D3t" to="h3y3:6jTTMHCXLTP" resolve="IKeyed" />
-                  <ref role="355D3u" to="h3y3:2ju2syjkkk9" resolve="key" />
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs3" id="5M3rB6Bhihc" role="37wK5m">
-              <node concept="37vLTw" id="5M3rB6Bhihd" role="3uHU7w">
-                <ref role="3cqZAo" node="2M_CqyUJRdE" resolve="node" />
-              </node>
-              <node concept="Xl_RD" id="5M3rB6Bhihe" role="3uHU7B">
-                <property role="Xl_RC" value="missing key: " />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="17QB3L" id="5M3rB6_QlA9" role="3clF45" />
-      <node concept="37vLTG" id="5M3rB6_QlAa" role="3clF46">
-        <property role="TrG5h" value="keyed" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3Tqbb2" id="5M3rB6_QlAb" role="1tU5fm">
-          <ref role="ehGHo" to="h3y3:6jTTMHCXLTP" resolve="IKeyed" />
-        </node>
-        <node concept="2AHcQZ" id="5M3rB6BhjoI" role="2AJF6D">
-          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
-        </node>
-      </node>
-      <node concept="3Tmbuc" id="5JNiskhZFpA" role="1B3o_S" />
-      <node concept="2AHcQZ" id="5M3rB6_Qndx" role="2AJF6D">
-        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
-      </node>
-    </node>
     <node concept="3Tm1VV" id="5JNiskhYWOF" role="1B3o_S" />
     <node concept="3uibUv" id="5JNiski3xOw" role="EKbjA">
       <ref role="3uigEE" node="5JNiski3jVc" resolve="ILionCoreConstants_2023_1" />
+    </node>
+    <node concept="3clFb_" id="7OJcYqwirz6" role="jymVt">
+      <property role="TrG5h" value="getM3" />
+      <node concept="3uibUv" id="7OJcYqwirz7" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwirz8" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwirz9" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwirza" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwirz3" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwirz4" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwirz5" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvS5bN" resolve="M3_LANGUAGE" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwirze" role="jymVt">
+      <property role="TrG5h" value="getLioncoreBuiltins" />
+      <node concept="3uibUv" id="7OJcYqwirzf" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwirzg" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwirzh" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwirzi" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwirzb" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwirzc" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwirzd" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvScQL" resolve="LIONCORE_BUILTINS" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwirzm" role="jymVt">
+      <property role="TrG5h" value="getString" />
+      <node concept="3uibUv" id="7OJcYqwirzn" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwirzo" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwirzp" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwirzq" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwirzj" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwirzk" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwirzl" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvSkE$" resolve="STRING" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwirzu" role="jymVt">
+      <property role="TrG5h" value="getBoolean" />
+      <node concept="3uibUv" id="7OJcYqwirzv" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwirzw" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwirzx" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwirzy" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwirzr" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwirzs" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwirzt" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvSsAf" resolve="BOOLEAN" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwirzA" role="jymVt">
+      <property role="TrG5h" value="getInteger" />
+      <node concept="3uibUv" id="7OJcYqwirzB" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwirzC" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwirzD" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwirzE" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwirzz" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwirz$" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwirz_" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvSxpd" resolve="INTEGER" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwirzI" role="jymVt">
+      <property role="TrG5h" value="getJson" />
+      <node concept="3uibUv" id="7OJcYqwirzJ" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqw2ryQ" resolve="ConstrainedPrimitiveTypeKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwirzK" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwirzL" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwirzM" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwirzF" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwirzG" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwirzH" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvSGCF" resolve="JSON" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwirzQ" role="jymVt">
+      <property role="TrG5h" value="getNode" />
+      <node concept="3uibUv" id="7OJcYqwirzR" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwirzS" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwirzT" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwirzU" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwirzN" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwirzO" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwirzP" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvSOTI" resolve="NODE" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwirzY" role="jymVt">
+      <property role="TrG5h" value="getAnnotation" />
+      <node concept="3uibUv" id="7OJcYqwirzZ" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwir$0" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwir$1" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwir$2" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwirzV" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwirzW" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwirzX" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvSX4c" resolve="ANNOTATION" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwir$6" role="jymVt">
+      <property role="TrG5h" value="getAnnotationContainment" />
+      <node concept="3uibUv" id="7OJcYqwir$7" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvQ8aH" resolve="ContainmentKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwir$8" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwir$9" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwir$a" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwir$3" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwir$4" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwir$5" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvT58p" resolve="ANNOTATION_CONTAINMENT" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwir$e" role="jymVt">
+      <property role="TrG5h" value="getINamed" />
+      <node concept="3uibUv" id="7OJcYqwir$f" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvXZ8V" resolve="InterfaceKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwir$g" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwir$h" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwir$i" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwir$b" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwir$c" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwir$d" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvTdFq" resolve="INAMED" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwir$m" role="jymVt">
+      <property role="TrG5h" value="getINamedName" />
+      <node concept="3uibUv" id="7OJcYqwir$n" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwir$o" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwir$p" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwir$q" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwir$j" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwir$k" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwir$l" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvTlIS" resolve="NAME" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwUZco" role="jymVt">
+      <property role="TrG5h" value="getAttributeLanguage" />
+      <node concept="3uibUv" id="7OJcYqwUZcp" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwUZcq" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwUZcR" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwV9ie" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwVb6L" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwV9ib" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwVfjU" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqw99Yc" resolve="ATTRIBUTE_LANGUAGE" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwUZcS" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
   </node>
   <node concept="3HP615" id="5JNiski3jVc">
@@ -11056,17 +14899,64 @@
       <node concept="17QB3L" id="5JNiski3jVg" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5JNiski3jVh" role="jymVt" />
+    <node concept="2tJIrI" id="7OJcYqwQlCm" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqwQm1k" role="jymVt">
+      <property role="TrG5h" value="getString" />
+      <node concept="3uibUv" id="7OJcYqwQm1l" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwQm1m" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQm1n" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqwQD9g" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwQD9h" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQD9i" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.m3.builtin.Built-in DataTypes.String" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwQDP3" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQDP4" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.core.structure.string" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwQE3p" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQE3q" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwQEhL" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQEhM" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.string as " />
+          </node>
+          <node concept="1dT_AA" id="7OJcYqwQEhN" role="1dT_Ay">
+            <node concept="92FcH" id="7OJcYqwQEhO" role="qph3F">
+              <node concept="TZ5HA" id="7OJcYqwQEhP" role="2XjZqd" />
+              <node concept="VXe08" id="7OJcYqwQEhQ" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SDataType" resolve="SDataType" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="7OJcYqwQEhR" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwQEwl" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQEwm" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: LionCore-builtins-String" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwQEIQ" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQEIR" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c/1082983041843" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiski3jVi" role="jymVt">
       <property role="TrG5h" value="lcStringType" />
       <node concept="3clFbS" id="5JNiski3jVj" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jVk" role="1B3o_S" />
       <node concept="3Tqbb2" id="5JNiski3jVl" role="3clF45">
         <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$pgd" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$pgg" role="3nqlJM">
-          <property role="x79VB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.String" />
-        </node>
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVm" role="jymVt">
@@ -11076,11 +14966,6 @@
       <node concept="3Tqbb2" id="5JNiski3jVp" role="3clF45">
         <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
       </node>
-      <node concept="P$JXv" id="5M8g5cS$pDp" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$pDs" role="3nqlJM">
-          <property role="x79VB" value="jetbrains.mps.lang.core.structure.string" />
-        </node>
-      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVq" role="jymVt">
       <property role="TrG5h" value="slangStringType" />
@@ -11089,82 +14974,43 @@
       <node concept="3uibUv" id="5JNiski3jVt" role="3clF45">
         <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
       </node>
-      <node concept="P$JXv" id="5M8g5cS$s9Z" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS$sa0" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS$sa1" role="1dT_Ay">
-            <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.string as " />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS$smz" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS$smL" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS$smN" role="2XjZqd" />
-              <node concept="VXe08" id="5M8g5cS$sn2" role="92FcQ">
-                <ref role="VXe09" to="c17a:~SDataType" resolve="SDataType" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS$smy" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVu" role="jymVt">
       <property role="TrG5h" value="keyStringType" />
       <node concept="3clFbS" id="5JNiski3jVv" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jVw" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jVx" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr$WmY" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr$Wn1" role="3nqlJM">
-          <property role="x79VB" value="LionCore-builtins-String" />
-        </node>
-      </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVy" role="jymVt">
       <property role="TrG5h" value="idStringType" />
       <node concept="3clFbS" id="5JNiski3jVz" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jV$" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jV_" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr$Yaz" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr$YaA" role="3nqlJM">
-          <property role="x79VB" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1082983041843" />
-        </node>
-      </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jVA" role="jymVt" />
-    <node concept="3clFb_" id="5JNiski3jVB" role="jymVt">
-      <property role="TrG5h" value="lcBooleanType" />
-      <node concept="3clFbS" id="5JNiski3jVC" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jVD" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jVE" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+    <node concept="3clFb_" id="7OJcYqwQm1t" role="jymVt">
+      <property role="TrG5h" value="getBoolean" />
+      <node concept="3uibUv" id="7OJcYqwQm1u" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
       </node>
-      <node concept="P$JXv" id="5M8g5cS$szI" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$szL" role="3nqlJM">
-          <property role="x79VB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.Boolean" />
+      <node concept="3Tm1VV" id="7OJcYqwQm1v" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQm1w" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqwQS4H" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwQS4I" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQS4J" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.m3.builtin.Built-in DataTypes.Boolean" />
+          </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jVF" role="jymVt">
-      <property role="TrG5h" value="mpsBooleanType" />
-      <node concept="3clFbS" id="5JNiski3jVG" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jVH" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jVI" role="3clF45">
-        <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$sWU" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$sWX" role="3nqlJM">
-          <property role="x79VB" value="jetbrains.mps.lang.core.structure.boolean" />
+        <node concept="TZ5HA" id="7OJcYqwQSj9" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQSja" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.core.structure.boolean" />
+          </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jVJ" role="jymVt">
-      <property role="TrG5h" value="slangBooleanType" />
-      <node concept="3clFbS" id="5JNiski3jVK" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jVL" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jVM" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$tlY" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwQSxv" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQSxw" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
         <node concept="TZ5HA" id="5M8g5cS$tyx" role="TZ5H$">
           <node concept="1dT_AC" id="5M8g5cS$tyy" role="1dT_Ay">
             <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.boolean as " />
@@ -11181,6 +15027,64 @@
             <property role="1dT_AB" value="" />
           </node>
         </node>
+        <node concept="TZ5HA" id="7OJcYqwQSJR" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQSJS" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: LionCore-builtins-Boolean" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwQSYh" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQSYi" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c/1082983657063" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jVB" role="jymVt">
+      <property role="TrG5h" value="lcBooleanType" />
+      <node concept="3clFbS" id="5JNiski3jVC" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jVD" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiski3jVE" role="3clF45">
+        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx3i2F" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3i2G" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3i2H" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3i2I" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jVF" role="jymVt">
+      <property role="TrG5h" value="mpsBooleanType" />
+      <node concept="3clFbS" id="5JNiski3jVG" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jVH" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiski3jVI" role="3clF45">
+        <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx3kbZ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3kc0" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3kc1" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3kc2" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jVJ" role="jymVt">
+      <property role="TrG5h" value="slangBooleanType" />
+      <node concept="3clFbS" id="5JNiski3jVK" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jVL" role="1B3o_S" />
+      <node concept="3uibUv" id="5JNiski3jVM" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx3mlF" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3mlG" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3mlH" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3mlI" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVN" role="jymVt">
@@ -11188,10 +15092,13 @@
       <node concept="3clFbS" id="5JNiski3jVO" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jVP" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jVQ" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr$ZCf" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr$ZCi" role="3nqlJM">
-          <property role="x79VB" value="LionCore-builtins-Boolean" />
+      <node concept="P$JXv" id="7OJcYqx3ovJ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3ovK" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3ovL" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3ovM" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jVR" role="jymVt">
@@ -11199,47 +15106,39 @@
       <node concept="3clFbS" id="5JNiski3jVS" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jVT" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jVU" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_00J" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_00M" role="3nqlJM">
-          <property role="x79VB" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1082983657063" />
+      <node concept="P$JXv" id="7OJcYqx3qEb" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3qEc" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3qEd" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3qEe" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jVV" role="jymVt" />
-    <node concept="3clFb_" id="5JNiski3jVW" role="jymVt">
-      <property role="TrG5h" value="lcIntegerType" />
-      <node concept="3clFbS" id="5JNiski3jVX" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jVY" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jVZ" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+    <node concept="3clFb_" id="7OJcYqwQm1A" role="jymVt">
+      <property role="TrG5h" value="getInteger" />
+      <node concept="3uibUv" id="7OJcYqwQm1B" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvL3W3" resolve="PrimitiveTypeKeyedMapping" />
       </node>
-      <node concept="P$JXv" id="5M8g5cS$u7Z" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$u82" role="3nqlJM">
-          <property role="x79VB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.Integer" />
+      <node concept="3Tm1VV" id="7OJcYqwQm1C" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQm1D" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqwQV2J" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwR0yT" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwR0yU" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.m3.builtin.Built-in DataTypes.Integer" />
+          </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jW0" role="jymVt">
-      <property role="TrG5h" value="mpsIntegerType" />
-      <node concept="3clFbS" id="5JNiski3jW1" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jW2" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jW3" role="3clF45">
-        <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$uUn" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$uUq" role="3nqlJM">
-          <property role="x79VB" value="jetbrains.mps.lang.core.structure.integer" />
+        <node concept="TZ5HA" id="7OJcYqwR0yV" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwR0yW" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.core.structure.integer" />
+          </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jW4" role="jymVt">
-      <property role="TrG5h" value="slangIntegerType" />
-      <node concept="3clFbS" id="5JNiski3jW5" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jW6" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jW7" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$vjz" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwR0yX" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwR0yY" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
         <node concept="TZ5HA" id="5M8g5cS$vw6" role="TZ5H$">
           <node concept="1dT_AC" id="5M8g5cS$vw7" role="1dT_Ay">
             <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.integer as " />
@@ -11256,6 +15155,64 @@
             <property role="1dT_AB" value="" />
           </node>
         </node>
+        <node concept="TZ5HA" id="7OJcYqwR0yZ" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwR0z0" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: LionCore-builtins-Integer" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwR0z1" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwR0z2" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c/1082983657062" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jVW" role="jymVt">
+      <property role="TrG5h" value="lcIntegerType" />
+      <node concept="3clFbS" id="5JNiski3jVX" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jVY" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiski3jVZ" role="3clF45">
+        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx3sOZ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3sP0" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3sP1" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3sP2" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jW0" role="jymVt">
+      <property role="TrG5h" value="mpsIntegerType" />
+      <node concept="3clFbS" id="5JNiski3jW1" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jW2" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiski3jW3" role="3clF45">
+        <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx3v0b" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3v0c" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3v0d" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3v0e" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jW4" role="jymVt">
+      <property role="TrG5h" value="slangIntegerType" />
+      <node concept="3clFbS" id="5JNiski3jW5" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jW6" role="1B3o_S" />
+      <node concept="3uibUv" id="5JNiski3jW7" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx3xbJ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3xbK" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3xbL" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3xbM" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jW8" role="jymVt">
@@ -11263,10 +15220,13 @@
       <node concept="3clFbS" id="5JNiski3jW9" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jWa" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jWb" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_1o8" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_1ob" role="3nqlJM">
-          <property role="x79VB" value="LionCore-builtins-Integer" />
+      <node concept="P$JXv" id="7OJcYqx3znF" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3znG" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3znH" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3znI" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jWc" role="jymVt">
@@ -11274,47 +15234,39 @@
       <node concept="3clFbS" id="5JNiski3jWd" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jWe" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jWf" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_2PL" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_2PO" role="3nqlJM">
-          <property role="x79VB" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1082983657062" />
+      <node concept="P$JXv" id="7OJcYqx3_zZ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3_$0" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3_$1" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3_$2" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jWg" role="jymVt" />
-    <node concept="3clFb_" id="5JNiski3jWh" role="jymVt">
-      <property role="TrG5h" value="lcJsonType" />
-      <node concept="3clFbS" id="5JNiski3jWi" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWj" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jWk" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+    <node concept="3clFb_" id="7OJcYqwQm1J" role="jymVt">
+      <property role="TrG5h" value="getJson" />
+      <node concept="3uibUv" id="7OJcYqwQm1K" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqw2ryQ" resolve="ConstrainedPrimitiveTypeKeyedMapping" />
       </node>
-      <node concept="P$JXv" id="5M8g5cS$uxb" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$uxe" role="3nqlJM">
-          <property role="x79VB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.JSON" />
+      <node concept="3Tm1VV" id="7OJcYqwQm1L" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQm1M" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqwQVhd" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwR05S" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwR05T" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.m3.builtin.Built-in DataTypes.JSON" />
+          </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWl" role="jymVt">
-      <property role="TrG5h" value="mpsJsonType" />
-      <node concept="3clFbS" id="5JNiski3jWm" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWn" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jWo" role="3clF45">
-        <ref role="ehGHo" to="tpce:fKAz7CR" resolve="ConstrainedDataTypeDeclaration" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$w5$" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$w5B" role="3nqlJM">
-          <property role="x79VB" value="io.lionweb.mps.m3.structure.JSON" />
+        <node concept="TZ5HA" id="7OJcYqwR05U" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwR05V" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: io.lionweb.mps.m3.structure.JSON" />
+          </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWp" role="jymVt">
-      <property role="TrG5h" value="slangJsonType" />
-      <node concept="3clFbS" id="5JNiski3jWq" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWr" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jWs" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$yBI" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwR05W" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwR05X" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
         <node concept="TZ5HA" id="5M8g5cS$yBJ" role="TZ5H$">
           <node concept="1dT_AC" id="5M8g5cS$yOh" role="1dT_Ay">
             <property role="1dT_AB" value="io.lionweb.mps.m3.structure.JSON as " />
@@ -11329,6 +15281,64 @@
           </node>
           <node concept="1dT_AC" id="5M8g5cS$yBK" role="1dT_Ay" />
         </node>
+        <node concept="TZ5HA" id="7OJcYqwR05Y" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwR05Z" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: LionCore-builtins-JSON" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwR060" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwR061" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: 01cf0d82-8d29-4fc4-be96-28abaf4ad33d/3631234780363744558" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jWh" role="jymVt">
+      <property role="TrG5h" value="lcJsonType" />
+      <node concept="3clFbS" id="5JNiski3jWi" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jWj" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiski3jWk" role="3clF45">
+        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx3BKF" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3BKG" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3BKH" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3BKI" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jWl" role="jymVt">
+      <property role="TrG5h" value="mpsJsonType" />
+      <node concept="3clFbS" id="5JNiski3jWm" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jWn" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiski3jWo" role="3clF45">
+        <ref role="ehGHo" to="tpce:fKAz7CR" resolve="ConstrainedDataTypeDeclaration" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx3DXJ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3DXK" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3DXL" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3DXM" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jWp" role="jymVt">
+      <property role="TrG5h" value="slangJsonType" />
+      <node concept="3clFbS" id="5JNiski3jWq" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jWr" role="1B3o_S" />
+      <node concept="3uibUv" id="5JNiski3jWs" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx3Gbb" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3Gbc" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3Gbd" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3Gbe" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jWt" role="jymVt">
@@ -11336,10 +15346,13 @@
       <node concept="3clFbS" id="5JNiski3jWu" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jWv" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jWw" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_4de" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_4dh" role="3nqlJM">
-          <property role="x79VB" value="LionCore-builtins-JSON" />
+      <node concept="P$JXv" id="7OJcYqx3IoZ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3Ip0" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3Ip1" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3Ip2" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jWx" role="jymVt">
@@ -11347,47 +15360,39 @@
       <node concept="3clFbS" id="5JNiski3jWy" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jWz" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jW$" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_6IL" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_6IO" role="3nqlJM">
-          <property role="x79VB" value="01cf0d82-8d29-4fc4-be96-28abaf4ad33d/3631234780363744558" />
+      <node concept="P$JXv" id="7OJcYqx3KBb" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3KBc" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3KBd" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3KBe" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jW_" role="jymVt" />
-    <node concept="3clFb_" id="5JNiski3jWA" role="jymVt">
-      <property role="TrG5h" value="lcNodeConcept" />
-      <node concept="3clFbS" id="5JNiski3jWB" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWC" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jWD" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjklrv" resolve="Concept" />
+    <node concept="3clFb_" id="7OJcYqwQm1S" role="jymVt">
+      <property role="TrG5h" value="getNode" />
+      <node concept="3uibUv" id="7OJcYqwQm1T" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
       </node>
-      <node concept="P$JXv" id="5M8g5cS$z0X" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$z10" role="3nqlJM">
-          <property role="x79VB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.Node" />
+      <node concept="3Tm1VV" id="7OJcYqwQm1U" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQm1V" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqwQVvF" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwQZCR" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQZCS" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.m3.builtin.Built-in DataTypes.Node" />
+          </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWE" role="jymVt">
-      <property role="TrG5h" value="mpsNodeConcept" />
-      <node concept="3clFbS" id="5JNiski3jWF" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWG" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jWH" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$_z_" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$_zC" role="3nqlJM">
-          <property role="x79VB" value="jetbrains.mps.lang.core.structure.BaseConcept" />
+        <node concept="TZ5HA" id="7OJcYqwQZCT" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQZCU" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.core.structure.BaseConcept" />
+          </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWI" role="jymVt">
-      <property role="TrG5h" value="slangNodeConcept" />
-      <node concept="3clFbS" id="5JNiski3jWJ" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWK" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jWL" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$C7a" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwQZCV" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQZCW" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
         <node concept="TZ5HA" id="5M8g5cS$Cw4" role="TZ5H$">
           <node concept="1dT_AC" id="5M8g5cS$Cw5" role="1dT_Ay">
             <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.BaseConcept as " />
@@ -11402,9 +15407,64 @@
           </node>
           <node concept="1dT_AC" id="5M8g5cS$Cwa" role="1dT_Ay" />
         </node>
-        <node concept="TZ5HA" id="5M8g5cS$C7b" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS$C7c" role="1dT_Ay" />
+        <node concept="TZ5HA" id="7OJcYqwQZCX" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQZCY" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: LionCore-builtins-Node" />
+          </node>
         </node>
+        <node concept="TZ5HA" id="7OJcYqwQZCZ" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQZD0" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jWA" role="jymVt">
+      <property role="TrG5h" value="lcNodeConcept" />
+      <node concept="3clFbS" id="5JNiski3jWB" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jWC" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiski3jWD" role="3clF45">
+        <ref role="ehGHo" to="h3y3:2ju2syjklrv" resolve="Concept" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx3MPJ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3MPK" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3MPL" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3MPM" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jWE" role="jymVt">
+      <property role="TrG5h" value="mpsNodeConcept" />
+      <node concept="3clFbS" id="5JNiski3jWF" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jWG" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiski3jWH" role="3clF45">
+        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx3P4F" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3P4G" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3P4H" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3P4I" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jWI" role="jymVt">
+      <property role="TrG5h" value="slangNodeConcept" />
+      <node concept="3clFbS" id="5JNiski3jWJ" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jWK" role="1B3o_S" />
+      <node concept="3uibUv" id="5JNiski3jWL" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx3RjZ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3Rk0" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3Rk1" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3Rk2" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jWM" role="jymVt">
@@ -11412,10 +15472,13 @@
       <node concept="3clFbS" id="5JNiski3jWN" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jWO" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jWP" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_77h" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_77k" role="3nqlJM">
-          <property role="x79VB" value="LionCore-builtins-Node" />
+      <node concept="P$JXv" id="7OJcYqx3TzF" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3TzG" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3TzH" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3TzI" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jWQ" role="jymVt">
@@ -11423,34 +15486,39 @@
       <node concept="3clFbS" id="5JNiski3jWR" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jWS" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jWT" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_9_f" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_9_i" role="3nqlJM">
-          <property role="x79VB" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626" />
+      <node concept="P$JXv" id="7OJcYqx3VNJ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3VNK" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3VNL" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3VNM" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jWU" role="jymVt" />
-    <node concept="3clFb_" id="5JNiski3jWV" role="jymVt">
-      <property role="TrG5h" value="mpsAnnotationConcept" />
-      <node concept="3clFbS" id="5JNiski3jWW" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWX" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jWY" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+    <node concept="3clFb_" id="7OJcYqwQm21" role="jymVt">
+      <property role="TrG5h" value="getAnnotation" />
+      <node concept="3uibUv" id="7OJcYqwQm22" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
       </node>
-      <node concept="P$JXv" id="5M8g5cS$CGP" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$CGS" role="3nqlJM">
-          <property role="x79VB" value="jetbrains.mps.lang.core.structure.NodeAttribute" />
+      <node concept="3Tm1VV" id="7OJcYqwQm23" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQm24" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqwQVI9" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwQZbQ" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQZbR" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: null" />
+          </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWZ" role="jymVt">
-      <property role="TrG5h" value="slangAnnotationConcept" />
-      <node concept="3clFbS" id="5JNiski3jX0" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jX1" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jX2" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$Fjt" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwQZbS" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQZbT" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.core.structure.NodeAttribute" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwQZbU" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQZbV" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
         <node concept="TZ5HA" id="5M8g5cS$FGn" role="TZ5H$">
           <node concept="1dT_AC" id="5M8g5cS$FGo" role="1dT_Ay">
             <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.NodeAttribute as " />
@@ -11465,9 +15533,48 @@
           </node>
           <node concept="1dT_AC" id="5M8g5cS$FGt" role="1dT_Ay" />
         </node>
-        <node concept="TZ5HA" id="5M8g5cS$Fju" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS$Fjv" role="1dT_Ay" />
+        <node concept="TZ5HA" id="7OJcYqwQZbW" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQZbX" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: null" />
+          </node>
         </node>
+        <node concept="TZ5HA" id="7OJcYqwQZbY" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQZbZ" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c/3364660638048049748" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jWV" role="jymVt">
+      <property role="TrG5h" value="mpsAnnotationConcept" />
+      <node concept="3clFbS" id="5JNiski3jWW" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jWX" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiski3jWY" role="3clF45">
+        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx3Y4b" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx3Y4c" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx3Y4d" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx3Y4e" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jWZ" role="jymVt">
+      <property role="TrG5h" value="slangAnnotationConcept" />
+      <node concept="3clFbS" id="5JNiski3jX0" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jX1" role="1B3o_S" />
+      <node concept="3uibUv" id="5JNiski3jX2" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx40kZ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx40l0" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx40l1" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx40l2" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jX3" role="jymVt">
@@ -11475,20 +15582,39 @@
       <node concept="3clFbS" id="5JNiski3jX4" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jX5" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jX6" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_9XJ" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_9XM" role="3nqlJM">
-          <property role="x79VB" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/3364660638048049748" />
+      <node concept="P$JXv" id="7OJcYqx42Ab" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx42Ac" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx42Ad" role="3HnX3l" />
         </node>
       </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jX7" role="jymVt">
-      <property role="TrG5h" value="slangAnnotationContainment" />
-      <node concept="3clFbS" id="5JNiski3jX8" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jX9" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jXa" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+      <node concept="2AHcQZ" id="7OJcYqx42Ae" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
-      <node concept="P$JXv" id="5M8g5cS$Jgo" role="lGtFl">
+    </node>
+    <node concept="2tJIrI" id="7OJcYqwSICt" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqwQm2a" role="jymVt">
+      <property role="TrG5h" value="getAnnotationContainment" />
+      <node concept="3uibUv" id="7OJcYqwQm2b" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvQ8aH" resolve="ContainmentKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwQm2c" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQm2d" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqwQVWB" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwQYIP" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQYIQ" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: null" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwQYIR" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQYIS" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.core.structure.BaseConcept.smodelAttribute" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwQYIT" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQYIU" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
         <node concept="TZ5HA" id="5M8g5cS$Jgp" role="TZ5H$">
           <node concept="1dT_AC" id="5M8g5cS$Jgq" role="1dT_Ay">
             <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.BaseConcept.smodelAttribute as " />
@@ -11505,6 +15631,32 @@
             <property role="1dT_AB" value="" />
           </node>
         </node>
+        <node concept="TZ5HA" id="7OJcYqwQYIV" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQYIW" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: null" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwQYIX" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQYIY" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626/5169995583184591170" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jX7" role="jymVt">
+      <property role="TrG5h" value="slangAnnotationContainment" />
+      <node concept="3clFbS" id="5JNiski3jX8" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jX9" role="1B3o_S" />
+      <node concept="3uibUv" id="5JNiski3jXa" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx44RJ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx44RK" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx44RL" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx44RM" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskitFWC" role="jymVt">
@@ -11514,10 +15666,13 @@
       <node concept="3Tqbb2" id="5JNiskitGo_" role="3clF45">
         <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
       </node>
-      <node concept="P$JXv" id="5M8g5cS$MAz" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$MAA" role="3nqlJM">
-          <property role="x79VB" value="jetbrains.mps.lang.core.structure.BaseConcept.smodelAttribute" />
+      <node concept="P$JXv" id="7OJcYqx479F" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx479G" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx479H" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx479I" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiydnL" role="jymVt">
@@ -11525,47 +15680,39 @@
       <node concept="3clFbS" id="5JNiskiydnM" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiskiydnN" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskiydnO" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_bqv" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_bqy" role="3nqlJM">
-          <property role="x79VB" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626/5169995583184591170" />
+      <node concept="P$JXv" id="7OJcYqx49rZ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx49s0" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx49s1" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx49s2" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jXb" role="jymVt" />
-    <node concept="3clFb_" id="5JNiski3jXc" role="jymVt">
-      <property role="TrG5h" value="lcINamedInterface" />
-      <node concept="3clFbS" id="5JNiski3jXd" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXe" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jXf" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjklHQ" resolve="Interface" />
+    <node concept="3clFb_" id="7OJcYqwQm2j" role="jymVt">
+      <property role="TrG5h" value="getINamed" />
+      <node concept="3uibUv" id="7OJcYqwQm2k" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvXZ8V" resolve="InterfaceKeyedMapping" />
       </node>
-      <node concept="P$JXv" id="5M8g5cS$QyV" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$QyY" role="3nqlJM">
-          <property role="x79VB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.INamed" />
+      <node concept="3Tm1VV" id="7OJcYqwQm2l" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQm2m" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqwQWb5" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwQYhO" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQYhP" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.m3.builtin.Built-in DataTypes.INamed" />
+          </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jXg" role="jymVt">
-      <property role="TrG5h" value="mpsINamedInterface" />
-      <node concept="3clFbS" id="5JNiski3jXh" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXi" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jXj" role="3clF45">
-        <ref role="ehGHo" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$TEV" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$TEY" role="3nqlJM">
-          <property role="x79VB" value="jetbrains.mps.lang.core.structure.INamedConcept" />
+        <node concept="TZ5HA" id="7OJcYqwQYhQ" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQYhR" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.core.structure.INamedConcept" />
+          </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jXk" role="jymVt">
-      <property role="TrG5h" value="slangINamedInterface" />
-      <node concept="3clFbS" id="5JNiski3jXl" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXm" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jXn" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SInterfaceConcept" resolve="SInterfaceConcept" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$Wir" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwQYhS" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQYhT" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
         <node concept="TZ5HA" id="5M8g5cS$Wis" role="TZ5H$">
           <node concept="1dT_AC" id="5M8g5cS$WFl" role="1dT_Ay">
             <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.INamedConcept as " />
@@ -11580,6 +15727,64 @@
           </node>
           <node concept="1dT_AC" id="5M8g5cS$Wit" role="1dT_Ay" />
         </node>
+        <node concept="TZ5HA" id="7OJcYqwQYhU" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQYhV" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: LionCore-builtins-INamed" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwQYhW" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQYhX" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jXc" role="jymVt">
+      <property role="TrG5h" value="lcINamedInterface" />
+      <node concept="3clFbS" id="5JNiski3jXd" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jXe" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiski3jXf" role="3clF45">
+        <ref role="ehGHo" to="h3y3:2ju2syjklHQ" resolve="Interface" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx4bIF" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4bIG" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4bIH" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4bII" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jXg" role="jymVt">
+      <property role="TrG5h" value="mpsINamedInterface" />
+      <node concept="3clFbS" id="5JNiski3jXh" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jXi" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiski3jXj" role="3clF45">
+        <ref role="ehGHo" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx4e1J" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4e1K" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4e1L" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4e1M" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jXk" role="jymVt">
+      <property role="TrG5h" value="slangINamedInterface" />
+      <node concept="3clFbS" id="5JNiski3jXl" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jXm" role="1B3o_S" />
+      <node concept="3uibUv" id="5JNiski3jXn" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SInterfaceConcept" resolve="SInterfaceConcept" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx4glb" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4glc" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4gld" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4gle" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jXo" role="jymVt">
@@ -11587,10 +15792,13 @@
       <node concept="3clFbS" id="5JNiski3jXp" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jXq" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jXr" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_cSP" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_cSS" role="3nqlJM">
-          <property role="x79VB" value="LionCore-builtins-INamed" />
+      <node concept="P$JXv" id="7OJcYqx4iCZ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4iD0" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4iD1" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4iD2" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jXs" role="jymVt">
@@ -11598,47 +15806,39 @@
       <node concept="3clFbS" id="5JNiski3jXt" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jXu" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jXv" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_fp5" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_fp8" role="3nqlJM">
-          <property role="x79VB" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468" />
+      <node concept="P$JXv" id="7OJcYqx4kXb" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4kXc" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4kXd" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4kXe" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jXw" role="jymVt" />
-    <node concept="3clFb_" id="5JNiski3jXx" role="jymVt">
-      <property role="TrG5h" value="lcNameProperty" />
-      <node concept="3clFbS" id="5JNiski3jXy" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXz" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jX$" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+    <node concept="3clFb_" id="7OJcYqwQm2s" role="jymVt">
+      <property role="TrG5h" value="getINamedName" />
+      <node concept="3uibUv" id="7OJcYqwQm2t" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
       </node>
-      <node concept="P$JXv" id="5M8g5cS$WG9" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$WGc" role="3nqlJM">
-          <property role="x79VB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.INamed.name" />
+      <node concept="3Tm1VV" id="7OJcYqwQm2u" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQm2v" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqwQWpz" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwQXON" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQXOO" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.m3.builtin.Built-in DataTypes.INamed.name" />
+          </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jX_" role="jymVt">
-      <property role="TrG5h" value="mpsNameProperty" />
-      <node concept="3clFbS" id="5JNiski3jXA" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXB" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jXC" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_0yH" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS_0yK" role="3nqlJM">
-          <property role="x79VB" value="jetbrains.mps.lang.core.structure.INamedConcept.name" />
+        <node concept="TZ5HA" id="7OJcYqwQXOP" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQXOQ" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.core.structure.INamedConcept.name" />
+          </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jXD" role="jymVt">
-      <property role="TrG5h" value="slangNameProperty" />
-      <node concept="3clFbS" id="5JNiski3jXE" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXF" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jXG" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_4Q8" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwQXOR" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQXOS" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
         <node concept="TZ5HA" id="5M8g5cS_4Q9" role="TZ5H$">
           <node concept="1dT_AC" id="5M8g5cS_52F" role="1dT_Ay">
             <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.INamedConcept.name as " />
@@ -11653,6 +15853,64 @@
           </node>
           <node concept="1dT_AC" id="5M8g5cS_4Qa" role="1dT_Ay" />
         </node>
+        <node concept="TZ5HA" id="7OJcYqwQXOT" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQXOU" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: LionCore-builtins-INamed-name" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwQXOV" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQXOW" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jXx" role="jymVt">
+      <property role="TrG5h" value="lcNameProperty" />
+      <node concept="3clFbS" id="5JNiski3jXy" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jXz" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiski3jX$" role="3clF45">
+        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx4nhJ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4nhK" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4nhL" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4nhM" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jX_" role="jymVt">
+      <property role="TrG5h" value="mpsNameProperty" />
+      <node concept="3clFbS" id="5JNiski3jXA" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jXB" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiski3jXC" role="3clF45">
+        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx4pAF" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4pAG" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4pAH" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4pAI" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jXD" role="jymVt">
+      <property role="TrG5h" value="slangNameProperty" />
+      <node concept="3clFbS" id="5JNiski3jXE" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jXF" role="1B3o_S" />
+      <node concept="3uibUv" id="5JNiski3jXG" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx4rVZ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4rW0" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4rW1" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4rW2" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jXH" role="jymVt">
@@ -11660,10 +15918,13 @@
       <node concept="3clFbS" id="5JNiski3jXI" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jXJ" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jXK" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_fL_" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_fLC" role="3nqlJM">
-          <property role="x79VB" value="LionCore-builtins-INamed-name" />
+      <node concept="P$JXv" id="7OJcYqx4uhF" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4uhG" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4uhH" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4uhI" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jXL" role="jymVt">
@@ -11671,47 +15932,29 @@
       <node concept="3clFbS" id="5JNiski3jXM" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jXN" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jXO" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_gZW" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_gZZ" role="3nqlJM">
-          <property role="x79VB" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+      <node concept="P$JXv" id="7OJcYqx4wBJ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4wBK" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4wBL" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4wBM" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jXP" role="jymVt" />
-    <node concept="3clFb_" id="5JNiski3jXQ" role="jymVt">
-      <property role="TrG5h" value="slangM3LanguageId" />
-      <node concept="3clFbS" id="5JNiski3jXR" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXS" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jXT" role="3clF45">
-        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+    <node concept="3clFb_" id="7OJcYqwQm12" role="jymVt">
+      <property role="TrG5h" value="getM3" />
+      <node concept="3uibUv" id="7OJcYqwQm13" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
       </node>
-      <node concept="P$JXv" id="34Q84zNOEIz" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNOFM1" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNOFM2" role="1dT_Ay">
-            <property role="1dT_AB" value="io.lionweb.mps.m3 as " />
-          </node>
-          <node concept="1dT_AA" id="34Q84zNOFM3" role="1dT_Ay">
-            <node concept="92FcH" id="34Q84zNOFM4" role="qph3F">
-              <node concept="TZ5HA" id="34Q84zNOFM5" role="2XjZqd" />
-              <node concept="VXe08" id="34Q84zNOFM6" role="92FcQ">
-                <ref role="VXe09" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="34Q84zNOFM7" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
+      <node concept="3Tm1VV" id="7OJcYqwQm14" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQm15" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqwQU_N" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwQWC3" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQWC4" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jXU" role="jymVt">
-      <property role="TrG5h" value="slangM3Language" />
-      <node concept="3clFbS" id="5JNiski3jXV" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXW" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jXX" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-      </node>
-      <node concept="P$JXv" id="34Q84zNOEW3" role="lGtFl">
         <node concept="TZ5HA" id="34Q84zNOGaP" role="TZ5H$">
           <node concept="1dT_AC" id="34Q84zNOGaQ" role="1dT_Ay">
             <property role="1dT_AB" value="io.lionweb.mps.m3 as " />
@@ -11728,6 +15971,79 @@
             <property role="1dT_AB" value="" />
           </node>
         </node>
+        <node concept="TZ5HA" id="7OJcYqwTWtg" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwTWth" role="1dT_Ay">
+            <property role="1dT_AB" value="slangId: " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwTWFP" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwTWFQ" role="1dT_Ay">
+            <property role="1dT_AB" value="io.lionweb.mps.m3 as " />
+          </node>
+          <node concept="1dT_AA" id="7OJcYqwTWFR" role="1dT_Ay">
+            <node concept="92FcH" id="7OJcYqwTWFS" role="qph3F">
+              <node concept="TZ5HA" id="7OJcYqwTWFT" role="2XjZqd" />
+              <node concept="VXe08" id="7OJcYqwTWFU" role="92FcQ">
+                <ref role="VXe09" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="7OJcYqwTWFV" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwTY6G" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwTY6H" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: 01cf0d82-8d29-4fc4-be96-28abaf4ad33d" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwQWC5" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwQWC6" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsVersion: 0" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwTYln" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwTYlo" role="1dT_Ay">
+            <property role="1dT_AB" value="lcVersion: 2023.1" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwTXRq" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwTXRr" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: io.lionweb.mps.m3 as key: LionCore-M3" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jXQ" role="jymVt">
+      <property role="TrG5h" value="slangM3LanguageId" />
+      <node concept="3clFbS" id="5JNiski3jXR" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jXS" role="1B3o_S" />
+      <node concept="3uibUv" id="5JNiski3jXT" role="3clF45">
+        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx4yYb" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4yYc" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4yYd" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4yYe" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jXU" role="jymVt">
+      <property role="TrG5h" value="slangM3Language" />
+      <node concept="3clFbS" id="5JNiski3jXV" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jXW" role="1B3o_S" />
+      <node concept="3uibUv" id="5JNiski3jXX" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx4_kZ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4_l0" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4_l1" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4_l2" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jXY" role="jymVt">
@@ -11735,12 +16051,13 @@
       <node concept="3clFbS" id="5JNiski3jXZ" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jY0" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jY1" role="3clF45" />
-      <node concept="P$JXv" id="34Q84zNOF9z" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNOF9$" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNOF9_" role="1dT_Ay">
-            <property role="1dT_AB" value="io.lionweb.mps.m3 as key: LionCore-M3" />
-          </node>
+      <node concept="P$JXv" id="7OJcYqx4BGb" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4BGc" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4BGd" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4BGe" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jY2" role="jymVt">
@@ -11748,12 +16065,13 @@
       <node concept="3clFbS" id="5JNiski3jY3" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jY4" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jY5" role="3clF45" />
-      <node concept="P$JXv" id="34Q84zNOFn3" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNOFn4" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNOFn5" role="1dT_Ay">
-            <property role="1dT_AB" value="io.lionweb.mps.m3 as id: 01cf0d82-8d29-4fc4-be96-28abaf4ad33d" />
-          </node>
+      <node concept="P$JXv" id="7OJcYqx4E3J" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4E3K" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4E3L" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4E3M" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jY6" role="jymVt">
@@ -11761,47 +16079,29 @@
       <node concept="3clFbS" id="5JNiski3jY7" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jY8" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jY9" role="3clF45" />
-      <node concept="P$JXv" id="34Q84zNOF$z" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNOF$$" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNOF$_" role="1dT_Ay">
-            <property role="1dT_AB" value="version of io.lionweb.mps.m3: 2023.1" />
-          </node>
+      <node concept="P$JXv" id="7OJcYqx4GrF" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4GrG" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4GrH" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4GrI" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jYa" role="jymVt" />
-    <node concept="3clFb_" id="5JNiski3jYb" role="jymVt">
-      <property role="TrG5h" value="slangCoreLanguageId" />
-      <node concept="3clFbS" id="5JNiski3jYc" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jYd" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jYe" role="3clF45">
-        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+    <node concept="3clFb_" id="7OJcYqwQm1b" role="jymVt">
+      <property role="TrG5h" value="getLioncoreBuiltins" />
+      <node concept="3uibUv" id="7OJcYqwQm1c" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
       </node>
-      <node concept="P$JXv" id="34Q84zNOWb5" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNOWb6" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNP3Ec" role="1dT_Ay">
-            <property role="1dT_AB" value="jetbrains.mps.lang.core as " />
+      <node concept="3Tm1VV" id="7OJcYqwQm1d" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQm1e" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqwQUOh" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwUkXg" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUkXh" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
           </node>
-          <node concept="1dT_AA" id="34Q84zNP3Ed" role="1dT_Ay">
-            <node concept="92FcH" id="34Q84zNP3Ee" role="qph3F">
-              <node concept="TZ5HA" id="34Q84zNP3Ef" role="2XjZqd" />
-              <node concept="VXe08" id="34Q84zNP3Eg" role="92FcQ">
-                <ref role="VXe09" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="34Q84zNOWb7" role="1dT_Ay" />
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jYf" role="jymVt">
-      <property role="TrG5h" value="slangCoreLanguage" />
-      <node concept="3clFbS" id="5JNiski3jYg" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jYh" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jYi" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-      </node>
-      <node concept="P$JXv" id="34Q84zNOXEE" role="lGtFl">
         <node concept="TZ5HA" id="34Q84zNOXEF" role="TZ5H$">
           <node concept="1dT_AC" id="34Q84zNP4RJ" role="1dT_Ay">
             <property role="1dT_AB" value="jetbrains.mps.lang.core as " />
@@ -11816,6 +16116,77 @@
           </node>
           <node concept="1dT_AC" id="34Q84zNOXEG" role="1dT_Ay" />
         </node>
+        <node concept="TZ5HA" id="7OJcYqwUkXp" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUkXq" role="1dT_Ay">
+            <property role="1dT_AB" value="slangId: " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="34Q84zNOWb6" role="TZ5H$">
+          <node concept="1dT_AC" id="34Q84zNP3Ec" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.core as " />
+          </node>
+          <node concept="1dT_AA" id="34Q84zNP3Ed" role="1dT_Ay">
+            <node concept="92FcH" id="34Q84zNP3Ee" role="qph3F">
+              <node concept="TZ5HA" id="34Q84zNP3Ef" role="2XjZqd" />
+              <node concept="VXe08" id="34Q84zNP3Eg" role="92FcQ">
+                <ref role="VXe09" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="34Q84zNOWb7" role="1dT_Ay" />
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUkXy" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUkXz" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUkX$" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUkX_" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsVersion: 2" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUkXA" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUkXB" role="1dT_Ay">
+            <property role="1dT_AB" value="lcVersion: 2023.1" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUkXC" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUkXD" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: LionCore-builtins" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jYb" role="jymVt">
+      <property role="TrG5h" value="slangCoreLanguageId" />
+      <node concept="3clFbS" id="5JNiski3jYc" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jYd" role="1B3o_S" />
+      <node concept="3uibUv" id="5JNiski3jYe" role="3clF45">
+        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx4INZ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4IO0" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4IO1" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4IO2" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiski3jYf" role="jymVt">
+      <property role="TrG5h" value="slangCoreLanguage" />
+      <node concept="3clFbS" id="5JNiski3jYg" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiski3jYh" role="1B3o_S" />
+      <node concept="3uibUv" id="5JNiski3jYi" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx4LcF" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4LcG" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4LcH" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4LcI" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jYj" role="jymVt">
@@ -11823,12 +16194,13 @@
       <node concept="3clFbS" id="5JNiski3jYk" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jYl" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jYm" role="3clF45" />
-      <node concept="P$JXv" id="34Q84zNOZan" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNOZao" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNOZap" role="1dT_Ay">
-            <property role="1dT_AB" value="jetbrains.mps.lang.core as key: LionCore-builtins" />
-          </node>
+      <node concept="P$JXv" id="7OJcYqx4N_J" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4N_K" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4N_L" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4N_M" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jYn" role="jymVt">
@@ -11836,12 +16208,13 @@
       <node concept="3clFbS" id="5JNiski3jYo" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jYp" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jYq" role="3clF45" />
-      <node concept="P$JXv" id="34Q84zNP0Ec" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNP0Ed" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNP0Ee" role="1dT_Ay">
-            <property role="1dT_AB" value="jetbrains.mps.lang.core as id: ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
-          </node>
+      <node concept="P$JXv" id="7OJcYqx4PZb" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4PZc" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4PZd" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4PZe" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jYr" role="jymVt">
@@ -11849,15 +16222,84 @@
       <node concept="3clFbS" id="5JNiski3jYs" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiski3jYt" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiski3jYu" role="3clF45" />
-      <node concept="P$JXv" id="34Q84zNP2a9" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNP2aa" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNP2ab" role="1dT_Ay">
-            <property role="1dT_AB" value="version of jetbrains.mps.lang.core: 2023.1" />
+      <node concept="P$JXv" id="7OJcYqx4SoZ" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4Sp0" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4Sp1" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4Sp2" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5JNiski3jYv" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqwQm2_" role="jymVt">
+      <property role="TrG5h" value="getAttributeLanguage" />
+      <node concept="3uibUv" id="7OJcYqwQm2A" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwQm2B" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQm2C" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqwQTqZ" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqwUnHq" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUnHr" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUoql" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUoqm" role="1dT_Ay">
+            <property role="1dT_AB" value="io.lionweb.mps.structure.attribute as " />
+          </node>
+          <node concept="1dT_AA" id="7OJcYqwUoqn" role="1dT_Ay">
+            <node concept="92FcH" id="7OJcYqwUoqo" role="qph3F">
+              <node concept="TZ5HA" id="7OJcYqwUoqp" role="2XjZqd" />
+              <node concept="VXe08" id="7OJcYqwUoqq" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SLanguage" resolve="SLanguage" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="7OJcYqwUoqr" role="1dT_Ay" />
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUnHz" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUnH$" role="1dT_Ay">
+            <property role="1dT_AB" value="slangId: " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUxWL" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUxWM" role="1dT_Ay">
+            <property role="1dT_AB" value="io.lionweb.mps.structure.attribute as " />
+          </node>
+          <node concept="1dT_AA" id="7OJcYqwUxWN" role="1dT_Ay">
+            <node concept="92FcH" id="7OJcYqwUxWO" role="qph3F">
+              <node concept="TZ5HA" id="7OJcYqwUxWP" role="2XjZqd" />
+              <node concept="VXe08" id="7OJcYqwUxWQ" role="92FcQ">
+                <ref role="VXe09" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="7OJcYqwUxWR" role="1dT_Ay" />
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUnHG" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUnHH" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: 411e5b27-8a76-482e-8af8-1704262b4468" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUnHI" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUnHJ" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsVersion: 0" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUnHK" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUnHL" role="1dT_Ay">
+            <property role="1dT_AB" value="lcVersion: 0" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqwUnHM" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqwUnHN" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: 411e5b27-8a76-482e-8af8-1704262b4468" />
           </node>
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="5JNiski3jYv" role="jymVt" />
     <node concept="3clFb_" id="5JNiski3jYw" role="jymVt">
       <property role="TrG5h" value="slangAttributeLanguage" />
       <node concept="3clFbS" id="5JNiski3jYx" role="3clF47" />
@@ -11865,25 +16307,26 @@
       <node concept="3uibUv" id="5JNiski3jYz" role="3clF45">
         <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
       </node>
-      <node concept="P$JXv" id="34Q84zNPmax" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNPnEQ" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNPnER" role="1dT_Ay">
-            <property role="1dT_AB" value="io.lionweb.mps.structure.attribute as " />
-          </node>
-          <node concept="1dT_AA" id="34Q84zNPnES" role="1dT_Ay">
-            <node concept="92FcH" id="34Q84zNPnET" role="qph3F">
-              <node concept="TZ5HA" id="34Q84zNPnEU" role="2XjZqd" />
-              <node concept="VXe08" id="34Q84zNPnEV" role="92FcQ">
-                <ref role="VXe09" to="c17a:~SLanguage" resolve="SLanguage" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="34Q84zNPnEW" role="1dT_Ay" />
+      <node concept="P$JXv" id="7OJcYqx4Xff" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx4Xfg" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4Xfh" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4Xfi" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jY$" role="jymVt" />
-    <node concept="2tJIrI" id="5JNiski3jY_" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqwXhGH" role="jymVt">
+      <property role="TrG5h" value="listLcLanguages" />
+      <node concept="3clFbS" id="7OJcYqwXhGK" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqwXhGL" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqwXdK9" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqwXgNR" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+        </node>
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiski3jYA" role="jymVt">
       <property role="TrG5h" value="listSLanguages" />
       <node concept="3clFbS" id="5JNiski3jYB" role="3clF47" />
@@ -11913,6 +16356,12 @@
         <node concept="x79VA" id="5JNiski3jYN" role="3nqlJM">
           <property role="x79VB" value="All LionCore languages." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx4ZDz" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx4ZD$" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx4ZD_" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jYO" role="jymVt">
@@ -11931,6 +16380,12 @@
         <node concept="x79VA" id="5JNiski3jYW" role="3nqlJM">
           <property role="x79VB" value="All LionCore language keys." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx524a" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx524b" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx524c" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jYX" role="jymVt">
@@ -11960,6 +16415,12 @@
         <node concept="x79VA" id="5JNiski3jZa" role="3nqlJM">
           <property role="x79VB" value="All LionCore language ids." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx54v7" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx54v8" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx54v9" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jZb" role="jymVt">
@@ -11994,9 +16455,25 @@
         <node concept="x79VA" id="5JNiski3jZq" role="3nqlJM">
           <property role="x79VB" value="All LionCore language versions." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx56Uq" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx56Ur" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx56Us" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jZr" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqwYDTB" role="jymVt">
+      <property role="TrG5h" value="listClassifiers" />
+      <node concept="3clFbS" id="7OJcYqwYDTE" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqwYDTF" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqwYaoG" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqwYDsj" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+        </node>
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiski3jZs" role="jymVt">
       <property role="TrG5h" value="listLcClassifiers" />
       <node concept="3clFbS" id="5JNiski3jZt" role="3clF47" />
@@ -12013,6 +16490,12 @@
         <node concept="x79VA" id="5JNiski3jZz" role="3nqlJM">
           <property role="x79VB" value="All LionCore builtin classifiers." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx59m3" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx59m4" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx59m5" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jZ$" role="jymVt">
@@ -12031,6 +16514,12 @@
         <node concept="x79VA" id="5JNiski3jZF" role="3nqlJM">
           <property role="x79VB" value="All LionCore builtin classifiers." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx5bM2" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5bM3" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5bM4" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jZG" role="jymVt">
@@ -12062,6 +16551,12 @@
         <node concept="x79VA" id="5JNiski3jZT" role="3nqlJM">
           <property role="x79VB" value="All LionCore builtin classifiers." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx5een" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5eeo" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5eep" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3jZU" role="jymVt">
@@ -12080,6 +16575,12 @@
         <node concept="x79VA" id="5JNiski3k02" role="3nqlJM">
           <property role="x79VB" value="All LionCore builtin classifier keys." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx5gF2" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5gF3" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5gF4" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3k03" role="jymVt">
@@ -12109,10 +16610,26 @@
         <node concept="x79VA" id="5JNiski3k0g" role="3nqlJM">
           <property role="x79VB" value="All LionCore builtin concept ids." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx5j83" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5j84" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5j85" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3k0h" role="jymVt" />
     <node concept="2tJIrI" id="5JNiski3k0i" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqwZxOH" role="jymVt">
+      <property role="TrG5h" value="listLcProperty" />
+      <node concept="3clFbS" id="7OJcYqwZxOK" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqwZxOL" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqwZryI" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqwZwhO" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+        </node>
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiski3k0j" role="jymVt">
       <property role="TrG5h" value="listLcProperties" />
       <node concept="3clFbS" id="5JNiski3k0k" role="3clF47" />
@@ -12129,6 +16646,12 @@
         <node concept="x79VA" id="5JNiski3k0q" role="3nqlJM">
           <property role="x79VB" value="All LionCore builtin properties." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx5l_s" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5l_t" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5l_u" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3k0r" role="jymVt">
@@ -12147,6 +16670,12 @@
         <node concept="x79VA" id="5JNiski3k0y" role="3nqlJM">
           <property role="x79VB" value="All LionCore builtin properties." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx5o39" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5o3a" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5o3b" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3k0z" role="jymVt">
@@ -12178,6 +16707,12 @@
         <node concept="x79VA" id="5JNiski3k0K" role="3nqlJM">
           <property role="x79VB" value="All LionCore builtin properties." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx5qxc" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5qxd" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5qxe" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3k0L" role="jymVt">
@@ -12196,6 +16731,12 @@
         <node concept="x79VA" id="5JNiski3k0T" role="3nqlJM">
           <property role="x79VB" value="All LionCore builtin property keys." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx5sZ_" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5sZA" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5sZB" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3k0U" role="jymVt">
@@ -12225,9 +16766,25 @@
         <node concept="x79VA" id="5JNiski3k17" role="3nqlJM">
           <property role="x79VB" value="All LionCore builtin property ids." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx5vuk" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5vul" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5vum" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3k18" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqx0tbv" role="jymVt">
+      <property role="TrG5h" value="listLcPrimitiveType" />
+      <node concept="3clFbS" id="7OJcYqx0tby" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqx0tbz" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqx0gEl" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqx0sJp" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+        </node>
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiski3k19" role="jymVt">
       <property role="TrG5h" value="listLcPrimitiveTypes" />
       <node concept="3clFbS" id="5JNiski3k1a" role="3clF47" />
@@ -12244,6 +16801,12 @@
         <node concept="x79VA" id="5JNiski3k1g" role="3nqlJM">
           <property role="x79VB" value="All LionCore builtin primitive types." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx5xXp" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5xXq" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5xXr" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3k1h" role="jymVt">
@@ -12262,6 +16825,12 @@
         <node concept="x79VA" id="5JNiski3k1o" role="3nqlJM">
           <property role="x79VB" value="All LionCore builtin primitive types." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx5$sO" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5$sP" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5$sQ" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3k1p" role="jymVt">
@@ -12293,6 +16862,12 @@
         <node concept="x79VA" id="5JNiski3k1A" role="3nqlJM">
           <property role="x79VB" value="All LionCore builtin primitive types." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx5AW_" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5AWA" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5AWB" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3k1B" role="jymVt">
@@ -12311,6 +16886,12 @@
         <node concept="x79VA" id="5JNiski3k1J" role="3nqlJM">
           <property role="x79VB" value="All LionCore builtin primitive type keys." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx5DsG" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5DsH" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5DsI" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiski3k1K" role="jymVt">
@@ -12340,6 +16921,28 @@
         <node concept="x79VA" id="5JNiski3k1X" role="3nqlJM">
           <property role="x79VB" value="All LionCore builtin primitive type ids." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx5FX9" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5FXa" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5FXb" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvFkM2" role="jymVt">
+      <property role="TrG5h" value="listSLanguagePrimitiveTypeLanguageKeys" />
+      <node concept="3clFbS" id="7OJcYqvFkM3" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqvFkM4" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqvFkM5" role="3clF45">
+        <node concept="17QB3L" id="7OJcYqvFmi$" role="_ZDj9" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx5ItW" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx5ItX" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5ItY" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5ItZ" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3k1Y" role="jymVt" />
@@ -12374,7 +16977,7 @@
     </node>
     <node concept="2tJIrI" id="5JNiskj5Yen" role="jymVt" />
     <node concept="3clFb_" id="5JNiskiswUo" role="jymVt">
-      <property role="TrG5h" value="isMpsInternalConcept" />
+      <property role="TrG5h" value="isMpsInternalElement" />
       <node concept="3clFbS" id="5JNiskiswUp" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiskiswUq" role="1B3o_S" />
       <node concept="10P_77" id="5JNiskiswUr" role="3clF45" />
@@ -12405,6 +17008,16 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3k2c" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqx1HDk" role="jymVt">
+      <property role="TrG5h" value="listMpsInternalClassifier" />
+      <node concept="3clFbS" id="7OJcYqx1HDn" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqx1HDo" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqx1B4G" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqx1G3E" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+        </node>
+      </node>
+    </node>
     <node concept="3clFb_" id="7weWCFlqTiI" role="jymVt">
       <property role="TrG5h" value="listMpsInternalClassifiers" />
       <node concept="3clFbS" id="7weWCFlqTiJ" role="3clF47" />
@@ -12421,6 +17034,12 @@
         <node concept="x79VA" id="7weWCFlqTiV" role="3nqlJM">
           <property role="x79VB" value="All MPS concepts that need special treatment in LionWeb." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx5KZa" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5KZb" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5KZc" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="7weWCFlqUnk" role="jymVt" />
@@ -12453,6 +17072,28 @@
         <node concept="x79VA" id="7weWCFlqTjg" role="3nqlJM">
           <property role="x79VB" value="All MPS concepts that need special treatment in LionWeb." />
         </node>
+        <node concept="TZ5HI" id="7OJcYqx5NwF" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5NwG" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5NwH" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="6Z_tmAeiDP1" role="jymVt">
+      <property role="TrG5h" value="listSLanguageInternalClassifierLanguageKeys" />
+      <node concept="3clFbS" id="6Z_tmAeiDP2" role="3clF47" />
+      <node concept="3Tm1VV" id="6Z_tmAeiDP3" role="1B3o_S" />
+      <node concept="_YKpA" id="6Z_tmAeiDP4" role="3clF45">
+        <node concept="17QB3L" id="6Z_tmAeiHRy" role="_ZDj9" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx5Q2y" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx5Q2z" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5Q2$" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5Q2_" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="7weWCFlqSXi" role="jymVt" />
@@ -12517,6 +17158,106 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3k2q" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqx2zDi" role="jymVt">
+      <property role="TrG5h" value="listMpsInternalFeature" />
+      <node concept="3clFbS" id="7OJcYqx2zDl" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqx2zDm" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqx2zai" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqx2zBy" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="6Z_tmAegIrR" role="jymVt">
+      <property role="TrG5h" value="listSLanguageInternalFeatures" />
+      <node concept="3clFbS" id="6Z_tmAegIrS" role="3clF47" />
+      <node concept="3Tm1VV" id="6Z_tmAegIrY" role="1B3o_S" />
+      <node concept="_YKpA" id="6Z_tmAegIrZ" role="3clF45">
+        <node concept="3uibUv" id="6Z_tmAegIs0" role="_ZDj9">
+          <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="6Z_tmAegIs1" role="lGtFl">
+        <node concept="TZ5HA" id="6Z_tmAegIs2" role="TZ5H$">
+          <node concept="1dT_AC" id="6Z_tmAegIs3" role="1dT_Ay">
+            <property role="1dT_AB" value="All MPS concept features that need special treatment in LionWeb as MPS " />
+          </node>
+          <node concept="1dT_AA" id="6Z_tmAegIs4" role="1dT_Ay">
+            <node concept="92FcH" id="6Z_tmAegIs5" role="qph3F">
+              <node concept="TZ5HA" id="6Z_tmAegIs6" role="2XjZqd" />
+              <node concept="VXe08" id="6Z_tmAegIs7" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="6Z_tmAegIs8" role="1dT_Ay">
+            <property role="1dT_AB" value="." />
+          </node>
+        </node>
+        <node concept="x79VA" id="6Z_tmAegIs9" role="3nqlJM">
+          <property role="x79VB" value="All MPS concept featuress that need special treatment in LionWeb." />
+        </node>
+        <node concept="TZ5HI" id="7OJcYqx5S$O" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5S$P" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5S$Q" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6Z_tmAegI4_" role="jymVt" />
+    <node concept="3clFb_" id="6Z_tmAegWRd" role="jymVt">
+      <property role="TrG5h" value="listSClassifierInternalFeatureIds" />
+      <node concept="3clFbS" id="6Z_tmAegWRe" role="3clF47" />
+      <node concept="3Tm1VV" id="6Z_tmAegWRk" role="1B3o_S" />
+      <node concept="_YKpA" id="6Z_tmAegWRl" role="3clF45">
+        <node concept="17QB3L" id="6Z_tmAegWRm" role="_ZDj9" />
+      </node>
+      <node concept="P$JXv" id="6Z_tmAegWRn" role="lGtFl">
+        <node concept="TZ5HA" id="6Z_tmAegWRo" role="TZ5H$">
+          <node concept="1dT_AC" id="6Z_tmAegWRp" role="1dT_Ay">
+            <property role="1dT_AB" value="All MPS concept features that need special treatment in LionWeb as stringified " />
+          </node>
+          <node concept="1dT_AA" id="6Z_tmAegWRq" role="1dT_Ay">
+            <node concept="92FcH" id="6Z_tmAegWRr" role="qph3F">
+              <node concept="TZ5HA" id="6Z_tmAegWRs" role="2XjZqd" />
+              <node concept="VXe08" id="6Z_tmAegWRt" role="92FcQ">
+                <ref role="VXe09" to="e8bb:~SConceptFeatureId" resolve="SConceptFeatureId" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="6Z_tmAegWRu" role="1dT_Ay">
+            <property role="1dT_AB" value="." />
+          </node>
+        </node>
+        <node concept="x79VA" id="6Z_tmAegWRv" role="3nqlJM">
+          <property role="x79VB" value="All MPS concept features that need special treatment in LionWeb." />
+        </node>
+        <node concept="TZ5HI" id="7OJcYqx5V7p" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5V7q" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5V7r" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvFsrp" role="jymVt">
+      <property role="TrG5h" value="listSClassifierInternalFeatureLanguageKeys" />
+      <node concept="3clFbS" id="7OJcYqvFsrq" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqvFsrr" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqvFsrs" role="3clF45">
+        <node concept="17QB3L" id="7OJcYqvFsrt" role="_ZDj9" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqx5XEk" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqx5XEl" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqx5XEm" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqx5XEn" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6Z_tmAegWvz" role="jymVt" />
     <node concept="3clFb_" id="5JNiski3k2r" role="jymVt">
       <property role="TrG5h" value="isAnnotationContainment" />
       <node concept="3clFbS" id="5JNiski3k2s" role="3clF47" />
@@ -12627,6 +17368,2117 @@
         <node concept="1dT_AC" id="6jTTMHD72JO" role="1dT_Ay">
           <property role="1dT_AB" value="Common place to access MPS language specifics" />
         </node>
+      </node>
+    </node>
+  </node>
+  <node concept="3HP615" id="7OJcYqvKf0O">
+    <property role="TrG5h" value="IKeyedMapping" />
+    <property role="3GE5qa" value="keyedMapping" />
+    <node concept="3clFb_" id="7OJcYqvKhKf" role="jymVt">
+      <property role="TrG5h" value="getLc" />
+      <node concept="3clFbS" id="7OJcYqvKhKi" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqvKhKj" role="1B3o_S" />
+      <node concept="16syzq" id="7OJcYqvKhJY" role="3clF45">
+        <ref role="16sUi3" node="7OJcYqvKf2B" resolve="LC" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOrhM" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvKihR" role="jymVt">
+      <property role="TrG5h" value="getMps" />
+      <node concept="3clFbS" id="7OJcYqvKihU" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqvKihV" role="1B3o_S" />
+      <node concept="16syzq" id="7OJcYqvKi19" role="3clF45">
+        <ref role="16sUi3" node="7OJcYqvKgVK" resolve="MPS" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOsLq" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvKizN" role="jymVt">
+      <property role="TrG5h" value="getSlang" />
+      <node concept="3clFbS" id="7OJcYqvKizQ" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqvKizR" role="1B3o_S" />
+      <node concept="16syzq" id="7OJcYqvKiz8" role="3clF45">
+        <ref role="16sUi3" node="7OJcYqvKhss" resolve="SLANG" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOugY" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvKiQm" role="jymVt">
+      <property role="TrG5h" value="getMpsId" />
+      <node concept="3clFbS" id="7OJcYqvKiQp" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqvKiQq" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqvKiPu" role="3clF45" />
+      <node concept="2AHcQZ" id="7OJcYqwOvK$" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvKjsH" role="jymVt">
+      <property role="TrG5h" value="getLcId" />
+      <node concept="3clFbS" id="7OJcYqvKjsK" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqvKjsL" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqvKjrr" role="3clF45" />
+      <node concept="2AHcQZ" id="7OJcYqwOxgc" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvKjL5" role="jymVt">
+      <property role="TrG5h" value="getLcKey" />
+      <node concept="3clFbS" id="7OJcYqvKjL8" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqvKjL9" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqvKjJA" role="3clF45" />
+      <node concept="2AHcQZ" id="7OJcYqwOyJW" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="7OJcYqvKf0P" role="1B3o_S" />
+    <node concept="16euLQ" id="7OJcYqvKf2B" role="16eVyc">
+      <property role="TrG5h" value="LC" />
+      <node concept="3Tqbb2" id="7OJcYqvKgV_" role="3ztrMU">
+        <ref role="ehGHo" to="h3y3:6jTTMHCXLTP" resolve="IKeyed" />
+      </node>
+    </node>
+    <node concept="16euLQ" id="7OJcYqvKgVK" role="16eVyc">
+      <property role="TrG5h" value="MPS" />
+      <node concept="3Tqbb2" id="7OJcYqvKhsf" role="3ztrMU">
+        <ref role="ehGHo" to="tpce:1ob16QT2yIl" resolve="INamedStructureElement" />
+      </node>
+    </node>
+    <node concept="16euLQ" id="7OJcYqvKhss" role="16eVyc">
+      <property role="TrG5h" value="SLANG" />
+    </node>
+  </node>
+  <node concept="312cEu" id="7OJcYqvKk3R">
+    <property role="3GE5qa" value="keyedMapping" />
+    <property role="TrG5h" value="AKeyedMapping" />
+    <property role="1sVAO0" value="true" />
+    <node concept="3Tm1VV" id="7OJcYqvKk3S" role="1B3o_S" />
+    <node concept="3uibUv" id="7OJcYqvKk$F" role="EKbjA">
+      <ref role="3uigEE" node="7OJcYqvKf0O" resolve="IKeyedMapping" />
+      <node concept="16syzq" id="7OJcYqvKzpv" role="11_B2D">
+        <ref role="16sUi3" node="7OJcYqvKyqV" resolve="LC" />
+      </node>
+      <node concept="16syzq" id="7OJcYqvKzFG" role="11_B2D">
+        <ref role="16sUi3" node="7OJcYqvKyqX" resolve="MPS" />
+      </node>
+      <node concept="16syzq" id="7OJcYqvKzZc" role="11_B2D">
+        <ref role="16sUi3" node="7OJcYqvKyqZ" resolve="SLANG" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqvKuMt" role="jymVt">
+      <property role="TrG5h" value="lc" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvKuMu" role="1B3o_S" />
+      <node concept="16syzq" id="7OJcYqvK_fa" role="1tU5fm">
+        <ref role="16sUi3" node="7OJcYqvKyqV" resolve="LC" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqvKuZN" role="jymVt">
+      <property role="TrG5h" value="mps" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvKuZO" role="1B3o_S" />
+      <node concept="16syzq" id="7OJcYqvK_Xq" role="1tU5fm">
+        <ref role="16sUi3" node="7OJcYqvKyqX" resolve="MPS" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqvKvcD" role="jymVt">
+      <property role="TrG5h" value="slang" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvKvcE" role="1B3o_S" />
+      <node concept="16syzq" id="7OJcYqvKAdS" role="1tU5fm">
+        <ref role="16sUi3" node="7OJcYqvKyqZ" resolve="SLANG" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqvKGN6" role="jymVt">
+      <property role="TrG5h" value="mpsId" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvKGN7" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqvKGN8" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="7OJcYqvKvqp" role="jymVt">
+      <property role="TrG5h" value="lcId" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvKvqq" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqvKvqs" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="7OJcYqvKvHt" role="jymVt">
+      <property role="TrG5h" value="lcKey" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvKvHu" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqvKvHw" role="1tU5fm" />
+    </node>
+    <node concept="3clFbW" id="7OJcYqvKqOn" role="jymVt">
+      <node concept="3cqZAl" id="7OJcYqvKqOo" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqvKqOp" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqvKqOr" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvKuMx" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvKuMz" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvKxhJ" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvKxqJ" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvKxhM" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvKuMt" resolve="lc" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7OJcYqvKuMB" role="37vLTx">
+              <ref role="3cqZAo" node="7OJcYqvKqXW" resolve="lc" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqvKuZR" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvKuZT" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvKwVB" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvKx1p" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvKwVE" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvKuZN" resolve="mps" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7OJcYqvKuZX" role="37vLTx">
+              <ref role="3cqZAo" node="7OJcYqvKrIp" resolve="mps" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqvKvcH" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvKvcJ" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvKwAW" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvKwJI" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvKwAZ" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvKvcD" resolve="slang" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7OJcYqvKvcN" role="37vLTx">
+              <ref role="3cqZAo" node="7OJcYqvKsJF" resolve="slang" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqvKJpZ" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvKL8m" role="3clFbG">
+            <node concept="37vLTw" id="7OJcYqvKLsq" role="37vLTx">
+              <ref role="3cqZAo" node="7OJcYqvKIah" resolve="mpsId" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqvKJIN" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvKJpX" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvKKvt" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvKGN6" resolve="mpsId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqvKvqt" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvKvqv" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvKwe3" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvKwtM" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvKwe6" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvKvqp" resolve="lcId" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7OJcYqvKvqz" role="37vLTx">
+              <ref role="3cqZAo" node="7OJcYqvKtv3" resolve="lcId" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqvKvHx" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvKvHz" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvKvXO" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvKw4Y" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvKvXR" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvKvHt" resolve="lcKey" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7OJcYqvKvHB" role="37vLTx">
+              <ref role="3cqZAo" node="7OJcYqvKu98" resolve="lcKey" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvKqXW" role="3clF46">
+        <property role="TrG5h" value="lc" />
+        <node concept="16syzq" id="7OJcYqvKAV4" role="1tU5fm">
+          <ref role="16sUi3" node="7OJcYqvKyqV" resolve="LC" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwLEfW" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvKrIp" role="3clF46">
+        <property role="TrG5h" value="mps" />
+        <node concept="16syzq" id="7OJcYqvKC2y" role="1tU5fm">
+          <ref role="16sUi3" node="7OJcYqvKyqX" resolve="MPS" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwLG8m" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvKsJF" role="3clF46">
+        <property role="TrG5h" value="slang" />
+        <node concept="16syzq" id="7OJcYqvKCwb" role="1tU5fm">
+          <ref role="16sUi3" node="7OJcYqvKyqZ" resolve="SLANG" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwLI9g" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvKIah" role="3clF46">
+        <property role="TrG5h" value="mpsId" />
+        <node concept="17QB3L" id="7OJcYqvKIai" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7OJcYqwLJSD" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvKtv3" role="3clF46">
+        <property role="TrG5h" value="lcId" />
+        <node concept="17QB3L" id="7OJcYqvKtSd" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7OJcYqwLLGE" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvKu98" role="3clF46">
+        <property role="TrG5h" value="lcKey" />
+        <node concept="17QB3L" id="7OJcYqvKuwW" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7OJcYqwLNwE" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvKqcL" role="jymVt">
+      <property role="TrG5h" value="getLc" />
+      <node concept="3Tm1VV" id="7OJcYqvKqcN" role="1B3o_S" />
+      <node concept="16syzq" id="7OJcYqvKETb" role="3clF45">
+        <ref role="16sUi3" node="7OJcYqvKyqV" resolve="LC" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqvKqcQ" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvKF89" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqvKF88" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqvKuMt" resolve="lc" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqvKqcR" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwO9GW" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvKqcS" role="jymVt">
+      <property role="TrG5h" value="getMps" />
+      <node concept="3Tm1VV" id="7OJcYqvKqcU" role="1B3o_S" />
+      <node concept="16syzq" id="7OJcYqvKFKj" role="3clF45">
+        <ref role="16sUi3" node="7OJcYqvKyqX" resolve="MPS" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqvKqcX" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvKFZ$" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqvKFZz" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqvKuZN" resolve="mps" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqvKqcY" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwNNqd" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvKqcZ" role="jymVt">
+      <property role="TrG5h" value="getSlang" />
+      <node concept="3Tm1VV" id="7OJcYqvKqd1" role="1B3o_S" />
+      <node concept="16syzq" id="7OJcYqvKGeV" role="3clF45">
+        <ref role="16sUi3" node="7OJcYqvKyqZ" resolve="SLANG" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqvKqd4" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvKGz_" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqvKGz$" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqvKvcD" resolve="slang" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqvKqd5" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwNU$S" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvKqd6" role="jymVt">
+      <property role="TrG5h" value="getMpsId" />
+      <node concept="3Tm1VV" id="7OJcYqvKqd8" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqvKqd9" role="3clF45" />
+      <node concept="3clFbS" id="7OJcYqvKqda" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvKODr" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqvKODo" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqvKGN6" resolve="mpsId" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqvKqdb" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwO2eF" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvKqdm" role="jymVt">
+      <property role="TrG5h" value="getLcId" />
+      <node concept="3Tm1VV" id="7OJcYqvKqdo" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqvKqdp" role="3clF45" />
+      <node concept="3clFbS" id="7OJcYqvKqdq" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvKPyr" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqvKPyo" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqvKvqp" resolve="lcId" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqvKqdr" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOgRW" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvKqdu" role="jymVt">
+      <property role="TrG5h" value="getLcKey" />
+      <node concept="3Tm1VV" id="7OJcYqvKqdw" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqvKqdx" role="3clF45" />
+      <node concept="3clFbS" id="7OJcYqvKqdy" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvKPOw" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYqvKPOt" role="3clFbG">
+            <ref role="3cqZAo" node="7OJcYqvKvHt" resolve="lcKey" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqvKqdz" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOiSc" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+    </node>
+    <node concept="16euLQ" id="7OJcYqvKyqV" role="16eVyc">
+      <property role="TrG5h" value="LC" />
+      <node concept="3Tqbb2" id="7OJcYqvKyqW" role="3ztrMU">
+        <ref role="ehGHo" to="h3y3:6jTTMHCXLTP" resolve="IKeyed" />
+      </node>
+    </node>
+    <node concept="16euLQ" id="7OJcYqvKyqX" role="16eVyc">
+      <property role="TrG5h" value="MPS" />
+      <node concept="3Tqbb2" id="7OJcYqvKyqY" role="3ztrMU">
+        <ref role="ehGHo" to="tpce:1ob16QT2yIl" resolve="INamedStructureElement" />
+      </node>
+    </node>
+    <node concept="16euLQ" id="7OJcYqvKyqZ" role="16eVyc">
+      <property role="TrG5h" value="SLANG" />
+    </node>
+    <node concept="2YIFZL" id="5M3rB6_QlA6" role="jymVt">
+      <property role="TrG5h" value="extractKey" />
+      <node concept="3clFbS" id="5M3rB6_QlAc" role="3clF47">
+        <node concept="3cpWs8" id="2M_CqyUJRdD" role="3cqZAp">
+          <node concept="3cpWsn" id="2M_CqyUJRdE" role="3cpWs9">
+            <property role="TrG5h" value="node" />
+            <node concept="3uibUv" id="2M_CqyUJRdF" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+            </node>
+            <node concept="37vLTw" id="2M_CqyUJSIU" role="33vP2m">
+              <ref role="3cqZAo" node="5M3rB6_QlAa" resolve="keyed" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5M3rB6_QlAd" role="3cqZAp">
+          <node concept="2YIFZM" id="5M3rB6Bhih1" role="3cqZAk">
+            <ref role="37wK5l" to="33ny:~Objects.requireNonNull(java.lang.Object,java.lang.String)" resolve="requireNonNull" />
+            <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+            <node concept="2OqwBi" id="2M_CqyUJVzp" role="37wK5m">
+              <node concept="37vLTw" id="2M_CqyUJUxY" role="2Oq$k0">
+                <ref role="3cqZAo" node="2M_CqyUJRdE" resolve="node" />
+              </node>
+              <node concept="liA8E" id="2M_CqyUJWnI" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNode.getProperty(org.jetbrains.mps.openapi.language.SProperty)" resolve="getProperty" />
+                <node concept="355D3s" id="2M_CqyUJYAI" role="37wK5m">
+                  <ref role="355D3t" to="h3y3:6jTTMHCXLTP" resolve="IKeyed" />
+                  <ref role="355D3u" to="h3y3:2ju2syjkkk9" resolve="key" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs3" id="5M3rB6Bhihc" role="37wK5m">
+              <node concept="37vLTw" id="5M3rB6Bhihd" role="3uHU7w">
+                <ref role="3cqZAo" node="2M_CqyUJRdE" resolve="node" />
+              </node>
+              <node concept="Xl_RD" id="5M3rB6Bhihe" role="3uHU7B">
+                <property role="Xl_RC" value="missing key: " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="5M3rB6_QlA9" role="3clF45" />
+      <node concept="37vLTG" id="5M3rB6_QlAa" role="3clF46">
+        <property role="TrG5h" value="keyed" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tqbb2" id="5M3rB6_QlAb" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:6jTTMHCXLTP" resolve="IKeyed" />
+        </node>
+        <node concept="2AHcQZ" id="5M3rB6BhjoI" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="5JNiskhZFpA" role="1B3o_S" />
+      <node concept="2AHcQZ" id="5M3rB6_Qndx" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+    <node concept="2YIFZL" id="7OJcYqwPBay" role="jymVt">
+      <property role="TrG5h" value="extractKeyOptional" />
+      <node concept="3clFbS" id="7OJcYqwPBaz" role="3clF47">
+        <node concept="3clFbJ" id="7OJcYqwPD5I" role="3cqZAp">
+          <node concept="3clFbS" id="7OJcYqwPD5K" role="3clFbx">
+            <node concept="3cpWs6" id="7OJcYqwPDVu" role="3cqZAp">
+              <node concept="10Nm6u" id="7OJcYqwPE6x" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3clFbC" id="7OJcYqwPDyr" role="3clFbw">
+            <node concept="10Nm6u" id="7OJcYqwPDLH" role="3uHU7w" />
+            <node concept="37vLTw" id="7OJcYqwPDfB" role="3uHU7B">
+              <ref role="3cqZAo" node="7OJcYqwPBaM" resolve="keyed" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7OJcYqwPBa$" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqwPBa_" role="3cpWs9">
+            <property role="TrG5h" value="node" />
+            <node concept="3uibUv" id="7OJcYqwPBaA" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+            </node>
+            <node concept="37vLTw" id="7OJcYqwPBaB" role="33vP2m">
+              <ref role="3cqZAo" node="7OJcYqwPBaM" resolve="keyed" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7OJcYqwPBaC" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwPBaE" role="3cqZAk">
+            <node concept="37vLTw" id="7OJcYqwPBaF" role="2Oq$k0">
+              <ref role="3cqZAo" node="7OJcYqwPBa_" resolve="node" />
+            </node>
+            <node concept="liA8E" id="7OJcYqwPBaG" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.getProperty(org.jetbrains.mps.openapi.language.SProperty)" resolve="getProperty" />
+              <node concept="355D3s" id="7OJcYqwPBaH" role="37wK5m">
+                <ref role="355D3t" to="h3y3:6jTTMHCXLTP" resolve="IKeyed" />
+                <ref role="355D3u" to="h3y3:2ju2syjkkk9" resolve="key" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="7OJcYqwPBaL" role="3clF45" />
+      <node concept="37vLTG" id="7OJcYqwPBaM" role="3clF46">
+        <property role="TrG5h" value="keyed" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tqbb2" id="7OJcYqwPBaN" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:6jTTMHCXLTP" resolve="IKeyed" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwPBaO" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="7OJcYqwPBaP" role="1B3o_S" />
+      <node concept="2AHcQZ" id="7OJcYqwPBaQ" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="7OJcYqvKWo$">
+    <property role="3GE5qa" value="keyedMapping" />
+    <property role="TrG5h" value="ConceptKeyedMapping" />
+    <node concept="3Tm1VV" id="7OJcYqvKWo_" role="1B3o_S" />
+    <node concept="3uibUv" id="7OJcYqvKWTq" role="1zkMxy">
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqvKX9U" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:2ju2syjklrv" resolve="Concept" />
+      </node>
+      <node concept="3Tqbb2" id="7OJcYqvKXaI" role="11_B2D">
+        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+      </node>
+      <node concept="3uibUv" id="7OJcYqvKXbF" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+    </node>
+    <node concept="3clFbW" id="7OJcYqvKXd$" role="jymVt">
+      <node concept="3cqZAl" id="7OJcYqvKXd_" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqvKXdA" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqvKXdC" role="3clF47">
+        <node concept="XkiVB" id="7OJcYqvKXdE" role="3cqZAp">
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <node concept="37vLTw" id="7OJcYqvKXdI" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvKXdF" resolve="lc" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqvKXdM" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvKXdJ" resolve="mps" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqvKXdQ" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvKXdN" resolve="slang" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqvMJpW" role="37wK5m">
+            <node concept="2YIFZM" id="7OJcYqvMLfi" role="2Oq$k0">
+              <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getConceptId(org.jetbrains.mps.openapi.model.SNode)" resolve="getConceptId" />
+              <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+              <node concept="37vLTw" id="7OJcYqvMLfj" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqvKXdJ" resolve="mps" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7OJcYqvMJpZ" role="2OqNvi">
+              <ref role="37wK5l" to="e8bb:~SConceptId.toString()" resolve="toString" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwPEJV" role="37wK5m">
+            <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <node concept="37vLTw" id="7OJcYqwPEJW" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqvKXdF" resolve="lc" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwPF25" role="37wK5m">
+            <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <node concept="37vLTw" id="7OJcYqwPF26" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqvKXdF" resolve="lc" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvKXdF" role="3clF46">
+        <property role="TrG5h" value="lc" />
+        <node concept="3Tqbb2" id="7OJcYqvKXAM" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjklrv" resolve="Concept" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwLt02" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvKXdJ" role="3clF46">
+        <property role="TrG5h" value="mps" />
+        <node concept="3Tqbb2" id="7OJcYqvKXVd" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwLxze" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvKXdN" role="3clF46">
+        <property role="TrG5h" value="slang" />
+        <node concept="3uibUv" id="7OJcYqvKYgj" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwL_IU" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+    </node>
+    <node concept="3uibUv" id="7OJcYqwYpbh" role="EKbjA">
+      <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqwYxKG" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:2ju2syjklrv" resolve="Concept" />
+      </node>
+      <node concept="3Tqbb2" id="7OJcYqwYxKH" role="11_B2D">
+        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+      </node>
+      <node concept="3uibUv" id="7OJcYqwYxKI" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="7OJcYqvL3W3">
+    <property role="3GE5qa" value="keyedMapping" />
+    <property role="TrG5h" value="PrimitiveTypeKeyedMapping" />
+    <node concept="3Tm1VV" id="7OJcYqvL3W4" role="1B3o_S" />
+    <node concept="3uibUv" id="7OJcYqvL4WJ" role="1zkMxy">
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqvL5bz" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+      </node>
+      <node concept="3Tqbb2" id="7OJcYqvL5cH" role="11_B2D">
+        <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
+      </node>
+      <node concept="3uibUv" id="7OJcYqvL5h1" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+      </node>
+    </node>
+    <node concept="3clFbW" id="7OJcYqvLccW" role="jymVt">
+      <node concept="3cqZAl" id="7OJcYqvLccX" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqvLccY" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqvLcd0" role="3clF47">
+        <node concept="XkiVB" id="7OJcYqvLcd2" role="3cqZAp">
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <node concept="37vLTw" id="7OJcYqvLcd6" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvLcd3" resolve="lc" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqvLcda" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvLcd7" resolve="mps" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqvLcde" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvLcdb" resolve="slang" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqvLV8A" role="37wK5m">
+            <node concept="2YIFZM" id="7OJcYqvLV8B" role="2Oq$k0">
+              <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
+              <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+              <node concept="37vLTw" id="7OJcYqvLV8C" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqvLcd7" resolve="mps" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7OJcYqvLV8D" role="2OqNvi">
+              <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwPrVr" role="37wK5m">
+            <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <node concept="37vLTw" id="7OJcYqvLM9o" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqvLcd3" resolve="lc" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwPrVs" role="37wK5m">
+            <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <node concept="37vLTw" id="7OJcYqvLIAw" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqvLcd3" resolve="lc" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvLcd3" role="3clF46">
+        <property role="TrG5h" value="lc" />
+        <node concept="3Tqbb2" id="7OJcYqvLcyp" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwNkQF" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvLcd7" role="3clF46">
+        <property role="TrG5h" value="mps" />
+        <node concept="3Tqbb2" id="7OJcYqvLcNH" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwNpk5" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvLcdb" role="3clF46">
+        <property role="TrG5h" value="slang" />
+        <node concept="3uibUv" id="7OJcYqvLeq0" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwNt$J" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwP92e" role="jymVt">
+      <property role="TrG5h" value="getLc" />
+      <node concept="3Tm1VV" id="7OJcYqwP92f" role="1B3o_S" />
+      <node concept="3Tqbb2" id="7OJcYqwP92g" role="3clF45">
+        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwP92h" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwP92i" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqwP92j" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwP92k" role="3cqZAp">
+          <node concept="3nyPlj" id="7OJcYqwP92l" role="3clFbG">
+            <ref role="37wK5l" node="7OJcYqvKqcL" resolve="getLc" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwP92m" role="jymVt">
+      <property role="TrG5h" value="getLcId" />
+      <node concept="3Tm1VV" id="7OJcYqwP92n" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqwP92o" role="3clF45" />
+      <node concept="2AHcQZ" id="7OJcYqwP92p" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwP92q" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqwP92r" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwP92s" role="3cqZAp">
+          <node concept="3nyPlj" id="7OJcYqwP92t" role="3clFbG">
+            <ref role="37wK5l" node="7OJcYqvKqdm" resolve="getLcId" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwP92u" role="jymVt">
+      <property role="TrG5h" value="getLcKey" />
+      <node concept="3Tm1VV" id="7OJcYqwP92v" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqwP92w" role="3clF45" />
+      <node concept="2AHcQZ" id="7OJcYqwP92x" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwP92y" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqwP92z" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwP92$" role="3cqZAp">
+          <node concept="3nyPlj" id="7OJcYqwP92_" role="3clFbG">
+            <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3uibUv" id="7OJcYqx0qrW" role="EKbjA">
+      <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqx0rRl" role="11_B2D">
+        <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="7OJcYqvMQ8$">
+    <property role="3GE5qa" value="keyedMapping" />
+    <property role="TrG5h" value="LanguageKeyedMapping" />
+    <node concept="312cEg" id="7OJcYqvMRnR" role="jymVt">
+      <property role="TrG5h" value="slang" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvMRnS" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqvMSEK" role="1tU5fm">
+        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqvNQAN" role="jymVt">
+      <property role="TrG5h" value="slangId" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvNMnT" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYqvNPdV" role="1tU5fm">
+        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqvMRnU" role="jymVt">
+      <property role="TrG5h" value="mpsId" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvMRnV" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqvNDGR" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="7OJcYqwoq92" role="jymVt">
+      <property role="TrG5h" value="mpsVersion" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqwopVI" role="1B3o_S" />
+      <node concept="10Oyi0" id="7OJcYqwoq8T" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="7OJcYqvMUJj" role="jymVt">
+      <property role="TrG5h" value="lcVersion" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvMUD_" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqvMUJa" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="7OJcYqvMRnX" role="jymVt">
+      <property role="TrG5h" value="lcId" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvMRnY" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqvMRnZ" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="7OJcYqvMRo0" role="jymVt">
+      <property role="TrG5h" value="lcKey" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqvMRo1" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqvMRo2" role="1tU5fm" />
+    </node>
+    <node concept="3clFbW" id="7OJcYqvMRo3" role="jymVt">
+      <node concept="3cqZAl" id="7OJcYqvMRo4" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqvMRo5" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqvMRo6" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvMRoj" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvMRok" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvMRol" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvMRom" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvMRon" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvMRnR" resolve="slang" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7OJcYqvMRoo" role="37vLTx">
+              <ref role="3cqZAo" node="7OJcYqvMRoH" resolve="slang" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqvNTvz" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvNU3e" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvNTFg" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvNTvx" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvNTUj" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvNQAN" resolve="slangId" />
+              </node>
+            </node>
+            <node concept="2YIFZM" id="7OJcYqvNU7d" role="37vLTx">
+              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
+              <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
+              <node concept="37vLTw" id="7OJcYqvNU7e" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqvMRoH" resolve="slang" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqvMRop" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvMRoq" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvMRos" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvMRot" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvMRou" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvMRnU" resolve="mpsId" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7OJcYqvO0ZH" role="37vLTx">
+              <node concept="37vLTw" id="7OJcYqvMRo$" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYqvNQAN" resolve="slangId" />
+              </node>
+              <node concept="liA8E" id="7OJcYqvO1e3" role="2OqNvi">
+                <ref role="37wK5l" to="e8bb:~SLanguageId.toString()" resolve="toString" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqwoqpx" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqworvi" role="3clFbG">
+            <node concept="2YIFZM" id="7OJcYqwo_HS" role="37vLTx">
+              <ref role="37wK5l" node="6jTTMHD72KX" resolve="getLanguageVersion" />
+              <ref role="1Pybhc" node="6jTTMHD72IS" resolve="MpsLanguageUtil" />
+              <node concept="37vLTw" id="7OJcYqwo_Vx" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqvMRoH" resolve="slang" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7OJcYqwoqAg" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqwoqpv" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqwoqJm" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqwoq92" resolve="mpsVersion" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqvMZyu" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvN09E" role="3clFbG">
+            <node concept="37vLTw" id="7OJcYqvN0fj" role="37vLTx">
+              <ref role="3cqZAo" node="7OJcYqvO4y8" resolve="lcVersion" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqvMZEN" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvMZys" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvMZNH" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvMUJj" resolve="lcVersion" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqvMRov" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvMRow" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvMRox" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvMRoy" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvMRoz" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvMRnX" resolve="lcId" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7OJcYqvOcYk" role="37vLTx">
+              <ref role="3cqZAo" node="7OJcYqvMRoN" resolve="lcId" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqvMRo_" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqvMRoA" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqvMRoB" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqvMRoC" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqvMRoD" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqvMRo0" resolve="lcKey" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7OJcYqvMRoE" role="37vLTx">
+              <ref role="3cqZAo" node="7OJcYqvMRoP" resolve="lcKey" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvMRoH" role="3clF46">
+        <property role="TrG5h" value="slang" />
+        <node concept="3uibUv" id="7OJcYqvMVDC" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwMsA0" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvO4y8" role="3clF46">
+        <property role="TrG5h" value="lcVersion" />
+        <node concept="17QB3L" id="7OJcYqvO6KI" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7OJcYqwMwUp" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvMRoN" role="3clF46">
+        <property role="TrG5h" value="lcId" />
+        <node concept="17QB3L" id="7OJcYqvMRoO" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7OJcYqwMzPl" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvMRoP" role="3clF46">
+        <property role="TrG5h" value="lcKey" />
+        <node concept="17QB3L" id="7OJcYqvMRoQ" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7OJcYqwMCa9" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbW" id="7OJcYqwqm3V" role="jymVt">
+      <node concept="3cqZAl" id="7OJcYqwqm3W" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqwqm3X" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwqm3Y" role="3clF47">
+        <node concept="1VxSAg" id="7OJcYqwqqWB" role="3cqZAp">
+          <ref role="37wK5l" node="7OJcYqvMRo3" resolve="LanguageKeyedMapping" />
+          <node concept="37vLTw" id="7OJcYqwqr1O" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqwqm4H" resolve="slang" />
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwqrGk" role="37wK5m">
+            <ref role="37wK5l" node="34Q84zMXVAC" resolve="getLanguageVersionString" />
+            <ref role="1Pybhc" node="6jTTMHD72IS" resolve="MpsLanguageUtil" />
+            <node concept="37vLTw" id="7OJcYqwqrGl" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqwqm4H" resolve="slang" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7OJcYqwqwht" role="37wK5m">
+            <node concept="2YIFZM" id="7OJcYqwquaC" role="2Oq$k0">
+              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
+              <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
+              <node concept="37vLTw" id="7OJcYqwquaD" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqwqm4H" resolve="slang" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7OJcYqwqxV5" role="2OqNvi">
+              <ref role="37wK5l" to="e8bb:~SLanguageId.toString()" resolve="toString" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7OJcYqwqyBX" role="37wK5m">
+            <node concept="2YIFZM" id="7OJcYqwqyBY" role="2Oq$k0">
+              <ref role="1Pybhc" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
+              <ref role="37wK5l" node="39$JcGG9B65" resolve="extractLanguageId" />
+              <node concept="37vLTw" id="7OJcYqwqyBZ" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqwqm4H" resolve="slang" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7OJcYqwqyC0" role="2OqNvi">
+              <ref role="37wK5l" to="e8bb:~SLanguageId.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqwqm4H" role="3clF46">
+        <property role="TrG5h" value="slang" />
+        <node concept="3uibUv" id="7OJcYqwqm4I" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="7OJcYqvMQ8_" role="1B3o_S" />
+    <node concept="3clFb_" id="7OJcYqvN0Q9" role="jymVt">
+      <property role="TrG5h" value="getSlang" />
+      <node concept="3uibUv" id="7OJcYqvN0Qa" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqvN0Qb" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqvN0Qc" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvN0Qd" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqvN0Q6" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqvN0Q7" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqvN0Q8" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvMRnR" resolve="slang" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwMGrb" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqw7aei" role="jymVt">
+      <property role="TrG5h" value="getSlangId" />
+      <node concept="3uibUv" id="7OJcYqw7aej" role="3clF45">
+        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqw7aek" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqw7ael" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqw7aem" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqw7aef" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqw7aeg" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqw7aeh" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvNQAN" resolve="slangId" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwMND3" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvN0Qh" role="jymVt">
+      <property role="TrG5h" value="getMpsId" />
+      <node concept="17QB3L" id="7OJcYqvN0Qi" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqvN0Qj" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqvN0Qk" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvN0Ql" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqvN0Qe" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqvN0Qf" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqvN0Qg" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvMRnU" resolve="mpsId" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwMSRo" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwoA7z" role="jymVt">
+      <property role="TrG5h" value="getMpsVersion" />
+      <node concept="10Oyi0" id="7OJcYqwoA7$" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqwoA7_" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwoA7A" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwoA7B" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwoA7w" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwoA7x" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwoA7y" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqwoq92" resolve="mpsVersion" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvN0Qp" role="jymVt">
+      <property role="TrG5h" value="getLcVersion" />
+      <node concept="17QB3L" id="7OJcYqvN0Qq" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqvN0Qr" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqvN0Qs" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvN0Qt" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqvN0Qm" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqvN0Qn" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqvN0Qo" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvMUJj" resolve="lcVersion" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwMZw2" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvN0Qx" role="jymVt">
+      <property role="TrG5h" value="getLcId" />
+      <node concept="17QB3L" id="7OJcYqvN0Qy" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqvN0Qz" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqvN0Q$" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvN0Q_" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqvN0Qu" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqvN0Qv" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqvN0Qw" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvMRnX" resolve="lcId" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwN6Bh" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqvN0QD" role="jymVt">
+      <property role="TrG5h" value="getLcKey" />
+      <node concept="17QB3L" id="7OJcYqvN0QE" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqvN0QF" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqvN0QG" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqvN0QH" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqvN0QA" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqvN0QB" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqvN0QC" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqvMRo0" resolve="lcKey" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwNdmB" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="7OJcYqvQ8aH">
+    <property role="3GE5qa" value="keyedMapping" />
+    <property role="TrG5h" value="ContainmentKeyedMapping" />
+    <node concept="3Tm1VV" id="7OJcYqvQ8aI" role="1B3o_S" />
+    <node concept="3uibUv" id="7OJcYqvQ8CZ" role="1zkMxy">
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqvQ91i" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:2ju2syjkkU6" resolve="Containment" />
+      </node>
+      <node concept="3Tqbb2" id="7OJcYqvQ92p" role="11_B2D">
+        <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+      </node>
+      <node concept="3uibUv" id="7OJcYqvQaqa" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+      </node>
+    </node>
+    <node concept="3clFbW" id="7OJcYqvQc4u" role="jymVt">
+      <node concept="3cqZAl" id="7OJcYqvQc4v" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqvQc4w" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqvQc4y" role="3clF47">
+        <node concept="XkiVB" id="7OJcYqvQc4$" role="3cqZAp">
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <node concept="37vLTw" id="7OJcYqvQc4C" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvQc4_" resolve="lc" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqvQc4G" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvQc4D" resolve="mps" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqvQc4K" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvQc4H" resolve="slang" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqvQTtJ" role="37wK5m">
+            <node concept="2YIFZM" id="7OJcYqvQTtK" role="2Oq$k0">
+              <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getLinkId(org.jetbrains.mps.openapi.model.SNode)" resolve="getLinkId" />
+              <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+              <node concept="37vLTw" id="7OJcYqvQTtL" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqvQc4D" resolve="mps" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7OJcYqvQTtM" role="2OqNvi">
+              <ref role="37wK5l" to="e8bb:~SContainmentLinkId.toString()" resolve="toString" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwPFPA" role="37wK5m">
+            <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <node concept="37vLTw" id="7OJcYqwPFPB" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqvQc4_" resolve="lc" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwPG7K" role="37wK5m">
+            <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <node concept="37vLTw" id="7OJcYqwPG7L" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqvQc4_" resolve="lc" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvQc4_" role="3clF46">
+        <property role="TrG5h" value="lc" />
+        <node concept="3Tqbb2" id="7OJcYqvQcnJ" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjkkU6" resolve="Containment" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwM2ZC" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvQc4D" role="3clF46">
+        <property role="TrG5h" value="mps" />
+        <node concept="3Tqbb2" id="7OJcYqvQcCR" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwM7Xp" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvQc4H" role="3clF46">
+        <property role="TrG5h" value="slang" />
+        <node concept="3uibUv" id="7OJcYqvQcU4" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwMcj$" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+    </node>
+    <node concept="3uibUv" id="7OJcYqx2xSv" role="EKbjA">
+      <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqx2yb9" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:2ju2syjkkU6" resolve="Containment" />
+      </node>
+      <node concept="3Tqbb2" id="7OJcYqx2yba" role="11_B2D">
+        <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+      </node>
+      <node concept="3uibUv" id="7OJcYqx2ybb" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="7OJcYqvRt75">
+    <property role="3GE5qa" value="keyedMapping" />
+    <property role="TrG5h" value="PropertyKeyMapping" />
+    <node concept="3Tm1VV" id="7OJcYqvRt76" role="1B3o_S" />
+    <node concept="3uibUv" id="7OJcYqvRt$z" role="1zkMxy">
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqvRtNn" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+      </node>
+      <node concept="3Tqbb2" id="7OJcYqvRv9c" role="11_B2D">
+        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+      </node>
+      <node concept="3uibUv" id="7OJcYqvRwvD" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+      </node>
+    </node>
+    <node concept="3clFbW" id="7OJcYqvRxYF" role="jymVt">
+      <node concept="3cqZAl" id="7OJcYqvRxYG" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqvRxYH" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqvRxYJ" role="3clF47">
+        <node concept="XkiVB" id="7OJcYqvRxYL" role="3cqZAp">
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <node concept="37vLTw" id="7OJcYqvRxYP" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvRxYM" resolve="lc" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqvRxYT" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvRxYQ" resolve="mps" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqvRxYX" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvRxYU" resolve="slang" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqvRBTx" role="37wK5m">
+            <node concept="2YIFZM" id="7OJcYqvRBTy" role="2Oq$k0">
+              <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getPropId(org.jetbrains.mps.openapi.model.SNode)" resolve="getPropId" />
+              <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+              <node concept="37vLTw" id="7OJcYqvRBTz" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqvRxYQ" resolve="mps" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7OJcYqvRBT$" role="2OqNvi">
+              <ref role="37wK5l" to="e8bb:~SPropertyId.toString()" resolve="toString" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwPH1O" role="37wK5m">
+            <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <node concept="37vLTw" id="7OJcYqwPH1P" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqvRxYM" resolve="lc" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwPHjY" role="37wK5m">
+            <ref role="37wK5l" node="7OJcYqwPBay" resolve="extractKeyOptional" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <node concept="37vLTw" id="7OJcYqwPHjZ" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqvRxYM" resolve="lc" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvRxYM" role="3clF46">
+        <property role="TrG5h" value="lc" />
+        <node concept="3Tqbb2" id="7OJcYqvRyk1" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwN_3V" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvRxYQ" role="3clF46">
+        <property role="TrG5h" value="mps" />
+        <node concept="3Tqbb2" id="7OJcYqvR$c2" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwNDQR" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvRxYU" role="3clF46">
+        <property role="TrG5h" value="slang" />
+        <node concept="3uibUv" id="7OJcYqvR_Ma" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwNIIE" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+    </node>
+    <node concept="3uibUv" id="7OJcYqx2wVp" role="EKbjA">
+      <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqx2xhq" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+      </node>
+      <node concept="3Tqbb2" id="7OJcYqx2xhr" role="11_B2D">
+        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+      </node>
+      <node concept="3uibUv" id="7OJcYqx2xhs" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="7OJcYqvXZ8V">
+    <property role="3GE5qa" value="keyedMapping" />
+    <property role="TrG5h" value="InterfaceKeyedMapping" />
+    <node concept="3Tm1VV" id="7OJcYqvXZ8W" role="1B3o_S" />
+    <node concept="3uibUv" id="7OJcYqvXZ8X" role="1zkMxy">
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqvXZ8Y" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:2ju2syjklHQ" resolve="Interface" />
+      </node>
+      <node concept="3Tqbb2" id="7OJcYqvXZ8Z" role="11_B2D">
+        <ref role="ehGHo" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
+      </node>
+      <node concept="3uibUv" id="7OJcYqvXZ90" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SInterfaceConcept" resolve="SInterfaceConcept" />
+      </node>
+    </node>
+    <node concept="3clFbW" id="7OJcYqvXZ91" role="jymVt">
+      <node concept="3cqZAl" id="7OJcYqvXZ92" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqvXZ93" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqvXZ94" role="3clF47">
+        <node concept="XkiVB" id="7OJcYqvXZ95" role="3cqZAp">
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <node concept="37vLTw" id="7OJcYqvXZ96" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvXZ9h" resolve="lc" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqvXZ97" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvXZ9j" resolve="mps" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqvXZ98" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvXZ9l" resolve="slang" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqvXZ99" role="37wK5m">
+            <node concept="2YIFZM" id="7OJcYqvXZ9a" role="2Oq$k0">
+              <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+              <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getConceptId(org.jetbrains.mps.openapi.model.SNode)" resolve="getConceptId" />
+              <node concept="37vLTw" id="7OJcYqvXZ9b" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqvXZ9j" resolve="mps" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7OJcYqvXZ9c" role="2OqNvi">
+              <ref role="37wK5l" to="e8bb:~SConceptId.toString()" resolve="toString" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwPrVx" role="37wK5m">
+            <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <node concept="37vLTw" id="7OJcYqvXZ9e" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqvXZ9h" resolve="lc" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwPrVy" role="37wK5m">
+            <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <node concept="37vLTw" id="7OJcYqvXZ9g" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqvXZ9h" resolve="lc" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvXZ9h" role="3clF46">
+        <property role="TrG5h" value="lc" />
+        <node concept="3Tqbb2" id="7OJcYqvXZ9i" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjklHQ" resolve="Interface" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwMgHX" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvXZ9j" role="3clF46">
+        <property role="TrG5h" value="mps" />
+        <node concept="3Tqbb2" id="7OJcYqvXZ9k" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwMjhA" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqvXZ9l" role="3clF46">
+        <property role="TrG5h" value="slang" />
+        <node concept="3uibUv" id="7OJcYqvXZ9m" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SInterfaceConcept" resolve="SInterfaceConcept" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwMnwX" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwOWjc" role="jymVt">
+      <property role="TrG5h" value="getLc" />
+      <node concept="3Tm1VV" id="7OJcYqwOWjd" role="1B3o_S" />
+      <node concept="3Tqbb2" id="7OJcYqwOWje" role="3clF45">
+        <ref role="ehGHo" to="h3y3:2ju2syjklHQ" resolve="Interface" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOWjf" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOWjg" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqwOWjh" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwOWji" role="3cqZAp">
+          <node concept="3nyPlj" id="7OJcYqwOWjj" role="3clFbG">
+            <ref role="37wK5l" node="7OJcYqvKqcL" resolve="getLc" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwOWjk" role="jymVt">
+      <property role="TrG5h" value="getLcId" />
+      <node concept="3Tm1VV" id="7OJcYqwOWjl" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqwOWjm" role="3clF45" />
+      <node concept="2AHcQZ" id="7OJcYqwOWjn" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOWjo" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqwOWjp" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwOWjq" role="3cqZAp">
+          <node concept="3nyPlj" id="7OJcYqwOWjr" role="3clFbG">
+            <ref role="37wK5l" node="7OJcYqvKqdm" resolve="getLcId" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwOWjs" role="jymVt">
+      <property role="TrG5h" value="getLcKey" />
+      <node concept="3Tm1VV" id="7OJcYqwOWjt" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqwOWju" role="3clF45" />
+      <node concept="2AHcQZ" id="7OJcYqwOWjv" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOWjw" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqwOWjx" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwOWjy" role="3cqZAp">
+          <node concept="3nyPlj" id="7OJcYqwOWjz" role="3clFbG">
+            <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3uibUv" id="7OJcYqwYBUK" role="EKbjA">
+      <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqx9Y_w" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:2ju2syjklHQ" resolve="Interface" />
+      </node>
+      <node concept="3Tqbb2" id="7OJcYqx9Y_x" role="11_B2D">
+        <ref role="ehGHo" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
+      </node>
+      <node concept="3uibUv" id="7OJcYqx9Y_y" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SInterfaceConcept" resolve="SInterfaceConcept" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="7OJcYqw2ryQ">
+    <property role="3GE5qa" value="keyedMapping" />
+    <property role="TrG5h" value="ConstrainedPrimitiveTypeKeyedMapping" />
+    <node concept="3Tm1VV" id="7OJcYqw2ryR" role="1B3o_S" />
+    <node concept="3uibUv" id="7OJcYqw2ryS" role="1zkMxy">
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqw2ryT" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+      </node>
+      <node concept="3Tqbb2" id="7OJcYqw2ryU" role="11_B2D">
+        <ref role="ehGHo" to="tpce:fKAz7CR" resolve="ConstrainedDataTypeDeclaration" />
+      </node>
+      <node concept="3uibUv" id="7OJcYqw2ryV" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+      </node>
+    </node>
+    <node concept="3clFbW" id="7OJcYqw2ryW" role="jymVt">
+      <node concept="3cqZAl" id="7OJcYqw2ryX" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqw2ryY" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqw2ryZ" role="3clF47">
+        <node concept="XkiVB" id="7OJcYqw2rz0" role="3cqZAp">
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <node concept="37vLTw" id="7OJcYqw2rz1" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqw2rzc" resolve="lc" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqw2rz2" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqw2rze" resolve="mps" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqw2rz3" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqw2rzg" resolve="slang" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqw2rz4" role="37wK5m">
+            <node concept="2YIFZM" id="7OJcYqw2rz5" role="2Oq$k0">
+              <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+              <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
+              <node concept="37vLTw" id="7OJcYqw2rz6" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqw2rze" resolve="mps" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7OJcYqw2rz7" role="2OqNvi">
+              <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwPrVz" role="37wK5m">
+            <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <node concept="37vLTw" id="7OJcYqw2rz9" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqw2rzc" resolve="lc" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwPrV$" role="37wK5m">
+            <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <node concept="37vLTw" id="7OJcYqw2rzb" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqw2rzc" resolve="lc" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqw2rzc" role="3clF46">
+        <property role="TrG5h" value="lc" />
+        <node concept="3Tqbb2" id="7OJcYqw2rzd" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwLPtD" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqw2rze" role="3clF46">
+        <property role="TrG5h" value="mps" />
+        <node concept="3Tqbb2" id="7OJcYqw2rzf" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:fKAz7CR" resolve="ConstrainedDataTypeDeclaration" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwLUg8" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqw2rzg" role="3clF46">
+        <property role="TrG5h" value="slang" />
+        <node concept="3uibUv" id="7OJcYqw2rzh" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwLYCE" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwOOzI" role="jymVt">
+      <property role="TrG5h" value="getLc" />
+      <node concept="3Tm1VV" id="7OJcYqwOOzJ" role="1B3o_S" />
+      <node concept="3Tqbb2" id="7OJcYqwOOzK" role="3clF45">
+        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOOzL" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOOzM" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqwOOzN" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwOOzO" role="3cqZAp">
+          <node concept="3nyPlj" id="7OJcYqwOOzP" role="3clFbG">
+            <ref role="37wK5l" node="7OJcYqvKqcL" resolve="getLc" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwOOzQ" role="jymVt">
+      <property role="TrG5h" value="getLcId" />
+      <node concept="3Tm1VV" id="7OJcYqwOOzR" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqwOOzS" role="3clF45" />
+      <node concept="2AHcQZ" id="7OJcYqwOOzT" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOOzU" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqwOOzV" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwOOzW" role="3cqZAp">
+          <node concept="3nyPlj" id="7OJcYqwOOzX" role="3clFbG">
+            <ref role="37wK5l" node="7OJcYqvKqdm" resolve="getLcId" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwOOzY" role="jymVt">
+      <property role="TrG5h" value="getLcKey" />
+      <node concept="3Tm1VV" id="7OJcYqwOOzZ" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqwOO$0" role="3clF45" />
+      <node concept="2AHcQZ" id="7OJcYqwOO$1" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOO$2" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqwOO$3" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwOO$4" role="3cqZAp">
+          <node concept="3nyPlj" id="7OJcYqwOO$5" role="3clFbG">
+            <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3uibUv" id="7OJcYqx0o5m" role="EKbjA">
+      <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqx0pzC" role="11_B2D">
+        <ref role="ehGHo" to="tpce:fKAz7CR" resolve="ConstrainedDataTypeDeclaration" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="7OJcYqwnwCi">
+    <property role="3GE5qa" value="keyedMapping" />
+    <property role="TrG5h" value="AnnotationPropertyKeyedMapping" />
+    <node concept="3Tm1VV" id="7OJcYqwnwCj" role="1B3o_S" />
+    <node concept="3uibUv" id="7OJcYqwnwCk" role="1zkMxy">
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqwnwCl" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
+      </node>
+      <node concept="3Tqbb2" id="7OJcYqwnwCm" role="11_B2D">
+        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+      </node>
+      <node concept="3uibUv" id="7OJcYqwnwCn" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqwpbTN" role="jymVt">
+      <property role="TrG5h" value="lcProp" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqwpbTO" role="1B3o_S" />
+      <node concept="3Tqbb2" id="7OJcYqwpbTQ" role="1tU5fm">
+        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7OJcYqwyo$l" role="jymVt">
+      <property role="TrG5h" value="lcPropKey" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYqwyoo7" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqwyo$5" role="1tU5fm" />
+    </node>
+    <node concept="3clFbW" id="7OJcYqwnwCo" role="jymVt">
+      <node concept="3cqZAl" id="7OJcYqwnwCp" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqwnwCq" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwnwCr" role="3clF47">
+        <node concept="XkiVB" id="7OJcYqwnwCs" role="3cqZAp">
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <node concept="37vLTw" id="7OJcYqwnwCt" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqwnwCC" resolve="lc" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqwnwCu" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqwnwCE" resolve="mpsProp" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqwnwCv" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqwnwCG" resolve="slangProp" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqwnwCw" role="37wK5m">
+            <node concept="2YIFZM" id="7OJcYqwo2pP" role="2Oq$k0">
+              <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getPropId(org.jetbrains.mps.openapi.model.SNode)" resolve="getPropId" />
+              <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+              <node concept="37vLTw" id="7OJcYqwo2pQ" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqwnwCE" resolve="mpsProp" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7OJcYqwnwCz" role="2OqNvi">
+              <ref role="37wK5l" to="e8bb:~SPropertyId.toString()" resolve="toString" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwPrV_" role="37wK5m">
+            <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <node concept="37vLTw" id="7OJcYqwnwC_" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqwnwCC" resolve="lc" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwPrVA" role="37wK5m">
+            <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <node concept="37vLTw" id="7OJcYqwnwCB" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqwnwCC" resolve="lc" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqwpbTR" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqwpbTT" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqwpdj3" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqwpdr4" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqwpdj6" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqwpbTN" resolve="lcProp" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="7OJcYqwpbTX" role="37vLTx">
+              <ref role="3cqZAo" node="7OJcYqwp9Gu" resolve="lcProp" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYqwyoMT" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYqwypx0" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYqwypaz" role="37vLTJ">
+              <node concept="Xjq3P" id="7OJcYqwyoMR" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7OJcYqwypeV" role="2OqNvi">
+                <ref role="2Oxat5" node="7OJcYqwyo$l" resolve="lcPropKey" />
+              </node>
+            </node>
+            <node concept="2YIFZM" id="7OJcYqwPrVB" role="37vLTx">
+              <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+              <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+              <node concept="37vLTw" id="7OJcYqwypS9" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqwp9Gu" resolve="lcProp" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqwnwCC" role="3clF46">
+        <property role="TrG5h" value="lc" />
+        <node concept="3Tqbb2" id="7OJcYqwnwCD" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwLkQf" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqwp9Gu" role="3clF46">
+        <property role="TrG5h" value="lcProp" />
+        <node concept="3Tqbb2" id="7OJcYqwp9WN" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwLmlc" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqwnwCE" role="3clF46">
+        <property role="TrG5h" value="mpsProp" />
+        <node concept="3Tqbb2" id="7OJcYqwnwCF" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwLnR_" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqwnwCG" role="3clF46">
+        <property role="TrG5h" value="slangProp" />
+        <node concept="3uibUv" id="7OJcYqwnwCH" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwLpiQ" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwOF7L" role="jymVt">
+      <property role="TrG5h" value="getLc" />
+      <node concept="3Tm1VV" id="7OJcYqwOF7M" role="1B3o_S" />
+      <node concept="3Tqbb2" id="7OJcYqwOF7N" role="3clF45">
+        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOF7O" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOF7P" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqwOF7Q" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwOF7R" role="3cqZAp">
+          <node concept="3nyPlj" id="7OJcYqwOF7S" role="3clFbG">
+            <ref role="37wK5l" node="7OJcYqvKqcL" resolve="getLc" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwOF7T" role="jymVt">
+      <property role="TrG5h" value="getLcId" />
+      <node concept="3Tm1VV" id="7OJcYqwOF7U" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqwOF7V" role="3clF45" />
+      <node concept="2AHcQZ" id="7OJcYqwOF7W" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOF7X" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqwOF7Y" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwOF7Z" role="3cqZAp">
+          <node concept="3nyPlj" id="7OJcYqwOF80" role="3clFbG">
+            <ref role="37wK5l" node="7OJcYqvKqdm" resolve="getLcId" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwOF81" role="jymVt">
+      <property role="TrG5h" value="getLcKey" />
+      <node concept="3Tm1VV" id="7OJcYqwOF82" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqwOF83" role="3clF45" />
+      <node concept="2AHcQZ" id="7OJcYqwOF84" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOF85" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqwOF86" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwOF87" role="3cqZAp">
+          <node concept="3nyPlj" id="7OJcYqwOF88" role="3clFbG">
+            <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwpe0k" role="jymVt">
+      <property role="TrG5h" value="getLcProp" />
+      <node concept="3Tqbb2" id="7OJcYqwpe0l" role="3clF45">
+        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwpe0m" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwpe0n" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwpe0o" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwpe0h" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwpe0i" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwpe0j" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqwpbTN" resolve="lcProp" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOKZ$" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwysbK" role="jymVt">
+      <property role="TrG5h" value="getLcPropKey" />
+      <node concept="17QB3L" id="7OJcYqwysbL" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqwysbM" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwysbN" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwysbO" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYqwysbH" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYqwysbI" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYqwysbJ" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYqwyo$l" resolve="lcPropKey" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwOMGE" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="7OJcYqwqLm4">
+    <property role="3GE5qa" value="keyedMapping" />
+    <property role="TrG5h" value="AnnotationConceptKeyedMapping" />
+    <node concept="3Tm1VV" id="7OJcYqwqLm5" role="1B3o_S" />
+    <node concept="3uibUv" id="7OJcYqwqLm6" role="1zkMxy">
+      <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqwqLm7" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
+      </node>
+      <node concept="3Tqbb2" id="7OJcYqwqLm8" role="11_B2D">
+        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+      </node>
+      <node concept="3uibUv" id="7OJcYqwqLm9" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+    </node>
+    <node concept="3clFbW" id="7OJcYqwqLmd" role="jymVt">
+      <node concept="3cqZAl" id="7OJcYqwqLme" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYqwqLmf" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwqLmg" role="3clF47">
+        <node concept="XkiVB" id="7OJcYqwqLmh" role="3cqZAp">
+          <ref role="37wK5l" node="7OJcYqvKqOn" resolve="AKeyedMapping" />
+          <node concept="37vLTw" id="7OJcYqwqLmi" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqwqLmz" resolve="lc" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqwqLmj" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqwqLmB" resolve="mps" />
+          </node>
+          <node concept="37vLTw" id="7OJcYqwqLmk" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqwqLmD" resolve="slang" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYqwqLml" role="37wK5m">
+            <node concept="2YIFZM" id="7OJcYqwqUVH" role="2Oq$k0">
+              <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getConceptId(org.jetbrains.mps.openapi.model.SNode)" resolve="getConceptId" />
+              <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+              <node concept="37vLTw" id="7OJcYqwqUVI" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqwqLmB" resolve="mps" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7OJcYqwqLmo" role="2OqNvi">
+              <ref role="37wK5l" to="e8bb:~SConceptId.toString()" resolve="toString" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwPrVC" role="37wK5m">
+            <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <node concept="37vLTw" id="7OJcYqwqLmq" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqwqLmz" resolve="lc" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="7OJcYqwPrVD" role="37wK5m">
+            <ref role="37wK5l" node="5M3rB6_QlA6" resolve="extractKey" />
+            <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedMapping" />
+            <node concept="37vLTw" id="7OJcYqwqLms" role="37wK5m">
+              <ref role="3cqZAo" node="7OJcYqwqLmz" resolve="lc" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqwqLmz" role="3clF46">
+        <property role="TrG5h" value="lc" />
+        <node concept="3Tqbb2" id="7OJcYqwqLm$" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwLeez" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqwqLmB" role="3clF46">
+        <property role="TrG5h" value="mps" />
+        <node concept="3Tqbb2" id="7OJcYqwqLmC" role="1tU5fm">
+          <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwLfBY" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYqwqLmD" role="3clF46">
+        <property role="TrG5h" value="slang" />
+        <node concept="3uibUv" id="7OJcYqwqLmE" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+        </node>
+        <node concept="2AHcQZ" id="7OJcYqwLh1w" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwO$_8" role="jymVt">
+      <property role="TrG5h" value="getLc" />
+      <node concept="3Tm1VV" id="7OJcYqwO$_9" role="1B3o_S" />
+      <node concept="3Tqbb2" id="7OJcYqwO$_g" role="3clF45">
+        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwO$_e" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwO$_f" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqwO$_h" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwO$_j" role="3cqZAp">
+          <node concept="3nyPlj" id="7OJcYqwO$_i" role="3clFbG">
+            <ref role="37wK5l" node="7OJcYqvKqcL" resolve="getLc" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwO$_k" role="jymVt">
+      <property role="TrG5h" value="getLcId" />
+      <node concept="3Tm1VV" id="7OJcYqwO$_l" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqwO$_m" role="3clF45" />
+      <node concept="2AHcQZ" id="7OJcYqwO$_q" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwO$_r" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqwO$_s" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwO$_u" role="3cqZAp">
+          <node concept="3nyPlj" id="7OJcYqwO$_t" role="3clFbG">
+            <ref role="37wK5l" node="7OJcYqvKqdm" resolve="getLcId" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYqwO$_v" role="jymVt">
+      <property role="TrG5h" value="getLcKey" />
+      <node concept="3Tm1VV" id="7OJcYqwO$_w" role="1B3o_S" />
+      <node concept="17QB3L" id="7OJcYqwO$_x" role="3clF45" />
+      <node concept="2AHcQZ" id="7OJcYqwO$__" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqwO$_A" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3clFbS" id="7OJcYqwO$_B" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqwO$_D" role="3cqZAp">
+          <node concept="3nyPlj" id="7OJcYqwO$_C" role="3clFbG">
+            <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="3HP615" id="7OJcYqwYeSL">
+    <property role="3GE5qa" value="keyedMapping" />
+    <property role="TrG5h" value="IClassifierKeyedMapping" />
+    <node concept="3Tm1VV" id="7OJcYqwYeSM" role="1B3o_S" />
+    <node concept="3uibUv" id="7OJcYqwYfpt" role="3HQHJm">
+      <ref role="3uigEE" node="7OJcYqvKf0O" resolve="IKeyedMapping" />
+      <node concept="16syzq" id="7OJcYqwYksP" role="11_B2D">
+        <ref role="16sUi3" node="7OJcYqwYfRg" resolve="LC" />
+      </node>
+      <node concept="16syzq" id="7OJcYqwYktb" role="11_B2D">
+        <ref role="16sUi3" node="7OJcYqwYfRi" resolve="MPS" />
+      </node>
+      <node concept="16syzq" id="7OJcYqwYktv" role="11_B2D">
+        <ref role="16sUi3" node="7OJcYqwYfRk" resolve="SLANG" />
+      </node>
+    </node>
+    <node concept="16euLQ" id="7OJcYqwYfRg" role="16eVyc">
+      <property role="TrG5h" value="LC" />
+      <node concept="3Tqbb2" id="7OJcYqwYfRh" role="3ztrMU">
+        <ref role="ehGHo" to="h3y3:2ju2syjkl4i" resolve="Classifier" />
+      </node>
+    </node>
+    <node concept="16euLQ" id="7OJcYqwYfRi" role="16eVyc">
+      <property role="TrG5h" value="MPS" />
+      <node concept="3Tqbb2" id="7OJcYqwYfRj" role="3ztrMU">
+        <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+      </node>
+    </node>
+    <node concept="16euLQ" id="7OJcYqwYfRk" role="16eVyc">
+      <property role="TrG5h" value="SLANG" />
+      <node concept="3uibUv" id="7OJcYqwYiUS" role="3ztrMU">
+        <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+      </node>
+    </node>
+  </node>
+  <node concept="3HP615" id="7OJcYqx0lp$">
+    <property role="3GE5qa" value="keyedMapping" />
+    <property role="TrG5h" value="IPrimitiveTypeKeyedMapping" />
+    <node concept="3Tm1VV" id="7OJcYqx0lp_" role="1B3o_S" />
+    <node concept="3uibUv" id="7OJcYqx0lUM" role="3HQHJm">
+      <ref role="3uigEE" node="7OJcYqvKf0O" resolve="IKeyedMapping" />
+      <node concept="3Tqbb2" id="7OJcYqx0muw" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
+      </node>
+      <node concept="16syzq" id="7OJcYqx0mvJ" role="11_B2D">
+        <ref role="16sUi3" node="7OJcYqx0mux" resolve="MPS" />
+      </node>
+      <node concept="3uibUv" id="7OJcYqx0ovs" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+      </node>
+    </node>
+    <node concept="16euLQ" id="7OJcYqx0mux" role="16eVyc">
+      <property role="TrG5h" value="MPS" />
+      <node concept="3Tqbb2" id="7OJcYqx0muy" role="3ztrMU">
+        <ref role="ehGHo" to="tpce:fKAxPRU" resolve="DataTypeDeclaration" />
+      </node>
+    </node>
+  </node>
+  <node concept="3HP615" id="7OJcYqx2vhv">
+    <property role="3GE5qa" value="keyedMapping" />
+    <property role="TrG5h" value="IFeatureKeyedMapping" />
+    <node concept="3Tm1VV" id="7OJcYqx2vhw" role="1B3o_S" />
+    <node concept="3uibUv" id="7OJcYqx2vQ1" role="3HQHJm">
+      <ref role="3uigEE" node="7OJcYqvKf0O" resolve="IKeyedMapping" />
+      <node concept="16syzq" id="7OJcYqx2wuc" role="11_B2D">
+        <ref role="16sUi3" node="7OJcYqx2wsI" resolve="LC" />
+      </node>
+      <node concept="16syzq" id="7OJcYqx2wuP" role="11_B2D">
+        <ref role="16sUi3" node="7OJcYqx2wsK" resolve="MPS" />
+      </node>
+      <node concept="16syzq" id="7OJcYqx2wvr" role="11_B2D">
+        <ref role="16sUi3" node="7OJcYqx2wsM" resolve="SLANG" />
+      </node>
+    </node>
+    <node concept="16euLQ" id="7OJcYqx2wsI" role="16eVyc">
+      <property role="TrG5h" value="LC" />
+      <node concept="3Tqbb2" id="7OJcYqx2wsJ" role="3ztrMU">
+        <ref role="ehGHo" to="h3y3:2ju2syjkkv_" resolve="Feature" />
+      </node>
+    </node>
+    <node concept="16euLQ" id="7OJcYqx2wsK" role="16eVyc">
+      <property role="TrG5h" value="MPS" />
+      <node concept="3Tqbb2" id="7OJcYqx2wsL" role="3ztrMU">
+        <ref role="ehGHo" to="tpce:1ob16QT2yIl" resolve="INamedStructureElement" />
+      </node>
+    </node>
+    <node concept="16euLQ" id="7OJcYqx2wsM" role="16eVyc">
+      <property role="TrG5h" value="SLANG" />
+      <node concept="3uibUv" id="7OJcYqx2wtt" role="3ztrMU">
+        <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
       </node>
     </node>
   </node>

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -255,18 +255,12 @@
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
       </concept>
-      <concept id="8465538089690331492" name="jetbrains.mps.baseLanguage.javadoc.structure.DeprecatedBlockDocTag" flags="ng" index="TZ5HI">
-        <child id="2667874559098216723" name="text" index="3HnX3l" />
-      </concept>
       <concept id="2217234381367188008" name="jetbrains.mps.baseLanguage.javadoc.structure.FieldDocReference" flags="ng" index="VUqz4" />
       <concept id="2217234381367049075" name="jetbrains.mps.baseLanguage.javadoc.structure.CodeInlineDocTag" flags="ng" index="VVOAv">
         <child id="3106559687488741665" name="line" index="2Xj1qM" />
       </concept>
       <concept id="2217234381367530212" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocReference" flags="ng" index="VXe08">
         <reference id="2217234381367530213" name="classifier" index="VXe09" />
-      </concept>
-      <concept id="2217234381367530195" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocReference" flags="ng" index="VXe0Z">
-        <reference id="2217234381367530196" name="methodDeclaration" index="VXe0S" />
       </concept>
       <concept id="5562345046718956738" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseVariableDocReference" flags="ng" index="YTMYr">
         <reference id="5562345046718956740" name="declaration" index="YTMYt" />
@@ -388,16 +382,12 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
-      <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
-        <child id="1176906787974" name="rightExpression" index="576Qk" />
-      </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
-      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
       <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
         <child id="1153944424730" name="inputSequence" index="2GsD0m" />
@@ -413,9 +403,6 @@
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
-      <concept id="4611582986551314327" name="jetbrains.mps.baseLanguage.collections.structure.OfTypeOperation" flags="nn" index="UnYns">
-        <child id="4611582986551314344" name="requestedType" index="UnYnz" />
-      </concept>
       <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
@@ -424,10 +411,10 @@
         <child id="1225711182005" name="list" index="1y566C" />
         <child id="1225711191269" name="index" index="1y58nS" />
       </concept>
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
-      <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
     </language>
   </registry>
   <node concept="312cEu" id="DUXtGZOlwJ">
@@ -1402,7 +1389,6 @@
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="5JNiskiqwrb" role="jymVt" />
     <node concept="3Tm1VV" id="DUXtGZOlwK" role="1B3o_S" />
     <node concept="3UR2Jj" id="1ilOlIESCSV" role="lGtFl">
       <node concept="TZ5HA" id="1ilOlIESCSW" role="TZ5H$">
@@ -1417,700 +1403,6 @@
     <node concept="3uibUv" id="5JNiskhZoZC" role="1zkMxy">
       <ref role="3uigEE" node="5JNiskhYWOE" resolve="LionCoreConstants_2023_1" />
     </node>
-    <node concept="3clFb_" id="5JNiskiq_M3" role="jymVt">
-      <property role="TrG5h" value="lcVirtualPackageAnnotation" />
-      <node concept="3clFbS" id="5JNiskiq_M4" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiq_M5" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwxLzI" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwxITp" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwxOfe" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwpe0k" resolve="getLcAnnotation" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiq_M7" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskiq_M8" role="3clF45">
-        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiq_Mc" role="jymVt">
-      <property role="TrG5h" value="mpsVirtualPackageProperty" />
-      <node concept="3clFbS" id="5JNiskiq_Md" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqwxQG6" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwxQG7" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwxQG8" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwxQG9" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiq_Mg" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskiq_Mh" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiq_Ml" role="jymVt">
-      <property role="TrG5h" value="slangVirtualPackageProperty" />
-      <node concept="3clFbS" id="5JNiskiq_Mm" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiq_Mn" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwy1Oa" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwy1Ob" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwy1Oc" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiq_Mp" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskiq_Mq" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiq_Mu" role="jymVt">
-      <property role="TrG5h" value="keyVirtualPackageAnnotation" />
-      <node concept="3clFbS" id="5JNiskiq_Mv" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiq_Mw" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwy6Je" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwy6Jf" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwy6Jg" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwysbK" resolve="getLcAnnotationKey" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiq_My" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiq_Mz" role="3clF45" />
-    </node>
-    <node concept="3clFb_" id="5JNiskiq_MB" role="jymVt">
-      <property role="TrG5h" value="idVirtualPackageProperty" />
-      <node concept="3clFbS" id="5JNiskiq_MC" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqwybNk" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwybNl" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwybNm" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwybNn" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiq_MF" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiq_MG" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="5JNiskirocj" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskiroj0" role="jymVt">
-      <property role="TrG5h" value="lcVirtualPackage_NameProperty" />
-      <node concept="3clFbS" id="5JNiskiroj1" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqwyhwv" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwyhww" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwyhwx" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwyhwy" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwOF7L" resolve="getLc" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiroj2" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskiroj3" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiroj4" role="jymVt">
-      <property role="TrG5h" value="keyVirtualPackage_NameProperty" />
-      <node concept="3clFbS" id="5JNiskiroj5" role="3clF47">
-        <node concept="3clFbF" id="5JNiskirBN7" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwyxU8" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwyvml" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwyzPh" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwOF81" resolve="getLcKey" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiroj6" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiroj7" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="5JNiskirofD" role="jymVt" />
-    <node concept="2tJIrI" id="5JNiskiqAo0" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskiqAL3" role="jymVt">
-      <property role="TrG5h" value="lcShortDescriptionAnnotation" />
-      <node concept="3clFbS" id="5JNiskiqAL4" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiqAL5" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwyCPK" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwyAfy" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwyFja" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwpe0k" resolve="getLcAnnotation" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiqAL7" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskiqAL8" role="3clF45">
-        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiqALc" role="jymVt">
-      <property role="TrG5h" value="mpsShortDescriptionProperty" />
-      <node concept="3clFbS" id="5JNiskiqALd" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiqALe" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwyHJT" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwyHJU" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwyHJV" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiqALg" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskiqALh" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiqALl" role="jymVt">
-      <property role="TrG5h" value="slangShortDescriptionProperty" />
-      <node concept="3clFbS" id="5JNiskiqALm" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiqALn" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwyMRf" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwyMRg" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwyMRh" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiqALp" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskiqALq" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiqALu" role="jymVt">
-      <property role="TrG5h" value="keyShortDescriptionAnnotation" />
-      <node concept="3clFbS" id="5JNiskiqALv" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiqALw" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwyRuv" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwyRuw" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwyRux" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwysbK" resolve="getLcAnnotationKey" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiqALy" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiqALz" role="3clF45" />
-    </node>
-    <node concept="3clFb_" id="5JNiskiqALB" role="jymVt">
-      <property role="TrG5h" value="idShortDescriptionProperty" />
-      <node concept="3clFbS" id="5JNiskiqALC" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiqALD" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwyWxX" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwyWxY" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwyWxZ" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwOF7T" resolve="getLcId" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiqALF" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiqALG" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="5JNiskiqApF" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskiroSo" role="jymVt">
-      <property role="TrG5h" value="lcShortDescription_DescriptionProperty" />
-      <node concept="3clFbS" id="5JNiskiroSp" role="3clF47">
-        <node concept="3clFbF" id="5JNiskirz2b" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwz1K6" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwz1K7" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwz1K8" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwOF7L" resolve="getLc" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiroSq" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskiroSr" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiroSs" role="jymVt">
-      <property role="TrG5h" value="keyShortDescription_DescriptionProperty" />
-      <node concept="3clFbS" id="5JNiskiroSt" role="3clF47">
-        <node concept="3clFbF" id="5JNiskir$Wq" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwz6o$" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwz6o_" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwz6oA" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwOF81" resolve="getLcKey" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiroSu" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiroSv" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="5JNiskiroOS" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskiKYx3" role="jymVt">
-      <property role="TrG5h" value="slangSpecificLanguageId" />
-      <node concept="3clFbS" id="5JNiskiKYx4" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiKYx5" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwzfwE" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwzblh" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwWDfJ" resolve="getSpecificLanguage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwzjLh" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqw7aei" resolve="getSlangId" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiKYx7" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskiKYx8" role="3clF45">
-        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiKYxc" role="jymVt">
-      <property role="TrG5h" value="slangSpecificLanguage" />
-      <node concept="3clFbS" id="5JNiskiKYxd" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiKYxe" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwzoWl" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwzoWm" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwWDfJ" resolve="getSpecificLanguage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwzoWn" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiKYxg" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskiKYxh" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiKYxl" role="jymVt">
-      <property role="TrG5h" value="keySpecificLanguage" />
-      <node concept="3clFbS" id="5JNiskiKYxm" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqwzvGm" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwzvGn" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwzvGo" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwWDfJ" resolve="getSpecificLanguage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwzvGp" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiKYxp" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiKYxq" role="3clF45" />
-    </node>
-    <node concept="3clFb_" id="5JNiskiKYxu" role="jymVt">
-      <property role="TrG5h" value="idSpecificLanguage" />
-      <node concept="3clFbS" id="5JNiskiKYxv" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqwzAvY" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwzAvZ" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwzAw0" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwWDfJ" resolve="getSpecificLanguage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwzAw1" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqdm" resolve="getLcId" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiKYxy" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiKYxz" role="3clF45" />
-    </node>
-    <node concept="3clFb_" id="5JNiskiKYxB" role="jymVt">
-      <property role="TrG5h" value="versionSpecificLanguage" />
-      <node concept="3clFbS" id="5JNiskiKYxC" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiKYxD" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwzHXH" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwzHXI" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwWDfJ" resolve="getSpecificLanguage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwzHXJ" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0Qp" resolve="getLcVersion" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskiKYxF" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiKYxG" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="5JNiskjpl83" role="jymVt" />
-    <node concept="3clFb_" id="34Q84zNPHRO" role="jymVt">
-      <property role="TrG5h" value="slangStructureLanguageId" />
-      <node concept="3Tm1VV" id="34Q84zNPHRQ" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNPHRR" role="3clF45">
-        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-      </node>
-      <node concept="3clFbS" id="34Q84zNPHS1" role="3clF47">
-        <node concept="3clFbF" id="34Q84zNQ5BE" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwzOGS" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwzOGT" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4t2" resolve="getStructureLanguage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwzOGU" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqw7aei" resolve="getSlangId" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="34Q84zNPHS2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="34Q84zNPHS5" role="jymVt">
-      <property role="TrG5h" value="slangStructureLanguage" />
-      <node concept="3Tm1VV" id="34Q84zNPHS7" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNPHS8" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-      </node>
-      <node concept="3clFbS" id="34Q84zNPHSi" role="3clF47">
-        <node concept="3clFbF" id="34Q84zNQ3z6" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwzVq9" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwzVqa" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4t2" resolve="getStructureLanguage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwzVqb" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="34Q84zNPHSj" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="34Q84zNPHSm" role="jymVt">
-      <property role="TrG5h" value="keyStructureLanguage" />
-      <node concept="3Tm1VV" id="34Q84zNPHSo" role="1B3o_S" />
-      <node concept="17QB3L" id="34Q84zNPHSp" role="3clF45" />
-      <node concept="3clFbS" id="34Q84zNPHSu" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqw$03f" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw$03h" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqw$03i" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4t2" resolve="getStructureLanguage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw$03j" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="34Q84zNPHSv" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="34Q84zNPHSy" role="jymVt">
-      <property role="TrG5h" value="idStructureLanguage" />
-      <node concept="3Tm1VV" id="34Q84zNPHS$" role="1B3o_S" />
-      <node concept="17QB3L" id="34Q84zNPHS_" role="3clF45" />
-      <node concept="3clFbS" id="34Q84zNPHSE" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqw$58w" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw$58y" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqw$58z" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4t2" resolve="getStructureLanguage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw$58$" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqdm" resolve="getLcId" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="34Q84zNPHSF" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="34Q84zNPHSI" role="jymVt">
-      <property role="TrG5h" value="versionStructureLanguage" />
-      <node concept="3Tm1VV" id="34Q84zNPHSK" role="1B3o_S" />
-      <node concept="17QB3L" id="34Q84zNPHSL" role="3clF45" />
-      <node concept="3clFbS" id="34Q84zNPHSQ" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqw$b0Z" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw$b11" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqw$b12" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4t2" resolve="getStructureLanguage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw$b13" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0Qp" resolve="getLcVersion" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="34Q84zNPHSR" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="34Q84zNNuO4" role="jymVt" />
-    <node concept="2tJIrI" id="34Q84zNR0So" role="jymVt" />
-    <node concept="3clFb_" id="34Q84zNR2iW" role="jymVt">
-      <property role="TrG5h" value="mpsAbstractConceptDeclarationConcept" />
-      <node concept="3Tm1VV" id="34Q84zNR2iY" role="1B3o_S" />
-      <node concept="3Tqbb2" id="34Q84zNR2iZ" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-      </node>
-      <node concept="3clFbS" id="34Q84zNR2j1" role="3clF47">
-        <node concept="3clFbF" id="34Q84zNRRuc" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw$iYn" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqw$gbt" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4ta" resolve="getClassifier" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw$lUK" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="34Q84zNR2j2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="7weWCFlnoxb" role="jymVt">
-      <property role="TrG5h" value="slangAbstractConceptConcept" />
-      <node concept="3Tm1VV" id="7weWCFlnoxd" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlnoxe" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-      </node>
-      <node concept="3clFbS" id="7weWCFlnoxg" role="3clF47">
-        <node concept="3clFbF" id="7weWCFlntkN" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw$oxR" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqw$oxS" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4ta" resolve="getClassifier" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw$oxT" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7weWCFlnoxh" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="34Q84zNS0hq" role="jymVt" />
-    <node concept="3clFb_" id="5M8g5cSB02B" role="jymVt">
-      <property role="TrG5h" value="mpsConceptDeclarationConcept" />
-      <node concept="3Tm1VV" id="5M8g5cSB02C" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5M8g5cSB02D" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-      </node>
-      <node concept="3clFbS" id="5M8g5cSB02E" role="3clF47">
-        <node concept="3clFbF" id="5M8g5cSB02F" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw$x4T" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqw$uic" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4ti" resolve="getConcept" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw$zwT" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5M8g5cSB02H" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5M8g5cSB02t" role="jymVt">
-      <property role="TrG5h" value="slangConceptConcept" />
-      <node concept="3Tm1VV" id="5M8g5cSB02u" role="1B3o_S" />
-      <node concept="3uibUv" id="5M8g5cSB02v" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-      </node>
-      <node concept="3clFbS" id="5M8g5cSB02w" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqw$Ab4" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw$Ab5" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqw$Ab6" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4ti" resolve="getConcept" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw$Ab7" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5M8g5cSB02z" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5M8g5cSB02s" role="jymVt" />
-    <node concept="3clFb_" id="5M8g5cSAY3h" role="jymVt">
-      <property role="TrG5h" value="mpsInterfaceConceptDeclarationConcept" />
-      <node concept="3Tm1VV" id="5M8g5cSAY3i" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5M8g5cSAY3j" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-      </node>
-      <node concept="3clFbS" id="5M8g5cSAY3k" role="3clF47">
-        <node concept="3clFbF" id="5M8g5cSAY3l" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw$FP$" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqw$FP_" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4tq" resolve="getInterface" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw$FPA" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5M8g5cSAY3n" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5M8g5cSAY37" role="jymVt">
-      <property role="TrG5h" value="slangInterfaceConceptConcept" />
-      <node concept="3Tm1VV" id="5M8g5cSAY38" role="1B3o_S" />
-      <node concept="3uibUv" id="5M8g5cSAY39" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-      </node>
-      <node concept="3clFbS" id="5M8g5cSAY3a" role="3clF47">
-        <node concept="3clFbF" id="5M8g5cSAY3b" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw$MEN" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqw$MEO" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4tq" resolve="getInterface" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw$MEP" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5M8g5cSAY3d" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5M8g5cSAY36" role="jymVt" />
-    <node concept="3clFb_" id="34Q84zNR2j3" role="jymVt">
-      <property role="TrG5h" value="mpsConceptAliasProperty" />
-      <node concept="3Tm1VV" id="34Q84zNR2j5" role="1B3o_S" />
-      <node concept="3Tqbb2" id="34Q84zNR2j6" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-      <node concept="3clFbS" id="34Q84zNR2j8" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqw_1Cw" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw_4v6" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqw_1Ct" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4ty" resolve="getConceptAlias" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw_7cM" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="34Q84zNR2j9" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="34Q84zNNvWd" role="jymVt">
-      <property role="TrG5h" value="slangConceptAliasProperty" />
-      <node concept="3clFbS" id="34Q84zNNvWe" role="3clF47">
-        <node concept="3clFbF" id="34Q84zNNvWf" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw_9Nj" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqw_9Nk" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4ty" resolve="getConceptAlias" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw_9Nl" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="34Q84zNNvWh" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNNvWi" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="34Q84zNS8TW" role="jymVt" />
-    <node concept="3clFb_" id="34Q84zNR2ja" role="jymVt">
-      <property role="TrG5h" value="mpsConceptShortDescriptionProperty" />
-      <node concept="3Tm1VV" id="34Q84zNR2jc" role="1B3o_S" />
-      <node concept="3Tqbb2" id="34Q84zNR2jd" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-      <node concept="3clFbS" id="34Q84zNR2jf" role="3clF47">
-        <node concept="3clFbF" id="34Q84zNRgiP" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw_ild" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqw_fwL" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4tE" resolve="getConceptShortDescription" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw_lfy" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="34Q84zNR2jg" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="34Q84zNO3I1" role="jymVt">
-      <property role="TrG5h" value="slangConceptShortDescriptionProperty" />
-      <node concept="3clFbS" id="34Q84zNO3I2" role="3clF47">
-        <node concept="3clFbF" id="34Q84zNO3I3" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw_nKB" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqw_nKC" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4tE" resolve="getConceptShortDescription" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw_nKD" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="34Q84zNO3I5" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNO3I6" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="34Q84zNSe_t" role="jymVt" />
-    <node concept="3clFb_" id="34Q84zNNvVV" role="jymVt">
-      <property role="TrG5h" value="lcConceptDescriptionAnnotation" />
-      <node concept="3clFbS" id="34Q84zNNvVW" role="3clF47">
-        <node concept="3clFbF" id="34Q84zNNvVX" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw_vPO" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqw_tob" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw_ymv" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwpe0k" resolve="getLcAnnotation" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="34Q84zNNvVZ" role="1B3o_S" />
-      <node concept="3Tqbb2" id="34Q84zNNvW0" role="3clF45">
-        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiskjple9" role="jymVt" />
     <node concept="2tJIrI" id="7OJcYqxrjYk" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxrn6T" role="jymVt">
       <property role="TrG5h" value="listSpecificAnnotationProperty" />
@@ -2141,36 +1433,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiskjpmgL" role="jymVt">
-      <property role="TrG5h" value="listSpecificAnnotationProperties" />
-      <node concept="3Tm1VV" id="5JNiskjpmgN" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskjpmgO" role="3clF45">
-        <node concept="3uibUv" id="5JNiskjpmgP" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-        </node>
-      </node>
-      <node concept="3clFbS" id="5JNiskjpmgR" role="3clF47">
-        <node concept="3clFbF" id="5JNiskjpnnO" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskjpnnP" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskjpnnQ" role="2ShVmc">
-              <node concept="1rXfSq" id="5JNiskjpnnS" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskiq_Ml" resolve="slangVirtualPackageProperty" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskjpnnT" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskiqALl" resolve="slangShortDescriptionProperty" />
-              </node>
-              <node concept="3uibUv" id="5JNiskjpnnU" role="HW$YZ">
-                <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5JNiskjpmgS" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiskix66D" role="jymVt" />
     <node concept="2tJIrI" id="7OJcYqx_9nN" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqx_dgL" role="jymVt">
       <property role="TrG5h" value="listMpsInternalFeature" />
@@ -2204,99 +1466,7 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiski$2VO" role="jymVt">
-      <property role="TrG5h" value="listMpsInternalFeatures" />
-      <node concept="3Tmbuc" id="5JNiski$2VU" role="1B3o_S" />
-      <node concept="2I9FWS" id="5JNiski$2VV" role="3clF45" />
-      <node concept="3clFbS" id="5JNiski$2W0" role="3clF47">
-        <node concept="3clFbF" id="5JNiski$2W3" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiski$4kO" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiski$4kP" role="2ShVmc">
-              <node concept="1rXfSq" id="5JNiski$4kQ" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskitK$i" resolve="mpsAnnotationContainment" />
-              </node>
-              <node concept="1rXfSq" id="5JNiski$79L" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskiq_Mc" resolve="mpsVirtualPackageProperty" />
-              </node>
-              <node concept="1rXfSq" id="5JNiski$8xk" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskiqALc" resolve="mpsShortDescriptionProperty" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5JNiski$2W1" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5JNiski$9iK" role="jymVt" />
-    <node concept="3clFb_" id="5JNiski$2W4" role="jymVt">
-      <property role="TrG5h" value="listSLanguageInternalFeatures" />
-      <node concept="3Tm1VV" id="6Z_tmAehb3w" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiski$2Wc" role="3clF45">
-        <node concept="3uibUv" id="5JNiski$2Wd" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
-        </node>
-      </node>
-      <node concept="3clFbS" id="5JNiski$2Wn" role="3clF47">
-        <node concept="3clFbF" id="5JNiskjpCAp" role="3cqZAp">
-          <node concept="2OqwBi" id="5JNiskjpx40" role="3clFbG">
-            <node concept="2OqwBi" id="5JNiskjpsUY" role="2Oq$k0">
-              <node concept="3nyPlj" id="5JNiskjpqpu" role="2Oq$k0">
-                <ref role="37wK5l" node="5JNiskix7ir" resolve="listSLanguageInternalFeatures" />
-              </node>
-              <node concept="3QWeyG" id="5JNiskjpv6X" role="2OqNvi">
-                <node concept="2OqwBi" id="5JNiskjpFkD" role="576Qk">
-                  <node concept="1rXfSq" id="5JNiskjpvTx" role="2Oq$k0">
-                    <ref role="37wK5l" node="5JNiskjpmgL" resolve="listSpecificAnnotationProperties" />
-                  </node>
-                  <node concept="UnYns" id="5JNiskjpGZw" role="2OqNvi">
-                    <node concept="3uibUv" id="5JNiskjpHWQ" role="UnYnz">
-                      <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="ANE8D" id="5JNiskjpykI" role="2OqNvi" />
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5JNiski$2Wo" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiski$ePF" role="jymVt" />
-    <node concept="3clFb_" id="5JNiski$2Wr" role="jymVt">
-      <property role="TrG5h" value="listSClassifierInternalFeatureIds" />
-      <node concept="3Tm1VV" id="6Z_tmAeh92R" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiski$2Wz" role="3clF45">
-        <node concept="17QB3L" id="5JNiski$2W$" role="_ZDj9" />
-      </node>
-      <node concept="3clFbS" id="5JNiski$2WI" role="3clF47">
-        <node concept="3clFbF" id="5JNiski$2WL" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiski$ftC" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiski$ftD" role="2ShVmc">
-              <node concept="17QB3L" id="5JNiski$ftE" role="HW$YZ" />
-              <node concept="1rXfSq" id="5JNiski$ftF" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskiyneZ" resolve="idAnnotationContainment" />
-              </node>
-              <node concept="1rXfSq" id="5JNiski$ie8" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskiq_MB" resolve="idVirtualPackageProperty" />
-              </node>
-              <node concept="1rXfSq" id="5JNiski$jyk" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskiqALB" resolve="idShortDescriptionProperty" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5JNiski$2WJ" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiskix72u" role="jymVt" />
-    <node concept="2tJIrI" id="7OJcYqxrUYO" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxrYau" role="jymVt">
       <property role="TrG5h" value="listConceptDescriptionProperty" />
       <node concept="3Tm1VV" id="7OJcYqxrYaw" role="1B3o_S" />
@@ -2326,36 +1496,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="34Q84zNNqfT" role="jymVt">
-      <property role="TrG5h" value="listConceptDescriptionProperties" />
-      <node concept="3Tm1VV" id="34Q84zNNqfV" role="1B3o_S" />
-      <node concept="_YKpA" id="34Q84zNNqfW" role="3clF45">
-        <node concept="3uibUv" id="34Q84zNNqfX" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-        </node>
-      </node>
-      <node concept="3clFbS" id="34Q84zNNqfZ" role="3clF47">
-        <node concept="3clFbF" id="34Q84zNShgC" role="3cqZAp">
-          <node concept="2ShNRf" id="34Q84zNShgA" role="3clFbG">
-            <node concept="Tc6Ow" id="34Q84zNSiPQ" role="2ShVmc">
-              <node concept="3uibUv" id="34Q84zNSlB5" role="HW$YZ">
-                <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-              </node>
-              <node concept="1rXfSq" id="34Q84zNSoau" role="HW$Y0">
-                <ref role="37wK5l" node="34Q84zNNvWd" resolve="slangConceptAliasProperty" />
-              </node>
-              <node concept="1rXfSq" id="34Q84zNSq_R" role="HW$Y0">
-                <ref role="37wK5l" node="34Q84zNO3I1" resolve="slangConceptShortDescriptionProperty" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="34Q84zNNqg0" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="7weWCFlmZps" role="jymVt" />
     <node concept="2tJIrI" id="5M8g5cSYLiu" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqx$xY7" role="jymVt">
       <property role="TrG5h" value="listLcLanguages" />
@@ -2401,170 +1541,6 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5M8g5cSYOn5" role="jymVt">
-      <property role="TrG5h" value="listSLanguages" />
-      <node concept="3Tm1VV" id="5M8g5cSYOnd" role="1B3o_S" />
-      <node concept="_YKpA" id="5M8g5cSYOne" role="3clF45">
-        <node concept="3uibUv" id="5M8g5cSYOnf" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5M8g5cSYOng" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-      <node concept="3clFbS" id="5M8g5cSYOnh" role="3clF47">
-        <node concept="3cpWs8" id="5M8g5cSZ6es" role="3cqZAp">
-          <node concept="3cpWsn" id="5M8g5cSZ6et" role="3cpWs9">
-            <property role="TrG5h" value="result" />
-            <node concept="_YKpA" id="5M8g5cSZ5fF" role="1tU5fm">
-              <node concept="3uibUv" id="5M8g5cSZ5fI" role="_ZDj9">
-                <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-              </node>
-            </node>
-            <node concept="3nyPlj" id="5M8g5cSZ6eu" role="33vP2m">
-              <ref role="37wK5l" node="5JNiskhYXbv" resolve="listSLanguages" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5M8g5cSZbB_" role="3cqZAp">
-          <node concept="2OqwBi" id="5M8g5cSZd5f" role="3clFbG">
-            <node concept="37vLTw" id="5M8g5cSZbBz" role="2Oq$k0">
-              <ref role="3cqZAo" node="5M8g5cSZ6et" resolve="result" />
-            </node>
-            <node concept="TSZUe" id="5M8g5cSZeXn" role="2OqNvi">
-              <node concept="1rXfSq" id="5M8g5cSZgO3" role="25WWJ7">
-                <ref role="37wK5l" node="34Q84zNPHS5" resolve="slangStructureLanguage" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5M8g5cSZmhS" role="3cqZAp">
-          <node concept="37vLTw" id="5M8g5cSZmhQ" role="3clFbG">
-            <ref role="3cqZAo" node="5M8g5cSZ6et" resolve="result" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5M8g5cSYOnk" role="jymVt">
-      <property role="TrG5h" value="listKeyLanguages" />
-      <node concept="3Tm1VV" id="5M8g5cSYOns" role="1B3o_S" />
-      <node concept="_YKpA" id="5M8g5cSYOnt" role="3clF45">
-        <node concept="17QB3L" id="5M8g5cSYOnu" role="_ZDj9" />
-      </node>
-      <node concept="2AHcQZ" id="5M8g5cSYOnv" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-      <node concept="3clFbS" id="5M8g5cSYOnw" role="3clF47">
-        <node concept="3cpWs8" id="5M8g5cSZocc" role="3cqZAp">
-          <node concept="3cpWsn" id="5M8g5cSZocd" role="3cpWs9">
-            <property role="TrG5h" value="result" />
-            <node concept="_YKpA" id="5M8g5cSZn5g" role="1tU5fm">
-              <node concept="17QB3L" id="5M8g5cSZn5j" role="_ZDj9" />
-            </node>
-            <node concept="3nyPlj" id="5M8g5cSZoce" role="33vP2m">
-              <ref role="37wK5l" node="5JNiskhYXbN" resolve="listKeyLanguages" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5M8g5cSZtpf" role="3cqZAp">
-          <node concept="2OqwBi" id="5M8g5cSZuPs" role="3clFbG">
-            <node concept="37vLTw" id="5M8g5cSZtpd" role="2Oq$k0">
-              <ref role="3cqZAo" node="5M8g5cSZocd" resolve="result" />
-            </node>
-            <node concept="TSZUe" id="5M8g5cSZxvh" role="2OqNvi">
-              <node concept="1rXfSq" id="5M8g5cSZLMr" role="25WWJ7">
-                <ref role="37wK5l" node="34Q84zNPHSm" resolve="keyStructureLanguage" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5M8g5cSYOny" role="3cqZAp">
-          <node concept="37vLTw" id="5M8g5cSZocf" role="3clFbG">
-            <ref role="3cqZAo" node="5M8g5cSZocd" resolve="result" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5M8g5cSYOnz" role="jymVt">
-      <property role="TrG5h" value="listSLanguageLanguageIds" />
-      <node concept="3Tm1VV" id="5M8g5cSYOnF" role="1B3o_S" />
-      <node concept="_YKpA" id="5M8g5cSYOnG" role="3clF45">
-        <node concept="17QB3L" id="5M8g5cSYOnH" role="_ZDj9" />
-      </node>
-      <node concept="2AHcQZ" id="5M8g5cSYOnI" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-      <node concept="3clFbS" id="5M8g5cSYOnJ" role="3clF47">
-        <node concept="3cpWs8" id="5M8g5cSZNIA" role="3cqZAp">
-          <node concept="3cpWsn" id="5M8g5cSZNIB" role="3cpWs9">
-            <property role="TrG5h" value="result" />
-            <node concept="_YKpA" id="5M8g5cSZMBI" role="1tU5fm">
-              <node concept="17QB3L" id="5M8g5cSZMBL" role="_ZDj9" />
-            </node>
-            <node concept="3nyPlj" id="5M8g5cSZNIC" role="33vP2m">
-              <ref role="37wK5l" node="5JNiskhYXc2" resolve="listSLanguageLanguageIds" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5M8g5cSZVO7" role="3cqZAp">
-          <node concept="2OqwBi" id="5M8g5cSZXjo" role="3clFbG">
-            <node concept="37vLTw" id="5M8g5cSZVO5" role="2Oq$k0">
-              <ref role="3cqZAo" node="5M8g5cSZNIB" resolve="result" />
-            </node>
-            <node concept="TSZUe" id="5M8g5cSZZZt" role="2OqNvi">
-              <node concept="1rXfSq" id="5M8g5cT01Z9" role="25WWJ7">
-                <ref role="37wK5l" node="34Q84zNPHSy" resolve="idStructureLanguage" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5M8g5cSYOnL" role="3cqZAp">
-          <node concept="37vLTw" id="5M8g5cSZNID" role="3clFbG">
-            <ref role="3cqZAo" node="5M8g5cSZNIB" resolve="result" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5M8g5cSYOnM" role="jymVt">
-      <property role="TrG5h" value="listVersionLanguages" />
-      <node concept="3Tm1VV" id="5M8g5cSYOnU" role="1B3o_S" />
-      <node concept="_YKpA" id="5M8g5cSYOnV" role="3clF45">
-        <node concept="17QB3L" id="5M8g5cSYOnW" role="_ZDj9" />
-      </node>
-      <node concept="2AHcQZ" id="5M8g5cSYOnX" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-      <node concept="3clFbS" id="5M8g5cSYOnY" role="3clF47">
-        <node concept="3cpWs8" id="5M8g5cT03YY" role="3cqZAp">
-          <node concept="3cpWsn" id="5M8g5cT03YZ" role="3cpWs9">
-            <property role="TrG5h" value="result" />
-            <node concept="_YKpA" id="5M8g5cT02T8" role="1tU5fm">
-              <node concept="17QB3L" id="5M8g5cT02Tb" role="_ZDj9" />
-            </node>
-            <node concept="3nyPlj" id="5M8g5cT03Z0" role="33vP2m">
-              <ref role="37wK5l" node="5JNiskhYXcm" resolve="listVersionLanguages" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5M8g5cT0cAd" role="3cqZAp">
-          <node concept="2OqwBi" id="5M8g5cT0e8$" role="3clFbG">
-            <node concept="37vLTw" id="5M8g5cT0cAb" role="2Oq$k0">
-              <ref role="3cqZAo" node="5M8g5cT03YZ" resolve="result" />
-            </node>
-            <node concept="TSZUe" id="5M8g5cT0gQx" role="2OqNvi">
-              <node concept="1rXfSq" id="5M8g5cT0iOW" role="25WWJ7">
-                <ref role="37wK5l" node="34Q84zNPHSI" resolve="versionStructureLanguage" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5M8g5cSYOo0" role="3cqZAp">
-          <node concept="37vLTw" id="5M8g5cT03Z1" role="3clFbG">
-            <ref role="3cqZAo" node="5M8g5cT03YZ" resolve="result" />
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="2tJIrI" id="7weWCFln0QZ" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxzJ_1" role="jymVt">
       <property role="TrG5h" value="listMpsInternalClassifier" />
@@ -2605,123 +1581,6 @@
             </node>
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="7weWCFln2o1" role="jymVt">
-      <property role="TrG5h" value="listMpsInternalClassifiers" />
-      <node concept="3Tm1VV" id="7weWCFlqObT" role="1B3o_S" />
-      <node concept="2I9FWS" id="7weWCFln2oa" role="3clF45">
-        <ref role="2I9WkF" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-      </node>
-      <node concept="3clFbS" id="7weWCFln2of" role="3clF47">
-        <node concept="3clFbF" id="7weWCFln2oi" role="3cqZAp">
-          <node concept="2ShNRf" id="7weWCFln6BC" role="3clFbG">
-            <node concept="Tc6Ow" id="7weWCFln6BD" role="2ShVmc">
-              <node concept="1rXfSq" id="7weWCFln6BE" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqgVl" resolve="mpsNodeConcept" />
-              </node>
-              <node concept="1rXfSq" id="7weWCFln6BF" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqsXL" resolve="mpsAnnotationConcept" />
-              </node>
-              <node concept="1rXfSq" id="7weWCFlnd9$" role="HW$Y0">
-                <ref role="37wK5l" node="34Q84zNR2iW" resolve="mpsAbstractConceptDeclarationConcept" />
-              </node>
-              <node concept="1rXfSq" id="5M8g5cSBLmK" role="HW$Y0">
-                <ref role="37wK5l" node="5M8g5cSB02B" resolve="mpsConceptDeclarationConcept" />
-              </node>
-              <node concept="1rXfSq" id="5M8g5cSBOLL" role="HW$Y0">
-                <ref role="37wK5l" node="5M8g5cSAY3h" resolve="mpsInterfaceConceptDeclarationConcept" />
-              </node>
-              <node concept="1rXfSq" id="6Z_tmAehXHe" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqBwd" resolve="mpsINamedInterface" />
-              </node>
-              <node concept="3Tqbb2" id="7weWCFln6BG" role="HW$YZ">
-                <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7weWCFln2og" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="7weWCFln2oj" role="jymVt">
-      <property role="TrG5h" value="listSLanguageInternalClassifiers" />
-      <node concept="3Tm1VV" id="7weWCFlqMLz" role="1B3o_S" />
-      <node concept="_YKpA" id="7weWCFln2os" role="3clF45">
-        <node concept="3uibUv" id="7weWCFln2ot" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-        </node>
-      </node>
-      <node concept="3clFbS" id="7weWCFln2oB" role="3clF47">
-        <node concept="3clFbF" id="7weWCFln2oE" role="3cqZAp">
-          <node concept="2ShNRf" id="7weWCFlnaja" role="3clFbG">
-            <node concept="Tc6Ow" id="7weWCFlnajb" role="2ShVmc">
-              <node concept="1rXfSq" id="7weWCFlnajc" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqgVh" resolve="slangNodeConcept" />
-              </node>
-              <node concept="1rXfSq" id="7weWCFlnajd" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqsXH" resolve="slangAnnotationConcept" />
-              </node>
-              <node concept="1rXfSq" id="7weWCFlogCi" role="HW$Y0">
-                <ref role="37wK5l" node="7weWCFlnoxb" resolve="slangAbstractConceptConcept" />
-              </node>
-              <node concept="1rXfSq" id="5M8g5cSBEjb" role="HW$Y0">
-                <ref role="37wK5l" node="5M8g5cSB02t" resolve="slangConceptConcept" />
-              </node>
-              <node concept="1rXfSq" id="5M8g5cSBHN5" role="HW$Y0">
-                <ref role="37wK5l" node="5M8g5cSAY37" resolve="slangInterfaceConceptConcept" />
-              </node>
-              <node concept="1rXfSq" id="6Z_tmAei1N5" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqBw9" resolve="slangINamedInterface" />
-              </node>
-              <node concept="3uibUv" id="7weWCFlnaje" role="HW$YZ">
-                <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7weWCFln2oC" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="7OJcYqvGEcS" role="jymVt">
-      <property role="TrG5h" value="listSLanguageInternalClassifierLanguageKeys" />
-      <node concept="3Tm1VV" id="7OJcYqvGEcU" role="1B3o_S" />
-      <node concept="_YKpA" id="7OJcYqvGEcV" role="3clF45">
-        <node concept="17QB3L" id="7OJcYqvGEcW" role="_ZDj9" />
-      </node>
-      <node concept="3clFbS" id="7OJcYqvGEcZ" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqvGJm$" role="3cqZAp">
-          <node concept="2ShNRf" id="7OJcYqvGJm_" role="3clFbG">
-            <node concept="Tc6Ow" id="7OJcYqvGJmA" role="2ShVmc">
-              <node concept="1rXfSq" id="7OJcYqvGO4Q" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
-              </node>
-              <node concept="1rXfSq" id="7OJcYqvGVEr" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqTR7" resolve="keyM3Language" />
-              </node>
-              <node concept="1rXfSq" id="7OJcYqvGY0t" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqTR7" resolve="keyM3Language" />
-              </node>
-              <node concept="1rXfSq" id="7OJcYqvH0nA" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqTR7" resolve="keyM3Language" />
-              </node>
-              <node concept="1rXfSq" id="7OJcYqvH2_K" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqTR7" resolve="keyM3Language" />
-              </node>
-              <node concept="1rXfSq" id="7OJcYqvH703" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
-              </node>
-              <node concept="17QB3L" id="7OJcYqvGQZB" role="HW$YZ" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqvGEd0" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="7OJcYqwv4sM" role="jymVt">
@@ -4538,56 +3397,71 @@
     <node concept="3clFb_" id="3M8YG$9CnuQ" role="jymVt">
       <property role="TrG5h" value="mapCoreLanguageKey" />
       <node concept="3clFbS" id="3M8YG$9CnuT" role="3clF47">
-        <node concept="3cpWs8" id="3M8YG$9Cx2X" role="3cqZAp">
-          <node concept="3cpWsn" id="3M8YG$9Cx2Y" role="3cpWs9">
-            <property role="TrG5h" value="index" />
-            <node concept="10Oyi0" id="3M8YG$9Cx2Z" role="1tU5fm" />
-            <node concept="2OqwBi" id="3M8YG$9Cx30" role="33vP2m">
-              <node concept="2OqwBi" id="3M8YG$9Cx31" role="2Oq$k0">
-                <node concept="37vLTw" id="3M8YG$9Cx32" role="2Oq$k0">
+        <node concept="3cpWs8" id="7OJcYq$oexp" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq$oexq" role="3cpWs9">
+            <property role="TrG5h" value="mapping" />
+            <node concept="3uibUv" id="7OJcYq$o1GQ" role="1tU5fm">
+              <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYq$oexr" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYq$oexs" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYq$oext" role="2Oq$k0">
                   <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
                 </node>
-                <node concept="liA8E" id="3M8YG$9Cx33" role="2OqNvi">
-                  <ref role="37wK5l" node="5JNiski3jYX" resolve="listSLanguageLanguageIds" />
+                <node concept="liA8E" id="7OJcYq$oexu" role="2OqNvi">
+                  <ref role="37wK5l" node="7OJcYqwXhGH" resolve="listLcLanguages" />
                 </node>
               </node>
-              <node concept="2WmjW8" id="3M8YG$9Cx34" role="2OqNvi">
-                <node concept="37vLTw" id="3M8YG$9CGYn" role="25WWJ7">
-                  <ref role="3cqZAo" node="3M8YG$9Cqto" resolve="languageId" />
+              <node concept="1z4cxt" id="7OJcYq$oexv" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYq$oexw" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYq$oexx" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYq$oexy" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYq$oexz" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYq$oex$" role="3uHU7w">
+                          <ref role="3cqZAo" node="3M8YG$9Cqto" resolve="languageId" />
+                        </node>
+                        <node concept="2OqwBi" id="7OJcYq$oex_" role="3uHU7B">
+                          <node concept="37vLTw" id="7OJcYq$oexA" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYq$oexC" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYq$oexB" role="2OqNvi">
+                            <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYq$oexC" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYq$oexD" role="1tU5fm" />
+                  </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbJ" id="3M8YG$9Cx3b" role="3cqZAp">
-          <node concept="3clFbS" id="3M8YG$9Cx3c" role="3clFbx">
-            <node concept="3cpWs6" id="3M8YG$9Cx3d" role="3cqZAp">
-              <node concept="1y4W85" id="3M8YG$9Cx3e" role="3cqZAk">
-                <node concept="37vLTw" id="3M8YG$9Cx3f" role="1y58nS">
-                  <ref role="3cqZAo" node="3M8YG$9Cx2Y" resolve="index" />
+        <node concept="3clFbJ" id="7OJcYq$ok0I" role="3cqZAp">
+          <node concept="3clFbS" id="7OJcYq$ok0K" role="3clFbx">
+            <node concept="3cpWs6" id="7OJcYq$os8$" role="3cqZAp">
+              <node concept="2OqwBi" id="7OJcYqzdYsT" role="3cqZAk">
+                <node concept="37vLTw" id="7OJcYq$oexE" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7OJcYq$oexq" resolve="mapping" />
                 </node>
-                <node concept="2OqwBi" id="3M8YG$9Cx3g" role="1y566C">
-                  <node concept="37vLTw" id="3M8YG$9Cx3h" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
-                  </node>
-                  <node concept="liA8E" id="3M8YG$9Cx3i" role="2OqNvi">
-                    <ref role="37wK5l" node="5JNiski3jYO" resolve="listKeyLanguages" />
-                  </node>
+                <node concept="liA8E" id="7OJcYqze1Y_" role="2OqNvi">
+                  <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
                 </node>
               </node>
             </node>
           </node>
-          <node concept="2d3UOw" id="3M8YG$9Cx3j" role="3clFbw">
-            <node concept="3cmrfG" id="3M8YG$9Cx3k" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="37vLTw" id="3M8YG$9Cx3l" role="3uHU7B">
-              <ref role="3cqZAo" node="3M8YG$9Cx2Y" resolve="index" />
+          <node concept="3y3z36" id="7OJcYq$oopA" role="3clFbw">
+            <node concept="10Nm6u" id="7OJcYq$opvL" role="3uHU7w" />
+            <node concept="37vLTw" id="7OJcYq$olwk" role="3uHU7B">
+              <ref role="3cqZAo" node="7OJcYq$oexq" resolve="mapping" />
             </node>
           </node>
         </node>
-        <node concept="3cpWs6" id="3M8YG$9CMlV" role="3cqZAp">
-          <node concept="10Nm6u" id="3M8YG$9COTg" role="3cqZAk" />
+        <node concept="3cpWs6" id="7OJcYq$o_md" role="3cqZAp">
+          <node concept="10Nm6u" id="7OJcYq$o_nk" role="3cqZAk" />
         </node>
       </node>
       <node concept="3Tm6S6" id="3M8YG$9CknW" role="1B3o_S" />
@@ -4609,26 +3483,43 @@
       <node concept="3clFbS" id="6fYiNFaH3n8" role="3clF47">
         <node concept="3clFbJ" id="5AGBwuFGC16" role="3cqZAp">
           <node concept="3clFbS" id="5AGBwuFGC18" role="3clFbx">
-            <node concept="3cpWs8" id="5AGBwuFKihU" role="3cqZAp">
-              <node concept="3cpWsn" id="5AGBwuFKihV" role="3cpWs9">
-                <property role="TrG5h" value="index" />
-                <node concept="10Oyi0" id="5AGBwuFKihW" role="1tU5fm" />
-                <node concept="2OqwBi" id="5AGBwuFKihX" role="33vP2m">
-                  <node concept="2OqwBi" id="5AGBwuFKihY" role="2Oq$k0">
-                    <node concept="37vLTw" id="5AGBwuFKihZ" role="2Oq$k0">
+            <node concept="3cpWs8" id="7OJcYqzewib" role="3cqZAp">
+              <node concept="3cpWsn" id="7OJcYqzewic" role="3cpWs9">
+                <property role="TrG5h" value="mapping" />
+                <node concept="3uibUv" id="7OJcYqzevMm" role="1tU5fm">
+                  <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
+                </node>
+                <node concept="2OqwBi" id="7OJcYqzewid" role="33vP2m">
+                  <node concept="2OqwBi" id="7OJcYqzewie" role="2Oq$k0">
+                    <node concept="37vLTw" id="7OJcYqzewif" role="2Oq$k0">
                       <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
                     </node>
-                    <node concept="liA8E" id="5AGBwuFKii0" role="2OqNvi">
-                      <ref role="37wK5l" node="5JNiski3jZG" resolve="listSLanguageClassifiers" />
+                    <node concept="liA8E" id="7OJcYqzewig" role="2OqNvi">
+                      <ref role="37wK5l" node="7OJcYqwYDTB" resolve="listClassifiers" />
                     </node>
                   </node>
-                  <node concept="2WmjW8" id="5AGBwuFKii1" role="2OqNvi">
-                    <node concept="0kSF2" id="5AGBwuFKii2" role="25WWJ7">
-                      <node concept="3uibUv" id="5AGBwuFKii3" role="0kSFW">
-                        <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                  <node concept="1z4cxt" id="7OJcYqzewih" role="2OqNvi">
+                    <node concept="1bVj0M" id="7OJcYqzewii" role="23t8la">
+                      <node concept="3clFbS" id="7OJcYqzewij" role="1bW5cS">
+                        <node concept="3clFbF" id="7OJcYqzewik" role="3cqZAp">
+                          <node concept="17R0WA" id="7OJcYqzewil" role="3clFbG">
+                            <node concept="37vLTw" id="7OJcYqzewim" role="3uHU7w">
+                              <ref role="3cqZAo" node="6fYiNFaH3ng" resolve="element" />
+                            </node>
+                            <node concept="2OqwBi" id="7OJcYqzewin" role="3uHU7B">
+                              <node concept="37vLTw" id="7OJcYqzewio" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7OJcYqzewiq" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="7OJcYqzewip" role="2OqNvi">
+                                <ref role="37wK5l" node="7OJcYqvKizN" resolve="getSlang" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
                       </node>
-                      <node concept="37vLTw" id="5AGBwuFKii4" role="0kSFX">
-                        <ref role="3cqZAo" node="6fYiNFaH3ng" resolve="element" />
+                      <node concept="Rh6nW" id="7OJcYqzewiq" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7OJcYqzewir" role="1tU5fm" />
                       </node>
                     </node>
                   </node>
@@ -4638,27 +3529,20 @@
             <node concept="3clFbJ" id="5AGBwuFKihH" role="3cqZAp">
               <node concept="3clFbS" id="5AGBwuFKihI" role="3clFbx">
                 <node concept="3cpWs6" id="5AGBwuFKihJ" role="3cqZAp">
-                  <node concept="1y4W85" id="5AGBwuFKihL" role="3cqZAk">
-                    <node concept="37vLTw" id="5AGBwuFKihM" role="1y58nS">
-                      <ref role="3cqZAo" node="5AGBwuFKihV" resolve="index" />
+                  <node concept="2OqwBi" id="7OJcYqzeJw7" role="3cqZAk">
+                    <node concept="37vLTw" id="7OJcYqzeI8K" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYqzewic" resolve="mapping" />
                     </node>
-                    <node concept="2OqwBi" id="5AGBwuFKihN" role="1y566C">
-                      <node concept="37vLTw" id="5AGBwuFKihO" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
-                      </node>
-                      <node concept="liA8E" id="5AGBwuFKihP" role="2OqNvi">
-                        <ref role="37wK5l" node="5JNiski3jZU" resolve="listKeyClassifiers" />
-                      </node>
+                    <node concept="liA8E" id="7OJcYqzeMgd" role="2OqNvi">
+                      <ref role="37wK5l" node="7OJcYqvKjL5" resolve="getLcKey" />
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="2d3UOw" id="5AGBwuFKihR" role="3clFbw">
-                <node concept="3cmrfG" id="5AGBwuFKihS" role="3uHU7w">
-                  <property role="3cmrfH" value="0" />
-                </node>
-                <node concept="37vLTw" id="5AGBwuFKihT" role="3uHU7B">
-                  <ref role="3cqZAo" node="5AGBwuFKihV" resolve="index" />
+              <node concept="3y3z36" id="7OJcYqzeDTH" role="3clFbw">
+                <node concept="10Nm6u" id="7OJcYqzeFu3" role="3uHU7w" />
+                <node concept="37vLTw" id="7OJcYqzeBaf" role="3uHU7B">
+                  <ref role="3cqZAo" node="7OJcYqzewic" resolve="mapping" />
                 </node>
               </node>
             </node>
@@ -4673,26 +3557,43 @@
               </node>
             </node>
             <node concept="3clFbS" id="5AGBwuFIGGv" role="3eOfB_">
-              <node concept="3cpWs8" id="5AGBwuFGX$Z" role="3cqZAp">
-                <node concept="3cpWsn" id="5AGBwuFGX_0" role="3cpWs9">
-                  <property role="TrG5h" value="index" />
-                  <node concept="10Oyi0" id="5AGBwuFHjX0" role="1tU5fm" />
-                  <node concept="2OqwBi" id="5AGBwuFHcrt" role="33vP2m">
-                    <node concept="2OqwBi" id="5AGBwuFGX_3" role="2Oq$k0">
-                      <node concept="37vLTw" id="5AGBwuFGX_4" role="2Oq$k0">
+              <node concept="3cpWs8" id="7OJcYqzffLn" role="3cqZAp">
+                <node concept="3cpWsn" id="7OJcYqzffLo" role="3cpWs9">
+                  <property role="TrG5h" value="mapping" />
+                  <node concept="3uibUv" id="7OJcYqzfe5K" role="1tU5fm">
+                    <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYqzffLp" role="33vP2m">
+                    <node concept="2OqwBi" id="7OJcYqzffLq" role="2Oq$k0">
+                      <node concept="37vLTw" id="7OJcYqzffLr" role="2Oq$k0">
                         <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
                       </node>
-                      <node concept="liA8E" id="5AGBwuFGX_5" role="2OqNvi">
-                        <ref role="37wK5l" node="5JNiski3k0z" resolve="listSLanguageProperties" />
+                      <node concept="liA8E" id="7OJcYqzffLs" role="2OqNvi">
+                        <ref role="37wK5l" node="7OJcYqwZxOH" resolve="listLcProperty" />
                       </node>
                     </node>
-                    <node concept="2WmjW8" id="5AGBwuFHdTq" role="2OqNvi">
-                      <node concept="0kSF2" id="5AGBwuFHgYU" role="25WWJ7">
-                        <node concept="3uibUv" id="5AGBwuFHgYW" role="0kSFW">
-                          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+                    <node concept="1z4cxt" id="7OJcYqzffLt" role="2OqNvi">
+                      <node concept="1bVj0M" id="7OJcYqzffLu" role="23t8la">
+                        <node concept="3clFbS" id="7OJcYqzffLv" role="1bW5cS">
+                          <node concept="3clFbF" id="7OJcYqzffLw" role="3cqZAp">
+                            <node concept="17R0WA" id="7OJcYqzffLx" role="3clFbG">
+                              <node concept="37vLTw" id="7OJcYqzffLy" role="3uHU7w">
+                                <ref role="3cqZAo" node="6fYiNFaH3ng" resolve="element" />
+                              </node>
+                              <node concept="2OqwBi" id="7OJcYqzffLz" role="3uHU7B">
+                                <node concept="37vLTw" id="7OJcYqzffL$" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7OJcYqzffLA" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="7OJcYqzffL_" role="2OqNvi">
+                                  <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
                         </node>
-                        <node concept="37vLTw" id="5AGBwuFHfOX" role="0kSFX">
-                          <ref role="3cqZAo" node="6fYiNFaH3ng" resolve="element" />
+                        <node concept="Rh6nW" id="7OJcYqzffLA" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="7OJcYqzffLB" role="1tU5fm" />
                         </node>
                       </node>
                     </node>
@@ -4702,27 +3603,20 @@
               <node concept="3clFbJ" id="5AGBwuFH3O3" role="3cqZAp">
                 <node concept="3clFbS" id="5AGBwuFH3O5" role="3clFbx">
                   <node concept="3cpWs6" id="5AGBwuFHFs8" role="3cqZAp">
-                    <node concept="1y4W85" id="5AGBwuFHFsb" role="3cqZAk">
-                      <node concept="37vLTw" id="5AGBwuFHFsc" role="1y58nS">
-                        <ref role="3cqZAo" node="5AGBwuFGX_0" resolve="index" />
+                    <node concept="2OqwBi" id="7OJcYqzfx95" role="3cqZAk">
+                      <node concept="37vLTw" id="7OJcYqzfvm_" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7OJcYqzffLo" resolve="mapping" />
                       </node>
-                      <node concept="2OqwBi" id="5AGBwuFHFsd" role="1y566C">
-                        <node concept="37vLTw" id="5AGBwuFHFse" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
-                        </node>
-                        <node concept="liA8E" id="5AGBwuFHFsf" role="2OqNvi">
-                          <ref role="37wK5l" node="5JNiski3k0L" resolve="listKeyProperties" />
-                        </node>
+                      <node concept="liA8E" id="7OJcYqzf$pg" role="2OqNvi">
+                        <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="2d3UOw" id="5AGBwuFHpB4" role="3clFbw">
-                  <node concept="3cmrfG" id="5AGBwuFHqtP" role="3uHU7w">
-                    <property role="3cmrfH" value="0" />
-                  </node>
-                  <node concept="37vLTw" id="5AGBwuFHmVo" role="3uHU7B">
-                    <ref role="3cqZAo" node="5AGBwuFGX_0" resolve="index" />
+                <node concept="3y3z36" id="7OJcYqzfoIH" role="3clFbw">
+                  <node concept="10Nm6u" id="7OJcYqzfrDw" role="3uHU7w" />
+                  <node concept="37vLTw" id="7OJcYqzfmO4" role="3uHU7B">
+                    <ref role="3cqZAo" node="7OJcYqzffLo" resolve="mapping" />
                   </node>
                 </node>
               </node>
@@ -4898,26 +3792,43 @@
     <node concept="3clFb_" id="4oHUzWXHJlQ" role="jymVt">
       <property role="TrG5h" value="findKeyFromAttribute" />
       <node concept="3clFbS" id="4oHUzWXHJlR" role="3clF47">
-        <node concept="3cpWs8" id="4oHUzWXHJlU" role="3cqZAp">
-          <node concept="3cpWsn" id="4oHUzWXHJlV" role="3cpWs9">
-            <property role="TrG5h" value="index" />
-            <node concept="10Oyi0" id="4oHUzWXHJlW" role="1tU5fm" />
-            <node concept="2OqwBi" id="4oHUzWXHJlX" role="33vP2m">
-              <node concept="2OqwBi" id="4oHUzWXHJlY" role="2Oq$k0">
-                <node concept="37vLTw" id="4oHUzWXHJlZ" role="2Oq$k0">
+        <node concept="3cpWs8" id="7OJcYqzfZ3V" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYqzfZ3W" role="3cpWs9">
+            <property role="TrG5h" value="mapping" />
+            <node concept="3uibUv" id="7OJcYqzfXzE" role="1tU5fm">
+              <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYqzfZ3X" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYqzfZ3Y" role="2Oq$k0">
+                <node concept="37vLTw" id="7OJcYqzfZ3Z" role="2Oq$k0">
                   <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
                 </node>
-                <node concept="liA8E" id="4oHUzWXHJm0" role="2OqNvi">
-                  <ref role="37wK5l" node="5JNiski3k1p" resolve="listSLanguagePrimitiveTypes" />
+                <node concept="liA8E" id="7OJcYqzfZ40" role="2OqNvi">
+                  <ref role="37wK5l" node="7OJcYqx0tbv" resolve="listLcPrimitiveType" />
                 </node>
               </node>
-              <node concept="2WmjW8" id="4oHUzWXHJm1" role="2OqNvi">
-                <node concept="0kSF2" id="4oHUzWXHJm2" role="25WWJ7">
-                  <node concept="3uibUv" id="4oHUzWXHJm3" role="0kSFW">
-                    <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+              <node concept="1z4cxt" id="7OJcYqzfZ41" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYqzfZ42" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYqzfZ43" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYqzfZ44" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYqzfZ45" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYqzfZ46" role="3uHU7w">
+                          <ref role="3cqZAo" node="4oHUzWXHJnn" resolve="element" />
+                        </node>
+                        <node concept="2OqwBi" id="7OJcYqzfZ47" role="3uHU7B">
+                          <node concept="37vLTw" id="7OJcYqzfZ48" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYqzfZ4a" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYqzfZ49" role="2OqNvi">
+                            <ref role="37wK5l" node="7OJcYqvKizN" resolve="getSlang" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
                   </node>
-                  <node concept="37vLTw" id="4oHUzWXHJm4" role="0kSFX">
-                    <ref role="3cqZAo" node="4oHUzWXHJnn" resolve="element" />
+                  <node concept="Rh6nW" id="7OJcYqzfZ4a" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYqzfZ4b" role="1tU5fm" />
                   </node>
                 </node>
               </node>
@@ -4927,27 +3838,20 @@
         <node concept="3clFbJ" id="4oHUzWXHJm5" role="3cqZAp">
           <node concept="3clFbS" id="4oHUzWXHJm6" role="3clFbx">
             <node concept="3cpWs6" id="4oHUzWXHJm7" role="3cqZAp">
-              <node concept="1y4W85" id="4oHUzWXHJm9" role="3cqZAk">
-                <node concept="37vLTw" id="4oHUzWXHJma" role="1y58nS">
-                  <ref role="3cqZAo" node="4oHUzWXHJlV" resolve="index" />
+              <node concept="2OqwBi" id="7OJcYqzgem5" role="3cqZAk">
+                <node concept="37vLTw" id="7OJcYqzgcRe" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7OJcYqzfZ3W" resolve="mapping" />
                 </node>
-                <node concept="2OqwBi" id="4oHUzWXHJmb" role="1y566C">
-                  <node concept="37vLTw" id="4oHUzWXHJmc" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5AGBwuFENz0" resolve="constants" />
-                  </node>
-                  <node concept="liA8E" id="4oHUzWXHJmd" role="2OqNvi">
-                    <ref role="37wK5l" node="5JNiski3k1B" resolve="listKeyPrimitiveTypes" />
-                  </node>
+                <node concept="liA8E" id="7OJcYqzghcE" role="2OqNvi">
+                  <ref role="37wK5l" node="7OJcYqvKjL5" resolve="getLcKey" />
                 </node>
               </node>
             </node>
           </node>
-          <node concept="2d3UOw" id="4oHUzWXHJmf" role="3clFbw">
-            <node concept="3cmrfG" id="4oHUzWXHJmg" role="3uHU7w">
-              <property role="3cmrfH" value="0" />
-            </node>
-            <node concept="37vLTw" id="4oHUzWXHJmh" role="3uHU7B">
-              <ref role="3cqZAo" node="4oHUzWXHJlV" resolve="index" />
+          <node concept="3y3z36" id="7OJcYqzg6sn" role="3clFbw">
+            <node concept="10Nm6u" id="7OJcYqzg99H" role="3uHU7w" />
+            <node concept="37vLTw" id="7OJcYqzg3Au" role="3uHU7B">
+              <ref role="3cqZAo" node="7OJcYqzfZ3W" resolve="mapping" />
             </node>
           </node>
         </node>
@@ -7442,113 +6346,7 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiskipPo2" role="jymVt">
-      <property role="TrG5h" value="lcVirtualPackageAnnotation" />
-      <node concept="3clFbS" id="5JNiskipPo3" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPo4" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskipPo5" role="3clF45">
-        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxsrNO" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxsrNP" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsrNQ" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsrNR" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskipPo6" role="jymVt">
-      <property role="TrG5h" value="mpsVirtualPackageProperty" />
-      <node concept="3clFbS" id="5JNiskipPo7" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPo8" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskipPo9" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxsrUT" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxsrUU" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsrUV" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsrUW" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskipPoa" role="jymVt">
-      <property role="TrG5h" value="slangVirtualPackageProperty" />
-      <node concept="3clFbS" id="5JNiskipPob" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPoc" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskipPod" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxss2e" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxss2f" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxss2g" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxss2h" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskipPoe" role="jymVt">
-      <property role="TrG5h" value="keyVirtualPackageAnnotation" />
-      <node concept="3clFbS" id="5JNiskipPof" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPog" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskipPoh" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqxss9N" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxss9O" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxss9P" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxss9Q" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskipPoi" role="jymVt">
-      <property role="TrG5h" value="idVirtualPackageProperty" />
-      <node concept="3clFbS" id="5JNiskipPoj" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPok" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskipPol" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqxsshC" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxsshD" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsshE" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsshF" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5JNiskirbH_" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskir74n" role="jymVt">
-      <property role="TrG5h" value="lcVirtualPackage_NameProperty" />
-      <node concept="3clFbS" id="5JNiskir74o" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskir74p" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskir74q" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxssy2" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxssy3" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxssy4" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxssy5" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskireGB" role="jymVt">
-      <property role="TrG5h" value="keyVirtualPackage_NameProperty" />
-      <node concept="3clFbS" id="5JNiskireGC" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskireGD" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskireGE" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqxsspH" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxsspI" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsspJ" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsspK" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5JNiskipPnR" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwQy$4" role="jymVt">
       <property role="TrG5h" value="getShortDescription" />
@@ -7611,113 +6409,7 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiskipPPY" role="jymVt">
-      <property role="TrG5h" value="lcShortDescriptionAnnotation" />
-      <node concept="3clFbS" id="5JNiskipPPZ" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPQ0" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskipPQ1" role="3clF45">
-        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxssEB" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxssEC" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxssED" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxssEE" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskipPPU" role="jymVt">
-      <property role="TrG5h" value="mpsShortDescriptionProperty" />
-      <node concept="3clFbS" id="5JNiskipPPV" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPPW" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskipPPX" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxssNs" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxssNt" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxssNu" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxssNv" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskipPPQ" role="jymVt">
-      <property role="TrG5h" value="slangShortDescriptionProperty" />
-      <node concept="3clFbS" id="5JNiskipPPR" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPPS" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskipPPT" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxssWx" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxssWy" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxssWz" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxssW$" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskipPPM" role="jymVt">
-      <property role="TrG5h" value="keyShortDescriptionAnnotation" />
-      <node concept="3clFbS" id="5JNiskipPPN" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPPO" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskipPPP" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqxst5Q" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxst5R" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxst5S" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxst5T" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskipPPI" role="jymVt">
-      <property role="TrG5h" value="idShortDescriptionProperty" />
-      <node concept="3clFbS" id="5JNiskipPPJ" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPPK" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskipPPL" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqxstfr" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxstfs" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxstft" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxstfu" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5JNiskirdbC" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskir8mM" role="jymVt">
-      <property role="TrG5h" value="lcShortDescription_DescriptionProperty" />
-      <node concept="3clFbS" id="5JNiskir8mN" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskir8mO" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskir8mP" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxstpg" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxstph" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxstpi" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxstpj" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskirgAw" role="jymVt">
-      <property role="TrG5h" value="keyShortDescription_DescriptionProperty" />
-      <node concept="3clFbS" id="5JNiskirgAx" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskirgAy" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskirgAz" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqxstzl" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxstzm" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxstzn" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxstzo" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5JNiskipPPH" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwUzr1" role="jymVt">
       <property role="TrG5h" value="getSpecificLanguage" />
@@ -7785,80 +6477,6 @@
             <property role="1dT_AB" value="lcKey: io-lionweb-mps-specific" />
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiKU44" role="jymVt">
-      <property role="TrG5h" value="slangSpecificLanguageId" />
-      <node concept="3clFbS" id="5JNiskiKU45" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskiKU46" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskiKU47" role="3clF45">
-        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxstHE" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxstHF" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxstHG" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxstHH" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiKU48" role="jymVt">
-      <property role="TrG5h" value="slangSpecificLanguage" />
-      <node concept="3clFbS" id="5JNiskiKU49" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskiKU4a" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskiKU4b" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxstSf" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxstSg" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxstSh" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxstSi" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiKU4c" role="jymVt">
-      <property role="TrG5h" value="keySpecificLanguage" />
-      <node concept="3clFbS" id="5JNiskiKU4d" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskiKU4e" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiKU4f" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqxsu34" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxsu35" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsu36" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsu37" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiKU4g" role="jymVt">
-      <property role="TrG5h" value="idSpecificLanguage" />
-      <node concept="3clFbS" id="5JNiskiKU4h" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskiKU4i" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiKU4j" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqxsue9" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxsuea" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsueb" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsuec" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiKU4k" role="jymVt">
-      <property role="TrG5h" value="versionSpecificLanguage" />
-      <node concept="3clFbS" id="5JNiskiKU4l" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskiKU4m" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiKU4n" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqxsupu" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxsupv" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsupw" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsupx" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskiswpe" role="jymVt" />
@@ -7934,80 +6552,6 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="34Q84zNODJt" role="jymVt">
-      <property role="TrG5h" value="slangStructureLanguageId" />
-      <node concept="3clFbS" id="34Q84zNODJu" role="3clF47" />
-      <node concept="3Tm1VV" id="34Q84zNODJv" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNODJw" role="3clF45">
-        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxsu_3" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxsu_4" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsu_5" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsu_6" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="34Q84zNODJD" role="jymVt">
-      <property role="TrG5h" value="slangStructureLanguage" />
-      <node concept="3clFbS" id="34Q84zNODJE" role="3clF47" />
-      <node concept="3Tm1VV" id="34Q84zNODJF" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNODJG" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxsuKS" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxsuKT" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsuKU" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsuKV" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="34Q84zNODJP" role="jymVt">
-      <property role="TrG5h" value="keyStructureLanguage" />
-      <node concept="3clFbS" id="34Q84zNODJQ" role="3clF47" />
-      <node concept="3Tm1VV" id="34Q84zNODJR" role="1B3o_S" />
-      <node concept="17QB3L" id="34Q84zNODJS" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqxsuWX" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxsuWY" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsuWZ" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsuX0" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="34Q84zNODJW" role="jymVt">
-      <property role="TrG5h" value="idStructureLanguage" />
-      <node concept="3clFbS" id="34Q84zNODJX" role="3clF47" />
-      <node concept="3Tm1VV" id="34Q84zNODJY" role="1B3o_S" />
-      <node concept="17QB3L" id="34Q84zNODJZ" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqxsv9i" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxsv9j" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsv9k" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsv9l" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="34Q84zNODK3" role="jymVt">
-      <property role="TrG5h" value="versionStructureLanguage" />
-      <node concept="3clFbS" id="34Q84zNODK4" role="3clF47" />
-      <node concept="3Tm1VV" id="34Q84zNODK5" role="1B3o_S" />
-      <node concept="17QB3L" id="34Q84zNODK6" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqxsvlR" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxsvlS" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsvlT" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsvlU" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="34Q84zNODKa" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwQy$m" role="jymVt">
       <property role="TrG5h" value="getClassifier" />
@@ -8058,38 +6602,6 @@
             <property role="1dT_AB" value="mpsId: c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135" />
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="34Q84zNQS_d" role="jymVt">
-      <property role="TrG5h" value="mpsAbstractConceptDeclarationConcept" />
-      <node concept="3clFbS" id="34Q84zNQS_g" role="3clF47" />
-      <node concept="3Tm1VV" id="34Q84zNQS_h" role="1B3o_S" />
-      <node concept="3Tqbb2" id="34Q84zNQRl3" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxsvyG" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxsvyH" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsvyI" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsvyJ" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="7weWCFlnm$K" role="jymVt">
-      <property role="TrG5h" value="slangAbstractConceptConcept" />
-      <node concept="3clFbS" id="7weWCFlnm$N" role="3clF47" />
-      <node concept="3Tm1VV" id="7weWCFlnm$O" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlnmfS" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxsvJL" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxsvJM" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsvJN" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsvJO" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNQU1i" role="jymVt" />
@@ -8144,38 +6656,6 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5M8g5cSAUka" role="jymVt">
-      <property role="TrG5h" value="mpsConceptDeclarationConcept" />
-      <node concept="3clFbS" id="5M8g5cSAUkb" role="3clF47" />
-      <node concept="3Tm1VV" id="5M8g5cSAUkc" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5M8g5cSAUkd" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxsvX6" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxsvX7" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsvX8" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsvX9" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5M8g5cSAUjY" role="jymVt">
-      <property role="TrG5h" value="slangConceptConcept" />
-      <node concept="3clFbS" id="5M8g5cSAUjZ" role="3clF47" />
-      <node concept="3Tm1VV" id="5M8g5cSAUk0" role="1B3o_S" />
-      <node concept="3uibUv" id="5M8g5cSAUk1" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxswaF" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxswaG" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxswaH" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxswaI" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5M8g5cSAUjX" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwQy$C" role="jymVt">
       <property role="TrG5h" value="getInterface" />
@@ -8228,38 +6708,6 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5M8g5cSAU2C" role="jymVt">
-      <property role="TrG5h" value="mpsInterfaceConceptDeclarationConcept" />
-      <node concept="3clFbS" id="5M8g5cSAU2D" role="3clF47" />
-      <node concept="3Tm1VV" id="5M8g5cSAU2E" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5M8g5cSAU2F" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxswow" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxswox" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxswoy" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxswoz" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5M8g5cSAU2s" role="jymVt">
-      <property role="TrG5h" value="slangInterfaceConceptConcept" />
-      <node concept="3clFbS" id="5M8g5cSAU2t" role="3clF47" />
-      <node concept="3Tm1VV" id="5M8g5cSAU2u" role="1B3o_S" />
-      <node concept="3uibUv" id="5M8g5cSAU2v" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxswA_" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxswAA" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxswAB" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxswAC" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5M8g5cSAU2r" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwQy$L" role="jymVt">
       <property role="TrG5h" value="getConceptAlias" />
@@ -8305,22 +6753,6 @@
             <property role="1dT_AB" value="mpsId: c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135/5092175715804935370" />
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="34Q84zNQVqH" role="jymVt">
-      <property role="TrG5h" value="mpsConceptAliasProperty" />
-      <node concept="3clFbS" id="34Q84zNQVqK" role="3clF47" />
-      <node concept="3Tm1VV" id="34Q84zNQVqL" role="1B3o_S" />
-      <node concept="3Tqbb2" id="34Q84zNQUak" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxswOU" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxswOV" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxswOW" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxswOX" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqxrdMT" role="jymVt" />
@@ -8370,22 +6802,6 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="34Q84zNQWR0" role="jymVt">
-      <property role="TrG5h" value="mpsConceptShortDescriptionProperty" />
-      <node concept="3clFbS" id="34Q84zNQWR1" role="3clF47" />
-      <node concept="3Tm1VV" id="34Q84zNQWR2" role="1B3o_S" />
-      <node concept="3Tqbb2" id="34Q84zNQWR3" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxsx3v" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxsx3w" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsx3x" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsx3y" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="34Q84zNQO5q" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqxreEB" role="jymVt">
       <property role="TrG5h" value="listSpecificAnnotationProperty" />
@@ -8396,39 +6812,12 @@
           <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
         </node>
       </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskjpaH9" role="jymVt">
-      <property role="TrG5h" value="listSpecificAnnotationProperties" />
-      <node concept="3clFbS" id="5JNiskjpaHc" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskjpaHd" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskjp6mY" role="3clF45">
-        <node concept="3uibUv" id="5JNiskjpaft" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-        </node>
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_6EV" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_6EW" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_6EX" role="1dT_Ay">
-            <property role="1dT_AB" value="All MPS node properties that are converted into LionWeb M1 annotations as " />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS_bYL" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS_bYZ" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS_bZ1" role="2XjZqd" />
-              <node concept="VXe08" id="5M8g5cS_bZg" role="92FcQ">
-                <ref role="VXe09" to="c17a:~SProperty" resolve="SProperty" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS_bYK" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
+      <node concept="P$JXv" id="7OJcYqyNMNX" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqyNMNY" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqyNMNZ" role="1dT_Ay">
+            <property role="1dT_AB" value="All MPS node properties that are converted into LionWeb M1 annotations." />
           </node>
         </node>
-        <node concept="TZ5HI" id="7OJcYqxsxik" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsxil" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsxim" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqxrf3I" role="jymVt" />
@@ -8441,39 +6830,12 @@
           <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
         </node>
       </node>
-    </node>
-    <node concept="3clFb_" id="34Q84zNtsh8" role="jymVt">
-      <property role="TrG5h" value="listConceptDescriptionProperties" />
-      <node concept="3clFbS" id="34Q84zNtsh9" role="3clF47" />
-      <node concept="3Tm1VV" id="34Q84zNtsha" role="1B3o_S" />
-      <node concept="_YKpA" id="34Q84zNtshb" role="3clF45">
-        <node concept="3uibUv" id="34Q84zNtshc" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-        </node>
-      </node>
-      <node concept="P$JXv" id="5M8g5cS_c3x" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS_c3y" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS_c3z" role="1dT_Ay">
-            <property role="1dT_AB" value="All MPS concept properties that are converted into LionWeb M2 annotations as " />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS_m9d" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS_mFy" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS_mF$" role="2XjZqd" />
-              <node concept="VXe08" id="5M8g5cS_ndY" role="92FcQ">
-                <ref role="VXe09" to="c17a:~SProperty" resolve="SProperty" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS_m9c" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
+      <node concept="P$JXv" id="7OJcYqyZqsX" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqyZqsY" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqyZqsZ" role="1dT_Ay">
+            <property role="1dT_AB" value="All MPS concept properties that are converted into LionWeb M2 annotations." />
           </node>
         </node>
-        <node concept="TZ5HI" id="7OJcYqxsxE3" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxsxE4" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxsxE5" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3Tm1VV" id="5JNiskhxHcY" role="1B3o_S" />
@@ -9473,964 +7835,6 @@
       <node concept="17QB3L" id="5JNiskhmwT4" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="5JNiskhmsVz" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskhmCGz" role="jymVt">
-      <property role="TrG5h" value="lcStringType" />
-      <node concept="3clFbS" id="5JNiskhmCGA" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhmEGU" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvYxMo" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwjJ_D" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzm" resolve="getString" />
-            </node>
-            <node concept="liA8E" id="7OJcYqvY_vW" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwP92e" resolve="getLc" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhmAEc" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskhmCD_" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhmKpL" role="jymVt">
-      <property role="TrG5h" value="mpsStringType" />
-      <node concept="3clFbS" id="5JNiskhmKpO" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhmMqw" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvYW1z" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqvZ0BD" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwjNua" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzm" resolve="getString" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhmIn2" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskhmKmN" role="3clF45">
-        <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhnnGw" role="jymVt">
-      <property role="TrG5h" value="slangStringType" />
-      <node concept="3clFbS" id="5JNiskhnnGx" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhnnGy" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvZ7I4" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqvZctT" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwjRij" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzm" resolve="getString" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhnnG$" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskhnnG_" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhntM$" role="jymVt">
-      <property role="TrG5h" value="keyStringType" />
-      <node concept="3clFbS" id="5JNiskhntM_" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhntMA" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvZjLy" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqvZluh" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwP92u" resolve="getLcKey" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwjV5e" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzm" resolve="getString" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhntMC" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhntMD" role="3clF45" />
-    </node>
-    <node concept="3clFb_" id="5JNiskhnzc0" role="jymVt">
-      <property role="TrG5h" value="idStringType" />
-      <node concept="3clFbS" id="5JNiskhnzc1" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhnzc2" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvZtGO" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqvZxHc" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwjYQV" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzm" resolve="getString" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhnzc4" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhnzc5" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="DUXtH0nOOu" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskhnMfh" role="jymVt">
-      <property role="TrG5h" value="lcBooleanType" />
-      <node concept="3clFbS" id="5JNiskhnMfi" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhoAwc" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvZCUf" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwk2HE" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzu" resolve="getBoolean" />
-            </node>
-            <node concept="liA8E" id="7OJcYqvZHFw" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwP92e" resolve="getLc" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhnMfj" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskhnMfk" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhnMfd" role="jymVt">
-      <property role="TrG5h" value="mpsBooleanType" />
-      <node concept="3clFbS" id="5JNiskhnMfe" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhoJ98" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvZOXp" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqvZTbY" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwk6$C" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzu" resolve="getBoolean" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhnMff" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskhnMfg" role="3clF45">
-        <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhnMf9" role="jymVt">
-      <property role="TrG5h" value="slangBooleanType" />
-      <node concept="3clFbS" id="5JNiskhnMfa" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhoKSA" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw01u9" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw067V" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwkaob" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzu" resolve="getBoolean" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhnMfb" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskhnMfc" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhnMf5" role="jymVt">
-      <property role="TrG5h" value="keyBooleanType" />
-      <node concept="3clFbS" id="5JNiskhnMf6" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhoMBQ" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw0iD0" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw0noW" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwP92u" resolve="getLcKey" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwkeaw" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzu" resolve="getBoolean" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhnMf7" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhnMf8" role="3clF45" />
-    </node>
-    <node concept="3clFb_" id="5JNiskhnMf1" role="jymVt">
-      <property role="TrG5h" value="idBooleanType" />
-      <node concept="3clFbS" id="5JNiskhnMf2" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhoOua" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw0uBc" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw0znP" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwkhLL" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzu" resolve="getBoolean" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhnMf3" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhnMf4" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="DUXtGZOqx1" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskhnZtN" role="jymVt">
-      <property role="TrG5h" value="lcIntegerType" />
-      <node concept="3clFbS" id="5JNiskhnZtO" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhphv_" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw0ETg" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwklHx" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzA" resolve="getInteger" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw0IXK" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwP92e" resolve="getLc" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhnZtP" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskhnZtQ" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhnZtJ" role="jymVt">
-      <property role="TrG5h" value="mpsIntegerType" />
-      <node concept="3clFbS" id="5JNiskhnZtK" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhpjmd" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw0Q8a" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw0Ud8" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwkpzT" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzA" resolve="getInteger" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhnZtL" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskhnZtM" role="3clF45">
-        <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhnZtF" role="jymVt">
-      <property role="TrG5h" value="slangIntegerType" />
-      <node concept="3clFbS" id="5JNiskhnZtG" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhplww" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw10Uh" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw15JU" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwktoe" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzA" resolve="getInteger" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhnZtH" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskhnZtI" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhnZtB" role="jymVt">
-      <property role="TrG5h" value="keyIntegerType" />
-      <node concept="3clFbS" id="5JNiskhnZtC" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhpngy" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw1d4p" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw1hUG" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwP92u" resolve="getLcKey" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwkxcH" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzA" resolve="getInteger" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhnZtD" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhnZtE" role="3clF45" />
-    </node>
-    <node concept="3clFb_" id="5JNiskhnZtz" role="jymVt">
-      <property role="TrG5h" value="idIntegerType" />
-      <node concept="3clFbS" id="5JNiskhnZt$" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhpp5e" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw1p4d" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw1qPp" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwk$x2" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzA" resolve="getInteger" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhnZt_" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhnZtA" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="48csSBPf4M5" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskhoaPB" role="jymVt">
-      <property role="TrG5h" value="lcJsonType" />
-      <node concept="3clFbS" id="5JNiskhoaPC" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhpPFg" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw1z4N" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwkCvK" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzI" resolve="getJson" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw1ATb" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwOOzI" resolve="getLc" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhoaPD" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskhoaPE" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhoaPz" role="jymVt">
-      <property role="TrG5h" value="mpsJsonType" />
-      <node concept="3clFbS" id="5JNiskhoaP$" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhpRku" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw20h_" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw20hB" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwkGHx" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzI" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhoaP_" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskhoaPA" role="3clF45">
-        <ref role="ehGHo" to="tpce:fKAz7CR" resolve="ConstrainedDataTypeDeclaration" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhoaPv" role="jymVt">
-      <property role="TrG5h" value="slangJsonType" />
-      <node concept="3clFbS" id="5JNiskhoaPw" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhpT7y" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw36$Z" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw3buS" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwkJZD" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzI" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhoaPx" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskhoaPy" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhoaPr" role="jymVt">
-      <property role="TrG5h" value="keyJsonType" />
-      <node concept="3clFbS" id="5JNiskhoaPs" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhpV0v" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw3iMH" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw3m_i" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwOOzY" resolve="getLcKey" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwkNOU" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzI" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhoaPt" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhoaPu" role="3clF45" />
-    </node>
-    <node concept="3clFb_" id="5JNiskhoaPn" role="jymVt">
-      <property role="TrG5h" value="idJsonType" />
-      <node concept="3clFbS" id="5JNiskhoaPo" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhpWNR" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw3tEr" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw3z0j" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwkRHc" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzI" resolve="getJson" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhoaPp" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhoaPq" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="39$JcGFBYDh" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskhqgVp" role="jymVt">
-      <property role="TrG5h" value="lcNodeConcept" />
-      <node concept="3clFbS" id="5JNiskhqgVq" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhrp2b" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw3EnR" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwkVyW" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw3Jc$" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcL" resolve="getLc" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqgVr" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskhqgVs" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjklrv" resolve="Concept" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhqgVl" role="jymVt">
-      <property role="TrG5h" value="mpsNodeConcept" />
-      <node concept="3clFbS" id="5JNiskhqgVm" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhrqP2" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw3XKm" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw432f" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwkZsd" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqgVn" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskhqgVo" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhqgVh" role="jymVt">
-      <property role="TrG5h" value="slangNodeConcept" />
-      <node concept="3clFbS" id="5JNiskhqgVi" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhrsEU" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw4kR2" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw4kR4" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwl3kZ" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqgVj" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskhqgVk" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhqgVd" role="jymVt">
-      <property role="TrG5h" value="keyNodeConcept" />
-      <node concept="3clFbS" id="5JNiskhqgVe" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhruvC" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw4ETM" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw4J4o" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwl6Ys" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqgVf" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhqgVg" role="3clF45" />
-    </node>
-    <node concept="3clFb_" id="5JNiskhqgV9" role="jymVt">
-      <property role="TrG5h" value="idNodeConcept" />
-      <node concept="3clFbS" id="5JNiskhqgVa" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhrwkS" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw4QKz" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw4S_v" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwlaSS" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzQ" resolve="getNode" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqgVb" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhqgVc" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="6jTTMHCZQ3M" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskhqsXL" role="jymVt">
-      <property role="TrG5h" value="mpsAnnotationConcept" />
-      <node concept="3clFbS" id="5JNiskhqsXM" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhs9RS" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw54Qd" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwleRF" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzY" resolve="getAnnotation" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw59S2" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqsXN" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskhqsXO" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhqsXH" role="jymVt">
-      <property role="TrG5h" value="slangAnnotationConcept" />
-      <node concept="3clFbS" id="5JNiskhqsXI" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhsb_y" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw5hu5" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw5myP" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwliL6" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzY" resolve="getAnnotation" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqsXJ" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskhqsXK" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhqsX_" role="jymVt">
-      <property role="TrG5h" value="idAnnotationConcept" />
-      <node concept="3clFbS" id="5JNiskhqsXA" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhsdte" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw5u7Y" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw5yxY" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwlmFd" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirzY" resolve="getAnnotation" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqsXB" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhqsXC" role="3clF45" />
-    </node>
-    <node concept="3clFb_" id="5JNiskhsfjt" role="jymVt">
-      <property role="TrG5h" value="slangAnnotationContainment" />
-      <node concept="3clFbS" id="5JNiskhsfju" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhsfjv" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw5S4f" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwlqBn" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwir$6" resolve="getAnnotationContainment" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw5TUm" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhsfjx" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskhsfjy" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskitK$i" role="jymVt">
-      <property role="TrG5h" value="mpsAnnotationContainment" />
-      <node concept="3clFbS" id="5JNiskitK$j" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqw6oBf" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw6oBg" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw6oBi" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwluyo" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwir$6" resolve="getAnnotationContainment" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskitK$m" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskitNZh" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiyneZ" role="jymVt">
-      <property role="TrG5h" value="idAnnotationContainment" />
-      <node concept="3Tm1VV" id="5JNiskiynf1" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiynf2" role="3clF45" />
-      <node concept="3clFbS" id="5JNiskiynf3" role="3clF47">
-        <node concept="3clFbF" id="5JNiskiyHyC" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw6Cyx" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw6Cyz" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwlys5" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwir$6" resolve="getAnnotationContainment" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5JNiskiynf4" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="30uXOOfMilH" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskhqBwh" role="jymVt">
-      <property role="TrG5h" value="lcINamedInterface" />
-      <node concept="3clFbS" id="5JNiskhqBwi" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhsT8h" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw6QLV" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwlAr7" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwir$e" resolve="getINamed" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw6VRP" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwOWjc" resolve="getLc" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqBwj" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskhqBwk" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjklHQ" resolve="Interface" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhqBwd" role="jymVt">
-      <property role="TrG5h" value="mpsINamedInterface" />
-      <node concept="3clFbS" id="5JNiskhqBwe" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqw70t6" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw70t7" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw70t9" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwlEm6" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwir$e" resolve="getINamed" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqBwf" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskhqBwg" role="3clF45">
-        <ref role="ehGHo" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhqBw9" role="jymVt">
-      <property role="TrG5h" value="slangINamedInterface" />
-      <node concept="3clFbS" id="5JNiskhqBwa" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhsWV5" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvXMaC" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqvXQD$" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwlIdH" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwir$e" resolve="getINamed" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqBwb" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskhqBwc" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SInterfaceConcept" resolve="SInterfaceConcept" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhqBw5" role="jymVt">
-      <property role="TrG5h" value="keyINamedInterface" />
-      <node concept="3clFbS" id="5JNiskhqBw6" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhsZ6k" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvXAqX" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqvXFiv" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqwOWjs" resolve="getLcKey" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwlM1g" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwir$e" resolve="getINamed" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqBw7" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhqBw8" role="3clF45" />
-    </node>
-    <node concept="3clFb_" id="5JNiskhqBw1" role="jymVt">
-      <property role="TrG5h" value="idINamedInterface" />
-      <node concept="3clFbS" id="5JNiskhqBw2" role="3clF47">
-        <node concept="3clFbF" id="5JNiskht12d" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvXoTx" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqvXtKI" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwlPWC" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwir$e" resolve="getINamed" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqBw3" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhqBw4" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="5AGBwuFJGvp" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskhqJpu" role="jymVt">
-      <property role="TrG5h" value="lcNameProperty" />
-      <node concept="3clFbS" id="5JNiskhqJpv" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhtHQh" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvXcyT" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwlTJI" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwir$m" resolve="getINamedName" />
-            </node>
-            <node concept="liA8E" id="7OJcYqvXh1H" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcL" resolve="getLc" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqJpw" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskhqJpx" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhqJpq" role="jymVt">
-      <property role="TrG5h" value="mpsNameProperty" />
-      <node concept="3clFbS" id="5JNiskhqJpr" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhtJI3" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvX1RD" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqvX5Oi" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcS" resolve="getMps" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwlXFr" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwir$m" resolve="getINamedName" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqJps" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskhqJpt" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhqJpm" role="jymVt">
-      <property role="TrG5h" value="slangNameProperty" />
-      <node concept="3clFbS" id="5JNiskhqJpn" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhtL_3" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvWPfy" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqvWTM1" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwm1_0" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwir$m" resolve="getINamedName" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqJpo" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskhqJpp" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhqJpi" role="jymVt">
-      <property role="TrG5h" value="keyNameProperty" />
-      <node concept="3clFbS" id="5JNiskhqJpj" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqvWCO9" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvWCOa" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqvWCOc" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwm5wU" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwir$m" resolve="getINamedName" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqJpk" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhqJpl" role="3clF45" />
-    </node>
-    <node concept="3clFb_" id="5JNiskhqJpe" role="jymVt">
-      <property role="TrG5h" value="idNameProperty" />
-      <node concept="3clFbS" id="5JNiskhqJpf" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhtPtj" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvWtzY" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqvWzas" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwm9d1" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwir$m" resolve="getINamedName" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqJpg" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhqJph" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="39$JcGFBN$Q" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskhqTRf" role="jymVt">
-      <property role="TrG5h" value="slangM3LanguageId" />
-      <node concept="3clFbS" id="5JNiskhqTRg" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqvWiye" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvWiyf" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwmdc4" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirz6" resolve="getM3" />
-            </node>
-            <node concept="liA8E" id="7OJcYqvWiyh" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqw7aei" resolve="getSlangId" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqTRh" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskhurRH" role="3clF45">
-        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhqTRb" role="jymVt">
-      <property role="TrG5h" value="slangM3Language" />
-      <node concept="3clFbS" id="5JNiskhqTRc" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhuzuI" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvWb0a" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqvWej4" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwmh6k" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirz6" resolve="getM3" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqTRd" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskhqTRe" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhqTR7" role="jymVt">
-      <property role="TrG5h" value="keyM3Language" />
-      <node concept="3clFbS" id="5JNiskhqTR8" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqw7pno" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw7pnp" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw7pnr" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwmkZn" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirz6" resolve="getM3" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqTR9" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhqTRa" role="3clF45" />
-    </node>
-    <node concept="3clFb_" id="5JNiskhqTR3" role="jymVt">
-      <property role="TrG5h" value="idM3Language" />
-      <node concept="3clFbS" id="5JNiskhqTR4" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqw7yPc" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw7yPd" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw7yPf" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqd6" resolve="getMpsId" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwmoWN" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirz6" resolve="getM3" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqTR5" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhqTR6" role="3clF45" />
-    </node>
-    <node concept="3clFb_" id="5JNiskhqTRj" role="jymVt">
-      <property role="TrG5h" value="versionM3Language" />
-      <node concept="3clFbS" id="5JNiskhqTRk" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqw7G8b" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw7G8c" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw7G8e" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0Qp" resolve="getLcVersion" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwmsQa" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirz6" resolve="getM3" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhqTRl" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhuHOn" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="5AGBwuFFBkK" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskhvkMR" role="jymVt">
-      <property role="TrG5h" value="slangCoreLanguageId" />
-      <node concept="3clFbS" id="5JNiskhvkMS" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhvkMT" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw7Uk2" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwmwdG" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirze" resolve="getLioncoreBuiltins" />
-            </node>
-            <node concept="liA8E" id="7OJcYqw7Z2v" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqw7aei" resolve="getSlangId" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhvkMV" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskhvkMW" role="3clF45">
-        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhv7gW" role="jymVt">
-      <property role="TrG5h" value="slangCoreLanguage" />
-      <node concept="3clFbS" id="5JNiskhv7gX" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqw83LK" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw83LL" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw83LN" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwm$bI" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirze" resolve="getLioncoreBuiltins" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhv7h0" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskhv7h1" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhv1Rx" role="jymVt">
-      <property role="TrG5h" value="keyBuiltinLanguage" />
-      <node concept="3clFbS" id="5JNiskhv1Ry" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqw8d2S" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw8d2T" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw8d2V" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwmBYp" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirze" resolve="getLioncoreBuiltins" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhv1R_" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhv1RA" role="3clF45" />
-    </node>
-    <node concept="3clFb_" id="5JNiskhuV1t" role="jymVt">
-      <property role="TrG5h" value="idBuiltinLanguage" />
-      <node concept="3clFbS" id="5JNiskhuV1u" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqw8mSI" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw8mSJ" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw8mSL" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqdm" resolve="getLcId" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwmFQa" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirze" resolve="getLioncoreBuiltins" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhuV1x" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhuV1y" role="3clF45" />
-    </node>
-    <node concept="3clFb_" id="5JNiskhuLWh" role="jymVt">
-      <property role="TrG5h" value="versionBuiltinLanguage" />
-      <node concept="3clFbS" id="5JNiskhuLWi" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqw8wi9" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqw8wia" role="3clFbG">
-            <node concept="liA8E" id="7OJcYqw8wic" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvN0Qp" resolve="getLcVersion" />
-            </node>
-            <node concept="1rXfSq" id="7OJcYqwmJKj" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwirze" resolve="getLioncoreBuiltins" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhuLWl" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskhuLWm" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="5AGBwuFFq4f" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskhvXBZ" role="jymVt">
-      <property role="TrG5h" value="slangAttributeLanguage" />
-      <node concept="3clFbS" id="5JNiskhvXC0" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqwaw$E" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqwa$Iv" role="3clFbG">
-            <node concept="1rXfSq" id="7OJcYqwmNK1" role="2Oq$k0">
-              <ref role="37wK5l" node="7OJcYqwUZco" resolve="getAttributeLanguage" />
-            </node>
-            <node concept="liA8E" id="7OJcYqwaDtk" role="2OqNvi">
-              <ref role="37wK5l" node="7OJcYqvKqcZ" resolve="getSlang" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhvXC3" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskhvXC4" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="7OJcYqwXwT1" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwXqX5" role="jymVt">
       <property role="TrG5h" value="listLcLanguages" />
       <node concept="3Tm1VV" id="7OJcYqwXqX7" role="1B3o_S" />
@@ -10457,111 +7861,6 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqwXqXb" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiski3Cws" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskhYXbv" role="jymVt">
-      <property role="TrG5h" value="listSLanguages" />
-      <node concept="3clFbS" id="5JNiskhYXbw" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXbx" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXby" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXbz" role="2ShVmc">
-              <node concept="3uibUv" id="5JNiskhYXb$" role="HW$YZ">
-                <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXb_" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqTRb" resolve="slangM3Language" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXbA" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhv7gW" resolve="slangCoreLanguage" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXbB" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskhYXbC" role="3clF45">
-        <node concept="3uibUv" id="5JNiskhYXbD" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5JNiskiuHD3" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXbN" role="jymVt">
-      <property role="TrG5h" value="listKeyLanguages" />
-      <node concept="3clFbS" id="5JNiskhYXbO" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXbP" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXbQ" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXbR" role="2ShVmc">
-              <node concept="17QB3L" id="5JNiskhYXbS" role="HW$YZ" />
-              <node concept="1rXfSq" id="5JNiskhYXbT" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqTR7" resolve="keyM3Language" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXbU" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXbV" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskhYXbW" role="3clF45">
-        <node concept="17QB3L" id="5JNiskhYXbX" role="_ZDj9" />
-      </node>
-      <node concept="2AHcQZ" id="5JNiskiuNLr" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXc2" role="jymVt">
-      <property role="TrG5h" value="listSLanguageLanguageIds" />
-      <node concept="3clFbS" id="5JNiskhYXc3" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXc4" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXc5" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXc6" role="2ShVmc">
-              <node concept="17QB3L" id="5JNiskhYXc7" role="HW$YZ" />
-              <node concept="1rXfSq" id="5JNiskhYXc8" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqTR3" resolve="idM3Language" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXc9" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhuV1t" resolve="idBuiltinLanguage" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXca" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskhYXcb" role="3clF45">
-        <node concept="17QB3L" id="5JNiskhYXcc" role="_ZDj9" />
-      </node>
-      <node concept="2AHcQZ" id="5JNiskiuTVO" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXcm" role="jymVt">
-      <property role="TrG5h" value="listVersionLanguages" />
-      <node concept="3clFbS" id="5JNiskhYXcn" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXco" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXcp" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXcq" role="2ShVmc">
-              <node concept="17QB3L" id="5JNiskhYXcr" role="HW$YZ" />
-              <node concept="1rXfSq" id="5JNiskhYXcs" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqTRj" resolve="versionM3Language" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXct" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhuLWh" resolve="versionBuiltinLanguage" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXcu" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskhYXcv" role="3clF45">
-        <node concept="17QB3L" id="5JNiskhYXcw" role="_ZDj9" />
-      </node>
-      <node concept="2AHcQZ" id="5JNiskiv07e" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -10595,140 +7894,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiskhYXcH" role="jymVt">
-      <property role="TrG5h" value="listLcClassifiers" />
-      <node concept="3clFbS" id="5JNiskhYXcI" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXcJ" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXcK" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXcL" role="2ShVmc">
-              <node concept="3Tqbb2" id="5JNiskhYXcM" role="HW$YZ">
-                <ref role="ehGHo" to="h3y3:2ju2syjkl4i" resolve="Classifier" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXcN" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqgVp" resolve="lcNodeConcept" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXcO" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqBwh" resolve="lcINamedInterface" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXcP" role="1B3o_S" />
-      <node concept="2I9FWS" id="5JNiskhYXcQ" role="3clF45">
-        <ref role="2I9WkF" to="h3y3:2ju2syjkl4i" resolve="Classifier" />
-      </node>
-      <node concept="2AHcQZ" id="5JNiskiv6fl" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXcV" role="jymVt">
-      <property role="TrG5h" value="listMpsClassifiers" />
-      <node concept="3clFbS" id="5JNiskhYXcW" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXcX" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXcY" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXcZ" role="2ShVmc">
-              <node concept="3Tqbb2" id="5JNiskhYXd0" role="HW$YZ">
-                <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXd1" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqgVl" resolve="mpsNodeConcept" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXd2" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqBwd" resolve="mpsINamedInterface" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXd3" role="1B3o_S" />
-      <node concept="2I9FWS" id="5JNiskhYXd4" role="3clF45">
-        <ref role="2I9WkF" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-      </node>
-      <node concept="2AHcQZ" id="5JNiskivj41" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXd9" role="jymVt">
-      <property role="TrG5h" value="listSLanguageClassifiers" />
-      <node concept="3clFbS" id="5JNiskhYXda" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXdb" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXdc" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXdd" role="2ShVmc">
-              <node concept="3uibUv" id="5JNiskhYXde" role="HW$YZ">
-                <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXdf" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqgVh" resolve="slangNodeConcept" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXdg" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqBw9" resolve="slangINamedInterface" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXdh" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskhYXdi" role="3clF45">
-        <node concept="3uibUv" id="5JNiskhYXdj" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5JNiskivpcd" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXdt" role="jymVt">
-      <property role="TrG5h" value="listKeyClassifiers" />
-      <node concept="3clFbS" id="5JNiskhYXdu" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXdv" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXdw" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXdx" role="2ShVmc">
-              <node concept="17QB3L" id="5JNiskhYXdy" role="HW$YZ" />
-              <node concept="1rXfSq" id="5JNiskhYXdz" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqgVd" resolve="keyNodeConcept" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXd$" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqBw5" resolve="keyINamedInterface" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXd_" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskhYXdA" role="3clF45">
-        <node concept="17QB3L" id="5JNiskhYXdB" role="_ZDj9" />
-      </node>
-      <node concept="2AHcQZ" id="5JNiskivvke" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXdG" role="jymVt">
-      <property role="TrG5h" value="listSClassifierIds" />
-      <node concept="3clFbS" id="5JNiskhYXdH" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXdI" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXdJ" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXdK" role="2ShVmc">
-              <node concept="17QB3L" id="5JNiskhYXdL" role="HW$YZ" />
-              <node concept="1rXfSq" id="5JNiskhYXdM" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqgV9" resolve="idNodeConcept" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXdN" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqBw1" resolve="idINamedInterface" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXdO" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskhYXdP" role="3clF45">
-        <node concept="17QB3L" id="5JNiskhYXdQ" role="_ZDj9" />
-      </node>
-      <node concept="2AHcQZ" id="5JNiskiv_sj" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiskhYXe0" role="jymVt" />
     <node concept="2tJIrI" id="5JNiskhYXe1" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwZBzt" role="jymVt">
       <property role="TrG5h" value="listLcProperty" />
@@ -10756,125 +7921,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiskhYXe2" role="jymVt">
-      <property role="TrG5h" value="listLcProperties" />
-      <node concept="3clFbS" id="5JNiskhYXe3" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXe4" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXe5" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXe6" role="2ShVmc">
-              <node concept="3Tqbb2" id="5JNiskhYXe7" role="HW$YZ">
-                <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXe8" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqJpu" resolve="lcNameProperty" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXe9" role="1B3o_S" />
-      <node concept="2I9FWS" id="5JNiskhYXea" role="3clF45">
-        <ref role="2I9WkF" to="h3y3:2ju2syjkkDM" resolve="Property" />
-      </node>
-      <node concept="2AHcQZ" id="5JNiskivF$b" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXef" role="jymVt">
-      <property role="TrG5h" value="listMpsProperties" />
-      <node concept="3clFbS" id="5JNiskhYXeg" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXeh" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXei" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXej" role="2ShVmc">
-              <node concept="3Tqbb2" id="5JNiskhYXek" role="HW$YZ">
-                <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXel" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqJpq" resolve="mpsNameProperty" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXem" role="1B3o_S" />
-      <node concept="2I9FWS" id="5JNiskhYXen" role="3clF45">
-        <ref role="2I9WkF" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-      <node concept="2AHcQZ" id="5JNiskivLG2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXes" role="jymVt">
-      <property role="TrG5h" value="listSLanguageProperties" />
-      <node concept="3clFbS" id="5JNiskhYXet" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXeu" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXev" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXew" role="2ShVmc">
-              <node concept="3uibUv" id="5JNiskhYXex" role="HW$YZ">
-                <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXey" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqJpm" resolve="slangNameProperty" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXez" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskhYXe$" role="3clF45">
-        <node concept="3uibUv" id="5JNiskhYXe_" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5JNiskivRSK" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXeJ" role="jymVt">
-      <property role="TrG5h" value="listKeyProperties" />
-      <node concept="3clFbS" id="5JNiskhYXeK" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXeL" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXeM" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXeN" role="2ShVmc">
-              <node concept="17QB3L" id="5JNiskhYXeO" role="HW$YZ" />
-              <node concept="1rXfSq" id="5JNiskhYXeP" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqJpi" resolve="keyNameProperty" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXeQ" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskhYXeR" role="3clF45">
-        <node concept="17QB3L" id="5JNiskhYXeS" role="_ZDj9" />
-      </node>
-      <node concept="2AHcQZ" id="5JNiskivY1Q" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXeX" role="jymVt">
-      <property role="TrG5h" value="listSPropertyIds" />
-      <node concept="3clFbS" id="5JNiskhYXeY" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXeZ" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXf0" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXf1" role="2ShVmc">
-              <node concept="17QB3L" id="5JNiskhYXf2" role="HW$YZ" />
-              <node concept="1rXfSq" id="5JNiskhYXf3" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqJpe" resolve="idNameProperty" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXf4" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskhYXf5" role="3clF45">
-        <node concept="17QB3L" id="5JNiskhYXf6" role="_ZDj9" />
-      </node>
-      <node concept="2AHcQZ" id="5JNiskiw49G" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiskhYXfg" role="jymVt" />
     <node concept="2tJIrI" id="7OJcYqx0zJr" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqx0D9N" role="jymVt">
       <property role="TrG5h" value="listLcPrimitiveType" />
@@ -10908,200 +7954,6 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqx0D9T" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXfh" role="jymVt">
-      <property role="TrG5h" value="listLcPrimitiveTypes" />
-      <node concept="3clFbS" id="5JNiskhYXfi" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXfj" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXfk" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXfl" role="2ShVmc">
-              <node concept="3Tqbb2" id="5JNiskhYXfm" role="HW$YZ">
-                <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXfn" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhnMfh" resolve="lcBooleanType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXfo" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhnZtN" resolve="lcIntegerType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXfp" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhmCGz" resolve="lcStringType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXfq" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhoaPB" resolve="lcJsonType" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXfr" role="1B3o_S" />
-      <node concept="2I9FWS" id="5JNiskhYXfs" role="3clF45">
-        <ref role="2I9WkF" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-      </node>
-      <node concept="2AHcQZ" id="5JNiskiwahl" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXfx" role="jymVt">
-      <property role="TrG5h" value="listMpsPrimitiveTypes" />
-      <node concept="3clFbS" id="5JNiskhYXfy" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXfz" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXf$" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXf_" role="2ShVmc">
-              <node concept="3Tqbb2" id="5JNiskhYXfA" role="HW$YZ">
-                <ref role="ehGHo" to="tpce:fKAxPRU" resolve="DataTypeDeclaration" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXfB" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhnMfd" resolve="mpsBooleanType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXfC" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhnZtJ" resolve="mpsIntegerType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXfD" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhmKpL" resolve="mpsStringType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXfE" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhoaPz" resolve="mpsJsonType" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXfF" role="1B3o_S" />
-      <node concept="2I9FWS" id="5JNiskhYXfG" role="3clF45">
-        <ref role="2I9WkF" to="tpce:fKAxPRU" resolve="DataTypeDeclaration" />
-      </node>
-      <node concept="2AHcQZ" id="5JNiskiwgoX" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXfL" role="jymVt">
-      <property role="TrG5h" value="listSLanguagePrimitiveTypes" />
-      <node concept="3clFbS" id="5JNiskhYXfM" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXfN" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXfO" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXfP" role="2ShVmc">
-              <node concept="3uibUv" id="5JNiskhYXfQ" role="HW$YZ">
-                <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXfR" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhnMf9" resolve="slangBooleanType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXfS" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhnZtF" resolve="slangIntegerType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXfT" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhnnGw" resolve="slangStringType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXfU" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhoaPv" resolve="slangJsonType" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXfV" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskhYXfW" role="3clF45">
-        <node concept="3uibUv" id="5JNiskhYXfX" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="5JNiskiwmKw" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXg7" role="jymVt">
-      <property role="TrG5h" value="listKeyPrimitiveTypes" />
-      <node concept="3clFbS" id="5JNiskhYXg8" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXg9" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXga" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXgb" role="2ShVmc">
-              <node concept="17QB3L" id="5JNiskhYXgc" role="HW$YZ" />
-              <node concept="1rXfSq" id="5JNiskhYXgd" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhnMf5" resolve="keyBooleanType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXge" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhnZtB" resolve="keyIntegerType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXgf" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhntM$" resolve="keyStringType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXgg" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhoaPr" resolve="keyJsonType" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXgh" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskhYXgi" role="3clF45">
-        <node concept="17QB3L" id="5JNiskhYXgj" role="_ZDj9" />
-      </node>
-      <node concept="2AHcQZ" id="5JNiskiwsBy" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXgo" role="jymVt">
-      <property role="TrG5h" value="listSPrimitiveTypeIds" />
-      <node concept="3clFbS" id="5JNiskhYXgp" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXgq" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXgr" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXgs" role="2ShVmc">
-              <node concept="17QB3L" id="5JNiskhYXgt" role="HW$YZ" />
-              <node concept="1rXfSq" id="5JNiskhYXgu" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhnMf1" resolve="idBooleanType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXgv" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhnZtz" resolve="idIntegerType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXgw" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhnzc0" resolve="idStringType" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXgx" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhoaPn" resolve="idJsonType" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5JNiskhYXgy" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskhYXgz" role="3clF45">
-        <node concept="17QB3L" id="5JNiskhYXg$" role="_ZDj9" />
-      </node>
-      <node concept="2AHcQZ" id="5JNiskiwyJ9" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="7OJcYqvG8kD" role="jymVt">
-      <property role="TrG5h" value="listSLanguagePrimitiveTypeLanguageKeys" />
-      <node concept="3Tm1VV" id="7OJcYqvG8kF" role="1B3o_S" />
-      <node concept="_YKpA" id="7OJcYqvG8kG" role="3clF45">
-        <node concept="17QB3L" id="7OJcYqvG8kH" role="_ZDj9" />
-      </node>
-      <node concept="3clFbS" id="7OJcYqvG8kI" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqvGdgt" role="3cqZAp">
-          <node concept="2ShNRf" id="7OJcYqvGdgu" role="3clFbG">
-            <node concept="Tc6Ow" id="7OJcYqvGdgv" role="2ShVmc">
-              <node concept="17QB3L" id="7OJcYqvGdgw" role="HW$YZ" />
-              <node concept="1rXfSq" id="7OJcYqvGn95" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
-              </node>
-              <node concept="1rXfSq" id="7OJcYqvGr7o" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
-              </node>
-              <node concept="1rXfSq" id="7OJcYqvGuDA" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
-              </node>
-              <node concept="1rXfSq" id="7OJcYqvGybO" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqvG8kJ" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -11518,6 +8370,9 @@
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
+      <node concept="2AHcQZ" id="7OJcYq$0Eok" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
     </node>
     <node concept="2tJIrI" id="5JNiskhYXhO" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqx1NIa" role="jymVt">
@@ -11549,155 +8404,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiskhYXhP" role="jymVt">
-      <property role="TrG5h" value="listMpsInternalClassifiers" />
-      <node concept="3clFbS" id="5JNiskhYXhQ" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXhR" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXhS" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXhT" role="2ShVmc">
-              <node concept="1rXfSq" id="5JNiskhYXhU" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqgVl" resolve="mpsNodeConcept" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXhV" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqsXL" resolve="mpsAnnotationConcept" />
-              </node>
-              <node concept="3Tqbb2" id="5JNiskhYXhW" role="HW$YZ">
-                <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="7weWCFlq$R_" role="1B3o_S" />
-      <node concept="2I9FWS" id="5JNiskhYXhY" role="3clF45">
-        <ref role="2I9WkF" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-      </node>
-      <node concept="P$JXv" id="5JNiskhYXhZ" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiskhYXi0" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiskhYXi1" role="1dT_Ay">
-            <property role="1dT_AB" value="All MPS concepts that need special treatment in LionWeb as MPS Concept." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiskhYXi2" role="3nqlJM">
-          <property role="x79VB" value="All MPS concepts that need special treatment in LionWeb." />
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXi3" role="jymVt">
-      <property role="TrG5h" value="listSLanguageInternalClassifiers" />
-      <node concept="3clFbS" id="5JNiskhYXi4" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXi5" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXi6" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXi7" role="2ShVmc">
-              <node concept="1rXfSq" id="5JNiskhYXi8" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqgVh" resolve="slangNodeConcept" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXi9" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqsXH" resolve="slangAnnotationConcept" />
-              </node>
-              <node concept="3uibUv" id="5JNiskhYXia" role="HW$YZ">
-                <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="7weWCFlqxOZ" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskhYXic" role="3clF45">
-        <node concept="3uibUv" id="5JNiskhYXid" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-        </node>
-      </node>
-      <node concept="P$JXv" id="5JNiskhYXie" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiskhYXif" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiskhYXig" role="1dT_Ay">
-            <property role="1dT_AB" value="All MPS concepts that need special treatment in LionWeb as MPS " />
-          </node>
-          <node concept="1dT_AA" id="5JNiskhYXih" role="1dT_Ay">
-            <node concept="92FcH" id="5JNiskhYXii" role="qph3F">
-              <node concept="TZ5HA" id="5JNiskhYXij" role="2XjZqd" />
-              <node concept="VXe08" id="5JNiskhYXik" role="92FcQ">
-                <ref role="VXe09" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5JNiskhYXil" role="1dT_Ay">
-            <property role="1dT_AB" value="." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiskhYXim" role="3nqlJM">
-          <property role="x79VB" value="All MPS concepts that need special treatment in LionWeb." />
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="7OJcYqvHsZE" role="jymVt">
-      <property role="TrG5h" value="listSLanguageInternalClassifierLanguageKeys" />
-      <node concept="3Tm1VV" id="7OJcYqvHsZG" role="1B3o_S" />
-      <node concept="_YKpA" id="7OJcYqvHsZH" role="3clF45">
-        <node concept="17QB3L" id="7OJcYqvHsZI" role="_ZDj9" />
-      </node>
-      <node concept="3clFbS" id="7OJcYqvHsZJ" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqvHy52" role="3cqZAp">
-          <node concept="2ShNRf" id="7OJcYqvHy50" role="3clFbG">
-            <node concept="Tc6Ow" id="7OJcYqvH_BY" role="2ShVmc">
-              <node concept="17QB3L" id="7OJcYqvHGxI" role="HW$YZ" />
-              <node concept="1rXfSq" id="7OJcYqvHNaL" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
-              </node>
-              <node concept="1rXfSq" id="7OJcYqvHUaA" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqTR7" resolve="keyM3Language" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqvHsZK" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskhYXin" role="jymVt">
-      <property role="TrG5h" value="listSClassifierInternalIds" />
-      <node concept="3clFbS" id="5JNiskhYXio" role="3clF47">
-        <node concept="3clFbF" id="5JNiskhYXip" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskhYXiq" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskhYXir" role="2ShVmc">
-              <node concept="17QB3L" id="5JNiskhYXis" role="HW$YZ" />
-              <node concept="1rXfSq" id="5JNiskhYXit" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqgV9" resolve="idNodeConcept" />
-              </node>
-              <node concept="1rXfSq" id="5JNiskhYXiu" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhqsX_" resolve="idAnnotationConcept" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tmbuc" id="5JNiskixjOs" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskhYXiw" role="3clF45">
-        <node concept="17QB3L" id="5JNiskhYXix" role="_ZDj9" />
-      </node>
-      <node concept="P$JXv" id="5JNiskhYXiy" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiskhYXiz" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiskhYXi$" role="1dT_Ay">
-            <property role="1dT_AB" value="All MPS concepts that need special treatment in LionWeb as stringified " />
-          </node>
-          <node concept="1dT_AA" id="5JNiskhYXi_" role="1dT_Ay">
-            <node concept="92FcH" id="5JNiskhYXiA" role="qph3F">
-              <node concept="TZ5HA" id="5JNiskhYXiB" role="2XjZqd" />
-              <node concept="VXe08" id="5JNiskhYXiC" role="92FcQ">
-                <ref role="VXe09" to="e8bb:~SConceptId" resolve="SConceptId" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5JNiskhYXiD" role="1dT_Ay">
-            <property role="1dT_AB" value="link jetbrains.mps.smodel.adapter.ids.SConceptId}." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiskhYXiE" role="3nqlJM">
-          <property role="x79VB" value="All MPS concepts that need special treatment in LionWeb." />
-        </node>
-      </node>
-    </node>
     <node concept="2tJIrI" id="5JNiskixn4F" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqx2F8j" role="jymVt">
       <property role="TrG5h" value="listMpsInternalFeature" />
@@ -11725,139 +8431,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiskix7id" role="jymVt">
-      <property role="TrG5h" value="listMpsInternalFeatures" />
-      <node concept="3clFbS" id="5JNiskix7ie" role="3clF47">
-        <node concept="3clFbF" id="5JNiskix7if" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskix7ig" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskix7ih" role="2ShVmc">
-              <node concept="1rXfSq" id="5JNiskix7ii" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskitK$i" resolve="mpsAnnotationContainment" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tmbuc" id="5JNiskixvcQ" role="1B3o_S" />
-      <node concept="2I9FWS" id="5JNiskix7im" role="3clF45" />
-      <node concept="P$JXv" id="5JNiskix7in" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiskix7io" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiskix7ip" role="1dT_Ay">
-            <property role="1dT_AB" value="All MPS concept features that need special treatment in LionWeb as MPS node." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiskix7iq" role="3nqlJM">
-          <property role="x79VB" value="All MPS concept features that need special treatment in LionWeb." />
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskix7ir" role="jymVt">
-      <property role="TrG5h" value="listSLanguageInternalFeatures" />
-      <node concept="3clFbS" id="5JNiskix7is" role="3clF47">
-        <node concept="3clFbF" id="5JNiskix7it" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskix7iu" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskix7iv" role="2ShVmc">
-              <node concept="1rXfSq" id="5JNiskix7iw" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhsfjt" resolve="slangAnnotationContainment" />
-              </node>
-              <node concept="3uibUv" id="5JNiskix7iy" role="HW$YZ">
-                <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="6Z_tmAegC7g" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskix7i$" role="3clF45">
-        <node concept="3uibUv" id="5JNiskix7i_" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
-        </node>
-      </node>
-      <node concept="P$JXv" id="5JNiskix7iA" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiskix7iB" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiskix7iC" role="1dT_Ay">
-            <property role="1dT_AB" value="All MPS concept features that need special treatment in LionWeb as MPS " />
-          </node>
-          <node concept="1dT_AA" id="5JNiskix7iD" role="1dT_Ay">
-            <node concept="92FcH" id="5JNiskix7iE" role="qph3F">
-              <node concept="TZ5HA" id="5JNiskix7iF" role="2XjZqd" />
-              <node concept="VXe08" id="5JNiskix7iG" role="92FcQ">
-                <ref role="VXe09" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5JNiskix7iH" role="1dT_Ay">
-            <property role="1dT_AB" value="." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiskix7iI" role="3nqlJM">
-          <property role="x79VB" value="All MPS concept featuress that need special treatment in LionWeb." />
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskix7iJ" role="jymVt">
-      <property role="TrG5h" value="listSClassifierInternalFeatureIds" />
-      <node concept="3clFbS" id="5JNiskix7iK" role="3clF47">
-        <node concept="3clFbF" id="5JNiskix7iL" role="3cqZAp">
-          <node concept="2ShNRf" id="5JNiskix7iM" role="3clFbG">
-            <node concept="Tc6Ow" id="5JNiskix7iN" role="2ShVmc">
-              <node concept="17QB3L" id="5JNiskix7iO" role="HW$YZ" />
-              <node concept="1rXfSq" id="5JNiskiz3Bz" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskiyneZ" resolve="idAnnotationContainment" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="6Z_tmAegSM$" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiskix7iS" role="3clF45">
-        <node concept="17QB3L" id="5JNiskix7iT" role="_ZDj9" />
-      </node>
-      <node concept="P$JXv" id="5JNiskix7iU" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiskix7iV" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiskix7iW" role="1dT_Ay">
-            <property role="1dT_AB" value="All MPS concept features that need special treatment in LionWeb as stringified " />
-          </node>
-          <node concept="1dT_AA" id="5JNiskix7iX" role="1dT_Ay">
-            <node concept="92FcH" id="5JNiskix7iY" role="qph3F">
-              <node concept="TZ5HA" id="5JNiskix7iZ" role="2XjZqd" />
-              <node concept="VXe08" id="5JNiskix7j0" role="92FcQ">
-                <ref role="VXe09" to="e8bb:~SConceptFeatureId" resolve="SConceptFeatureId" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5JNiskix7j1" role="1dT_Ay">
-            <property role="1dT_AB" value="." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiskix7j2" role="3nqlJM">
-          <property role="x79VB" value="All MPS concept features that need special treatment in LionWeb." />
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="7OJcYqvFAaf" role="jymVt">
-      <property role="TrG5h" value="listSClassifierInternalFeatureLanguageKeys" />
-      <node concept="3Tm1VV" id="7OJcYqvFAah" role="1B3o_S" />
-      <node concept="_YKpA" id="7OJcYqvFAai" role="3clF45">
-        <node concept="17QB3L" id="7OJcYqvFAaj" role="_ZDj9" />
-      </node>
-      <node concept="3clFbS" id="7OJcYqvFAak" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqvFFc0" role="3cqZAp">
-          <node concept="2ShNRf" id="7OJcYqvFFbY" role="3clFbG">
-            <node concept="Tc6Ow" id="7OJcYqvFKXm" role="2ShVmc">
-              <node concept="17QB3L" id="7OJcYqvFQyl" role="HW$YZ" />
-              <node concept="1rXfSq" id="7OJcYqvFXag" role="HW$Y0">
-                <ref role="37wK5l" node="5JNiskhv1Rx" resolve="keyBuiltinLanguage" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqvFAal" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiskixnqO" role="jymVt" />
     <node concept="2tJIrI" id="5JNiskhYXbt" role="jymVt" />
     <node concept="2YIFZL" id="39$JcGG9B65" role="jymVt">
       <property role="TrG5h" value="extractLanguageId" />
@@ -12200,50 +8773,6 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiski3jVq" role="jymVt">
-      <property role="TrG5h" value="slangStringType" />
-      <node concept="3clFbS" id="5JNiski3jVr" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jVs" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jVt" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqxES3o" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxES3p" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxES3q" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxES3r" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jVu" role="jymVt">
-      <property role="TrG5h" value="keyStringType" />
-      <node concept="3clFbS" id="5JNiski3jVv" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jVw" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jVx" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqxES_H" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxES_I" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxES_J" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxES_K" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jVy" role="jymVt">
-      <property role="TrG5h" value="idStringType" />
-      <node concept="3clFbS" id="5JNiski3jVz" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jV$" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jV_" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqxET8i" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqxET8j" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqxET8k" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqxET8l" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5JNiski3jVA" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwQm1t" role="jymVt">
       <property role="TrG5h" value="getBoolean" />
@@ -12294,82 +8823,6 @@
             <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c/1082983657063" />
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jVB" role="jymVt">
-      <property role="TrG5h" value="lcBooleanType" />
-      <node concept="3clFbS" id="5JNiski3jVC" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jVD" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jVE" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx3i2F" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3i2G" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3i2H" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3i2I" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jVF" role="jymVt">
-      <property role="TrG5h" value="mpsBooleanType" />
-      <node concept="3clFbS" id="5JNiski3jVG" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jVH" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jVI" role="3clF45">
-        <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx3kbZ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3kc0" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3kc1" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3kc2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jVJ" role="jymVt">
-      <property role="TrG5h" value="slangBooleanType" />
-      <node concept="3clFbS" id="5JNiski3jVK" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jVL" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jVM" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx3mlF" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3mlG" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3mlH" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3mlI" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jVN" role="jymVt">
-      <property role="TrG5h" value="keyBooleanType" />
-      <node concept="3clFbS" id="5JNiski3jVO" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jVP" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jVQ" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx3ovJ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3ovK" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3ovL" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3ovM" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jVR" role="jymVt">
-      <property role="TrG5h" value="idBooleanType" />
-      <node concept="3clFbS" id="5JNiski3jVS" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jVT" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jVU" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx3qEb" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3qEc" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3qEd" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3qEe" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jVV" role="jymVt" />
@@ -12424,82 +8877,6 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiski3jVW" role="jymVt">
-      <property role="TrG5h" value="lcIntegerType" />
-      <node concept="3clFbS" id="5JNiski3jVX" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jVY" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jVZ" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx3sOZ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3sP0" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3sP1" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3sP2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jW0" role="jymVt">
-      <property role="TrG5h" value="mpsIntegerType" />
-      <node concept="3clFbS" id="5JNiski3jW1" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jW2" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jW3" role="3clF45">
-        <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx3v0b" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3v0c" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3v0d" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3v0e" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jW4" role="jymVt">
-      <property role="TrG5h" value="slangIntegerType" />
-      <node concept="3clFbS" id="5JNiski3jW5" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jW6" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jW7" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx3xbJ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3xbK" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3xbL" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3xbM" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jW8" role="jymVt">
-      <property role="TrG5h" value="keyIntegerType" />
-      <node concept="3clFbS" id="5JNiski3jW9" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWa" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jWb" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx3znF" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3znG" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3znH" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3znI" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWc" role="jymVt">
-      <property role="TrG5h" value="idIntegerType" />
-      <node concept="3clFbS" id="5JNiski3jWd" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWe" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jWf" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx3_zZ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3_$0" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3_$1" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3_$2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5JNiski3jWg" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwQm1J" role="jymVt">
       <property role="TrG5h" value="getJson" />
@@ -12548,82 +8925,6 @@
             <property role="1dT_AB" value="mpsId: 01cf0d82-8d29-4fc4-be96-28abaf4ad33d/3631234780363744558" />
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWh" role="jymVt">
-      <property role="TrG5h" value="lcJsonType" />
-      <node concept="3clFbS" id="5JNiski3jWi" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWj" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jWk" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx3BKF" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3BKG" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3BKH" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3BKI" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWl" role="jymVt">
-      <property role="TrG5h" value="mpsJsonType" />
-      <node concept="3clFbS" id="5JNiski3jWm" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWn" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jWo" role="3clF45">
-        <ref role="ehGHo" to="tpce:fKAz7CR" resolve="ConstrainedDataTypeDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx3DXJ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3DXK" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3DXL" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3DXM" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWp" role="jymVt">
-      <property role="TrG5h" value="slangJsonType" />
-      <node concept="3clFbS" id="5JNiski3jWq" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWr" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jWs" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx3Gbb" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3Gbc" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3Gbd" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3Gbe" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWt" role="jymVt">
-      <property role="TrG5h" value="keyJsonType" />
-      <node concept="3clFbS" id="5JNiski3jWu" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWv" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jWw" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx3IoZ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3Ip0" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3Ip1" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3Ip2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWx" role="jymVt">
-      <property role="TrG5h" value="idJsonType" />
-      <node concept="3clFbS" id="5JNiski3jWy" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWz" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jW$" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx3KBb" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3KBc" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3KBd" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3KBe" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jW_" role="jymVt" />
@@ -12676,82 +8977,6 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiski3jWA" role="jymVt">
-      <property role="TrG5h" value="lcNodeConcept" />
-      <node concept="3clFbS" id="5JNiski3jWB" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWC" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jWD" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjklrv" resolve="Concept" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx3MPJ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3MPK" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3MPL" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3MPM" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWE" role="jymVt">
-      <property role="TrG5h" value="mpsNodeConcept" />
-      <node concept="3clFbS" id="5JNiski3jWF" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWG" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jWH" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx3P4F" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3P4G" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3P4H" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3P4I" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWI" role="jymVt">
-      <property role="TrG5h" value="slangNodeConcept" />
-      <node concept="3clFbS" id="5JNiski3jWJ" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWK" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jWL" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx3RjZ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3Rk0" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3Rk1" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3Rk2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWM" role="jymVt">
-      <property role="TrG5h" value="keyNodeConcept" />
-      <node concept="3clFbS" id="5JNiski3jWN" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWO" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jWP" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx3TzF" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3TzG" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3TzH" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3TzI" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWQ" role="jymVt">
-      <property role="TrG5h" value="idNodeConcept" />
-      <node concept="3clFbS" id="5JNiski3jWR" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWS" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jWT" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx3VNJ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3VNK" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3VNL" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3VNM" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5JNiski3jWU" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwQm21" role="jymVt">
       <property role="TrG5h" value="getAnnotation" />
@@ -12800,52 +9025,6 @@
             <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c/3364660638048049748" />
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWV" role="jymVt">
-      <property role="TrG5h" value="mpsAnnotationConcept" />
-      <node concept="3clFbS" id="5JNiski3jWW" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jWX" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jWY" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx3Y4b" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx3Y4c" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx3Y4d" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx3Y4e" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jWZ" role="jymVt">
-      <property role="TrG5h" value="slangAnnotationConcept" />
-      <node concept="3clFbS" id="5JNiski3jX0" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jX1" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jX2" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx40kZ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx40l0" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx40l1" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx40l2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jX3" role="jymVt">
-      <property role="TrG5h" value="idAnnotationConcept" />
-      <node concept="3clFbS" id="5JNiski3jX4" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jX5" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jX6" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx42Ab" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx42Ac" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx42Ad" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx42Ae" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqwSICt" role="jymVt" />
@@ -12900,52 +9079,6 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiski3jX7" role="jymVt">
-      <property role="TrG5h" value="slangAnnotationContainment" />
-      <node concept="3clFbS" id="5JNiski3jX8" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jX9" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jXa" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx44RJ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx44RK" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx44RL" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx44RM" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskitFWC" role="jymVt">
-      <property role="TrG5h" value="mpsAnnotationContainment" />
-      <node concept="3clFbS" id="5JNiskitFWD" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskitFWE" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskitGo_" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx479F" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx479G" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx479H" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx479I" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskiydnL" role="jymVt">
-      <property role="TrG5h" value="idAnnotationContainment" />
-      <node concept="3clFbS" id="5JNiskiydnM" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskiydnN" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskiydnO" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx49rZ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx49s0" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx49s1" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx49s2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5JNiski3jXb" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwQm2j" role="jymVt">
       <property role="TrG5h" value="getINamed" />
@@ -12996,82 +9129,6 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiski3jXc" role="jymVt">
-      <property role="TrG5h" value="lcINamedInterface" />
-      <node concept="3clFbS" id="5JNiski3jXd" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXe" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jXf" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjklHQ" resolve="Interface" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx4bIF" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4bIG" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4bIH" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4bII" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jXg" role="jymVt">
-      <property role="TrG5h" value="mpsINamedInterface" />
-      <node concept="3clFbS" id="5JNiski3jXh" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXi" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jXj" role="3clF45">
-        <ref role="ehGHo" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx4e1J" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4e1K" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4e1L" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4e1M" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jXk" role="jymVt">
-      <property role="TrG5h" value="slangINamedInterface" />
-      <node concept="3clFbS" id="5JNiski3jXl" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXm" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jXn" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SInterfaceConcept" resolve="SInterfaceConcept" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx4glb" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4glc" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4gld" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4gle" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jXo" role="jymVt">
-      <property role="TrG5h" value="keyINamedInterface" />
-      <node concept="3clFbS" id="5JNiski3jXp" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXq" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jXr" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx4iCZ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4iD0" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4iD1" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4iD2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jXs" role="jymVt">
-      <property role="TrG5h" value="idINamedInterface" />
-      <node concept="3clFbS" id="5JNiski3jXt" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXu" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jXv" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx4kXb" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4kXc" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4kXd" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4kXe" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5JNiski3jXw" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwQm2s" role="jymVt">
       <property role="TrG5h" value="getINamedName" />
@@ -13120,82 +9177,6 @@
             <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jXx" role="jymVt">
-      <property role="TrG5h" value="lcNameProperty" />
-      <node concept="3clFbS" id="5JNiski3jXy" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXz" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jX$" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx4nhJ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4nhK" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4nhL" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4nhM" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jX_" role="jymVt">
-      <property role="TrG5h" value="mpsNameProperty" />
-      <node concept="3clFbS" id="5JNiski3jXA" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXB" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiski3jXC" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx4pAF" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4pAG" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4pAH" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4pAI" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jXD" role="jymVt">
-      <property role="TrG5h" value="slangNameProperty" />
-      <node concept="3clFbS" id="5JNiski3jXE" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXF" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jXG" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx4rVZ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4rW0" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4rW1" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4rW2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jXH" role="jymVt">
-      <property role="TrG5h" value="keyNameProperty" />
-      <node concept="3clFbS" id="5JNiski3jXI" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXJ" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jXK" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx4uhF" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4uhG" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4uhH" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4uhI" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jXL" role="jymVt">
-      <property role="TrG5h" value="idNameProperty" />
-      <node concept="3clFbS" id="5JNiski3jXM" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXN" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jXO" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx4wBJ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4wBK" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4wBL" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4wBM" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jXP" role="jymVt" />
@@ -13269,80 +9250,6 @@
             <property role="1dT_AB" value="lcKey: io.lionweb.mps.m3 as key: LionCore-M3" />
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jXQ" role="jymVt">
-      <property role="TrG5h" value="slangM3LanguageId" />
-      <node concept="3clFbS" id="5JNiski3jXR" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXS" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jXT" role="3clF45">
-        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx4yYb" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4yYc" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4yYd" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4yYe" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jXU" role="jymVt">
-      <property role="TrG5h" value="slangM3Language" />
-      <node concept="3clFbS" id="5JNiski3jXV" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jXW" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jXX" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx4_kZ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4_l0" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4_l1" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4_l2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jXY" role="jymVt">
-      <property role="TrG5h" value="keyM3Language" />
-      <node concept="3clFbS" id="5JNiski3jXZ" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jY0" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jY1" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx4BGb" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4BGc" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4BGd" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4BGe" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jY2" role="jymVt">
-      <property role="TrG5h" value="idM3Language" />
-      <node concept="3clFbS" id="5JNiski3jY3" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jY4" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jY5" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx4E3J" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4E3K" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4E3L" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4E3M" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jY6" role="jymVt">
-      <property role="TrG5h" value="versionM3Language" />
-      <node concept="3clFbS" id="5JNiski3jY7" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jY8" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jY9" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx4GrF" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4GrG" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4GrH" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4GrI" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jYa" role="jymVt" />
@@ -13482,80 +9389,6 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiski3jYb" role="jymVt">
-      <property role="TrG5h" value="slangCoreLanguageId" />
-      <node concept="3clFbS" id="5JNiski3jYc" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jYd" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jYe" role="3clF45">
-        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx4INZ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4IO0" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4IO1" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4IO2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jYf" role="jymVt">
-      <property role="TrG5h" value="slangCoreLanguage" />
-      <node concept="3clFbS" id="5JNiski3jYg" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jYh" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jYi" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx4LcF" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4LcG" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4LcH" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4LcI" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jYj" role="jymVt">
-      <property role="TrG5h" value="keyBuiltinLanguage" />
-      <node concept="3clFbS" id="5JNiski3jYk" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jYl" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jYm" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx4N_J" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4N_K" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4N_L" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4N_M" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jYn" role="jymVt">
-      <property role="TrG5h" value="idBuiltinLanguage" />
-      <node concept="3clFbS" id="5JNiski3jYo" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jYp" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jYq" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx4PZb" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4PZc" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4PZd" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4PZe" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jYr" role="jymVt">
-      <property role="TrG5h" value="versionBuiltinLanguage" />
-      <node concept="3clFbS" id="5JNiski3jYs" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jYt" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiski3jYu" role="3clF45" />
-      <node concept="P$JXv" id="7OJcYqx4SoZ" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4Sp0" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4Sp1" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4Sp2" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5JNiski3jYv" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwQm2_" role="jymVt">
       <property role="TrG5h" value="getAttributeLanguage" />
@@ -13625,22 +9458,6 @@
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5JNiski3jYw" role="jymVt">
-      <property role="TrG5h" value="slangAttributeLanguage" />
-      <node concept="3clFbS" id="5JNiski3jYx" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jYy" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiski3jYz" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx4Xff" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx4Xfg" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4Xfh" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4Xfi" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="5JNiski3jY$" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwXhGH" role="jymVt">
       <property role="TrG5h" value="listLcLanguages" />
@@ -13651,141 +9468,12 @@
           <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
         </node>
       </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jYA" role="jymVt">
-      <property role="TrG5h" value="listSLanguages" />
-      <node concept="3clFbS" id="5JNiski3jYB" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jYC" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiski3jYD" role="3clF45">
-        <node concept="3uibUv" id="5JNiski3jYE" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-        </node>
-      </node>
-      <node concept="P$JXv" id="5JNiski3jYF" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3jYG" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3jYH" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore languages as MPS " />
-          </node>
-          <node concept="1dT_AA" id="5JNiski3jYI" role="1dT_Ay">
-            <node concept="92FcH" id="5JNiski3jYJ" role="qph3F">
-              <node concept="TZ5HA" id="5JNiski3jYK" role="2XjZqd" />
-              <node concept="VXe08" id="5JNiski3jYL" role="92FcQ">
-                <ref role="VXe09" to="c17a:~SLanguage" resolve="SLanguage" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5JNiski3jYM" role="1dT_Ay">
-            <property role="1dT_AB" value="." />
+      <node concept="P$JXv" id="7OJcYqz8mI0" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqz8mI1" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqz8mI2" role="1dT_Ay">
+            <property role="1dT_AB" value="All LionCore languages." />
           </node>
         </node>
-        <node concept="x79VA" id="5JNiski3jYN" role="3nqlJM">
-          <property role="x79VB" value="All LionCore languages." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx4ZDz" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx4ZD$" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx4ZD_" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jYO" role="jymVt">
-      <property role="TrG5h" value="listKeyLanguages" />
-      <node concept="3clFbS" id="5JNiski3jYP" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jYQ" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiski3jYR" role="3clF45">
-        <node concept="17QB3L" id="5JNiski3jYS" role="_ZDj9" />
-      </node>
-      <node concept="P$JXv" id="5JNiski3jYT" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3jYU" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3jYV" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore languages as LionWeb language key." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiski3jYW" role="3nqlJM">
-          <property role="x79VB" value="All LionCore language keys." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx524a" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx524b" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx524c" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jYX" role="jymVt">
-      <property role="TrG5h" value="listSLanguageLanguageIds" />
-      <node concept="3clFbS" id="5JNiski3jYY" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jYZ" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiski3jZ0" role="3clF45">
-        <node concept="17QB3L" id="5JNiski3jZ1" role="_ZDj9" />
-      </node>
-      <node concept="P$JXv" id="5JNiski3jZ2" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3jZ3" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3jZ4" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore languages as stringified MPS " />
-          </node>
-          <node concept="1dT_AA" id="5JNiski3jZ5" role="1dT_Ay">
-            <node concept="92FcH" id="5JNiski3jZ6" role="qph3F">
-              <node concept="TZ5HA" id="5JNiski3jZ7" role="2XjZqd" />
-              <node concept="VXe08" id="5JNiski3jZ8" role="92FcQ">
-                <ref role="VXe09" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5JNiski3jZ9" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiski3jZa" role="3nqlJM">
-          <property role="x79VB" value="All LionCore language ids." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx54v7" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx54v8" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx54v9" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jZb" role="jymVt">
-      <property role="TrG5h" value="listVersionLanguages" />
-      <node concept="3clFbS" id="5JNiski3jZc" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jZd" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiski3jZe" role="3clF45">
-        <node concept="17QB3L" id="5JNiski3jZf" role="_ZDj9" />
-      </node>
-      <node concept="P$JXv" id="5JNiski3jZg" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3jZh" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3jZi" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore language versions." />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="5JNiski3jZj" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3jZk" role="1dT_Ay">
-            <property role="1dT_AB" value="Should be the same as " />
-          </node>
-          <node concept="1dT_AA" id="5JNiski3jZl" role="1dT_Ay">
-            <node concept="92FcH" id="5JNiski3jZm" role="qph3F">
-              <node concept="TZ5HA" id="5JNiski3jZn" role="2XjZqd" />
-              <node concept="VXe0Z" id="5JNiski3jZo" role="92FcQ">
-                <ref role="VXe0S" node="5JNiski3jVd" resolve="lionCoreVersion" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5JNiski3jZp" role="1dT_Ay">
-            <property role="1dT_AB" value="." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiski3jZq" role="3nqlJM">
-          <property role="x79VB" value="All LionCore language versions." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx56Uq" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx56Ur" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx56Us" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3jZr" role="jymVt" />
@@ -13798,149 +9486,12 @@
           <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
         </node>
       </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jZs" role="jymVt">
-      <property role="TrG5h" value="listLcClassifiers" />
-      <node concept="3clFbS" id="5JNiski3jZt" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jZu" role="1B3o_S" />
-      <node concept="2I9FWS" id="5JNiski3jZv" role="3clF45">
-        <ref role="2I9WkF" to="h3y3:2ju2syjkl4i" resolve="Classifier" />
-      </node>
-      <node concept="P$JXv" id="5JNiski3jZw" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3jZx" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3jZy" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin classifiers as M3 Classifier." />
+      <node concept="P$JXv" id="7OJcYqzglge" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqzglgf" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqzglgg" role="1dT_Ay">
+            <property role="1dT_AB" value="All LionCore builtin classifiers." />
           </node>
         </node>
-        <node concept="x79VA" id="5JNiski3jZz" role="3nqlJM">
-          <property role="x79VB" value="All LionCore builtin classifiers." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx59m3" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx59m4" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx59m5" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jZ$" role="jymVt">
-      <property role="TrG5h" value="listMpsClassifiers" />
-      <node concept="3clFbS" id="5JNiski3jZ_" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jZA" role="1B3o_S" />
-      <node concept="2I9FWS" id="5JNiski3jZB" role="3clF45">
-        <ref role="2I9WkF" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-      </node>
-      <node concept="P$JXv" id="5JNiski3jZC" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3jZD" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3jZE" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin classifiers as MPS Concept." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiski3jZF" role="3nqlJM">
-          <property role="x79VB" value="All LionCore builtin classifiers." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5bM2" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5bM3" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5bM4" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jZG" role="jymVt">
-      <property role="TrG5h" value="listSLanguageClassifiers" />
-      <node concept="3clFbS" id="5JNiski3jZH" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jZI" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiski3jZJ" role="3clF45">
-        <node concept="3uibUv" id="5JNiski3jZK" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-        </node>
-      </node>
-      <node concept="P$JXv" id="5JNiski3jZL" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3jZM" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3jZN" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin classifiers as MPS " />
-          </node>
-          <node concept="1dT_AA" id="5JNiski3jZO" role="1dT_Ay">
-            <node concept="92FcH" id="5JNiski3jZP" role="qph3F">
-              <node concept="TZ5HA" id="5JNiski3jZQ" role="2XjZqd" />
-              <node concept="VXe08" id="5JNiski3jZR" role="92FcQ">
-                <ref role="VXe09" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5JNiski3jZS" role="1dT_Ay">
-            <property role="1dT_AB" value="." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiski3jZT" role="3nqlJM">
-          <property role="x79VB" value="All LionCore builtin classifiers." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5een" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5eeo" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5eep" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3jZU" role="jymVt">
-      <property role="TrG5h" value="listKeyClassifiers" />
-      <node concept="3clFbS" id="5JNiski3jZV" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3jZW" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiski3jZX" role="3clF45">
-        <node concept="17QB3L" id="5JNiski3jZY" role="_ZDj9" />
-      </node>
-      <node concept="P$JXv" id="5JNiski3jZZ" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3k00" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3k01" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin classifiers as LionWeb classifier key." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiski3k02" role="3nqlJM">
-          <property role="x79VB" value="All LionCore builtin classifier keys." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5gF2" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5gF3" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5gF4" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3k03" role="jymVt">
-      <property role="TrG5h" value="listSClassifierIds" />
-      <node concept="3clFbS" id="5JNiski3k04" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3k05" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiski3k06" role="3clF45">
-        <node concept="17QB3L" id="5JNiski3k07" role="_ZDj9" />
-      </node>
-      <node concept="P$JXv" id="5JNiski3k08" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3k09" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3k0a" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin classifiers as stringified " />
-          </node>
-          <node concept="1dT_AA" id="5JNiski3k0b" role="1dT_Ay">
-            <node concept="92FcH" id="5JNiski3k0c" role="qph3F">
-              <node concept="TZ5HA" id="5JNiski3k0d" role="2XjZqd" />
-              <node concept="VXe08" id="5JNiski3k0e" role="92FcQ">
-                <ref role="VXe09" to="e8bb:~SConceptId" resolve="SConceptId" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5JNiski3k0f" role="1dT_Ay">
-            <property role="1dT_AB" value="." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiski3k0g" role="3nqlJM">
-          <property role="x79VB" value="All LionCore builtin concept ids." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5j83" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5j84" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5j85" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3k0h" role="jymVt" />
@@ -13954,149 +9505,12 @@
           <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
         </node>
       </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3k0j" role="jymVt">
-      <property role="TrG5h" value="listLcProperties" />
-      <node concept="3clFbS" id="5JNiski3k0k" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3k0l" role="1B3o_S" />
-      <node concept="2I9FWS" id="5JNiski3k0m" role="3clF45">
-        <ref role="2I9WkF" to="h3y3:2ju2syjkkDM" resolve="Property" />
-      </node>
-      <node concept="P$JXv" id="5JNiski3k0n" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3k0o" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3k0p" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin properties as M3 Property." />
+      <node concept="P$JXv" id="7OJcYqzqWrX" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqzqWrY" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqzqWrZ" role="1dT_Ay">
+            <property role="1dT_AB" value="All LionCore builtin properties." />
           </node>
         </node>
-        <node concept="x79VA" id="5JNiski3k0q" role="3nqlJM">
-          <property role="x79VB" value="All LionCore builtin properties." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5l_s" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5l_t" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5l_u" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3k0r" role="jymVt">
-      <property role="TrG5h" value="listMpsProperties" />
-      <node concept="3clFbS" id="5JNiski3k0s" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3k0t" role="1B3o_S" />
-      <node concept="2I9FWS" id="5JNiski3k0u" role="3clF45">
-        <ref role="2I9WkF" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-      <node concept="P$JXv" id="5JNiski3k0v" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3k0w" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3k0x" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin properties as MPS Property." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiski3k0y" role="3nqlJM">
-          <property role="x79VB" value="All LionCore builtin properties." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5o39" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5o3a" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5o3b" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3k0z" role="jymVt">
-      <property role="TrG5h" value="listSLanguageProperties" />
-      <node concept="3clFbS" id="5JNiski3k0$" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3k0_" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiski3k0A" role="3clF45">
-        <node concept="3uibUv" id="5JNiski3k0B" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-        </node>
-      </node>
-      <node concept="P$JXv" id="5JNiski3k0C" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3k0D" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3k0E" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin properties as MPS " />
-          </node>
-          <node concept="1dT_AA" id="5JNiski3k0F" role="1dT_Ay">
-            <node concept="92FcH" id="5JNiski3k0G" role="qph3F">
-              <node concept="TZ5HA" id="5JNiski3k0H" role="2XjZqd" />
-              <node concept="VXe08" id="5JNiski3k0I" role="92FcQ">
-                <ref role="VXe09" to="c17a:~SProperty" resolve="SProperty" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5JNiski3k0J" role="1dT_Ay">
-            <property role="1dT_AB" value="." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiski3k0K" role="3nqlJM">
-          <property role="x79VB" value="All LionCore builtin properties." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5qxc" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5qxd" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5qxe" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3k0L" role="jymVt">
-      <property role="TrG5h" value="listKeyProperties" />
-      <node concept="3clFbS" id="5JNiski3k0M" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3k0N" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiski3k0O" role="3clF45">
-        <node concept="17QB3L" id="5JNiski3k0P" role="_ZDj9" />
-      </node>
-      <node concept="P$JXv" id="5JNiski3k0Q" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3k0R" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3k0S" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin properties as LionWeb property key." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiski3k0T" role="3nqlJM">
-          <property role="x79VB" value="All LionCore builtin property keys." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5sZ_" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5sZA" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5sZB" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3k0U" role="jymVt">
-      <property role="TrG5h" value="listSPropertyIds" />
-      <node concept="3clFbS" id="5JNiski3k0V" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3k0W" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiski3k0X" role="3clF45">
-        <node concept="17QB3L" id="5JNiski3k0Y" role="_ZDj9" />
-      </node>
-      <node concept="P$JXv" id="5JNiski3k0Z" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3k10" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3k11" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin properties as stringified MPS " />
-          </node>
-          <node concept="1dT_AA" id="5JNiski3k12" role="1dT_Ay">
-            <node concept="92FcH" id="5JNiski3k13" role="qph3F">
-              <node concept="TZ5HA" id="5JNiski3k14" role="2XjZqd" />
-              <node concept="VXe08" id="5JNiski3k15" role="92FcQ">
-                <ref role="VXe09" to="e8bb:~SPropertyId" resolve="SPropertyId" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5JNiski3k16" role="1dT_Ay">
-            <property role="1dT_AB" value="." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiski3k17" role="3nqlJM">
-          <property role="x79VB" value="All LionCore builtin property ids." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5vuk" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5vul" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5vum" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3k18" role="jymVt" />
@@ -14109,165 +9523,12 @@
           <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeKeyedMapping" />
         </node>
       </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3k19" role="jymVt">
-      <property role="TrG5h" value="listLcPrimitiveTypes" />
-      <node concept="3clFbS" id="5JNiski3k1a" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3k1b" role="1B3o_S" />
-      <node concept="2I9FWS" id="5JNiski3k1c" role="3clF45">
-        <ref role="2I9WkF" to="h3y3:2ju2syjko87" resolve="PrimitiveType" />
-      </node>
-      <node concept="P$JXv" id="5JNiski3k1d" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3k1e" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3k1f" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin primitive types as M3 PrimitiveType." />
+      <node concept="P$JXv" id="7OJcYqzr6Eu" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqzr6Ev" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqzr6Ew" role="1dT_Ay">
+            <property role="1dT_AB" value="All LionCore builtin primitive types." />
           </node>
         </node>
-        <node concept="x79VA" id="5JNiski3k1g" role="3nqlJM">
-          <property role="x79VB" value="All LionCore builtin primitive types." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5xXp" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5xXq" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5xXr" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3k1h" role="jymVt">
-      <property role="TrG5h" value="listMpsPrimitiveTypes" />
-      <node concept="3clFbS" id="5JNiski3k1i" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3k1j" role="1B3o_S" />
-      <node concept="2I9FWS" id="5JNiski3k1k" role="3clF45">
-        <ref role="2I9WkF" to="tpce:fKAxPRU" resolve="DataTypeDeclaration" />
-      </node>
-      <node concept="P$JXv" id="5JNiski3k1l" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3k1m" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3k1n" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin primitive types as MPS DataType." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiski3k1o" role="3nqlJM">
-          <property role="x79VB" value="All LionCore builtin primitive types." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5$sO" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5$sP" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5$sQ" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3k1p" role="jymVt">
-      <property role="TrG5h" value="listSLanguagePrimitiveTypes" />
-      <node concept="3clFbS" id="5JNiski3k1q" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3k1r" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiski3k1s" role="3clF45">
-        <node concept="3uibUv" id="5JNiski3k1t" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-        </node>
-      </node>
-      <node concept="P$JXv" id="5JNiski3k1u" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3k1v" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3k1w" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin primitive types as MPS " />
-          </node>
-          <node concept="1dT_AA" id="5JNiski3k1x" role="1dT_Ay">
-            <node concept="92FcH" id="5JNiski3k1y" role="qph3F">
-              <node concept="TZ5HA" id="5JNiski3k1z" role="2XjZqd" />
-              <node concept="VXe08" id="5JNiski3k1$" role="92FcQ">
-                <ref role="VXe09" to="c17a:~SDataType" resolve="SDataType" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5JNiski3k1_" role="1dT_Ay">
-            <property role="1dT_AB" value="." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiski3k1A" role="3nqlJM">
-          <property role="x79VB" value="All LionCore builtin primitive types." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5AW_" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5AWA" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5AWB" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3k1B" role="jymVt">
-      <property role="TrG5h" value="listKeyPrimitiveTypes" />
-      <node concept="3clFbS" id="5JNiski3k1C" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3k1D" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiski3k1E" role="3clF45">
-        <node concept="17QB3L" id="5JNiski3k1F" role="_ZDj9" />
-      </node>
-      <node concept="P$JXv" id="5JNiski3k1G" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3k1H" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3k1I" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin primitive types as LionWeb primitive type key." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiski3k1J" role="3nqlJM">
-          <property role="x79VB" value="All LionCore builtin primitive type keys." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5DsG" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5DsH" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5DsI" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiski3k1K" role="jymVt">
-      <property role="TrG5h" value="listSPrimitiveTypeIds" />
-      <node concept="3clFbS" id="5JNiski3k1L" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiski3k1M" role="1B3o_S" />
-      <node concept="_YKpA" id="5JNiski3k1N" role="3clF45">
-        <node concept="17QB3L" id="5JNiski3k1O" role="_ZDj9" />
-      </node>
-      <node concept="P$JXv" id="5JNiski3k1P" role="lGtFl">
-        <node concept="TZ5HA" id="5JNiski3k1Q" role="TZ5H$">
-          <node concept="1dT_AC" id="5JNiski3k1R" role="1dT_Ay">
-            <property role="1dT_AB" value="All LionCore builtin primitive types as stringified MPS " />
-          </node>
-          <node concept="1dT_AA" id="5JNiski3k1S" role="1dT_Ay">
-            <node concept="92FcH" id="5JNiski3k1T" role="qph3F">
-              <node concept="TZ5HA" id="5JNiski3k1U" role="2XjZqd" />
-              <node concept="VXe08" id="5JNiski3k1V" role="92FcQ">
-                <ref role="VXe09" to="e8bb:~SDataTypeId" resolve="SDataTypeId" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5JNiski3k1W" role="1dT_Ay">
-            <property role="1dT_AB" value="." />
-          </node>
-        </node>
-        <node concept="x79VA" id="5JNiski3k1X" role="3nqlJM">
-          <property role="x79VB" value="All LionCore builtin primitive type ids." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5FX9" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5FXa" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5FXb" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="7OJcYqvFkM2" role="jymVt">
-      <property role="TrG5h" value="listSLanguagePrimitiveTypeLanguageKeys" />
-      <node concept="3clFbS" id="7OJcYqvFkM3" role="3clF47" />
-      <node concept="3Tm1VV" id="7OJcYqvFkM4" role="1B3o_S" />
-      <node concept="_YKpA" id="7OJcYqvFkM5" role="3clF45">
-        <node concept="17QB3L" id="7OJcYqvFmi$" role="_ZDj9" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx5ItW" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx5ItX" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5ItY" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5ItZ" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiski3k1Y" role="jymVt" />
@@ -14342,85 +9603,15 @@
           <ref role="3uigEE" node="7OJcYqwYeSL" resolve="IClassifierKeyedMapping" />
         </node>
       </node>
-    </node>
-    <node concept="3clFb_" id="7weWCFlqTiI" role="jymVt">
-      <property role="TrG5h" value="listMpsInternalClassifiers" />
-      <node concept="3clFbS" id="7weWCFlqTiJ" role="3clF47" />
-      <node concept="3Tm1VV" id="7weWCFlqTiQ" role="1B3o_S" />
-      <node concept="2I9FWS" id="7weWCFlqTiR" role="3clF45">
-        <ref role="2I9WkF" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-      </node>
-      <node concept="P$JXv" id="7weWCFlqTiS" role="lGtFl">
-        <node concept="TZ5HA" id="7weWCFlqTiT" role="TZ5H$">
-          <node concept="1dT_AC" id="7weWCFlqTiU" role="1dT_Ay">
-            <property role="1dT_AB" value="All MPS concepts that need special treatment in LionWeb as MPS Concept." />
+      <node concept="P$JXv" id="7OJcYqz$mTR" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqz$mTS" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqz$mTT" role="1dT_Ay">
+            <property role="1dT_AB" value="All MPS concepts that need special treatment in LionWeb." />
           </node>
         </node>
-        <node concept="x79VA" id="7weWCFlqTiV" role="3nqlJM">
-          <property role="x79VB" value="All MPS concepts that need special treatment in LionWeb." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5KZa" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5KZb" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5KZc" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="7weWCFlqUnk" role="jymVt" />
-    <node concept="3clFb_" id="7weWCFlqTiX" role="jymVt">
-      <property role="TrG5h" value="listSLanguageInternalClassifiers" />
-      <node concept="3clFbS" id="7weWCFlqTiY" role="3clF47" />
-      <node concept="3Tm1VV" id="7weWCFlqTj5" role="1B3o_S" />
-      <node concept="_YKpA" id="7weWCFlqTj6" role="3clF45">
-        <node concept="3uibUv" id="7weWCFlqTj7" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-        </node>
-      </node>
-      <node concept="P$JXv" id="7weWCFlqTj8" role="lGtFl">
-        <node concept="TZ5HA" id="7weWCFlqTj9" role="TZ5H$">
-          <node concept="1dT_AC" id="7weWCFlqTja" role="1dT_Ay">
-            <property role="1dT_AB" value="All MPS concepts that need special treatment in LionWeb as MPS " />
-          </node>
-          <node concept="1dT_AA" id="7weWCFlqTjb" role="1dT_Ay">
-            <node concept="92FcH" id="7weWCFlqTjc" role="qph3F">
-              <node concept="TZ5HA" id="7weWCFlqTjd" role="2XjZqd" />
-              <node concept="VXe08" id="7weWCFlqTje" role="92FcQ">
-                <ref role="VXe09" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="7weWCFlqTjf" role="1dT_Ay">
-            <property role="1dT_AB" value="." />
-          </node>
-        </node>
-        <node concept="x79VA" id="7weWCFlqTjg" role="3nqlJM">
-          <property role="x79VB" value="All MPS concepts that need special treatment in LionWeb." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5NwF" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5NwG" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5NwH" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="6Z_tmAeiDP1" role="jymVt">
-      <property role="TrG5h" value="listSLanguageInternalClassifierLanguageKeys" />
-      <node concept="3clFbS" id="6Z_tmAeiDP2" role="3clF47" />
-      <node concept="3Tm1VV" id="6Z_tmAeiDP3" role="1B3o_S" />
-      <node concept="_YKpA" id="6Z_tmAeiDP4" role="3clF45">
-        <node concept="17QB3L" id="6Z_tmAeiHRy" role="_ZDj9" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx5Q2y" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx5Q2z" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5Q2$" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5Q2_" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
     <node concept="2tJIrI" id="7weWCFlqSXi" role="jymVt" />
     <node concept="3clFb_" id="5JNiski3k2d" role="jymVt">
       <property role="TrG5h" value="isMpsInternalFeature" />
@@ -14492,97 +9683,15 @@
           <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureKeyedMapping" />
         </node>
       </node>
-    </node>
-    <node concept="3clFb_" id="6Z_tmAegIrR" role="jymVt">
-      <property role="TrG5h" value="listSLanguageInternalFeatures" />
-      <node concept="3clFbS" id="6Z_tmAegIrS" role="3clF47" />
-      <node concept="3Tm1VV" id="6Z_tmAegIrY" role="1B3o_S" />
-      <node concept="_YKpA" id="6Z_tmAegIrZ" role="3clF45">
-        <node concept="3uibUv" id="6Z_tmAegIs0" role="_ZDj9">
-          <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
-        </node>
-      </node>
-      <node concept="P$JXv" id="6Z_tmAegIs1" role="lGtFl">
-        <node concept="TZ5HA" id="6Z_tmAegIs2" role="TZ5H$">
-          <node concept="1dT_AC" id="6Z_tmAegIs3" role="1dT_Ay">
-            <property role="1dT_AB" value="All MPS concept features that need special treatment in LionWeb as MPS " />
-          </node>
-          <node concept="1dT_AA" id="6Z_tmAegIs4" role="1dT_Ay">
-            <node concept="92FcH" id="6Z_tmAegIs5" role="qph3F">
-              <node concept="TZ5HA" id="6Z_tmAegIs6" role="2XjZqd" />
-              <node concept="VXe08" id="6Z_tmAegIs7" role="92FcQ">
-                <ref role="VXe09" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="6Z_tmAegIs8" role="1dT_Ay">
-            <property role="1dT_AB" value="." />
+      <node concept="P$JXv" id="7OJcYqz$s$f" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqz$s$g" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqz$s$h" role="1dT_Ay">
+            <property role="1dT_AB" value="All MPS concept features that need special treatment in LionWeb." />
           </node>
         </node>
-        <node concept="x79VA" id="6Z_tmAegIs9" role="3nqlJM">
-          <property role="x79VB" value="All MPS concept featuress that need special treatment in LionWeb." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5S$O" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5S$P" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5S$Q" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="6Z_tmAegI4_" role="jymVt" />
-    <node concept="3clFb_" id="6Z_tmAegWRd" role="jymVt">
-      <property role="TrG5h" value="listSClassifierInternalFeatureIds" />
-      <node concept="3clFbS" id="6Z_tmAegWRe" role="3clF47" />
-      <node concept="3Tm1VV" id="6Z_tmAegWRk" role="1B3o_S" />
-      <node concept="_YKpA" id="6Z_tmAegWRl" role="3clF45">
-        <node concept="17QB3L" id="6Z_tmAegWRm" role="_ZDj9" />
-      </node>
-      <node concept="P$JXv" id="6Z_tmAegWRn" role="lGtFl">
-        <node concept="TZ5HA" id="6Z_tmAegWRo" role="TZ5H$">
-          <node concept="1dT_AC" id="6Z_tmAegWRp" role="1dT_Ay">
-            <property role="1dT_AB" value="All MPS concept features that need special treatment in LionWeb as stringified " />
-          </node>
-          <node concept="1dT_AA" id="6Z_tmAegWRq" role="1dT_Ay">
-            <node concept="92FcH" id="6Z_tmAegWRr" role="qph3F">
-              <node concept="TZ5HA" id="6Z_tmAegWRs" role="2XjZqd" />
-              <node concept="VXe08" id="6Z_tmAegWRt" role="92FcQ">
-                <ref role="VXe09" to="e8bb:~SConceptFeatureId" resolve="SConceptFeatureId" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="6Z_tmAegWRu" role="1dT_Ay">
-            <property role="1dT_AB" value="." />
-          </node>
-        </node>
-        <node concept="x79VA" id="6Z_tmAegWRv" role="3nqlJM">
-          <property role="x79VB" value="All MPS concept features that need special treatment in LionWeb." />
-        </node>
-        <node concept="TZ5HI" id="7OJcYqx5V7p" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5V7q" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5V7r" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="3clFb_" id="7OJcYqvFsrp" role="jymVt">
-      <property role="TrG5h" value="listSClassifierInternalFeatureLanguageKeys" />
-      <node concept="3clFbS" id="7OJcYqvFsrq" role="3clF47" />
-      <node concept="3Tm1VV" id="7OJcYqvFsrr" role="1B3o_S" />
-      <node concept="_YKpA" id="7OJcYqvFsrs" role="3clF45">
-        <node concept="17QB3L" id="7OJcYqvFsrt" role="_ZDj9" />
-      </node>
-      <node concept="P$JXv" id="7OJcYqx5XEk" role="lGtFl">
-        <node concept="TZ5HI" id="7OJcYqx5XEl" role="3nqlJM">
-          <node concept="TZ5HA" id="7OJcYqx5XEm" role="3HnX3l" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqx5XEn" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="6Z_tmAegWvz" role="jymVt" />
     <node concept="3clFb_" id="5JNiski3k2r" role="jymVt">
       <property role="TrG5h" value="isAnnotationContainment" />
       <node concept="3clFbS" id="5JNiski3k2s" role="3clF47" />

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -36,7 +36,6 @@
     <import index="4xw4" ref="r:23ccdcd2-ac4f-4247-aad5-4d197fcb7e18(io.lionweb.mps.specific.lang)" />
     <import index="i2js" ref="r:8a5810a5-6291-48f8-84a1-e0b9d037018c(io.lionweb.mps.m3.core)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
-    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -1439,7 +1438,7 @@
       <property role="TrG5h" value="listMpsInternalFeatures" />
       <node concept="3Tm1VV" id="7OJcYqx_dgM" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqx_dgN" role="3clF45">
-        <node concept="3uibUv" id="7OJcYqx_dgO" role="_ZDj9">
+        <node concept="3uibUv" id="7OJcYq$Hp4G" role="_ZDj9">
           <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
         </node>
       </node>
@@ -1450,9 +1449,6 @@
         <node concept="3clFbF" id="7OJcYqx_f5m" role="3cqZAp">
           <node concept="2ShNRf" id="7OJcYqx_f5g" role="3clFbG">
             <node concept="Tc6Ow" id="7OJcYqx_h8A" role="2ShVmc">
-              <node concept="3uibUv" id="7OJcYqx_ldi" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
-              </node>
               <node concept="1rXfSq" id="7OJcYqx_rFe" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqwir$6" resolve="getAnnotationContainment" />
               </node>
@@ -1461,6 +1457,9 @@
               </node>
               <node concept="1rXfSq" id="7OJcYqx_C8l" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
+              </node>
+              <node concept="3uibUv" id="7OJcYq$HqJo" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
               </node>
             </node>
           </node>
@@ -3065,25 +3064,6 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="6Z_tmAe7l68" role="3cqZAp">
-          <node concept="2OqwBi" id="6Z_tmAe7l65" role="3clFbG">
-            <node concept="10M0yZ" id="6Z_tmAe7l66" role="2Oq$k0">
-              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
-            </node>
-            <node concept="liA8E" id="6Z_tmAe7l67" role="2OqNvi">
-              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-              <node concept="3cpWs3" id="6Z_tmAe7zE0" role="37wK5m">
-                <node concept="37vLTw" id="6Z_tmAe7_$q" role="3uHU7w">
-                  <ref role="3cqZAo" node="3M8YG$9CZoT" resolve="coreLanguage" />
-                </node>
-                <node concept="Xl_RD" id="6Z_tmAe7nMd" role="3uHU7B">
-                  <property role="Xl_RC" value="coreLanguage: " />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1X3_iC" id="6Z_tmAe8zMm" role="lGtFl">
           <property role="3V$3am" value="statement" />
           <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
@@ -3273,25 +3253,6 @@
                 </node>
                 <node concept="liA8E" id="3M8YG$9DkOM" role="2OqNvi">
                   <ref role="37wK5l" to="e8bb:~SLanguageId.toString()" resolve="toString" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="6Z_tmAe7LIe" role="3cqZAp">
-          <node concept="2OqwBi" id="6Z_tmAe7LIf" role="3clFbG">
-            <node concept="10M0yZ" id="6Z_tmAe7LIg" role="2Oq$k0">
-              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
-              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-            </node>
-            <node concept="liA8E" id="6Z_tmAe7LIh" role="2OqNvi">
-              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-              <node concept="3cpWs3" id="6Z_tmAe7LIi" role="37wK5m">
-                <node concept="37vLTw" id="6Z_tmAe7LIj" role="3uHU7w">
-                  <ref role="3cqZAo" node="3M8YG$9DkOE" resolve="coreLanguage" />
-                </node>
-                <node concept="Xl_RD" id="6Z_tmAe7LIk" role="3uHU7B">
-                  <property role="Xl_RC" value="coreLanguage2: " />
                 </node>
               </node>
             </node>
@@ -8438,7 +8399,7 @@
       <property role="TrG5h" value="listMpsInternalFeatures" />
       <node concept="3Tm1VV" id="7OJcYqx2F8l" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqx2F8m" role="3clF45">
-        <node concept="3uibUv" id="7OJcYqx2F8n" role="_ZDj9">
+        <node concept="3uibUv" id="7OJcYq$HjLD" role="_ZDj9">
           <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
         </node>
       </node>
@@ -8446,11 +8407,11 @@
         <node concept="3clFbF" id="7OJcYqx2QyC" role="3cqZAp">
           <node concept="2ShNRf" id="7OJcYqx2QyA" role="3clFbG">
             <node concept="Tc6Ow" id="7OJcYqx2UOb" role="2ShVmc">
-              <node concept="3uibUv" id="7OJcYqx33I5" role="HW$YZ">
-                <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
-              </node>
               <node concept="1rXfSq" id="7OJcYqx3dhF" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqwir$6" resolve="getAnnotationContainment" />
+              </node>
+              <node concept="3uibUv" id="7OJcYq$HlAq" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
               </node>
             </node>
           </node>
@@ -9743,7 +9704,7 @@
       <node concept="3clFbS" id="7OJcYqx2zDl" role="3clF47" />
       <node concept="3Tm1VV" id="7OJcYqx2zDm" role="1B3o_S" />
       <node concept="_YKpA" id="7OJcYqx2zai" role="3clF45">
-        <node concept="3uibUv" id="7OJcYqx2zBy" role="_ZDj9">
+        <node concept="3uibUv" id="7OJcYq$HopG" role="_ZDj9">
           <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
         </node>
       </node>
@@ -10516,16 +10477,20 @@
           <node concept="37vLTw" id="7OJcYqvLcde" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqvLcdb" resolve="slang" />
           </node>
-          <node concept="2OqwBi" id="7OJcYqvLV8A" role="37wK5m">
-            <node concept="2YIFZM" id="7OJcYqvLV8B" role="2Oq$k0">
-              <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
-              <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-              <node concept="37vLTw" id="7OJcYqvLV8C" role="37wK5m">
-                <ref role="3cqZAo" node="7OJcYqvLcd7" resolve="mps" />
+          <node concept="2YIFZM" id="7OJcYq_kIue" role="37wK5m">
+            <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+            <ref role="37wK5l" to="wyt6:~Long.toString(long)" resolve="toString" />
+            <node concept="2OqwBi" id="7OJcYq_kF6m" role="37wK5m">
+              <node concept="2YIFZM" id="7OJcYqvLV8B" role="2Oq$k0">
+                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
+                <node concept="37vLTw" id="7OJcYqvLV8C" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqvLcd7" resolve="mps" />
+                </node>
               </node>
-            </node>
-            <node concept="liA8E" id="7OJcYqvLV8D" role="2OqNvi">
-              <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
+              <node concept="liA8E" id="7OJcYq_kFK_" role="2OqNvi">
+                <ref role="37wK5l" to="e8bb:~SElementId.getIdValue()" resolve="getIdValue" />
+              </node>
             </node>
           </node>
           <node concept="2YIFZM" id="7OJcYqwPrVr" role="37wK5m">
@@ -11083,16 +11048,7 @@
       </node>
     </node>
     <node concept="3uibUv" id="7OJcYqx2wVp" role="EKbjA">
-      <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
-      <node concept="3Tqbb2" id="7OJcYqx2xhq" role="11_B2D">
-        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-      </node>
-      <node concept="3Tqbb2" id="7OJcYqx2xhr" role="11_B2D">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-      <node concept="3uibUv" id="7OJcYqx2xhs" role="11_B2D">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-      </node>
+      <ref role="3uigEE" node="7OJcYq$EbsZ" resolve="IPropertyStaple" />
     </node>
   </node>
   <node concept="312cEu" id="7OJcYqvXZ8V">
@@ -11282,16 +11238,20 @@
           <node concept="37vLTw" id="7OJcYqw2rz3" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqw2rzg" resolve="slang" />
           </node>
-          <node concept="2OqwBi" id="7OJcYqw2rz4" role="37wK5m">
-            <node concept="2YIFZM" id="7OJcYqw2rz5" role="2Oq$k0">
-              <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-              <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
-              <node concept="37vLTw" id="7OJcYqw2rz6" role="37wK5m">
-                <ref role="3cqZAo" node="7OJcYqw2rze" resolve="mps" />
+          <node concept="2YIFZM" id="7OJcYq_kVFd" role="37wK5m">
+            <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+            <ref role="37wK5l" to="wyt6:~Long.toString(long)" resolve="toString" />
+            <node concept="2OqwBi" id="7OJcYq_kVFe" role="37wK5m">
+              <node concept="2YIFZM" id="7OJcYq_kVFf" role="2Oq$k0">
+                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
+                <node concept="37vLTw" id="7OJcYq_kVFg" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqw2rze" resolve="mps" />
+                </node>
               </node>
-            </node>
-            <node concept="liA8E" id="7OJcYqw2rz7" role="2OqNvi">
-              <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
+              <node concept="liA8E" id="7OJcYq_kVFh" role="2OqNvi">
+                <ref role="37wK5l" to="e8bb:~SElementId.getIdValue()" resolve="getIdValue" />
+              </node>
             </node>
           </node>
           <node concept="2YIFZM" id="7OJcYqwPrVz" role="37wK5m">
@@ -11636,16 +11596,7 @@
       </node>
     </node>
     <node concept="3uibUv" id="7OJcYqx_G_k" role="EKbjA">
-      <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
-      <node concept="3Tqbb2" id="7OJcYqx_HDU" role="11_B2D">
-        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-      </node>
-      <node concept="3Tqbb2" id="7OJcYqx_HDV" role="11_B2D">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-      <node concept="3uibUv" id="7OJcYqx_HDW" role="11_B2D">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-      </node>
+      <ref role="3uigEE" node="7OJcYq$EbsZ" resolve="IPropertyStaple" />
     </node>
   </node>
   <node concept="312cEu" id="7OJcYqwqLm4">
@@ -11894,6 +11845,23 @@
       <property role="TrG5h" value="SLANG" />
       <node concept="3uibUv" id="7OJcYqx2wtt" role="3ztrMU">
         <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
+      </node>
+    </node>
+  </node>
+  <node concept="3HP615" id="7OJcYq$EbsZ">
+    <property role="3GE5qa" value="staple" />
+    <property role="TrG5h" value="IPropertyStaple" />
+    <node concept="3Tm1VV" id="7OJcYq$Ebt0" role="1B3o_S" />
+    <node concept="3uibUv" id="7OJcYq$Ebt1" role="3HQHJm">
+      <ref role="3uigEE" node="7OJcYqx2vhv" resolve="IFeatureStaple" />
+      <node concept="3Tqbb2" id="7OJcYq$Ebt6" role="11_B2D">
+        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+      </node>
+      <node concept="3Tqbb2" id="7OJcYq$Ebt8" role="11_B2D">
+        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+      </node>
+      <node concept="3uibUv" id="7OJcYq$Eci_" role="11_B2D">
+        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
       </node>
     </node>
   </node>

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -10479,6 +10479,13 @@
   <node concept="312cEu" id="7OJcYqvL3W3">
     <property role="3GE5qa" value="staple" />
     <property role="TrG5h" value="PrimitiveTypeStaple" />
+    <node concept="312cEg" id="7OJcYq_mmlN" role="jymVt">
+      <property role="TrG5h" value="mpsPropId" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYq_mlg0" role="1B3o_S" />
+      <node concept="3cpWsb" id="7OJcYq_moJw" role="1tU5fm" />
+    </node>
+    <node concept="2tJIrI" id="7OJcYq_mmHq" role="jymVt" />
     <node concept="3Tm1VV" id="7OJcYqvL3W4" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqvL4WJ" role="1zkMxy">
       <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
@@ -10507,20 +10514,16 @@
           <node concept="37vLTw" id="7OJcYqvLcde" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqvLcdb" resolve="slang" />
           </node>
-          <node concept="2YIFZM" id="7OJcYq_kIue" role="37wK5m">
-            <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-            <ref role="37wK5l" to="wyt6:~Long.toString(long)" resolve="toString" />
-            <node concept="2OqwBi" id="7OJcYq_kF6m" role="37wK5m">
-              <node concept="2YIFZM" id="7OJcYqvLV8B" role="2Oq$k0">
-                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
-                <node concept="37vLTw" id="7OJcYqvLV8C" role="37wK5m">
-                  <ref role="3cqZAo" node="7OJcYqvLcd7" resolve="mps" />
-                </node>
+          <node concept="2OqwBi" id="7OJcYq_lUJg" role="37wK5m">
+            <node concept="2YIFZM" id="7OJcYq_lUJh" role="2Oq$k0">
+              <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
+              <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+              <node concept="37vLTw" id="7OJcYq_lUJi" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqvLcd7" resolve="mps" />
               </node>
-              <node concept="liA8E" id="7OJcYq_kFK_" role="2OqNvi">
-                <ref role="37wK5l" to="e8bb:~SElementId.getIdValue()" resolve="getIdValue" />
-              </node>
+            </node>
+            <node concept="liA8E" id="7OJcYq_lUJj" role="2OqNvi">
+              <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
             </node>
           </node>
           <node concept="2YIFZM" id="7OJcYqwPrVr" role="37wK5m">
@@ -10535,6 +10538,26 @@
             <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqvLIAw" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqvLcd3" resolve="lc" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq_mndi" role="3cqZAp" />
+        <node concept="3clFbF" id="7OJcYq_mnyF" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYq_mo6t" role="3clFbG">
+            <node concept="37vLTw" id="7OJcYq_mnyD" role="37vLTJ">
+              <ref role="3cqZAo" node="7OJcYq_mmlN" resolve="mpsPropId" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYq_mpKy" role="37vLTx">
+              <node concept="2YIFZM" id="7OJcYq_mpgo" role="2Oq$k0">
+                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
+                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+                <node concept="37vLTw" id="7OJcYq_mpgp" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqvLcd7" resolve="mps" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7OJcYq_mqoh" role="2OqNvi">
+                <ref role="37wK5l" to="e8bb:~SElementId.getIdValue()" resolve="getIdValue" />
+              </node>
             </node>
           </node>
         </node>
@@ -10627,6 +10650,24 @@
       <ref role="3uigEE" node="7OJcYqx0lp$" resolve="IPrimitiveTypeStaple" />
       <node concept="3Tqbb2" id="7OJcYqx0rRl" role="11_B2D">
         <ref role="ehGHo" to="tpce:fKQkHSB" resolve="PrimitiveDataTypeDeclaration" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYq_mqIh" role="jymVt">
+      <property role="TrG5h" value="getMpsPropId" />
+      <node concept="3cpWsb" id="7OJcYq_mqIi" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYq_mqIj" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYq_mqIk" role="3clF47">
+        <node concept="3clFbF" id="7OJcYq_mqIl" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq_mqIe" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYq_mqIf" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYq_mqIg" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYq_mmlN" resolve="mpsPropId" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYq_mrtg" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
   </node>
@@ -11240,6 +11281,13 @@
   <node concept="312cEu" id="7OJcYqw2ryQ">
     <property role="3GE5qa" value="staple" />
     <property role="TrG5h" value="ConstrainedPrimitiveTypeStaple" />
+    <node concept="312cEg" id="7OJcYq_mt5b" role="jymVt">
+      <property role="TrG5h" value="mpsPropId" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="7OJcYq_mt5c" role="1B3o_S" />
+      <node concept="3cpWsb" id="7OJcYq_mt5d" role="1tU5fm" />
+    </node>
+    <node concept="2tJIrI" id="7OJcYq_msyO" role="jymVt" />
     <node concept="3Tm1VV" id="7OJcYqw2ryR" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqw2ryS" role="1zkMxy">
       <ref role="3uigEE" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
@@ -11268,20 +11316,16 @@
           <node concept="37vLTw" id="7OJcYqw2rz3" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqw2rzg" resolve="slang" />
           </node>
-          <node concept="2YIFZM" id="7OJcYq_kVFd" role="37wK5m">
-            <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
-            <ref role="37wK5l" to="wyt6:~Long.toString(long)" resolve="toString" />
-            <node concept="2OqwBi" id="7OJcYq_kVFe" role="37wK5m">
-              <node concept="2YIFZM" id="7OJcYq_kVFf" role="2Oq$k0">
-                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
-                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
-                <node concept="37vLTw" id="7OJcYq_kVFg" role="37wK5m">
-                  <ref role="3cqZAo" node="7OJcYqw2rze" resolve="mps" />
-                </node>
+          <node concept="2OqwBi" id="7OJcYq_kVFe" role="37wK5m">
+            <node concept="2YIFZM" id="7OJcYq_kVFf" role="2Oq$k0">
+              <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
+              <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+              <node concept="37vLTw" id="7OJcYq_kVFg" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYqw2rze" resolve="mps" />
               </node>
-              <node concept="liA8E" id="7OJcYq_kVFh" role="2OqNvi">
-                <ref role="37wK5l" to="e8bb:~SElementId.getIdValue()" resolve="getIdValue" />
-              </node>
+            </node>
+            <node concept="liA8E" id="7OJcYq_lS5p" role="2OqNvi">
+              <ref role="37wK5l" to="e8bb:~SElementId.toString()" resolve="toString" />
             </node>
           </node>
           <node concept="2YIFZM" id="7OJcYqwPrVz" role="37wK5m">
@@ -11296,6 +11340,26 @@
             <ref role="1Pybhc" node="7OJcYqvKk3R" resolve="AKeyedStaple" />
             <node concept="37vLTw" id="7OJcYqw2rzb" role="37wK5m">
               <ref role="3cqZAo" node="7OJcYqw2rzc" resolve="lc" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq_muor" role="3cqZAp" />
+        <node concept="3clFbF" id="7OJcYq_muos" role="3cqZAp">
+          <node concept="37vLTI" id="7OJcYq_muot" role="3clFbG">
+            <node concept="37vLTw" id="7OJcYq_muou" role="37vLTJ">
+              <ref role="3cqZAo" node="7OJcYq_mt5b" resolve="mpsPropId" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYq_muov" role="37vLTx">
+              <node concept="2YIFZM" id="7OJcYq_muow" role="2Oq$k0">
+                <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
+                <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getDatatypeId(org.jetbrains.mps.openapi.model.SNode)" resolve="getDatatypeId" />
+                <node concept="37vLTw" id="7OJcYq_muox" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqw2rze" resolve="mps" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7OJcYq_muoy" role="2OqNvi">
+                <ref role="37wK5l" to="e8bb:~SElementId.getIdValue()" resolve="getIdValue" />
+              </node>
             </node>
           </node>
         </node>
@@ -11382,6 +11446,24 @@
             <ref role="37wK5l" node="7OJcYqvKqdu" resolve="getLcKey" />
           </node>
         </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="7OJcYq_mvJr" role="jymVt">
+      <property role="TrG5h" value="getMpsPropId" />
+      <node concept="3cpWsb" id="7OJcYq_mvJs" role="3clF45" />
+      <node concept="3Tm1VV" id="7OJcYq_mvJt" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYq_mvJu" role="3clF47">
+        <node concept="3clFbF" id="7OJcYq_mvJv" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq_mvJw" role="3clFbG">
+            <node concept="Xjq3P" id="7OJcYq_mvJx" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7OJcYq_mvJy" role="2OqNvi">
+              <ref role="2Oxat5" node="7OJcYq_mt5b" resolve="mpsPropId" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYq_mvJz" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3uibUv" id="7OJcYqx0o5m" role="EKbjA">
@@ -11823,6 +11905,12 @@
   <node concept="3HP615" id="7OJcYqx0lp$">
     <property role="3GE5qa" value="staple" />
     <property role="TrG5h" value="IPrimitiveTypeStaple" />
+    <node concept="3clFb_" id="7OJcYq_mkbH" role="jymVt">
+      <property role="TrG5h" value="getMpsPropId" />
+      <node concept="3clFbS" id="7OJcYq_mkbK" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYq_mkbL" role="1B3o_S" />
+      <node concept="3cpWsb" id="7OJcYq_mrDn" role="3clF45" />
+    </node>
     <node concept="3Tm1VV" id="7OJcYqx0lp_" role="1B3o_S" />
     <node concept="3uibUv" id="7OJcYqx0lUM" role="3HQHJm">
       <ref role="3uigEE" node="7OJcYqvKf0O" resolve="IKeyedStaple" />

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -34,6 +34,7 @@
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" />
     <import index="pjrh" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter(MPS.Core/)" />
     <import index="4xw4" ref="r:23ccdcd2-ac4f-4247-aad5-4d197fcb7e18(io.lionweb.mps.specific.lang)" />
+    <import index="i2js" ref="r:8a5810a5-6291-48f8-84a1-e0b9d037018c(io.lionweb.mps.m3.core)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
   </imports>
@@ -460,7 +461,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqwuG9n" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqwuG9o" role="1tU5fm">
-        <ref role="3uigEE" node="7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqwuLVt" role="jymVt">
@@ -971,18 +972,18 @@
             </node>
             <node concept="2ShNRf" id="7OJcYqwuG9R" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqwuG9S" role="2ShVmc">
-                <ref role="37wK5l" node="7OJcYqwqLmd" resolve="AnnotationConceptKeyedMapping" />
-                <node concept="2OqwBi" id="7OJcYqwuG9T" role="37wK5m">
-                  <node concept="2tJFMh" id="7OJcYqwuG9U" role="2Oq$k0">
-                    <node concept="ZC_QK" id="7OJcYqwuG9V" role="2tJFKM">
-                      <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
-                      <node concept="ZC_QK" id="7OJcYqwuG9W" role="2aWVGa">
-                        <ref role="2aWVGs" to="4xw4:34Q84zMNsGk" resolve="ConceptDescription" />
+                <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptKeyedMapping" />
+                <node concept="2OqwBi" id="7OJcYqxyU$z" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqxyU$$" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqxyU$_" role="2tJFKM">
+                      <ref role="2aWVGs" to="i2js:5sACIIs$PgG" resolve="LionCore_M3" />
+                      <node concept="ZC_QK" id="7OJcYqxyU$A" role="2aWVGa">
+                        <ref role="2aWVGs" to="i2js:5sACIIs$PgR" resolve="Classifier" />
                       </node>
                     </node>
                   </node>
-                  <node concept="Vyspw" id="7OJcYqwuG9X" role="2OqNvi">
-                    <node concept="37vLTw" id="7OJcYqwuG9Y" role="Vysub">
+                  <node concept="Vyspw" id="7OJcYqxyU$B" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqxyU$C" role="Vysub">
                       <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
                     </node>
                   </node>
@@ -1056,7 +1057,21 @@
             <node concept="2ShNRf" id="7OJcYqwuLVQ" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqwuLVR" role="2ShVmc">
                 <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptKeyedMapping" />
-                <node concept="10Nm6u" id="7OJcYqwuLVS" role="37wK5m" />
+                <node concept="2OqwBi" id="7OJcYqxyKk_" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqxyKkA" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqxyKkB" role="2tJFKM">
+                      <ref role="2aWVGs" to="i2js:5sACIIs$PgG" resolve="LionCore_M3" />
+                      <node concept="ZC_QK" id="7OJcYqxyKkC" role="2aWVGa">
+                        <ref role="2aWVGs" to="i2js:5sACIIs$PgU" resolve="Concept" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqxyKkD" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqxyKkE" role="Vysub">
+                      <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
                 <node concept="37vLTw" id="7OJcYqwuLVT" role="37wK5m">
                   <ref role="3cqZAo" node="7OJcYqwtwQF" resolve="mpsConcept" />
                 </node>
@@ -1126,7 +1141,21 @@
             <node concept="2ShNRf" id="7OJcYqwuQlD" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqwuQlE" role="2ShVmc">
                 <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptKeyedMapping" />
-                <node concept="10Nm6u" id="7OJcYqwuQlF" role="37wK5m" />
+                <node concept="2OqwBi" id="7OJcYqxyBTW" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqxywqd" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqxyyn2" role="2tJFKM">
+                      <ref role="2aWVGs" to="i2js:5sACIIs$PgG" resolve="LionCore_M3" />
+                      <node concept="ZC_QK" id="7OJcYqxy$ix" role="2aWVGa">
+                        <ref role="2aWVGs" to="i2js:5sACIIs$PgY" resolve="Interface" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqxyE26" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqxyFXk" role="Vysub">
+                      <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
                 <node concept="37vLTw" id="7OJcYqwuQlG" role="37wK5m">
                   <ref role="3cqZAo" node="7OJcYqwtH6R" resolve="mpsInterface" />
                 </node>
@@ -1199,7 +1228,24 @@
             <node concept="2ShNRf" id="7OJcYqwuULx" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqwuULy" role="2ShVmc">
                 <ref role="37wK5l" node="7OJcYqvRxYF" resolve="PropertyKeyMapping" />
-                <node concept="10Nm6u" id="7OJcYqwuULz" role="37wK5m" />
+                <node concept="2OqwBi" id="7OJcYqxx6ng" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqxx6nh" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqxx6ni" role="2tJFKM">
+                      <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
+                      <node concept="ZC_QK" id="7OJcYqxx6nj" role="2aWVGa">
+                        <ref role="2aWVGs" to="4xw4:34Q84zMNsGk" resolve="ConceptDescription" />
+                        <node concept="ZC_QK" id="7OJcYqxx6nk" role="2aWVGa">
+                          <ref role="2aWVGs" to="4xw4:34Q84zMPiDq" resolve="conceptAlias" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqxx6nl" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqxx6nm" role="Vysub">
+                      <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
                 <node concept="37vLTw" id="7OJcYqwuUL$" role="37wK5m">
                   <ref role="3cqZAo" node="7OJcYqwtTqK" resolve="mpsConceptAliasProp" />
                 </node>
@@ -1284,7 +1330,24 @@
             <node concept="2ShNRf" id="7OJcYqwuZis" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqwuZit" role="2ShVmc">
                 <ref role="37wK5l" node="7OJcYqvRxYF" resolve="PropertyKeyMapping" />
-                <node concept="10Nm6u" id="7OJcYqwuZiu" role="37wK5m" />
+                <node concept="2OqwBi" id="7OJcYqxwYIB" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqxwYIC" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqxwYID" role="2tJFKM">
+                      <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
+                      <node concept="ZC_QK" id="7OJcYqxwYIE" role="2aWVGa">
+                        <ref role="2aWVGs" to="4xw4:34Q84zMNsGk" resolve="ConceptDescription" />
+                        <node concept="ZC_QK" id="7OJcYqxx2$_" role="2aWVGa">
+                          <ref role="2aWVGs" to="4xw4:34Q84zMPiD_" resolve="conceptShortDescription" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqxwYIF" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqxwYIG" role="Vysub">
+                      <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
                 <node concept="37vLTw" id="7OJcYqwuZiv" role="37wK5m">
                   <ref role="3cqZAo" node="7OJcYqwu7gv" resolve="mpsConceptShortDescriptionProp" />
                 </node>
@@ -2045,6 +2108,36 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskjple9" role="jymVt" />
+    <node concept="2tJIrI" id="7OJcYqxrjYk" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxrn6T" role="jymVt">
+      <property role="TrG5h" value="listSpecificAnnotationProperty" />
+      <node concept="3Tm1VV" id="7OJcYqxrn6V" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqxrn6W" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqxrn6X" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqxrn6Z" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqxrqN6" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqxrqN4" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqxrtDV" role="2ShVmc">
+              <node concept="3uibUv" id="7OJcYqxrz8N" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqxrCQw" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwv4sM" resolve="getVirtualPackage" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqxrIiy" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwv4sU" resolve="getShortDescription" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxrn70" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiskjpmgL" role="jymVt">
       <property role="TrG5h" value="listSpecificAnnotationProperties" />
       <node concept="3Tm1VV" id="5JNiskjpmgN" role="1B3o_S" />
@@ -2167,6 +2260,36 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskix72u" role="jymVt" />
+    <node concept="2tJIrI" id="7OJcYqxrUYO" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxrYau" role="jymVt">
+      <property role="TrG5h" value="listConceptDescriptionProperty" />
+      <node concept="3Tm1VV" id="7OJcYqxrYaw" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqxrYax" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqxrYay" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7OJcYqxrYa$" role="3clF47">
+        <node concept="3clFbF" id="7OJcYqxs4Km" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYqxs4Kk" role="3clFbG">
+            <node concept="Tc6Ow" id="7OJcYqxs7mo" role="2ShVmc">
+              <node concept="3uibUv" id="7OJcYqxsd5i" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqxsiXX" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwv4ty" resolve="getConceptAlias" />
+              </node>
+              <node concept="1rXfSq" id="7OJcYqxsoBg" role="HW$Y0">
+                <ref role="37wK5l" node="7OJcYqwv4tE" resolve="getConceptShortDescription" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxrYa_" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="34Q84zNNqfT" role="jymVt">
       <property role="TrG5h" value="listConceptDescriptionProperties" />
       <node concept="3Tm1VV" id="34Q84zNNqfV" role="1B3o_S" />
@@ -2534,7 +2657,7 @@
     <node concept="3clFb_" id="7OJcYqwv4ta" role="jymVt">
       <property role="TrG5h" value="getClassifier" />
       <node concept="3uibUv" id="7OJcYqwv4tb" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
       </node>
       <node concept="3Tm1VV" id="7OJcYqwv4tc" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwv4td" role="3clF47">
@@ -7136,6 +7259,7 @@
   </node>
   <node concept="3HP615" id="5JNiskhxHcX">
     <property role="TrG5h" value="ILionCoreConstants" />
+    <node concept="2tJIrI" id="7OJcYqwQyqk" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwQyzV" role="jymVt">
       <property role="TrG5h" value="getVirtualPackage" />
       <node concept="3uibUv" id="7OJcYqwQyzW" role="3clF45">
@@ -7143,7 +7267,168 @@
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQyzX" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQyzY" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqxpSwt" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqxqloi" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqloj" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.specific.lang.MPS-specific annotations.VirtualPackage" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqlok" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqlol" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.core.structure.BaseConcept.virtualPackage" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqlom" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqlon" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="5M8g5cS$api" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS$apj" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.BaseConcept.virtualPackage as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS$c0j" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS$cxA" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS$cxC" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS$d30" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SProperty" resolve="SProperty" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS$c0i" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqloo" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqlop" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: VirtualPackage" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqloq" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqlor" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626/1193676396447" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqlos" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqlot" role="1dT_Ay">
+            <property role="1dT_AB" value="lcProp: io.lionweb.mps.m3.builtin.Built-in DataTypes.INamed.name" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqlou" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqlov" role="1dT_Ay">
+            <property role="1dT_AB" value="lcPropKey: LionCore-builtins-INamed-name" />
+          </node>
+        </node>
+      </node>
     </node>
+    <node concept="3clFb_" id="5JNiskipPo2" role="jymVt">
+      <property role="TrG5h" value="lcVirtualPackageAnnotation" />
+      <node concept="3clFbS" id="5JNiskipPo3" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiskipPo4" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiskipPo5" role="3clF45">
+        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqxsrNO" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxsrNP" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsrNQ" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsrNR" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiskipPo6" role="jymVt">
+      <property role="TrG5h" value="mpsVirtualPackageProperty" />
+      <node concept="3clFbS" id="5JNiskipPo7" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiskipPo8" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiskipPo9" role="3clF45">
+        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqxsrUT" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxsrUU" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsrUV" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsrUW" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiskipPoa" role="jymVt">
+      <property role="TrG5h" value="slangVirtualPackageProperty" />
+      <node concept="3clFbS" id="5JNiskipPob" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiskipPoc" role="1B3o_S" />
+      <node concept="3uibUv" id="5JNiskipPod" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqxss2e" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxss2f" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxss2g" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxss2h" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiskipPoe" role="jymVt">
+      <property role="TrG5h" value="keyVirtualPackageAnnotation" />
+      <node concept="3clFbS" id="5JNiskipPof" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiskipPog" role="1B3o_S" />
+      <node concept="17QB3L" id="5JNiskipPoh" role="3clF45" />
+      <node concept="P$JXv" id="7OJcYqxss9N" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxss9O" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxss9P" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxss9Q" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiskipPoi" role="jymVt">
+      <property role="TrG5h" value="idVirtualPackageProperty" />
+      <node concept="3clFbS" id="5JNiskipPoj" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiskipPok" role="1B3o_S" />
+      <node concept="17QB3L" id="5JNiskipPol" role="3clF45" />
+      <node concept="P$JXv" id="7OJcYqxsshC" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxsshD" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsshE" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsshF" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5JNiskirbH_" role="jymVt" />
+    <node concept="3clFb_" id="5JNiskir74n" role="jymVt">
+      <property role="TrG5h" value="lcVirtualPackage_NameProperty" />
+      <node concept="3clFbS" id="5JNiskir74o" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiskir74p" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiskir74q" role="3clF45">
+        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqxssy2" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxssy3" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxssy4" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxssy5" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiskireGB" role="jymVt">
+      <property role="TrG5h" value="keyVirtualPackage_NameProperty" />
+      <node concept="3clFbS" id="5JNiskireGC" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiskireGD" role="1B3o_S" />
+      <node concept="17QB3L" id="5JNiskireGE" role="3clF45" />
+      <node concept="P$JXv" id="7OJcYqxsspH" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxsspI" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsspJ" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsspK" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5JNiskipPnR" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwQy$4" role="jymVt">
       <property role="TrG5h" value="getShortDescription" />
       <node concept="3uibUv" id="7OJcYqwQy$5" role="3clF45">
@@ -7151,55 +7436,168 @@
       </node>
       <node concept="3Tm1VV" id="7OJcYqwQy$6" role="1B3o_S" />
       <node concept="3clFbS" id="7OJcYqwQy$7" role="3clF47" />
-    </node>
-    <node concept="3clFb_" id="7OJcYqwQy$d" role="jymVt">
-      <property role="TrG5h" value="getStructureLanguage" />
-      <node concept="3uibUv" id="7OJcYqwQy$e" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
+      <node concept="P$JXv" id="7OJcYqxpTFc" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqxqibc" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqibd" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.specific.lang.MPS-specific annotations.ShortDescription" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqibe" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqibf" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.core.structure.BaseConcept.shortDescription" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqibg" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqibh" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="5M8g5cS$lNu" role="TZ5H$">
+          <node concept="1dT_AC" id="5M8g5cS$lNv" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.BaseConcept.shortDescription as " />
+          </node>
+          <node concept="1dT_AA" id="5M8g5cS$lRC" role="1dT_Ay">
+            <node concept="92FcH" id="5M8g5cS$lRQ" role="qph3F">
+              <node concept="TZ5HA" id="5M8g5cS$lRS" role="2XjZqd" />
+              <node concept="VXe08" id="5M8g5cS$lS7" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SProperty" resolve="SProperty" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="5M8g5cS$lRB" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqibi" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqibj" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: ShortDescription" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqibk" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqibl" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626/1156234966388" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqlbo" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqlbp" role="1dT_Ay">
+            <property role="1dT_AB" value="lcProp: io.lionweb.mps.specific.lang.MPS-specific annotations.ShortDescription.description" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqlhO" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqlhP" role="1dT_Ay">
+            <property role="1dT_AB" value="lcPropKey: ShortDescription-description" />
+          </node>
+        </node>
       </node>
-      <node concept="3Tm1VV" id="7OJcYqwQy$f" role="1B3o_S" />
-      <node concept="3clFbS" id="7OJcYqwQy$g" role="3clF47" />
     </node>
-    <node concept="3clFb_" id="7OJcYqwQy$m" role="jymVt">
-      <property role="TrG5h" value="getClassifier" />
-      <node concept="3uibUv" id="7OJcYqwQy$n" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqwqLm4" resolve="AnnotationConceptKeyedMapping" />
+    <node concept="3clFb_" id="5JNiskipPPY" role="jymVt">
+      <property role="TrG5h" value="lcShortDescriptionAnnotation" />
+      <node concept="3clFbS" id="5JNiskipPPZ" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiskipPQ0" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiskipPQ1" role="3clF45">
+        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
       </node>
-      <node concept="3Tm1VV" id="7OJcYqwQy$o" role="1B3o_S" />
-      <node concept="3clFbS" id="7OJcYqwQy$p" role="3clF47" />
-    </node>
-    <node concept="3clFb_" id="7OJcYqwQy$v" role="jymVt">
-      <property role="TrG5h" value="getConcept" />
-      <node concept="3uibUv" id="7OJcYqwQy$w" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+      <node concept="P$JXv" id="7OJcYqxssEB" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxssEC" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxssED" role="3HnX3l" />
+        </node>
       </node>
-      <node concept="3Tm1VV" id="7OJcYqwQy$x" role="1B3o_S" />
-      <node concept="3clFbS" id="7OJcYqwQy$y" role="3clF47" />
-    </node>
-    <node concept="3clFb_" id="7OJcYqwQy$C" role="jymVt">
-      <property role="TrG5h" value="getInterface" />
-      <node concept="3uibUv" id="7OJcYqwQy$D" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+      <node concept="2AHcQZ" id="7OJcYqxssEE" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
-      <node concept="3Tm1VV" id="7OJcYqwQy$E" role="1B3o_S" />
-      <node concept="3clFbS" id="7OJcYqwQy$F" role="3clF47" />
     </node>
-    <node concept="3clFb_" id="7OJcYqwQy$L" role="jymVt">
-      <property role="TrG5h" value="getConceptAlias" />
-      <node concept="3uibUv" id="7OJcYqwQy$M" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+    <node concept="3clFb_" id="5JNiskipPPU" role="jymVt">
+      <property role="TrG5h" value="mpsShortDescriptionProperty" />
+      <node concept="3clFbS" id="5JNiskipPPV" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiskipPPW" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiskipPPX" role="3clF45">
+        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
       </node>
-      <node concept="3Tm1VV" id="7OJcYqwQy$N" role="1B3o_S" />
-      <node concept="3clFbS" id="7OJcYqwQy$O" role="3clF47" />
-    </node>
-    <node concept="3clFb_" id="7OJcYqwQy$U" role="jymVt">
-      <property role="TrG5h" value="getConceptShortDescription" />
-      <node concept="3uibUv" id="7OJcYqwQy$V" role="3clF45">
-        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+      <node concept="P$JXv" id="7OJcYqxssNs" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxssNt" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxssNu" role="3HnX3l" />
+        </node>
       </node>
-      <node concept="3Tm1VV" id="7OJcYqwQy$W" role="1B3o_S" />
-      <node concept="3clFbS" id="7OJcYqwQy$X" role="3clF47" />
+      <node concept="2AHcQZ" id="7OJcYqxssNv" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
     </node>
+    <node concept="3clFb_" id="5JNiskipPPQ" role="jymVt">
+      <property role="TrG5h" value="slangShortDescriptionProperty" />
+      <node concept="3clFbS" id="5JNiskipPPR" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiskipPPS" role="1B3o_S" />
+      <node concept="3uibUv" id="5JNiskipPPT" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqxssWx" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxssWy" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxssWz" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxssW$" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiskipPPM" role="jymVt">
+      <property role="TrG5h" value="keyShortDescriptionAnnotation" />
+      <node concept="3clFbS" id="5JNiskipPPN" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiskipPPO" role="1B3o_S" />
+      <node concept="17QB3L" id="5JNiskipPPP" role="3clF45" />
+      <node concept="P$JXv" id="7OJcYqxst5Q" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxst5R" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxst5S" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxst5T" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiskipPPI" role="jymVt">
+      <property role="TrG5h" value="idShortDescriptionProperty" />
+      <node concept="3clFbS" id="5JNiskipPPJ" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiskipPPK" role="1B3o_S" />
+      <node concept="17QB3L" id="5JNiskipPPL" role="3clF45" />
+      <node concept="P$JXv" id="7OJcYqxstfr" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxstfs" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxstft" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxstfu" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5JNiskirdbC" role="jymVt" />
+    <node concept="3clFb_" id="5JNiskir8mM" role="jymVt">
+      <property role="TrG5h" value="lcShortDescription_DescriptionProperty" />
+      <node concept="3clFbS" id="5JNiskir8mN" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiskir8mO" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5JNiskir8mP" role="3clF45">
+        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqxstpg" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxstph" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxstpi" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxstpj" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5JNiskirgAw" role="jymVt">
+      <property role="TrG5h" value="keyShortDescription_DescriptionProperty" />
+      <node concept="3clFbS" id="5JNiskirgAx" role="3clF47" />
+      <node concept="3Tm1VV" id="5JNiskirgAy" role="1B3o_S" />
+      <node concept="17QB3L" id="5JNiskirgAz" role="3clF45" />
+      <node concept="P$JXv" id="7OJcYqxstzl" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxstzm" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxstzn" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxstzo" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5JNiskipPPH" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwUzr1" role="jymVt">
       <property role="TrG5h" value="getSpecificLanguage" />
       <node concept="3uibUv" id="7OJcYqwUzr2" role="3clF45">
@@ -7268,207 +7666,6 @@
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="7OJcYqwQyqk" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskipPo2" role="jymVt">
-      <property role="TrG5h" value="lcVirtualPackageAnnotation" />
-      <node concept="3clFbS" id="5JNiskipPo3" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPo4" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskipPo5" role="3clF45">
-        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$2Gt" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$2Gw" role="3nqlJM">
-          <property role="x79VB" value="io.lionweb.mps.specific.lang.MPS-specific annotations.VirtualPackage" />
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskipPo6" role="jymVt">
-      <property role="TrG5h" value="mpsVirtualPackageProperty" />
-      <node concept="3clFbS" id="5JNiskipPo7" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPo8" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskipPo9" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$3uH" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$3uK" role="3nqlJM">
-          <property role="x79VB" value="jetbrains.mps.lang.core.structure.BaseConcept.virtualPackage" />
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskipPoa" role="jymVt">
-      <property role="TrG5h" value="slangVirtualPackageProperty" />
-      <node concept="3clFbS" id="5JNiskipPob" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPoc" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskipPod" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$4BM" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS$api" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS$apj" role="1dT_Ay">
-            <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.BaseConcept.virtualPackage as " />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS$c0j" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS$cxA" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS$cxC" role="2XjZqd" />
-              <node concept="VXe08" id="5M8g5cS$d30" role="92FcQ">
-                <ref role="VXe09" to="c17a:~SProperty" resolve="SProperty" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS$c0i" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskipPoe" role="jymVt">
-      <property role="TrG5h" value="keyVirtualPackageAnnotation" />
-      <node concept="3clFbS" id="5JNiskipPof" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPog" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskipPoh" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_jlL" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_jlO" role="3nqlJM">
-          <property role="x79VB" value="VirtualPackage" />
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskipPoi" role="jymVt">
-      <property role="TrG5h" value="idVirtualPackageProperty" />
-      <node concept="3clFbS" id="5JNiskipPoj" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPok" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskipPol" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_k4w" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_k4z" role="3nqlJM">
-          <property role="x79VB" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626/1193676396447" />
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiskirbH_" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskir74n" role="jymVt">
-      <property role="TrG5h" value="lcVirtualPackage_NameProperty" />
-      <node concept="3clFbS" id="5JNiskir74o" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskir74p" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskir74q" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$e5U" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$e5X" role="3nqlJM">
-          <property role="x79VB" value="io.lionweb.mps.m3.builtin.Built-in DataTypes.INamed.name" />
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskireGB" role="jymVt">
-      <property role="TrG5h" value="keyVirtualPackage_NameProperty" />
-      <node concept="3clFbS" id="5JNiskireGC" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskireGD" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskireGE" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_kOz" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_kOA" role="3nqlJM">
-          <property role="x79VB" value="LionCore-builtins-INamed-name" />
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiskipPnR" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskipPPY" role="jymVt">
-      <property role="TrG5h" value="lcShortDescriptionAnnotation" />
-      <node concept="3clFbS" id="5JNiskipPPZ" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPQ0" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskipPQ1" role="3clF45">
-        <ref role="ehGHo" to="h3y3:18UigYQyrxa" resolve="Annotation" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$jFb" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$jFe" role="3nqlJM">
-          <property role="x79VB" value="io.lionweb.mps.specific.lang.MPS-specific annotations.ShortDescription" />
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskipPPU" role="jymVt">
-      <property role="TrG5h" value="mpsShortDescriptionProperty" />
-      <node concept="3clFbS" id="5JNiskipPPV" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPPW" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskipPPX" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$kJ5" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$kJ8" role="3nqlJM">
-          <property role="x79VB" value="jetbrains.mps.lang.core.structure.BaseConcept.shortDescription" />
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskipPPQ" role="jymVt">
-      <property role="TrG5h" value="slangShortDescriptionProperty" />
-      <node concept="3clFbS" id="5JNiskipPPR" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPPS" role="1B3o_S" />
-      <node concept="3uibUv" id="5JNiskipPPT" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$lNt" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cS$lNu" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cS$lNv" role="1dT_Ay">
-            <property role="1dT_AB" value="jetbrains.mps.lang.core.structure.BaseConcept.shortDescription as " />
-          </node>
-          <node concept="1dT_AA" id="5M8g5cS$lRC" role="1dT_Ay">
-            <node concept="92FcH" id="5M8g5cS$lRQ" role="qph3F">
-              <node concept="TZ5HA" id="5M8g5cS$lRS" role="2XjZqd" />
-              <node concept="VXe08" id="5M8g5cS$lS7" role="92FcQ">
-                <ref role="VXe09" to="c17a:~SProperty" resolve="SProperty" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="5M8g5cS$lRB" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskipPPM" role="jymVt">
-      <property role="TrG5h" value="keyShortDescriptionAnnotation" />
-      <node concept="3clFbS" id="5JNiskipPPN" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPPO" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskipPPP" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_lys" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_lyv" role="3nqlJM">
-          <property role="x79VB" value="ShortDescription" />
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskipPPI" role="jymVt">
-      <property role="TrG5h" value="idShortDescriptionProperty" />
-      <node concept="3clFbS" id="5JNiskipPPJ" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskipPPK" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskipPPL" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_mjh" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_mjk" role="3nqlJM">
-          <property role="x79VB" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626/1156234966388" />
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiskirdbC" role="jymVt" />
-    <node concept="3clFb_" id="5JNiskir8mM" role="jymVt">
-      <property role="TrG5h" value="lcShortDescription_DescriptionProperty" />
-      <node concept="3clFbS" id="5JNiskir8mN" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskir8mO" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5JNiskir8mP" role="3clF45">
-        <ref role="ehGHo" to="h3y3:2ju2syjkkDM" resolve="Property" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cS$lWo" role="lGtFl">
-        <node concept="x79VA" id="5M8g5cS$lWr" role="3nqlJM">
-          <property role="x79VB" value="io.lionweb.mps.specific.lang.MPS-specific annotations.ShortDescription.description" />
-        </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="5JNiskirgAw" role="jymVt">
-      <property role="TrG5h" value="keyShortDescription_DescriptionProperty" />
-      <node concept="3clFbS" id="5JNiskirgAx" role="3clF47" />
-      <node concept="3Tm1VV" id="5JNiskirgAy" role="1B3o_S" />
-      <node concept="17QB3L" id="5JNiskirgAz" role="3clF45" />
-      <node concept="P$JXv" id="5IwPrBr_n1o" role="lGtFl">
-        <node concept="x79VA" id="5IwPrBr_n1r" role="3nqlJM">
-          <property role="x79VB" value="ShortDescription-description" />
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5JNiskipPPH" role="jymVt" />
     <node concept="3clFb_" id="5JNiskiKU44" role="jymVt">
       <property role="TrG5h" value="slangSpecificLanguageId" />
       <node concept="3clFbS" id="5JNiskiKU45" role="3clF47" />
@@ -7476,23 +7673,13 @@
       <node concept="3uibUv" id="5JNiskiKU47" role="3clF45">
         <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
       </node>
-      <node concept="P$JXv" id="34Q84zNO$oi" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNO$oj" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNO$ok" role="1dT_Ay">
-            <property role="1dT_AB" value="io.lionweb.mps.specific as " />
-          </node>
-          <node concept="1dT_AA" id="34Q84zNO_dq" role="1dT_Ay">
-            <node concept="92FcH" id="34Q84zNO_dC" role="qph3F">
-              <node concept="TZ5HA" id="34Q84zNO_dE" role="2XjZqd" />
-              <node concept="VXe08" id="34Q84zNO_e$" role="92FcQ">
-                <ref role="VXe09" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="34Q84zNO_dp" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
+      <node concept="P$JXv" id="7OJcYqxstHE" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxstHF" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxstHG" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxstHH" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiKU48" role="jymVt">
@@ -7502,23 +7689,13 @@
       <node concept="3uibUv" id="5JNiskiKU4b" role="3clF45">
         <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
       </node>
-      <node concept="P$JXv" id="34Q84zNO_fn" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNO_iF" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNO_iG" role="1dT_Ay">
-            <property role="1dT_AB" value="io.lionweb.mps.specific as " />
-          </node>
-          <node concept="1dT_AA" id="34Q84zNO_iH" role="1dT_Ay">
-            <node concept="92FcH" id="34Q84zNO_iI" role="qph3F">
-              <node concept="TZ5HA" id="34Q84zNO_iJ" role="2XjZqd" />
-              <node concept="VXe08" id="34Q84zNO_iK" role="92FcQ">
-                <ref role="VXe09" to="c17a:~SLanguage" resolve="SLanguage" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="34Q84zNO_iL" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
+      <node concept="P$JXv" id="7OJcYqxstSf" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxstSg" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxstSh" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxstSi" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiKU4c" role="jymVt">
@@ -7526,15 +7703,13 @@
       <node concept="3clFbS" id="5JNiskiKU4d" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiskiKU4e" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskiKU4f" role="3clF45" />
-      <node concept="P$JXv" id="34Q84zNO_sK" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNO_sL" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNO_w4" role="1dT_Ay">
-            <property role="1dT_AB" value="io.lionweb.mps.specific as key" />
-          </node>
+      <node concept="P$JXv" id="7OJcYqxsu34" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxsu35" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsu36" role="3HnX3l" />
         </node>
-        <node concept="x79VA" id="5IwPrBr_oXM" role="3nqlJM">
-          <property role="x79VB" value="io.lionweb.mps.specific" />
-        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsu37" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiKU4g" role="jymVt">
@@ -7542,15 +7717,13 @@
       <node concept="3clFbS" id="5JNiskiKU4h" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiskiKU4i" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskiKU4j" role="3clF45" />
-      <node concept="P$JXv" id="34Q84zNO_zK" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNO_zL" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNO_zM" role="1dT_Ay">
-            <property role="1dT_AB" value="io.lionweb.mps.specific as id" />
-          </node>
+      <node concept="P$JXv" id="7OJcYqxsue9" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxsuea" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsueb" role="3HnX3l" />
         </node>
-        <node concept="x79VA" id="5IwPrBr_oM1" role="3nqlJM">
-          <property role="x79VB" value="io.lionweb.mps.specific" />
-        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsuec" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="5JNiskiKU4k" role="jymVt">
@@ -7558,52 +7731,29 @@
       <node concept="3clFbS" id="5JNiskiKU4l" role="3clF47" />
       <node concept="3Tm1VV" id="5JNiskiKU4m" role="1B3o_S" />
       <node concept="17QB3L" id="5JNiskiKU4n" role="3clF45" />
-      <node concept="P$JXv" id="34Q84zNO_Ek" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNO_El" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNO_Em" role="1dT_Ay">
-            <property role="1dT_AB" value="version of io.lionweb.mps.specific" />
-          </node>
+      <node concept="P$JXv" id="7OJcYqxsupu" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxsupv" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsupw" role="3HnX3l" />
         </node>
-        <node concept="x79VA" id="5IwPrBr_p9z" role="3nqlJM">
-          <property role="x79VB" value="0" />
-        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsupx" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5JNiskiswpe" role="jymVt" />
-    <node concept="3clFb_" id="34Q84zNODJt" role="jymVt">
-      <property role="TrG5h" value="slangStructureLanguageId" />
-      <node concept="3clFbS" id="34Q84zNODJu" role="3clF47" />
-      <node concept="3Tm1VV" id="34Q84zNODJv" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNODJw" role="3clF45">
-        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+    <node concept="3clFb_" id="7OJcYqwQy$d" role="jymVt">
+      <property role="TrG5h" value="getStructureLanguage" />
+      <node concept="3uibUv" id="7OJcYqwQy$e" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageKeyedMapping" />
       </node>
-      <node concept="P$JXv" id="34Q84zNODJx" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNODJy" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNODJz" role="1dT_Ay">
-            <property role="1dT_AB" value="jetbrains.mps.lang.structure as " />
-          </node>
-          <node concept="1dT_AA" id="34Q84zNODJ$" role="1dT_Ay">
-            <node concept="92FcH" id="34Q84zNODJ_" role="qph3F">
-              <node concept="TZ5HA" id="34Q84zNODJA" role="2XjZqd" />
-              <node concept="VXe08" id="34Q84zNODJB" role="92FcQ">
-                <ref role="VXe09" to="e8bb:~SLanguageId" resolve="SLanguageId" />
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="34Q84zNODJC" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
+      <node concept="3Tm1VV" id="7OJcYqwQy$f" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQy$g" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqxpJvK" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqxqCaL" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqCaM" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="34Q84zNODJD" role="jymVt">
-      <property role="TrG5h" value="slangStructureLanguage" />
-      <node concept="3clFbS" id="34Q84zNODJE" role="3clF47" />
-      <node concept="3Tm1VV" id="34Q84zNODJF" role="1B3o_S" />
-      <node concept="3uibUv" id="34Q84zNODJG" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
-      </node>
-      <node concept="P$JXv" id="34Q84zNODJH" role="lGtFl">
         <node concept="TZ5HA" id="34Q84zNODJI" role="TZ5H$">
           <node concept="1dT_AC" id="34Q84zNODJJ" role="1dT_Ay">
             <property role="1dT_AB" value="jetbrains.mps.lang.structure as " />
@@ -7620,6 +7770,79 @@
             <property role="1dT_AB" value="" />
           </node>
         </node>
+        <node concept="TZ5HA" id="7OJcYqxqCaU" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqCaV" role="1dT_Ay">
+            <property role="1dT_AB" value="slangId: " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="34Q84zNODJy" role="TZ5H$">
+          <node concept="1dT_AC" id="34Q84zNODJz" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.structure as " />
+          </node>
+          <node concept="1dT_AA" id="34Q84zNODJ$" role="1dT_Ay">
+            <node concept="92FcH" id="34Q84zNODJ_" role="qph3F">
+              <node concept="TZ5HA" id="34Q84zNODJA" role="2XjZqd" />
+              <node concept="VXe08" id="34Q84zNODJB" role="92FcQ">
+                <ref role="VXe09" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="34Q84zNODJC" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqCb3" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqCb4" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: c72da2b9-7cce-4447-8389-f407dc1158b7" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqCb5" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqCb6" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsVersion: 9" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqCb7" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqCb8" role="1dT_Ay">
+            <property role="1dT_AB" value="lcVersion: 9" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqCb9" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqCba" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: c72da2b9-7cce-4447-8389-f407dc1158b7" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="34Q84zNODJt" role="jymVt">
+      <property role="TrG5h" value="slangStructureLanguageId" />
+      <node concept="3clFbS" id="34Q84zNODJu" role="3clF47" />
+      <node concept="3Tm1VV" id="34Q84zNODJv" role="1B3o_S" />
+      <node concept="3uibUv" id="34Q84zNODJw" role="3clF45">
+        <ref role="3uigEE" to="e8bb:~SLanguageId" resolve="SLanguageId" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqxsu_3" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxsu_4" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsu_5" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsu_6" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="34Q84zNODJD" role="jymVt">
+      <property role="TrG5h" value="slangStructureLanguage" />
+      <node concept="3clFbS" id="34Q84zNODJE" role="3clF47" />
+      <node concept="3Tm1VV" id="34Q84zNODJF" role="1B3o_S" />
+      <node concept="3uibUv" id="34Q84zNODJG" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqxsuKS" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxsuKT" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsuKU" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsuKV" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNODJP" role="jymVt">
@@ -7627,12 +7850,13 @@
       <node concept="3clFbS" id="34Q84zNODJQ" role="3clF47" />
       <node concept="3Tm1VV" id="34Q84zNODJR" role="1B3o_S" />
       <node concept="17QB3L" id="34Q84zNODJS" role="3clF45" />
-      <node concept="P$JXv" id="34Q84zNODJT" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNODJU" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNODJV" role="1dT_Ay">
-            <property role="1dT_AB" value="jetbrains.mps.lang.structure as key: " />
-          </node>
+      <node concept="P$JXv" id="7OJcYqxsuWX" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxsuWY" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsuWZ" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsuX0" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNODJW" role="jymVt">
@@ -7640,12 +7864,13 @@
       <node concept="3clFbS" id="34Q84zNODJX" role="3clF47" />
       <node concept="3Tm1VV" id="34Q84zNODJY" role="1B3o_S" />
       <node concept="17QB3L" id="34Q84zNODJZ" role="3clF45" />
-      <node concept="P$JXv" id="34Q84zNODK0" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNODK1" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNODK2" role="1dT_Ay">
-            <property role="1dT_AB" value="jetbrains.mps.lang.structure as id" />
-          </node>
+      <node concept="P$JXv" id="7OJcYqxsv9i" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxsv9j" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsv9k" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsv9l" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3clFb_" id="34Q84zNODK3" role="jymVt">
@@ -7653,38 +7878,39 @@
       <node concept="3clFbS" id="34Q84zNODK4" role="3clF47" />
       <node concept="3Tm1VV" id="34Q84zNODK5" role="1B3o_S" />
       <node concept="17QB3L" id="34Q84zNODK6" role="3clF45" />
-      <node concept="P$JXv" id="34Q84zNODK7" role="lGtFl">
-        <node concept="TZ5HA" id="34Q84zNODK8" role="TZ5H$">
-          <node concept="1dT_AC" id="34Q84zNODK9" role="1dT_Ay">
-            <property role="1dT_AB" value="version of jetbrains.mps.lang.structure" />
-          </node>
+      <node concept="P$JXv" id="7OJcYqxsvlR" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxsvlS" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsvlT" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsvlU" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNODKa" role="jymVt" />
-    <node concept="3clFb_" id="34Q84zNQS_d" role="jymVt">
-      <property role="TrG5h" value="mpsAbstractConceptDeclarationConcept" />
-      <node concept="3clFbS" id="34Q84zNQS_g" role="3clF47" />
-      <node concept="3Tm1VV" id="34Q84zNQS_h" role="1B3o_S" />
-      <node concept="3Tqbb2" id="34Q84zNQRl3" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+    <node concept="3clFb_" id="7OJcYqwQy$m" role="jymVt">
+      <property role="TrG5h" value="getClassifier" />
+      <node concept="3uibUv" id="7OJcYqwQy$n" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
       </node>
-      <node concept="P$JXv" id="5M8g5cSzLqs" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cSzLqt" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cSzLqu" role="1dT_Ay">
-            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" />
+      <node concept="3Tm1VV" id="7OJcYqwQy$o" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQy$p" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqxpUQ3" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqxqfFT" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqfFU" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.m3.core.LionCore_M3.Classifier" />
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="7weWCFlnm$K" role="jymVt">
-      <property role="TrG5h" value="slangAbstractConceptConcept" />
-      <node concept="3clFbS" id="7weWCFlnm$N" role="3clF47" />
-      <node concept="3Tm1VV" id="7weWCFlnm$O" role="1B3o_S" />
-      <node concept="3uibUv" id="7weWCFlnmfS" role="3clF45">
-        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cSzNOu" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqxqfFV" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqfFW" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqfFX" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqfFY" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
         <node concept="TZ5HA" id="5M8g5cSzNOv" role="TZ5H$">
           <node concept="1dT_AC" id="5M8g5cSzNOw" role="1dT_Ay">
             <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration as " />
@@ -7701,32 +7927,74 @@
             <property role="1dT_AB" value="" />
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="34Q84zNQU1i" role="jymVt" />
-    <node concept="3clFb_" id="5M8g5cSAUka" role="jymVt">
-      <property role="TrG5h" value="mpsConceptDeclarationConcept" />
-      <node concept="3clFbS" id="5M8g5cSAUkb" role="3clF47" />
-      <node concept="3Tm1VV" id="5M8g5cSAUkc" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5M8g5cSAUkd" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cSAUke" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cSAUkf" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cSAUkg" role="1dT_Ay">
-            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.ConceptDeclaration" />
+        <node concept="TZ5HA" id="7OJcYqxqfFZ" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqfG0" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: Classifier" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqfG1" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqfG2" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135" />
           </node>
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5M8g5cSAUjY" role="jymVt">
-      <property role="TrG5h" value="slangConceptConcept" />
-      <node concept="3clFbS" id="5M8g5cSAUjZ" role="3clF47" />
-      <node concept="3Tm1VV" id="5M8g5cSAUk0" role="1B3o_S" />
-      <node concept="3uibUv" id="5M8g5cSAUk1" role="3clF45">
+    <node concept="3clFb_" id="34Q84zNQS_d" role="jymVt">
+      <property role="TrG5h" value="mpsAbstractConceptDeclarationConcept" />
+      <node concept="3clFbS" id="34Q84zNQS_g" role="3clF47" />
+      <node concept="3Tm1VV" id="34Q84zNQS_h" role="1B3o_S" />
+      <node concept="3Tqbb2" id="34Q84zNQRl3" role="3clF45">
+        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqxsvyG" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxsvyH" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsvyI" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsvyJ" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="7weWCFlnm$K" role="jymVt">
+      <property role="TrG5h" value="slangAbstractConceptConcept" />
+      <node concept="3clFbS" id="7weWCFlnm$N" role="3clF47" />
+      <node concept="3Tm1VV" id="7weWCFlnm$O" role="1B3o_S" />
+      <node concept="3uibUv" id="7weWCFlnmfS" role="3clF45">
         <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
       </node>
-      <node concept="P$JXv" id="5M8g5cSAUk2" role="lGtFl">
+      <node concept="P$JXv" id="7OJcYqxsvJL" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxsvJM" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsvJN" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsvJO" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="34Q84zNQU1i" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqwQy$v" role="jymVt">
+      <property role="TrG5h" value="getConcept" />
+      <node concept="3uibUv" id="7OJcYqwQy$w" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwQy$x" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQy$y" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqxpW12" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqxq1Y5" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxq1Y6" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.m3.core.LionCore_M3.Concept" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxq1Y7" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxq1Y8" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.structure.structure.ConceptDeclaration" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxq1Y9" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxq1Ya" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
         <node concept="TZ5HA" id="5M8g5cSAUk3" role="TZ5H$">
           <node concept="1dT_AC" id="5M8g5cSAUk4" role="1dT_Ay">
             <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.ConceptDeclaration as " />
@@ -7743,32 +8011,74 @@
             <property role="1dT_AB" value="" />
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5M8g5cSAUjX" role="jymVt" />
-    <node concept="3clFb_" id="5M8g5cSAU2C" role="jymVt">
-      <property role="TrG5h" value="mpsInterfaceConceptDeclarationConcept" />
-      <node concept="3clFbS" id="5M8g5cSAU2D" role="3clF47" />
-      <node concept="3Tm1VV" id="5M8g5cSAU2E" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5M8g5cSAU2F" role="3clF45">
-        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-      </node>
-      <node concept="P$JXv" id="5M8g5cSAU2G" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cSAU2H" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cSAU2I" role="1dT_Ay">
-            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.InterfaceConceptDeclaration" />
+        <node concept="TZ5HA" id="7OJcYqxq1Yi" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxq1Yj" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: Concept" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxq1Yk" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxq1Yl" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: c72da2b9-7cce-4447-8389-f407dc1158b7/1071489090640" />
           </node>
         </node>
       </node>
     </node>
-    <node concept="3clFb_" id="5M8g5cSAU2s" role="jymVt">
-      <property role="TrG5h" value="slangInterfaceConceptConcept" />
-      <node concept="3clFbS" id="5M8g5cSAU2t" role="3clF47" />
-      <node concept="3Tm1VV" id="5M8g5cSAU2u" role="1B3o_S" />
-      <node concept="3uibUv" id="5M8g5cSAU2v" role="3clF45">
+    <node concept="3clFb_" id="5M8g5cSAUka" role="jymVt">
+      <property role="TrG5h" value="mpsConceptDeclarationConcept" />
+      <node concept="3clFbS" id="5M8g5cSAUkb" role="3clF47" />
+      <node concept="3Tm1VV" id="5M8g5cSAUkc" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5M8g5cSAUkd" role="3clF45">
+        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqxsvX6" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxsvX7" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsvX8" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsvX9" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5M8g5cSAUjY" role="jymVt">
+      <property role="TrG5h" value="slangConceptConcept" />
+      <node concept="3clFbS" id="5M8g5cSAUjZ" role="3clF47" />
+      <node concept="3Tm1VV" id="5M8g5cSAUk0" role="1B3o_S" />
+      <node concept="3uibUv" id="5M8g5cSAUk1" role="3clF45">
         <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
       </node>
-      <node concept="P$JXv" id="5M8g5cSAU2w" role="lGtFl">
+      <node concept="P$JXv" id="7OJcYqxswaF" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxswaG" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxswaH" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxswaI" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5M8g5cSAUjX" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqwQy$C" role="jymVt">
+      <property role="TrG5h" value="getInterface" />
+      <node concept="3uibUv" id="7OJcYqwQy$D" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvKWo$" resolve="ConceptKeyedMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwQy$E" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQy$F" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqxpXc9" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqxq8$a" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxq8$b" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.m3.core.LionCore_M3.Interface" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxq8$c" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxq8$d" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.structure.structure.InterfaceConceptDeclaration" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxq8$e" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxq8$f" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
         <node concept="TZ5HA" id="5M8g5cSAU2x" role="TZ5H$">
           <node concept="1dT_AC" id="5M8g5cSAU2y" role="1dT_Ay">
             <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.InterfaceConceptDeclaration as " />
@@ -7785,9 +8095,97 @@
             <property role="1dT_AB" value="" />
           </node>
         </node>
+        <node concept="TZ5HA" id="7OJcYqxq8$g" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxq8$h" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: Interface" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxq8$i" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxq8$j" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: c72da2b9-7cce-4447-8389-f407dc1158b7/1169125989551" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5M8g5cSAU2C" role="jymVt">
+      <property role="TrG5h" value="mpsInterfaceConceptDeclarationConcept" />
+      <node concept="3clFbS" id="5M8g5cSAU2D" role="3clF47" />
+      <node concept="3Tm1VV" id="5M8g5cSAU2E" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5M8g5cSAU2F" role="3clF45">
+        <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqxswow" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxswox" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxswoy" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxswoz" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5M8g5cSAU2s" role="jymVt">
+      <property role="TrG5h" value="slangInterfaceConceptConcept" />
+      <node concept="3clFbS" id="5M8g5cSAU2t" role="3clF47" />
+      <node concept="3Tm1VV" id="5M8g5cSAU2u" role="1B3o_S" />
+      <node concept="3uibUv" id="5M8g5cSAU2v" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SConcept" resolve="SConcept" />
+      </node>
+      <node concept="P$JXv" id="7OJcYqxswA_" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxswAA" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxswAB" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxswAC" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="5M8g5cSAU2r" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqwQy$L" role="jymVt">
+      <property role="TrG5h" value="getConceptAlias" />
+      <node concept="3uibUv" id="7OJcYqwQy$M" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwQy$N" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQy$O" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqxpYno" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqxqd$E" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqd$F" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.specific.lang.MPS-specific annotations.ConceptDescription.conceptAlias" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqd$G" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqd$H" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration.conceptAlias" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqd$I" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqd$J" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration.conceptAlias as " />
+          </node>
+          <node concept="1dT_AA" id="7OJcYqxwQsa" role="1dT_Ay">
+            <node concept="92FcH" id="7OJcYqxwQso" role="qph3F">
+              <node concept="TZ5HA" id="7OJcYqxwQsq" role="2XjZqd" />
+              <node concept="VXe08" id="7OJcYqxwQsD" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SProperty" resolve="SProperty" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="7OJcYqxwQs9" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqd$K" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqd$L" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: ConceptDescription-conceptAlias" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqd$M" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqd$N" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135/5092175715804935370" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="3clFb_" id="34Q84zNQVqH" role="jymVt">
       <property role="TrG5h" value="mpsConceptAliasProperty" />
       <node concept="3clFbS" id="34Q84zNQVqK" role="3clF47" />
@@ -7795,10 +8193,58 @@
       <node concept="3Tqbb2" id="34Q84zNQUak" role="3clF45">
         <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
       </node>
-      <node concept="P$JXv" id="5M8g5cSzOBt" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cSzOBu" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cSzOBv" role="1dT_Ay">
-            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration.conceptAlias" />
+      <node concept="P$JXv" id="7OJcYqxswOU" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxswOV" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxswOW" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxswOX" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqxrdMT" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqwQy$U" role="jymVt">
+      <property role="TrG5h" value="getConceptShortDescription" />
+      <node concept="3uibUv" id="7OJcYqwQy$V" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
+      </node>
+      <node concept="3Tm1VV" id="7OJcYqwQy$W" role="1B3o_S" />
+      <node concept="3clFbS" id="7OJcYqwQy$X" role="3clF47" />
+      <node concept="P$JXv" id="7OJcYqxpZyJ" role="lGtFl">
+        <node concept="TZ5HA" id="7OJcYqxqb$5" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqb$6" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.specific.lang.MPS-specific annotations.ConceptDescription.conceptShortDescription" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqb$7" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqb$8" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration.conceptShortDescription" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxwRvQ" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxwRvR" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration.conceptShortDescription as " />
+          </node>
+          <node concept="1dT_AA" id="7OJcYqxwRvS" role="1dT_Ay">
+            <node concept="92FcH" id="7OJcYqxwRvT" role="qph3F">
+              <node concept="TZ5HA" id="7OJcYqxwRvU" role="2XjZqd" />
+              <node concept="VXe08" id="7OJcYqxwRvV" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SProperty" resolve="SProperty" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="7OJcYqxwRvW" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqb$b" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqb$c" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: ConceptDescription-conceptShortDescription" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7OJcYqxqb$d" role="TZ5H$">
+          <node concept="1dT_AC" id="7OJcYqxqb$e" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135/4628067390765907488" />
           </node>
         </node>
       </node>
@@ -7810,15 +8256,26 @@
       <node concept="3Tqbb2" id="34Q84zNQWR3" role="3clF45">
         <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
       </node>
-      <node concept="P$JXv" id="5M8g5cSzONm" role="lGtFl">
-        <node concept="TZ5HA" id="5M8g5cSzONn" role="TZ5H$">
-          <node concept="1dT_AC" id="5M8g5cSzONo" role="1dT_Ay">
-            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration.conceptShortDescription" />
-          </node>
+      <node concept="P$JXv" id="7OJcYqxsx3v" role="lGtFl">
+        <node concept="TZ5HI" id="7OJcYqxsx3w" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsx3x" role="3HnX3l" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsx3y" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNQO5q" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxreEB" role="jymVt">
+      <property role="TrG5h" value="listSpecificAnnotationProperty" />
+      <node concept="3clFbS" id="7OJcYqxreEE" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqxreEF" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqxreug" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqxreE$" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyKeyedMapping" />
+        </node>
+      </node>
+    </node>
     <node concept="3clFb_" id="5JNiskjpaH9" role="jymVt">
       <property role="TrG5h" value="listSpecificAnnotationProperties" />
       <node concept="3clFbS" id="5JNiskjpaHc" role="3clF47" />
@@ -7844,6 +8301,23 @@
           <node concept="1dT_AC" id="5M8g5cS_bYK" role="1dT_Ay">
             <property role="1dT_AB" value="" />
           </node>
+        </node>
+        <node concept="TZ5HI" id="7OJcYqxsxik" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsxil" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsxim" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7OJcYqxrf3I" role="jymVt" />
+    <node concept="3clFb_" id="7OJcYqxrfm4" role="jymVt">
+      <property role="TrG5h" value="listConceptDescriptionProperty" />
+      <node concept="3clFbS" id="7OJcYqxrfm5" role="3clF47" />
+      <node concept="3Tm1VV" id="7OJcYqxrfm6" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYqxrfm7" role="3clF45">
+        <node concept="3uibUv" id="7OJcYqxrfm8" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyKeyMapping" />
         </node>
       </node>
     </node>
@@ -7873,6 +8347,12 @@
             <property role="1dT_AB" value="" />
           </node>
         </node>
+        <node concept="TZ5HI" id="7OJcYqxsxE3" role="3nqlJM">
+          <node concept="TZ5HA" id="7OJcYqxsxE4" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7OJcYqxsxE5" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="3Tm1VV" id="5JNiskhxHcY" role="1B3o_S" />
@@ -8505,7 +8985,21 @@
             <node concept="2ShNRf" id="7OJcYqvSX4D" role="37vLTx">
               <node concept="1pGfFk" id="7OJcYqvSX4E" role="2ShVmc">
                 <ref role="37wK5l" node="7OJcYqvKXd$" resolve="ConceptKeyedMapping" />
-                <node concept="10Nm6u" id="7OJcYqvSX4F" role="37wK5m" />
+                <node concept="2OqwBi" id="7OJcYqxx$KA" role="37wK5m">
+                  <node concept="2tJFMh" id="7OJcYqxxjCI" role="2Oq$k0">
+                    <node concept="ZC_QK" id="7OJcYqxxmLD" role="2tJFKM">
+                      <ref role="2aWVGs" to="i2js:5sACIIs$PgG" resolve="LionCore_M3" />
+                      <node concept="ZC_QK" id="7OJcYqxxpTc" role="2aWVGa">
+                        <ref role="2aWVGs" to="i2js:7OJcYqxxt15" resolve="Annotation" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="7OJcYqxxCcW" role="2OqNvi">
+                    <node concept="37vLTw" id="7OJcYqxxF89" role="Vysub">
+                      <ref role="3cqZAo" node="5JNiski3MAO" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
                 <node concept="37vLTw" id="7OJcYqwdEw6" role="37wK5m">
                   <ref role="3cqZAo" node="7OJcYqwdEw0" resolve="mpsAnnotation" />
                 </node>
@@ -12066,7 +12560,7 @@
       <node concept="P$JXv" id="7OJcYqwQVI9" role="lGtFl">
         <node concept="TZ5HA" id="7OJcYqwQZbQ" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqwQZbR" role="1dT_Ay">
-            <property role="1dT_AB" value="lc: null" />
+            <property role="1dT_AB" value="lc: io.lionweb.mps.m3.core.LionCore_M3.Annotation" />
           </node>
         </node>
         <node concept="TZ5HA" id="7OJcYqwQZbS" role="TZ5H$">
@@ -12095,7 +12589,7 @@
         </node>
         <node concept="TZ5HA" id="7OJcYqwQZbW" role="TZ5H$">
           <node concept="1dT_AC" id="7OJcYqwQZbX" role="1dT_Ay">
-            <property role="1dT_AB" value="lcKey: null" />
+            <property role="1dT_AB" value="lcKey: Annotation" />
           </node>
         </node>
         <node concept="TZ5HA" id="7OJcYqwQZbY" role="TZ5H$">

--- a/solutions/io.lionweb.mps.server.plugin/models/io.lionweb.mps.server.plugin.plugin.mps
+++ b/solutions/io.lionweb.mps.server.plugin/models/io.lionweb.mps.server.plugin.plugin.mps
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:e9aef8de-c070-4f17-bc53-8d34ed91e36a(io.lionweb.mps.server.plugin.plugin)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="817e4e70-961e-4a95-98a1-15e9f32231f1" name="jetbrains.mps.ide.httpsupport" version="0" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
@@ -1373,6 +1374,14 @@
                     <node concept="2ShNRf" id="7weWCFlyI7w" role="37wK5m">
                       <node concept="HV5vD" id="7weWCFlyJjA" role="2ShVmc">
                         <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                      </node>
+                    </node>
+                    <node concept="2ShNRf" id="7OJcYqxWU5C" role="37wK5m">
+                      <node concept="1pGfFk" id="7OJcYqxWU$b" role="2ShVmc">
+                        <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                        <node concept="37vLTw" id="7OJcYqxWW1H" role="37wK5m">
+                          <ref role="3cqZAo" node="3f2P4cbACoK" resolve="repository" />
+                        </node>
                       </node>
                     </node>
                   </node>

--- a/solutions/io.lionweb.mps.server.plugin/models/io.lionweb.mps.server.plugin.plugin.mps
+++ b/solutions/io.lionweb.mps.server.plugin/models/io.lionweb.mps.server.plugin.plugin.mps
@@ -1339,6 +1339,7 @@
         <node concept="3cpWs8" id="2q_M4ySt_UC" role="3cqZAp">
           <node concept="3cpWsn" id="2q_M4ySt_UD" role="3cpWs9">
             <property role="TrG5h" value="reader" />
+            <property role="3TUv4t" value="true" />
             <node concept="3uibUv" id="2q_M4ySt_Qm" role="1tU5fm">
               <ref role="3uigEE" to="k9nz:~CharSequenceReader" resolve="CharSequenceReader" />
             </node>
@@ -1347,78 +1348,6 @@
                 <ref role="37wK5l" to="k9nz:~CharSequenceReader.&lt;init&gt;(java.lang.CharSequence)" resolve="CharSequenceReader" />
                 <node concept="37vLTw" id="2q_M4ySt_UG" role="37wK5m">
                   <ref role="3cqZAo" node="2q_M4yStcxB" resolve="body" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="2q_M4yStFVb" role="3cqZAp">
-          <node concept="3cpWsn" id="2q_M4yStFVc" role="3cpWs9">
-            <property role="TrG5h" value="deserializer" />
-            <node concept="3uibUv" id="2q_M4yStFSR" role="1tU5fm">
-              <ref role="3uigEE" to="6peh:z1IqfFwqda" resolve="Deserializer" />
-            </node>
-            <node concept="2ShNRf" id="2q_M4yStFVd" role="33vP2m">
-              <node concept="1pGfFk" id="2q_M4yStFVe" role="2ShVmc">
-                <ref role="37wK5l" to="6peh:5wsogBctgVc" resolve="Deserializer" />
-                <node concept="37vLTw" id="2q_M4yStFVf" role="37wK5m">
-                  <ref role="3cqZAo" node="2q_M4ySt_UD" resolve="reader" />
-                </node>
-                <node concept="2ShNRf" id="5hsSXrmD6rv" role="37wK5m">
-                  <node concept="1pGfFk" id="5hsSXrmDcUm" role="2ShVmc">
-                    <ref role="37wK5l" to="6peh:5JNiskj4SJa" resolve="JsonConstants" />
-                    <node concept="2YIFZM" id="5hsSXrmDeQ3" role="37wK5m">
-                      <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
-                      <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
-                    </node>
-                    <node concept="2ShNRf" id="7weWCFlyI7w" role="37wK5m">
-                      <node concept="HV5vD" id="7weWCFlyJjA" role="2ShVmc">
-                        <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
-                      </node>
-                    </node>
-                    <node concept="2ShNRf" id="7OJcYqxWU5C" role="37wK5m">
-                      <node concept="1pGfFk" id="7OJcYqxWU$b" role="2ShVmc">
-                        <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
-                        <node concept="37vLTw" id="7OJcYqxWW1H" role="37wK5m">
-                          <ref role="3cqZAo" node="3f2P4cbACoK" resolve="repository" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="2q_M4yStIdG" role="3cqZAp">
-          <node concept="3KEzu6" id="7W6jYlyVaaj" role="3cpWs9">
-            <property role="TrG5h" value="jsonNodes" />
-            <node concept="2OqwBi" id="7W6jYlyVaar" role="33vP2m">
-              <node concept="37vLTw" id="7W6jYlyVaas" role="2Oq$k0">
-                <ref role="3cqZAo" node="2q_M4yStFVc" resolve="deserializer" />
-              </node>
-              <node concept="liA8E" id="7W6jYlyVaat" role="2OqNvi">
-                <ref role="37wK5l" to="6peh:z1IqfFwqy3" resolve="deserialize" />
-              </node>
-            </node>
-            <node concept="PeGgZ" id="7W6jYlyVaai" role="1tU5fm" />
-          </node>
-        </node>
-        <node concept="3clFbF" id="3f2P4cbBoO9" role="3cqZAp">
-          <node concept="2OqwBi" id="3f2P4cbBpJs" role="3clFbG">
-            <node concept="37vLTw" id="3f2P4cbBoO7" role="2Oq$k0">
-              <ref role="3cqZAo" node="2q_M4ySu0Gu" resolve="log" />
-            </node>
-            <node concept="TSZUe" id="3f2P4cbBriJ" role="2OqNvi">
-              <node concept="3cpWs3" id="3f2P4cbBrGW" role="25WWJ7">
-                <node concept="2OqwBi" id="3f2P4cbBrGX" role="3uHU7w">
-                  <node concept="37vLTw" id="3f2P4cbBrGY" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7W6jYlyVaaj" resolve="jsonNodes" />
-                  </node>
-                  <node concept="34oBXx" id="3f2P4cbBrGZ" role="2OqNvi" />
-                </node>
-                <node concept="Xl_RD" id="3f2P4cbBrH0" role="3uHU7B">
-                  <property role="Xl_RC" value="jsonNodes count: " />
                 </node>
               </node>
             </node>
@@ -1491,6 +1420,78 @@
                   </node>
                 </node>
                 <node concept="3clFbS" id="3LyuSndKV4A" role="1zxBo7">
+                  <node concept="3cpWs8" id="2q_M4yStFVb" role="3cqZAp">
+                    <node concept="3cpWsn" id="2q_M4yStFVc" role="3cpWs9">
+                      <property role="TrG5h" value="deserializer" />
+                      <node concept="3uibUv" id="2q_M4yStFSR" role="1tU5fm">
+                        <ref role="3uigEE" to="6peh:z1IqfFwqda" resolve="Deserializer" />
+                      </node>
+                      <node concept="2ShNRf" id="2q_M4yStFVd" role="33vP2m">
+                        <node concept="1pGfFk" id="2q_M4yStFVe" role="2ShVmc">
+                          <ref role="37wK5l" to="6peh:5wsogBctgVc" resolve="Deserializer" />
+                          <node concept="37vLTw" id="2q_M4yStFVf" role="37wK5m">
+                            <ref role="3cqZAo" node="2q_M4ySt_UD" resolve="reader" />
+                          </node>
+                          <node concept="2ShNRf" id="5hsSXrmD6rv" role="37wK5m">
+                            <node concept="1pGfFk" id="5hsSXrmDcUm" role="2ShVmc">
+                              <ref role="37wK5l" to="6peh:5JNiskj4SJa" resolve="JsonConstants" />
+                              <node concept="2YIFZM" id="5hsSXrmDeQ3" role="37wK5m">
+                                <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
+                                <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                              </node>
+                              <node concept="2ShNRf" id="7weWCFlyI7w" role="37wK5m">
+                                <node concept="HV5vD" id="7weWCFlyJjA" role="2ShVmc">
+                                  <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                                </node>
+                              </node>
+                              <node concept="2ShNRf" id="7OJcYqxWU5C" role="37wK5m">
+                                <node concept="1pGfFk" id="7OJcYqxWU$b" role="2ShVmc">
+                                  <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                                  <node concept="37vLTw" id="7OJcYqxWW1H" role="37wK5m">
+                                    <ref role="3cqZAo" node="3f2P4cbACoK" resolve="repository" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="2q_M4yStIdG" role="3cqZAp">
+                    <node concept="3KEzu6" id="7W6jYlyVaaj" role="3cpWs9">
+                      <property role="TrG5h" value="jsonNodes" />
+                      <node concept="2OqwBi" id="7W6jYlyVaar" role="33vP2m">
+                        <node concept="37vLTw" id="7W6jYlyVaas" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2q_M4yStFVc" resolve="deserializer" />
+                        </node>
+                        <node concept="liA8E" id="7W6jYlyVaat" role="2OqNvi">
+                          <ref role="37wK5l" to="6peh:z1IqfFwqy3" resolve="deserialize" />
+                        </node>
+                      </node>
+                      <node concept="PeGgZ" id="7W6jYlyVaai" role="1tU5fm" />
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="3f2P4cbBoO9" role="3cqZAp">
+                    <node concept="2OqwBi" id="3f2P4cbBpJs" role="3clFbG">
+                      <node concept="37vLTw" id="3f2P4cbBoO7" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2q_M4ySu0Gu" resolve="log" />
+                      </node>
+                      <node concept="TSZUe" id="3f2P4cbBriJ" role="2OqNvi">
+                        <node concept="3cpWs3" id="3f2P4cbBrGW" role="25WWJ7">
+                          <node concept="2OqwBi" id="3f2P4cbBrGX" role="3uHU7w">
+                            <node concept="37vLTw" id="3f2P4cbBrGY" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7W6jYlyVaaj" resolve="jsonNodes" />
+                            </node>
+                            <node concept="34oBXx" id="3f2P4cbBrGZ" role="2OqNvi" />
+                          </node>
+                          <node concept="Xl_RD" id="3f2P4cbBrH0" role="3uHU7B">
+                            <property role="Xl_RC" value="jsonNodes count: " />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
                   <node concept="3cpWs8" id="3LyuSndOh3j" role="3cqZAp">
                     <node concept="3cpWsn" id="3LyuSndOh3k" role="3cpWs9">
                       <property role="TrG5h" value="converter" />

--- a/solutions/io.lionweb.mps.server.test/io.lionweb.mps.server.test.msd
+++ b/solutions/io.lionweb.mps.server.test/io.lionweb.mps.server.test.msd
@@ -16,6 +16,8 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">39d4fcb0-6a78-41ac-8e8f-01bb784b65fc(io.lionweb.mps.json)</dependency>
     <dependency reexport="false">9d6d7230-3178-4b3f-a837-7c0180c86207(io.lionweb.lionweb.java)</dependency>
+    <dependency reexport="false">9ccd1228-8082-4d7d-953e-0ef0386dcd6a(io.lionweb.mps.json.test)</dependency>
+    <dependency reexport="false">7350a1d7-537e-4f0d-9965-e91c82522d7d(io.lionweb.mps.m3.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
@@ -34,6 +36,8 @@
     <module reference="9d6d7230-3178-4b3f-a837-7c0180c86207(io.lionweb.lionweb.java)" version="0" />
     <module reference="4d96f781-5fa4-4d94-817a-c51f74fdf43f(io.lionweb.mps.converter)" version="0" />
     <module reference="39d4fcb0-6a78-41ac-8e8f-01bb784b65fc(io.lionweb.mps.json)" version="0" />
+    <module reference="9ccd1228-8082-4d7d-953e-0ef0386dcd6a(io.lionweb.mps.json.test)" version="0" />
+    <module reference="7350a1d7-537e-4f0d-9965-e91c82522d7d(io.lionweb.mps.m3.runtime)" version="0" />
     <module reference="3cf912e1-3ecb-4ed7-81f8-67be9bc432ee(io.lionweb.mps.server.test)" version="0" />
   </dependencyVersions>
 </solution>

--- a/solutions/io.lionweb.mps.server.test/io.lionweb.mps.server.test.msd
+++ b/solutions/io.lionweb.mps.server.test/io.lionweb.mps.server.test.msd
@@ -18,6 +18,7 @@
     <dependency reexport="false">9d6d7230-3178-4b3f-a837-7c0180c86207(io.lionweb.lionweb.java)</dependency>
     <dependency reexport="false">9ccd1228-8082-4d7d-953e-0ef0386dcd6a(io.lionweb.mps.json.test)</dependency>
     <dependency reexport="false">7350a1d7-537e-4f0d-9965-e91c82522d7d(io.lionweb.mps.m3.runtime)</dependency>
+    <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
@@ -32,7 +33,9 @@
     <language slang="l:537f9cb0-0f25-3c76-8b86-308f45010100:library" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="9d6d7230-3178-4b3f-a837-7c0180c86207(io.lionweb.lionweb.java)" version="0" />
     <module reference="4d96f781-5fa4-4d94-817a-c51f74fdf43f(io.lionweb.mps.converter)" version="0" />
     <module reference="39d4fcb0-6a78-41ac-8e8f-01bb784b65fc(io.lionweb.mps.json)" version="0" />

--- a/solutions/io.lionweb.mps.server.test/models/io.lionweb.mps.server.test.language@tests.mps
+++ b/solutions/io.lionweb.mps.server.test/models/io.lionweb.mps.server.test.language@tests.mps
@@ -15,14 +15,26 @@
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="6peh" ref="r:677983a1-6578-432d-8175-68c906e0375c(io.lionweb.mps.json)" />
     <import index="xfsv" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.serialization.data(io.lionweb.lionweb.java/)" />
-    <import index="imb3" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.language(io.lionweb.lioncore.java/)" />
-    <import index="cz4z" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.self(io.lionweb.lioncore.java/)" />
+    <import index="imb3" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.language(io.lionweb.lionweb.java/)" />
+    <import index="cz4z" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.self(io.lionweb.lionweb.java/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="ofrr" ref="r:6a974d9b-2388-4f82-8f03-f540b2d0448e(io.lionweb.mps.json.test.json2lioncore@tests)" />
     <import index="y7p" ref="r:3303ef0b-a58e-4f50-b3cb-bd3d7aaf3653(io.lionweb.mps.m3.runtime)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
+        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
+      </concept>
+      <concept id="1225469856668" name="jetbrains.mps.lang.test.structure.ModelExpression" flags="nn" index="1jGwE1" />
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <child id="1216993439383" name="methods" index="1qtyYc" />
+        <child id="1217501895093" name="testMethods" index="1SL9yI" />
+      </concept>
+      <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
+    </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
@@ -30,7 +42,6 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
-      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
         <reference id="2820489544401957798" name="classifier" index="HV5vE" />
       </concept>
@@ -77,7 +88,6 @@
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
-      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -111,10 +121,6 @@
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
-      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
-        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
-      </concept>
-      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
@@ -126,7 +132,6 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
-      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
@@ -135,19 +140,22 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
+    <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ng" index="2WEnae">
+        <reference id="1205756909548" name="member" index="2WH_rO" />
+      </concept>
+      <concept id="1205769003971" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodDeclaration" flags="ng" index="2XrIbr" />
+      <concept id="1205769149993" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodCallOperation" flags="nn" index="2XshWL">
+        <child id="1205770614681" name="actualArgument" index="2XxRq1" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="1216130694486" name="jetbrains.mps.baseLanguage.unitTest.structure.ITestCase" flags="ng" index="B2rLd">
+        <property id="6427619394892729757" name="canNotRunInProcess" index="26Nn1l" />
+      </concept>
       <concept id="7080278351417106679" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertIsNotNull" flags="nn" index="2Hmddi">
         <child id="7080278351417106681" name="expression" index="2Hmdds" />
-      </concept>
-      <concept id="1171931690126" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethod" flags="ig" index="3s$Bmu">
-        <property id="1171931690128" name="methodName" index="3s$Bm0" />
-      </concept>
-      <concept id="1171931851043" name="jetbrains.mps.baseLanguage.unitTest.structure.BTestCase" flags="ig" index="3s_ewN">
-        <property id="1171931851045" name="testCaseName" index="3s_ewP" />
-        <child id="1171931851044" name="testMethodList" index="3s_ewO" />
-      </concept>
-      <concept id="1171931858461" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethodList" flags="ng" index="3s_gsd">
-        <child id="1171931858462" name="testMethod" index="3s_gse" />
       </concept>
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -202,885 +210,398 @@
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
-  <node concept="3s_ewN" id="6jI_U5eoODa">
-    <property role="3s_ewP" value="LanguagesLionCore" />
-    <node concept="3clFb_" id="6jI_U5eFMET" role="jymVt">
-      <property role="TrG5h" value="retrieveTestLang" />
-      <node concept="3clFbS" id="6jI_U5eFMEW" role="3clF47">
-        <node concept="3cpWs8" id="6jI_U5eoP9C" role="3cqZAp">
-          <node concept="3cpWsn" id="6jI_U5eoP9D" role="3cpWs9">
-            <property role="TrG5h" value="httpClient" />
-            <node concept="3uibUv" id="6jI_U5eoP8T" role="1tU5fm">
-              <ref role="3uigEE" to="781x:~HttpClient" resolve="HttpClient" />
+  <node concept="1lH9Xt" id="7OJcYq_$cDX">
+    <property role="TrG5h" value="Instance" />
+    <property role="26Nn1l" value="true" />
+    <node concept="1LZb2c" id="7OJcYq_$g2X" role="1SL9yI">
+      <property role="TrG5h" value="readInstanceFromServer" />
+      <node concept="3cqZAl" id="7OJcYq_$g2Y" role="3clF45" />
+      <node concept="3clFbS" id="7OJcYq_$g32" role="3clF47">
+        <node concept="3cpWs8" id="7OJcYq_$g3V" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_$g3W" role="3cpWs9">
+            <property role="TrG5h" value="instances" />
+            <node concept="_YKpA" id="7OJcYq_$g3X" role="1tU5fm">
+              <node concept="3uibUv" id="7OJcYq_$g3Y" role="_ZDj9">
+                <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
+              </node>
             </node>
-            <node concept="2OqwBi" id="6jI_U5eoP9E" role="33vP2m">
-              <node concept="2OqwBi" id="6jI_U5eoP9F" role="2Oq$k0">
-                <node concept="2YIFZM" id="6jI_U5eoP9G" role="2Oq$k0">
-                  <ref role="37wK5l" to="781x:~HttpClient.newBuilder()" resolve="newBuilder" />
-                  <ref role="1Pybhc" to="781x:~HttpClient" resolve="HttpClient" />
+            <node concept="2OqwBi" id="7OJcYq_$$ZY" role="33vP2m">
+              <node concept="2WthIp" id="7OJcYq_$_01" role="2Oq$k0" />
+              <node concept="2XshWL" id="7OJcYq_$_03" role="2OqNvi">
+                <ref role="2WH_rO" node="7OJcYq_$egS" resolve="read" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7OJcYq_$g40" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq_$g41" role="3tpDZA">
+            <node concept="37vLTw" id="7OJcYq_$g42" role="2Oq$k0">
+              <ref role="3cqZAo" node="7OJcYq_$g3W" resolve="instances" />
+            </node>
+            <node concept="34oBXx" id="7OJcYq_$g43" role="2OqNvi" />
+          </node>
+          <node concept="3cmrfG" id="7OJcYq_$g44" role="3tpDZB">
+            <property role="3cmrfH" value="3" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="7OJcYq_$gcX" role="1SL9yI">
+      <property role="TrG5h" value="writeUnchangedToServer" />
+      <node concept="3cqZAl" id="7OJcYq_$gcY" role="3clF45" />
+      <node concept="3clFbS" id="7OJcYq_$gd2" role="3clF47">
+        <node concept="3cpWs8" id="7OJcYq_$gfB" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_$gfC" role="3cpWs9">
+            <property role="TrG5h" value="originalInstances" />
+            <node concept="_YKpA" id="7OJcYq_$gfD" role="1tU5fm">
+              <node concept="3uibUv" id="7OJcYq_$gfE" role="_ZDj9">
+                <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7OJcYq_$_3v" role="33vP2m">
+              <node concept="2WthIp" id="7OJcYq_$_3y" role="2Oq$k0" />
+              <node concept="2XshWL" id="7OJcYq_$_3$" role="2OqNvi">
+                <ref role="2WH_rO" node="7OJcYq_$egS" resolve="read" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq_$gfG" role="3cqZAp" />
+        <node concept="3clFbF" id="7OJcYq_$L8z" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq_$LiE" role="3clFbG">
+            <node concept="2WthIp" id="7OJcYq_$L8x" role="2Oq$k0" />
+            <node concept="2XshWL" id="7OJcYq_$LB6" role="2OqNvi">
+              <ref role="2WH_rO" node="7OJcYq_$fKN" resolve="write" />
+              <node concept="37vLTw" id="7OJcYq_$LRo" role="2XxRq1">
+                <ref role="3cqZAo" node="7OJcYq_$gfC" resolve="originalInstances" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq_$gfK" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYq_$gfL" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_$gfM" role="3cpWs9">
+            <property role="TrG5h" value="newInstances" />
+            <node concept="_YKpA" id="7OJcYq_$gfN" role="1tU5fm">
+              <node concept="3uibUv" id="7OJcYq_$gfO" role="_ZDj9">
+                <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7OJcYq_$_pv" role="33vP2m">
+              <node concept="2WthIp" id="7OJcYq_$_py" role="2Oq$k0" />
+              <node concept="2XshWL" id="7OJcYq_$_p$" role="2OqNvi">
+                <ref role="2WH_rO" node="7OJcYq_$egS" resolve="read" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq_$gfQ" role="3cqZAp" />
+        <node concept="3vlDli" id="7OJcYq_$gfR" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYq_$gfS" role="3tpDZB">
+            <node concept="2i4dXS" id="7OJcYq_$gfT" role="2ShVmc">
+              <node concept="37vLTw" id="7OJcYq_$gfU" role="I$8f6">
+                <ref role="3cqZAo" node="7OJcYq_$gfC" resolve="originalInstances" />
+              </node>
+            </node>
+          </node>
+          <node concept="2ShNRf" id="7OJcYq_$gfV" role="3tpDZA">
+            <node concept="2i4dXS" id="7OJcYq_$gfW" role="2ShVmc">
+              <node concept="37vLTw" id="7OJcYq_$gfX" role="I$8f6">
+                <ref role="3cqZAo" node="7OJcYq_$gfM" resolve="newInstances" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="7OJcYq_$gKi" role="1SL9yI">
+      <property role="TrG5h" value="writeChangedToServer" />
+      <node concept="3cqZAl" id="7OJcYq_$gKj" role="3clF45" />
+      <node concept="3clFbS" id="7OJcYq_$gKn" role="3clF47">
+        <node concept="3cpWs8" id="7OJcYq_$h3r" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_$h3s" role="3cpWs9">
+            <property role="TrG5h" value="originalInstances" />
+            <node concept="_YKpA" id="7OJcYq_$h3t" role="1tU5fm">
+              <node concept="3uibUv" id="7OJcYq_$h3u" role="_ZDj9">
+                <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7OJcYq_$_JD" role="33vP2m">
+              <node concept="2WthIp" id="7OJcYq_$_JG" role="2Oq$k0" />
+              <node concept="2XshWL" id="7OJcYq_$_JI" role="2OqNvi">
+                <ref role="2WH_rO" node="7OJcYq_$egS" resolve="read" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq_$h3w" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYq_$h3x" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_$h3y" role="3cpWs9">
+            <property role="TrG5h" value="libNode" />
+            <node concept="3uibUv" id="7OJcYq_$h3z" role="1tU5fm">
+              <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
+            </node>
+            <node concept="10Nm6u" id="7OJcYq_$h3$" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7OJcYq_$h3_" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_$h3A" role="3cpWs9">
+            <property role="TrG5h" value="libNameProperty" />
+            <node concept="3uibUv" id="7OJcYq_$h3B" role="1tU5fm">
+              <ref role="3uigEE" to="xfsv:~SerializedPropertyValue" resolve="SerializedPropertyValue" />
+            </node>
+            <node concept="10Nm6u" id="7OJcYq_$h3C" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="2Gpval" id="7OJcYq_$h3D" role="3cqZAp">
+          <node concept="2GrKxI" id="7OJcYq_$h3E" role="2Gsz3X">
+            <property role="TrG5h" value="origInstance" />
+          </node>
+          <node concept="37vLTw" id="7OJcYq_$h3F" role="2GsD0m">
+            <ref role="3cqZAo" node="7OJcYq_$h3s" resolve="originalInstances" />
+          </node>
+          <node concept="3clFbS" id="7OJcYq_$h3G" role="2LFqv$">
+            <node concept="2Gpval" id="7OJcYq_$h3H" role="3cqZAp">
+              <node concept="2GrKxI" id="7OJcYq_$h3I" role="2Gsz3X">
+                <property role="TrG5h" value="prop" />
+              </node>
+              <node concept="2OqwBi" id="7OJcYq_$h3J" role="2GsD0m">
+                <node concept="2GrUjf" id="7OJcYq_$h3K" role="2Oq$k0">
+                  <ref role="2Gs0qQ" node="7OJcYq_$h3E" resolve="origInstance" />
                 </node>
-                <node concept="liA8E" id="6jI_U5eoP9H" role="2OqNvi">
-                  <ref role="37wK5l" to="781x:~HttpClient$Builder.connectTimeout(java.time.Duration)" resolve="connectTimeout" />
-                  <node concept="2YIFZM" id="6jI_U5eoP9I" role="37wK5m">
-                    <ref role="1Pybhc" to="28m1:~Duration" resolve="Duration" />
-                    <ref role="37wK5l" to="28m1:~Duration.ofSeconds(long)" resolve="ofSeconds" />
-                    <node concept="3cmrfG" id="6jI_U5eoP9J" role="37wK5m">
-                      <property role="3cmrfH" value="2" />
+                <node concept="liA8E" id="7OJcYq_$h3L" role="2OqNvi">
+                  <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getProperties()" resolve="getProperties" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="7OJcYq_$h3M" role="2LFqv$">
+                <node concept="3clFbJ" id="7OJcYq_$h3N" role="3cqZAp">
+                  <node concept="17R0WA" id="7OJcYq_$h3O" role="3clFbw">
+                    <node concept="Xl_RD" id="7OJcYq_$h3P" role="3uHU7w">
+                      <property role="Xl_RC" value="MyLib" />
                     </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="liA8E" id="6jI_U5eoP9K" role="2OqNvi">
-                <ref role="37wK5l" to="781x:~HttpClient$Builder.build()" resolve="build" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="6jI_U5er2Ni" role="3cqZAp" />
-        <node concept="3cpWs8" id="6jI_U5eqI5p" role="3cqZAp">
-          <node concept="3cpWsn" id="6jI_U5eqI5q" role="3cpWs9">
-            <property role="TrG5h" value="request" />
-            <node concept="3uibUv" id="6jI_U5eqHZ$" role="1tU5fm">
-              <ref role="3uigEE" to="781x:~HttpRequest" resolve="HttpRequest" />
-            </node>
-            <node concept="2OqwBi" id="6jI_U5eqI5r" role="33vP2m">
-              <node concept="2OqwBi" id="6jI_U5eqI5s" role="2Oq$k0">
-                <node concept="2YIFZM" id="6jI_U5eqI5t" role="2Oq$k0">
-                  <ref role="37wK5l" to="781x:~HttpRequest.newBuilder(java.net.URI)" resolve="newBuilder" />
-                  <ref role="1Pybhc" to="781x:~HttpRequest" resolve="HttpRequest" />
-                  <node concept="2YIFZM" id="6jI_U5eqI5u" role="37wK5m">
-                    <ref role="37wK5l" to="zf81:~URI.create(java.lang.String)" resolve="create" />
-                    <ref role="1Pybhc" to="zf81:~URI" resolve="URI" />
-                    <node concept="Xl_RD" id="6jI_U5eqI5v" role="37wK5m">
-                      <property role="Xl_RC" value="http://127.0.0.1:63320/lionweb/language?moduleRef=08caad75-8246-4427-bb4d-8444b6c5c729()" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="liA8E" id="6jI_U5eqI5w" role="2OqNvi">
-                  <ref role="37wK5l" to="781x:~HttpRequest$Builder.GET()" resolve="GET" />
-                </node>
-              </node>
-              <node concept="liA8E" id="6jI_U5eqI5x" role="2OqNvi">
-                <ref role="37wK5l" to="781x:~HttpRequest$Builder.build()" resolve="build" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="6jI_U5eqIkb" role="3cqZAp">
-          <node concept="3cpWsn" id="6jI_U5eqIkc" role="3cpWs9">
-            <property role="TrG5h" value="response" />
-            <node concept="3uibUv" id="6jI_U5eqIhc" role="1tU5fm">
-              <ref role="3uigEE" to="781x:~HttpResponse" resolve="HttpResponse" />
-              <node concept="3uibUv" id="6jI_U5eqIhf" role="11_B2D">
-                <ref role="3uigEE" to="guwi:~InputStream" resolve="InputStream" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="6jI_U5eqIkd" role="33vP2m">
-              <node concept="37vLTw" id="6jI_U5eqIke" role="2Oq$k0">
-                <ref role="3cqZAo" node="6jI_U5eoP9D" resolve="httpClient" />
-              </node>
-              <node concept="liA8E" id="6jI_U5eqIkf" role="2OqNvi">
-                <ref role="37wK5l" to="781x:~HttpClient.send(java.net.http.HttpRequest,java.net.http.HttpResponse$BodyHandler)" resolve="send" />
-                <node concept="37vLTw" id="6jI_U5eqIkg" role="37wK5m">
-                  <ref role="3cqZAo" node="6jI_U5eqI5q" resolve="request" />
-                </node>
-                <node concept="2YIFZM" id="6jI_U5erbhU" role="37wK5m">
-                  <ref role="1Pybhc" to="781x:~HttpResponse$BodyHandlers" resolve="HttpResponse.BodyHandlers" />
-                  <ref role="37wK5l" to="781x:~HttpResponse$BodyHandlers.ofInputStream()" resolve="ofInputStream" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3vlDli" id="6jI_U5eqJev" role="3cqZAp">
-          <node concept="10M0yZ" id="6jI_U5eqK3w" role="3tpDZB">
-            <ref role="1PxDUh" to="zf81:~HttpURLConnection" resolve="HttpURLConnection" />
-            <ref role="3cqZAo" to="zf81:~HttpURLConnection.HTTP_OK" resolve="HTTP_OK" />
-          </node>
-          <node concept="2OqwBi" id="6jI_U5eqJvV" role="3tpDZA">
-            <node concept="37vLTw" id="6jI_U5eqJnr" role="2Oq$k0">
-              <ref role="3cqZAo" node="6jI_U5eqIkc" resolve="response" />
-            </node>
-            <node concept="liA8E" id="6jI_U5eqJEg" role="2OqNvi">
-              <ref role="37wK5l" to="781x:~HttpResponse.statusCode()" resolve="statusCode" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="6jI_U5eqK81" role="3cqZAp" />
-        <node concept="3cpWs8" id="7jdzMamfK1k" role="3cqZAp">
-          <node concept="3cpWsn" id="7jdzMamfK1l" role="3cpWs9">
-            <property role="TrG5h" value="unserializer" />
-            <node concept="3uibUv" id="7jdzMamfK1m" role="1tU5fm">
-              <ref role="3uigEE" to="6peh:z1IqfFwqda" resolve="Deserializer" />
-            </node>
-            <node concept="2ShNRf" id="7jdzMamfK1n" role="33vP2m">
-              <node concept="1pGfFk" id="7jdzMamfK1o" role="2ShVmc">
-                <ref role="37wK5l" to="6peh:z1IqfFwqeg" resolve="Deserializer" />
-                <node concept="2OqwBi" id="7jdzMamfK1p" role="37wK5m">
-                  <node concept="37vLTw" id="7jdzMamfK1q" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6jI_U5eqIkc" resolve="response" />
-                  </node>
-                  <node concept="liA8E" id="7jdzMamfK1r" role="2OqNvi">
-                    <ref role="37wK5l" to="781x:~HttpResponse.body()" resolve="body" />
-                  </node>
-                </node>
-                <node concept="2ShNRf" id="5hsSXrmDtPA" role="37wK5m">
-                  <node concept="1pGfFk" id="5hsSXrmDtPB" role="2ShVmc">
-                    <ref role="37wK5l" to="6peh:5JNiskj4SJa" resolve="JsonConstants" />
-                    <node concept="2YIFZM" id="5hsSXrmDtPC" role="37wK5m">
-                      <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
-                      <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
-                    </node>
-                    <node concept="2ShNRf" id="7weWCFlze2c" role="37wK5m">
-                      <node concept="HV5vD" id="7weWCFlze2d" role="2ShVmc">
-                        <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                    <node concept="2OqwBi" id="7OJcYq_$h3Q" role="3uHU7B">
+                      <node concept="2GrUjf" id="7OJcYq_$h3R" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="7OJcYq_$h3I" resolve="prop" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYq_$h3S" role="2OqNvi">
+                        <ref role="37wK5l" to="xfsv:~SerializedPropertyValue.getValue()" resolve="getValue" />
                       </node>
                     </node>
-                    <node concept="10Nm6u" id="7OJcYqxXqvw" role="37wK5m" />
+                  </node>
+                  <node concept="3clFbS" id="7OJcYq_$h3T" role="3clFbx">
+                    <node concept="3clFbF" id="7OJcYq_$h3U" role="3cqZAp">
+                      <node concept="37vLTI" id="7OJcYq_$h3V" role="3clFbG">
+                        <node concept="2GrUjf" id="7OJcYq_$h3W" role="37vLTx">
+                          <ref role="2Gs0qQ" node="7OJcYq_$h3E" resolve="origInstance" />
+                        </node>
+                        <node concept="37vLTw" id="7OJcYq_$h3X" role="37vLTJ">
+                          <ref role="3cqZAo" node="7OJcYq_$h3y" resolve="libNode" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="7OJcYq_$h3Y" role="3cqZAp">
+                      <node concept="37vLTI" id="7OJcYq_$h3Z" role="3clFbG">
+                        <node concept="2GrUjf" id="7OJcYq_$h40" role="37vLTx">
+                          <ref role="2Gs0qQ" node="7OJcYq_$h3I" resolve="prop" />
+                        </node>
+                        <node concept="37vLTw" id="7OJcYq_$h41" role="37vLTJ">
+                          <ref role="3cqZAo" node="7OJcYq_$h3A" resolve="libNameProperty" />
+                        </node>
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="6jI_U5erbxh" role="3cqZAp">
-          <node concept="3KEzu6" id="7W6jYlyZBiS" role="3cpWs9">
-            <property role="TrG5h" value="roots" />
-            <node concept="2OqwBi" id="7W6jYlyZBj0" role="33vP2m">
-              <node concept="37vLTw" id="7W6jYlyZBj1" role="2Oq$k0">
-                <ref role="3cqZAo" node="7jdzMamfK1l" resolve="unserializer" />
-              </node>
-              <node concept="liA8E" id="7W6jYlyZBj2" role="2OqNvi">
-                <ref role="37wK5l" to="6peh:z1IqfFwqy3" resolve="deserialize" />
+        <node concept="3clFbF" id="7OJcYq_$h42" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq_$h43" role="3clFbG">
+            <node concept="37vLTw" id="7OJcYq_$h44" role="2Oq$k0">
+              <ref role="3cqZAo" node="7OJcYq_$h3A" resolve="libNameProperty" />
+            </node>
+            <node concept="liA8E" id="7OJcYq_$h45" role="2OqNvi">
+              <ref role="37wK5l" to="xfsv:~SerializedPropertyValue.setValue(java.lang.String)" resolve="setValue" />
+              <node concept="Xl_RD" id="7OJcYq_$h46" role="37wK5m">
+                <property role="Xl_RC" value="NewLib" />
               </node>
             </node>
-            <node concept="PeGgZ" id="7W6jYlyZBiR" role="1tU5fm" />
           </node>
         </node>
-        <node concept="3clFbH" id="6jI_U5erc6r" role="3cqZAp" />
-        <node concept="3vFxKo" id="6jI_U5erV_O" role="3cqZAp">
-          <node concept="2OqwBi" id="6jI_U5erWhs" role="3vFALc">
-            <node concept="37vLTw" id="6jI_U5erVJV" role="2Oq$k0">
-              <ref role="3cqZAo" node="7W6jYlyZBiS" resolve="roots" />
+        <node concept="3clFbH" id="7OJcYq_$h47" role="3cqZAp" />
+        <node concept="3clFbF" id="7OJcYq_$Ips" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq_$Ipm" role="3clFbG">
+            <node concept="2WthIp" id="7OJcYq_$Ipp" role="2Oq$k0" />
+            <node concept="2XshWL" id="7OJcYq_$Ipr" role="2OqNvi">
+              <ref role="2WH_rO" node="7OJcYq_$fKN" resolve="write" />
+              <node concept="2ShNRf" id="7OJcYq_$h4a" role="2XxRq1">
+                <node concept="2HTt$P" id="7OJcYq_$h4b" role="2ShVmc">
+                  <node concept="3uibUv" id="7OJcYq_$h4c" role="2HTBi0">
+                    <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
+                  </node>
+                  <node concept="37vLTw" id="7OJcYq_$h4d" role="2HTEbv">
+                    <ref role="3cqZAo" node="7OJcYq_$h3y" resolve="libNode" />
+                  </node>
+                </node>
+              </node>
             </node>
-            <node concept="1v1jN8" id="6jI_U5erWVL" role="2OqNvi" />
           </node>
         </node>
-        <node concept="3clFbH" id="6jI_U5eFO35" role="3cqZAp" />
-        <node concept="3cpWs6" id="6jI_U5eFOHs" role="3cqZAp">
-          <node concept="37vLTw" id="6jI_U5eFP0Y" role="3cqZAk">
-            <ref role="3cqZAo" node="7W6jYlyZBiS" resolve="roots" />
+        <node concept="3clFbH" id="7OJcYq_$h4e" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYq_$h4f" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_$h4g" role="3cpWs9">
+            <property role="TrG5h" value="newInstances" />
+            <node concept="_YKpA" id="7OJcYq_$h4h" role="1tU5fm">
+              <node concept="3uibUv" id="7OJcYq_$h4i" role="_ZDj9">
+                <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7OJcYq_$A2z" role="33vP2m">
+              <node concept="2WthIp" id="7OJcYq_$A2A" role="2Oq$k0" />
+              <node concept="2XshWL" id="7OJcYq_$A2C" role="2OqNvi">
+                <ref role="2WH_rO" node="7OJcYq_$egS" resolve="read" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq_$h4k" role="3cqZAp" />
+        <node concept="3vlDli" id="7OJcYq_$h4l" role="3cqZAp">
+          <node concept="2ShNRf" id="7OJcYq_$h4m" role="3tpDZB">
+            <node concept="2i4dXS" id="7OJcYq_$h4n" role="2ShVmc">
+              <node concept="37vLTw" id="7OJcYq_$h4o" role="I$8f6">
+                <ref role="3cqZAo" node="7OJcYq_$h3s" resolve="originalInstances" />
+              </node>
+            </node>
+          </node>
+          <node concept="2ShNRf" id="7OJcYq_$h4p" role="3tpDZA">
+            <node concept="2i4dXS" id="7OJcYq_$h4q" role="2ShVmc">
+              <node concept="37vLTw" id="7OJcYq_$h4r" role="I$8f6">
+                <ref role="3cqZAo" node="7OJcYq_$h4g" resolve="newInstances" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq_$h4s" role="3cqZAp" />
+        <node concept="3clFbF" id="7OJcYq_$h4t" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq_$h4u" role="3clFbG">
+            <node concept="37vLTw" id="7OJcYq_$h4v" role="2Oq$k0">
+              <ref role="3cqZAo" node="7OJcYq_$h3A" resolve="libNameProperty" />
+            </node>
+            <node concept="liA8E" id="7OJcYq_$h4w" role="2OqNvi">
+              <ref role="37wK5l" to="xfsv:~SerializedPropertyValue.setValue(java.lang.String)" resolve="setValue" />
+              <node concept="Xl_RD" id="7OJcYq_$h4x" role="37wK5m">
+                <property role="Xl_RC" value="MyLib" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7OJcYq_$JOM" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq_$JOG" role="3clFbG">
+            <node concept="2WthIp" id="7OJcYq_$JOJ" role="2Oq$k0" />
+            <node concept="2XshWL" id="7OJcYq_$JOL" role="2OqNvi">
+              <ref role="2WH_rO" node="7OJcYq_$fKN" resolve="write" />
+              <node concept="2ShNRf" id="7OJcYq_$h4$" role="2XxRq1">
+                <node concept="2HTt$P" id="7OJcYq_$h4_" role="2ShVmc">
+                  <node concept="3uibUv" id="7OJcYq_$h4A" role="2HTBi0">
+                    <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
+                  </node>
+                  <node concept="37vLTw" id="7OJcYq_$h4B" role="2HTEbv">
+                    <ref role="3cqZAo" node="7OJcYq_$h3y" resolve="libNode" />
+                  </node>
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
-      <node concept="_YKpA" id="6jI_U5eFMtV" role="3clF45">
-        <node concept="3uibUv" id="7jdzMameUVX" role="_ZDj9">
-          <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
-        </node>
-      </node>
-      <node concept="3uibUv" id="6jI_U5eFQNT" role="Sfmx6">
-        <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
-      </node>
-      <node concept="3Tm6S6" id="6jI_U5eFRPE" role="1B3o_S" />
-      <node concept="3uibUv" id="6jI_U5eFTWm" role="Sfmx6">
+      <node concept="3uibUv" id="7OJcYq_$HzE" role="Sfmx6">
         <ref role="3uigEE" to="wyt6:~InterruptedException" resolve="InterruptedException" />
       </node>
-    </node>
-    <node concept="2tJIrI" id="6jI_U5eHHyA" role="jymVt" />
-    <node concept="3Tm1VV" id="6jI_U5eoODb" role="1B3o_S" />
-    <node concept="3s_gsd" id="6jI_U5eoODc" role="3s_ewO">
-      <node concept="3s$Bmu" id="6jI_U5eoOEd" role="3s_gse">
-        <property role="3s$Bm0" value="refToBuiltinPropertyType" />
-        <node concept="3cqZAl" id="6jI_U5eoOEe" role="3clF45" />
-        <node concept="3Tm1VV" id="6jI_U5eoOEf" role="1B3o_S" />
-        <node concept="3clFbS" id="6jI_U5eoOEg" role="3clF47">
-          <node concept="3cpWs8" id="6jI_U5eFWAK" role="3cqZAp">
-            <node concept="3KEzu6" id="7W6jYlyZKAI" role="3cpWs9">
-              <property role="TrG5h" value="roots" />
-              <node concept="1rXfSq" id="7W6jYlyZKAO" role="33vP2m">
-                <ref role="37wK5l" node="6jI_U5eFMET" resolve="retrieveTestLang" />
-              </node>
-              <node concept="PeGgZ" id="7W6jYlyZKAH" role="1tU5fm" />
-            </node>
-          </node>
-          <node concept="3clFbH" id="6jI_U5erZx_" role="3cqZAp" />
-          <node concept="3cpWs8" id="6jI_U5es9G2" role="3cqZAp">
-            <node concept="3KEzu6" id="7W6jYlyZKVz" role="3cpWs9">
-              <property role="TrG5h" value="stringProp" />
-              <node concept="2OqwBi" id="7W6jYlyZKVJ" role="33vP2m">
-                <node concept="1rXfSq" id="7W6jYlyZKVK" role="2Oq$k0">
-                  <ref role="37wK5l" node="6jI_U5eHMI3" resolve="filter" />
-                  <node concept="37vLTw" id="7W6jYlyZKVL" role="37wK5m">
-                    <ref role="3cqZAo" node="7W6jYlyZKAI" resolve="roots" />
-                  </node>
-                  <node concept="2YIFZM" id="7W6jYlyZKVM" role="37wK5m">
-                    <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-                    <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.LanguageEntity)" resolve="from" />
-                    <node concept="2YIFZM" id="7W6jYlyZKVN" role="37wK5m">
-                      <ref role="37wK5l" to="cz4z:~LionCore.getProperty()" resolve="getProperty" />
-                      <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
-                    </node>
-                  </node>
-                  <node concept="Xl_RD" id="7W6jYlyZKVO" role="37wK5m">
-                    <property role="Xl_RC" value="stringProp" />
-                  </node>
-                </node>
-                <node concept="1uHKPH" id="7W6jYlyZKVP" role="2OqNvi" />
-              </node>
-              <node concept="PeGgZ" id="7W6jYlyZKVy" role="1tU5fm" />
-            </node>
-          </node>
-          <node concept="3clFbH" id="6jI_U5esKQj" role="3cqZAp" />
-          <node concept="2Hmddi" id="6jI_U5esLrA" role="3cqZAp">
-            <node concept="37vLTw" id="6jI_U5esLYH" role="2Hmdds">
-              <ref role="3cqZAo" node="7W6jYlyZKVz" resolve="stringProp" />
-            </node>
-          </node>
-          <node concept="3cpWs8" id="6jI_U5etv$k" role="3cqZAp">
-            <node concept="3cpWsn" id="6jI_U5etv$l" role="3cpWs9">
-              <property role="TrG5h" value="type" />
-              <node concept="3uibUv" id="6jI_U5etvo0" role="1tU5fm">
-                <ref role="3uigEE" to="xfsv:~SerializedReferenceValue" resolve="SerializedReferenceValue" />
-              </node>
-              <node concept="2OqwBi" id="6jI_U5etv$m" role="33vP2m">
-                <node concept="2OqwBi" id="6jI_U5etv$n" role="2Oq$k0">
-                  <node concept="2OqwBi" id="6jI_U5etv$o" role="2Oq$k0">
-                    <node concept="37vLTw" id="6jI_U5etv$p" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7W6jYlyZKVz" resolve="stringProp" />
-                    </node>
-                    <node concept="liA8E" id="6jI_U5etv$q" role="2OqNvi">
-                      <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getReferences()" resolve="getReferences" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="6jI_U5etv$r" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="6jI_U5etv$s" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3vlDli" id="6jI_U5et2uc" role="3cqZAp">
-            <node concept="2OqwBi" id="6jI_U5etiBs" role="3tpDZA">
-              <node concept="2OqwBi" id="6jI_U5etAFP" role="2Oq$k0">
-                <node concept="2OqwBi" id="6jI_U5et$9u" role="2Oq$k0">
-                  <node concept="2OqwBi" id="6jI_U5etyp3" role="2Oq$k0">
-                    <node concept="37vLTw" id="6jI_U5eth83" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6jI_U5etv$l" resolve="type" />
-                    </node>
-                    <node concept="liA8E" id="6jI_U5etz6E" role="2OqNvi">
-                      <ref role="37wK5l" to="xfsv:~SerializedReferenceValue.getValue()" resolve="getValue" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="6jI_U5et_Wh" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="6jI_U5etBCd" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-                </node>
-              </node>
-              <node concept="liA8E" id="6jI_U5etju9" role="2OqNvi">
-                <ref role="37wK5l" to="xfsv:~SerializedReferenceValue$Entry.getResolveInfo()" resolve="getResolveInfo" />
-              </node>
-            </node>
-            <node concept="Xl_RD" id="6jI_U5eGadZ" role="3tpDZB">
-              <property role="Xl_RC" value="String" />
-            </node>
-          </node>
-          <node concept="3vlDli" id="6jI_U5etIRR" role="3cqZAp">
-            <node concept="2OqwBi" id="6jI_U5etIRS" role="3tpDZA">
-              <node concept="2OqwBi" id="6jI_U5etIRT" role="2Oq$k0">
-                <node concept="2OqwBi" id="6jI_U5etIRU" role="2Oq$k0">
-                  <node concept="2OqwBi" id="6jI_U5etIRV" role="2Oq$k0">
-                    <node concept="37vLTw" id="6jI_U5etIRW" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6jI_U5etv$l" resolve="type" />
-                    </node>
-                    <node concept="liA8E" id="6jI_U5etIRX" role="2OqNvi">
-                      <ref role="37wK5l" to="xfsv:~SerializedReferenceValue.getValue()" resolve="getValue" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="6jI_U5etIRY" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="6jI_U5etIRZ" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-                </node>
-              </node>
-              <node concept="liA8E" id="6jI_U5etIS0" role="2OqNvi">
-                <ref role="37wK5l" to="xfsv:~SerializedReferenceValue$Entry.getReference()" resolve="getReference" />
-              </node>
-            </node>
-            <node concept="Xl_RD" id="6jI_U5eGcEi" role="3tpDZB">
-              <property role="Xl_RC" value="LionCore-builtins-String" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3s$Bmu" id="6jI_U5eG4Ax" role="3s_gse">
-        <property role="3s$Bm0" value="refToBuiltinNode" />
-        <node concept="3cqZAl" id="6jI_U5eG4Ay" role="3clF45" />
-        <node concept="3Tm1VV" id="6jI_U5eG4Az" role="1B3o_S" />
-        <node concept="3clFbS" id="6jI_U5eG4A$" role="3clF47">
-          <node concept="3cpWs8" id="6jI_U5eG4A_" role="3cqZAp">
-            <node concept="3KEzu6" id="7W6jYlyZNYr" role="3cpWs9">
-              <property role="TrG5h" value="roots" />
-              <node concept="1rXfSq" id="7W6jYlyZNYx" role="33vP2m">
-                <ref role="37wK5l" node="6jI_U5eFMET" resolve="retrieveTestLang" />
-              </node>
-              <node concept="PeGgZ" id="7W6jYlyZNYq" role="1tU5fm" />
-            </node>
-          </node>
-          <node concept="3clFbH" id="6jI_U5eG4AE" role="3cqZAp" />
-          <node concept="3cpWs8" id="6jI_U5eG4AW" role="3cqZAp">
-            <node concept="3KEzu6" id="7W6jYlyZOix" role="3cpWs9">
-              <property role="TrG5h" value="stringProp" />
-              <node concept="2OqwBi" id="7W6jYlyZOiH" role="33vP2m">
-                <node concept="1rXfSq" id="7W6jYlyZOiI" role="2Oq$k0">
-                  <ref role="37wK5l" node="6jI_U5eHMI3" resolve="filter" />
-                  <node concept="37vLTw" id="7W6jYlyZOiJ" role="37wK5m">
-                    <ref role="3cqZAo" node="7W6jYlyZNYr" resolve="roots" />
-                  </node>
-                  <node concept="2YIFZM" id="7W6jYlyZOiK" role="37wK5m">
-                    <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-                    <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.LanguageEntity)" resolve="from" />
-                    <node concept="2YIFZM" id="7W6jYlyZOiL" role="37wK5m">
-                      <ref role="37wK5l" to="cz4z:~LionCore.getContainment()" resolve="getContainment" />
-                      <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
-                    </node>
-                  </node>
-                  <node concept="Xl_RD" id="7W6jYlyZOiM" role="37wK5m">
-                    <property role="Xl_RC" value="anything" />
-                  </node>
-                </node>
-                <node concept="1uHKPH" id="7W6jYlyZOiN" role="2OqNvi" />
-              </node>
-              <node concept="PeGgZ" id="7W6jYlyZOiw" role="1tU5fm" />
-            </node>
-          </node>
-          <node concept="3clFbH" id="6jI_U5eG4BO" role="3cqZAp" />
-          <node concept="2Hmddi" id="6jI_U5eG4BP" role="3cqZAp">
-            <node concept="37vLTw" id="6jI_U5eG4BQ" role="2Hmdds">
-              <ref role="3cqZAo" node="7W6jYlyZOix" resolve="stringProp" />
-            </node>
-          </node>
-          <node concept="3cpWs8" id="6jI_U5eG4BR" role="3cqZAp">
-            <node concept="3cpWsn" id="6jI_U5eG4BS" role="3cpWs9">
-              <property role="TrG5h" value="type" />
-              <node concept="3uibUv" id="6jI_U5eG4BT" role="1tU5fm">
-                <ref role="3uigEE" to="xfsv:~SerializedReferenceValue" resolve="SerializedReferenceValue" />
-              </node>
-              <node concept="2OqwBi" id="6jI_U5eG4BU" role="33vP2m">
-                <node concept="2OqwBi" id="6jI_U5eG4BV" role="2Oq$k0">
-                  <node concept="2OqwBi" id="6jI_U5eG4BW" role="2Oq$k0">
-                    <node concept="37vLTw" id="6jI_U5eG4BX" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7W6jYlyZOix" resolve="stringProp" />
-                    </node>
-                    <node concept="liA8E" id="6jI_U5eG4BY" role="2OqNvi">
-                      <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getReferences()" resolve="getReferences" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="6jI_U5eG4BZ" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="6jI_U5eG4C0" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3vlDli" id="6jI_U5eG4C1" role="3cqZAp">
-            <node concept="2OqwBi" id="6jI_U5eG4C2" role="3tpDZA">
-              <node concept="2OqwBi" id="6jI_U5eG4C3" role="2Oq$k0">
-                <node concept="2OqwBi" id="6jI_U5eG4C4" role="2Oq$k0">
-                  <node concept="2OqwBi" id="6jI_U5eG4C5" role="2Oq$k0">
-                    <node concept="37vLTw" id="6jI_U5eG4C6" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6jI_U5eG4BS" resolve="type" />
-                    </node>
-                    <node concept="liA8E" id="6jI_U5eG4C7" role="2OqNvi">
-                      <ref role="37wK5l" to="xfsv:~SerializedReferenceValue.getValue()" resolve="getValue" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="6jI_U5eG4C8" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="6jI_U5eG4C9" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-                </node>
-              </node>
-              <node concept="liA8E" id="6jI_U5eG4Ca" role="2OqNvi">
-                <ref role="37wK5l" to="xfsv:~SerializedReferenceValue$Entry.getResolveInfo()" resolve="getResolveInfo" />
-              </node>
-            </node>
-            <node concept="Xl_RD" id="6jI_U5eGfOZ" role="3tpDZB">
-              <property role="Xl_RC" value="Node" />
-            </node>
-          </node>
-          <node concept="3vlDli" id="6jI_U5eG4Ce" role="3cqZAp">
-            <node concept="2OqwBi" id="6jI_U5eG4Cf" role="3tpDZA">
-              <node concept="2OqwBi" id="6jI_U5eG4Cg" role="2Oq$k0">
-                <node concept="2OqwBi" id="6jI_U5eG4Ch" role="2Oq$k0">
-                  <node concept="2OqwBi" id="6jI_U5eG4Ci" role="2Oq$k0">
-                    <node concept="37vLTw" id="6jI_U5eG4Cj" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6jI_U5eG4BS" resolve="type" />
-                    </node>
-                    <node concept="liA8E" id="6jI_U5eG4Ck" role="2OqNvi">
-                      <ref role="37wK5l" to="xfsv:~SerializedReferenceValue.getValue()" resolve="getValue" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="6jI_U5eG4Cl" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="6jI_U5eG4Cm" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-                </node>
-              </node>
-              <node concept="liA8E" id="6jI_U5eG4Cn" role="2OqNvi">
-                <ref role="37wK5l" to="xfsv:~SerializedReferenceValue$Entry.getReference()" resolve="getReference" />
-              </node>
-            </node>
-            <node concept="Xl_RD" id="6jI_U5eGhkW" role="3tpDZB">
-              <property role="Xl_RC" value="LionCore-builtins-Node" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3s$Bmu" id="6jI_U5eGvFo" role="3s_gse">
-        <property role="3s$Bm0" value="refToBuiltinINamed" />
-        <node concept="3cqZAl" id="6jI_U5eGvFp" role="3clF45" />
-        <node concept="3Tm1VV" id="6jI_U5eGvFq" role="1B3o_S" />
-        <node concept="3clFbS" id="6jI_U5eGvFr" role="3clF47">
-          <node concept="3cpWs8" id="6jI_U5eGvFs" role="3cqZAp">
-            <node concept="3KEzu6" id="7W6jYlyZRjC" role="3cpWs9">
-              <property role="TrG5h" value="roots" />
-              <node concept="1rXfSq" id="7W6jYlyZRjI" role="33vP2m">
-                <ref role="37wK5l" node="6jI_U5eFMET" resolve="retrieveTestLang" />
-              </node>
-              <node concept="PeGgZ" id="7W6jYlyZRjB" role="1tU5fm" />
-            </node>
-          </node>
-          <node concept="3clFbH" id="5TNjoy28$d1" role="3cqZAp" />
-          <node concept="3cpWs8" id="6jI_U5eGvFN" role="3cqZAp">
-            <node concept="3KEzu6" id="7W6jYlyZRCr" role="3cpWs9">
-              <property role="TrG5h" value="stringProp" />
-              <node concept="2OqwBi" id="7W6jYlyZRCB" role="33vP2m">
-                <node concept="1rXfSq" id="7W6jYlyZRCC" role="2Oq$k0">
-                  <ref role="37wK5l" node="6jI_U5eHMI3" resolve="filter" />
-                  <node concept="37vLTw" id="7W6jYlyZRCD" role="37wK5m">
-                    <ref role="3cqZAo" node="7W6jYlyZRjC" resolve="roots" />
-                  </node>
-                  <node concept="2YIFZM" id="7W6jYlyZRCE" role="37wK5m">
-                    <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-                    <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.LanguageEntity)" resolve="from" />
-                    <node concept="2YIFZM" id="3sjZ$nYTmc6" role="37wK5m">
-                      <ref role="37wK5l" to="cz4z:~LionCore.getInterface()" resolve="getInterface" />
-                      <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
-                    </node>
-                  </node>
-                  <node concept="Xl_RD" id="7W6jYlyZRCG" role="37wK5m">
-                    <property role="Xl_RC" value="TestInterfaceExtends3" />
-                  </node>
-                </node>
-                <node concept="1uHKPH" id="7W6jYlyZRCH" role="2OqNvi" />
-              </node>
-              <node concept="PeGgZ" id="7W6jYlyZRCq" role="1tU5fm" />
-            </node>
-          </node>
-          <node concept="3clFbH" id="6jI_U5eGvGF" role="3cqZAp" />
-          <node concept="2Hmddi" id="6jI_U5eGvGG" role="3cqZAp">
-            <node concept="37vLTw" id="6jI_U5eGvGH" role="2Hmdds">
-              <ref role="3cqZAo" node="7W6jYlyZRCr" resolve="stringProp" />
-            </node>
-          </node>
-          <node concept="3cpWs8" id="6jI_U5eGvGI" role="3cqZAp">
-            <node concept="3cpWsn" id="6jI_U5eGvGJ" role="3cpWs9">
-              <property role="TrG5h" value="type" />
-              <node concept="3uibUv" id="6jI_U5eGvGK" role="1tU5fm">
-                <ref role="3uigEE" to="xfsv:~SerializedReferenceValue" resolve="SerializedReferenceValue" />
-              </node>
-              <node concept="2OqwBi" id="6jI_U5eGvGL" role="33vP2m">
-                <node concept="2OqwBi" id="6jI_U5eGvGM" role="2Oq$k0">
-                  <node concept="2OqwBi" id="6jI_U5eGvGN" role="2Oq$k0">
-                    <node concept="37vLTw" id="6jI_U5eGvGO" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7W6jYlyZRCr" resolve="stringProp" />
-                    </node>
-                    <node concept="liA8E" id="6jI_U5eGvGP" role="2OqNvi">
-                      <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getReferences()" resolve="getReferences" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="6jI_U5eGvGQ" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="6jI_U5eGvGR" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="6jI_U5eGTz8" role="3cqZAp">
-            <node concept="3cpWsn" id="6jI_U5eGTz9" role="3cpWs9">
-              <property role="TrG5h" value="named" />
-              <node concept="3uibUv" id="6jI_U5eGTeH" role="1tU5fm">
-                <ref role="3uigEE" to="xfsv:~SerializedReferenceValue$Entry" resolve="SerializedReferenceValue.Entry" />
-              </node>
-              <node concept="2OqwBi" id="6jI_U5eGTza" role="33vP2m">
-                <node concept="1eOMI4" id="5TNjoy28PTA" role="2Oq$k0">
-                  <node concept="10QFUN" id="5TNjoy28PT_" role="1eOMHV">
-                    <node concept="2OqwBi" id="5TNjoy28PTy" role="10QFUP">
-                      <node concept="37vLTw" id="5TNjoy28PTz" role="2Oq$k0">
-                        <ref role="3cqZAo" node="6jI_U5eGvGJ" resolve="type" />
-                      </node>
-                      <node concept="liA8E" id="5TNjoy28PT$" role="2OqNvi">
-                        <ref role="37wK5l" to="xfsv:~SerializedReferenceValue.getValue()" resolve="getValue" />
-                      </node>
-                    </node>
-                    <node concept="_YKpA" id="5TNjoy28QBB" role="10QFUM">
-                      <node concept="3uibUv" id="5TNjoy28QZp" role="_ZDj9">
-                        <ref role="3uigEE" to="xfsv:~SerializedReferenceValue$Entry" resolve="SerializedReferenceValue.Entry" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="1z4cxt" id="5TNjoy28SQT" role="2OqNvi">
-                  <node concept="1bVj0M" id="5TNjoy28SQW" role="23t8la">
-                    <node concept="3clFbS" id="5TNjoy28SQX" role="1bW5cS">
-                      <node concept="3clFbF" id="5TNjoy28TRt" role="3cqZAp">
-                        <node concept="17R0WA" id="5TNjoy28Vhp" role="3clFbG">
-                          <node concept="2OqwBi" id="5TNjoy28Ulv" role="3uHU7B">
-                            <node concept="37vLTw" id="5TNjoy28TRs" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5TNjoy28SQY" resolve="it" />
-                            </node>
-                            <node concept="liA8E" id="5TNjoy28UNp" role="2OqNvi">
-                              <ref role="37wK5l" to="xfsv:~SerializedReferenceValue$Entry.getReference()" resolve="getReference" />
-                            </node>
-                          </node>
-                          <node concept="Xl_RD" id="5TNjoy28V$k" role="3uHU7w">
-                            <property role="Xl_RC" value="LionCore-builtins-INamed" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Rh6nW" id="5TNjoy28SQY" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="5TNjoy28SQZ" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="2Hmddi" id="5TNjoy28WH2" role="3cqZAp">
-            <node concept="37vLTw" id="5TNjoy28WZU" role="2Hmdds">
-              <ref role="3cqZAo" node="6jI_U5eGTz9" resolve="named" />
-            </node>
-          </node>
-          <node concept="3vlDli" id="6jI_U5eGvGS" role="3cqZAp">
-            <node concept="2OqwBi" id="6jI_U5eGvGT" role="3tpDZA">
-              <node concept="37vLTw" id="6jI_U5eGXid" role="2Oq$k0">
-                <ref role="3cqZAo" node="6jI_U5eGTz9" resolve="named" />
-              </node>
-              <node concept="liA8E" id="6jI_U5eGvH1" role="2OqNvi">
-                <ref role="37wK5l" to="xfsv:~SerializedReferenceValue$Entry.getResolveInfo()" resolve="getResolveInfo" />
-              </node>
-            </node>
-            <node concept="Xl_RD" id="6jI_U5eGvH2" role="3tpDZB">
-              <property role="Xl_RC" value="INamed" />
-            </node>
-          </node>
-        </node>
+      <node concept="3uibUv" id="7OJcYq_$HM2" role="Sfmx6">
+        <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
       </node>
     </node>
-    <node concept="3clFb_" id="6jI_U5eHEdg" role="jymVt">
-      <property role="TrG5h" value="nameMp" />
-      <node concept="3Tm6S6" id="6jI_U5eHEdh" role="1B3o_S" />
-      <node concept="3uibUv" id="6jI_U5eHEdi" role="3clF45">
-        <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-      </node>
-      <node concept="3clFbS" id="6jI_U5eHEd5" role="3clF47">
-        <node concept="3cpWs6" id="6jI_U5eHEd6" role="3cqZAp">
-          <node concept="2YIFZM" id="6jI_U5eHEd7" role="3cqZAk">
-            <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-            <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.Feature)" resolve="from" />
-            <node concept="2OqwBi" id="6jI_U5eHEd8" role="37wK5m">
-              <node concept="2OqwBi" id="6jI_U5eHEd9" role="2Oq$k0">
-                <node concept="2OqwBi" id="6jI_U5eHEda" role="2Oq$k0">
-                  <node concept="liA8E" id="6jI_U5eHEdc" role="2OqNvi">
-                    <ref role="37wK5l" to="imb3:~Classifier.allProperties()" resolve="allProperties" />
-                  </node>
-                  <node concept="2OqwBi" id="5TNjoy1x1d5" role="2Oq$k0">
-                    <node concept="2ShNRf" id="5TNjoy1wVur" role="2Oq$k0">
-                      <node concept="1pGfFk" id="5TNjoy1wX1V" role="2ShVmc">
-                        <ref role="37wK5l" to="6peh:5JNiskj4SJa" resolve="JsonConstants" />
-                        <node concept="2YIFZM" id="5TNjoy1wZVJ" role="37wK5m">
-                          <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
-                          <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
-                        </node>
-                        <node concept="2ShNRf" id="7weWCFlzbut" role="37wK5m">
-                          <node concept="HV5vD" id="7weWCFlzbuu" role="2ShVmc">
-                            <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
-                          </node>
-                        </node>
-                        <node concept="10Nm6u" id="7OJcYqxXtXS" role="37wK5m" />
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="5TNjoy1x3nU" role="2OqNvi">
-                      <ref role="37wK5l" to="6peh:5TNjoy1vudm" resolve="getINamed" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="liA8E" id="6jI_U5eHEdd" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
-                </node>
-              </node>
-              <node concept="liA8E" id="6jI_U5eHEde" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="6jI_U5eHJlS" role="jymVt" />
-    <node concept="3clFb_" id="6jI_U5eHMI3" role="jymVt">
-      <property role="TrG5h" value="filter" />
-      <node concept="3clFbS" id="6jI_U5eHMI6" role="3clF47">
-        <node concept="3clFbF" id="6jI_U5eHTZe" role="3cqZAp">
-          <node concept="2OqwBi" id="6jI_U5eHTZg" role="3clFbG">
-            <node concept="2OqwBi" id="6jI_U5eHTZh" role="2Oq$k0">
-              <node concept="37vLTw" id="6jI_U5eHTZi" role="2Oq$k0">
-                <ref role="3cqZAo" node="6jI_U5eHRV$" resolve="roots" />
-              </node>
-              <node concept="3zZkjj" id="6jI_U5eHTZj" role="2OqNvi">
-                <node concept="1bVj0M" id="6jI_U5eHTZk" role="23t8la">
-                  <node concept="3clFbS" id="6jI_U5eHTZl" role="1bW5cS">
-                    <node concept="3clFbF" id="6jI_U5eHTZm" role="3cqZAp">
-                      <node concept="17R0WA" id="6jI_U5eHTZn" role="3clFbG">
-                        <node concept="37vLTw" id="6jI_U5eHTZo" role="3uHU7w">
-                          <ref role="3cqZAo" node="6jI_U5eHOxv" resolve="concept" />
-                        </node>
-                        <node concept="2OqwBi" id="6jI_U5eHTZp" role="3uHU7B">
-                          <node concept="37vLTw" id="6jI_U5eHTZq" role="2Oq$k0">
-                            <ref role="3cqZAo" node="6jI_U5eHTZs" resolve="it" />
-                          </node>
-                          <node concept="liA8E" id="6jI_U5eHTZr" role="2OqNvi">
-                            <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getClassifier()" resolve="getClassifier" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="Rh6nW" id="6jI_U5eHTZs" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="6jI_U5eHTZt" role="1tU5fm" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3zZkjj" id="6jI_U5eIasc" role="2OqNvi">
-              <node concept="1bVj0M" id="6jI_U5eIase" role="23t8la">
-                <node concept="3clFbS" id="6jI_U5eIasf" role="1bW5cS">
-                  <node concept="3clFbF" id="6jI_U5eIasg" role="3cqZAp">
-                    <node concept="2OqwBi" id="6jI_U5eIash" role="3clFbG">
-                      <node concept="2OqwBi" id="6jI_U5eIasi" role="2Oq$k0">
-                        <node concept="2OqwBi" id="6jI_U5eIasj" role="2Oq$k0">
-                          <node concept="1eOMI4" id="6jI_U5eIask" role="2Oq$k0">
-                            <node concept="10QFUN" id="6jI_U5eIasl" role="1eOMHV">
-                              <node concept="2OqwBi" id="6jI_U5eIasm" role="10QFUP">
-                                <node concept="37vLTw" id="6jI_U5eIasn" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="6jI_U5eIasM" resolve="it" />
-                                </node>
-                                <node concept="liA8E" id="6jI_U5eIaso" role="2OqNvi">
-                                  <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getProperties()" resolve="getProperties" />
-                                </node>
-                              </node>
-                              <node concept="_YKpA" id="6jI_U5eIasp" role="10QFUM">
-                                <node concept="3uibUv" id="6jI_U5eIasq" role="_ZDj9">
-                                  <ref role="3uigEE" to="xfsv:~SerializedPropertyValue" resolve="SerializedPropertyValue" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="3zZkjj" id="6jI_U5eIasr" role="2OqNvi">
-                            <node concept="1bVj0M" id="6jI_U5eIass" role="23t8la">
-                              <node concept="3clFbS" id="6jI_U5eIast" role="1bW5cS">
-                                <node concept="3clFbF" id="6jI_U5eIasu" role="3cqZAp">
-                                  <node concept="17R0WA" id="6jI_U5eIasv" role="3clFbG">
-                                    <node concept="1rXfSq" id="6jI_U5eIcum" role="3uHU7w">
-                                      <ref role="37wK5l" node="6jI_U5eHEdg" resolve="nameMp" />
-                                    </node>
-                                    <node concept="2OqwBi" id="6jI_U5eIasx" role="3uHU7B">
-                                      <node concept="37vLTw" id="6jI_U5eIasy" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="6jI_U5eIas$" resolve="it" />
-                                      </node>
-                                      <node concept="liA8E" id="6jI_U5eIasz" role="2OqNvi">
-                                        <ref role="37wK5l" to="xfsv:~SerializedPropertyValue.getMetaPointer()" resolve="getMetaPointer" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Rh6nW" id="6jI_U5eIas$" role="1bW2Oz">
-                                <property role="TrG5h" value="it" />
-                                <node concept="2jxLKc" id="6jI_U5eIas_" role="1tU5fm" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3zZkjj" id="6jI_U5eIasA" role="2OqNvi">
-                          <node concept="1bVj0M" id="6jI_U5eIasB" role="23t8la">
-                            <node concept="3clFbS" id="6jI_U5eIasC" role="1bW5cS">
-                              <node concept="3clFbF" id="6jI_U5eIasD" role="3cqZAp">
-                                <node concept="17R0WA" id="6jI_U5eIasE" role="3clFbG">
-                                  <node concept="2OqwBi" id="6jI_U5eIasF" role="3uHU7B">
-                                    <node concept="37vLTw" id="6jI_U5eIasG" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="6jI_U5eIasJ" resolve="it" />
-                                    </node>
-                                    <node concept="liA8E" id="6jI_U5eIasH" role="2OqNvi">
-                                      <ref role="37wK5l" to="xfsv:~SerializedPropertyValue.getValue()" resolve="getValue" />
-                                    </node>
-                                  </node>
-                                  <node concept="37vLTw" id="6jI_U5eIgh5" role="3uHU7w">
-                                    <ref role="3cqZAo" node="6jI_U5eHQ6i" resolve="name" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="Rh6nW" id="6jI_U5eIasJ" role="1bW2Oz">
-                              <property role="TrG5h" value="it" />
-                              <node concept="2jxLKc" id="6jI_U5eIasK" role="1tU5fm" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3GX2aA" id="6jI_U5eIasL" role="2OqNvi" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="Rh6nW" id="6jI_U5eIasM" role="1bW2Oz">
-                  <property role="TrG5h" value="it" />
-                  <node concept="2jxLKc" id="6jI_U5eIasN" role="1tU5fm" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm6S6" id="6jI_U5eHKW4" role="1B3o_S" />
-      <node concept="A3Dl8" id="6jI_U5eHMGv" role="3clF45">
-        <node concept="3uibUv" id="5TNjoy1GXZq" role="A3Ik2">
-          <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="6jI_U5eHRV$" role="3clF46">
-        <property role="TrG5h" value="roots" />
-        <node concept="A3Dl8" id="6jI_U5eHTIb" role="1tU5fm">
-          <node concept="3uibUv" id="5TNjoy1GZeL" role="A3Ik2">
-            <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="6jI_U5eHOxv" role="3clF46">
-        <property role="TrG5h" value="concept" />
-        <node concept="3uibUv" id="6jI_U5eHOxu" role="1tU5fm">
-          <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="6jI_U5eHQ6i" role="3clF46">
-        <property role="TrG5h" value="name" />
-        <node concept="17QB3L" id="6jI_U5eHRSr" role="1tU5fm" />
-      </node>
-    </node>
-  </node>
-  <node concept="3s_ewN" id="6Fo9k$JyLNs">
-    <property role="3s_ewP" value="Instance" />
-    <node concept="3clFb_" id="6Fo9k$JySGH" role="jymVt">
+    <node concept="2XrIbr" id="7OJcYq_$egS" role="1qtyYc">
       <property role="TrG5h" value="read" />
-      <node concept="3clFbS" id="6Fo9k$JySGK" role="3clF47">
-        <node concept="3cpWs8" id="6Fo9k$JySHl" role="3cqZAp">
-          <node concept="3cpWsn" id="6Fo9k$JySHm" role="3cpWs9">
+      <node concept="3clFbS" id="7OJcYq_$egU" role="3clF47">
+        <node concept="3cpWs8" id="7OJcYq_$eh6" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_$eh7" role="3cpWs9">
             <property role="TrG5h" value="httpClient" />
-            <node concept="3uibUv" id="6Fo9k$JySHn" role="1tU5fm">
+            <node concept="3uibUv" id="7OJcYq_$eh8" role="1tU5fm">
               <ref role="3uigEE" to="781x:~HttpClient" resolve="HttpClient" />
             </node>
-            <node concept="2OqwBi" id="6Fo9k$JySHo" role="33vP2m">
-              <node concept="2OqwBi" id="6Fo9k$JySHp" role="2Oq$k0">
-                <node concept="2YIFZM" id="6Fo9k$JySHq" role="2Oq$k0">
-                  <ref role="1Pybhc" to="781x:~HttpClient" resolve="HttpClient" />
+            <node concept="2OqwBi" id="7OJcYq_$eh9" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYq_$eha" role="2Oq$k0">
+                <node concept="2YIFZM" id="7OJcYq_$ehb" role="2Oq$k0">
                   <ref role="37wK5l" to="781x:~HttpClient.newBuilder()" resolve="newBuilder" />
+                  <ref role="1Pybhc" to="781x:~HttpClient" resolve="HttpClient" />
                 </node>
-                <node concept="liA8E" id="6Fo9k$JySHr" role="2OqNvi">
+                <node concept="liA8E" id="7OJcYq_$ehc" role="2OqNvi">
                   <ref role="37wK5l" to="781x:~HttpClient$Builder.connectTimeout(java.time.Duration)" resolve="connectTimeout" />
-                  <node concept="2YIFZM" id="6Fo9k$JySHs" role="37wK5m">
-                    <ref role="1Pybhc" to="28m1:~Duration" resolve="Duration" />
+                  <node concept="2YIFZM" id="7OJcYq_$ehd" role="37wK5m">
                     <ref role="37wK5l" to="28m1:~Duration.ofSeconds(long)" resolve="ofSeconds" />
-                    <node concept="3cmrfG" id="6Fo9k$JySHt" role="37wK5m">
+                    <ref role="1Pybhc" to="28m1:~Duration" resolve="Duration" />
+                    <node concept="3cmrfG" id="7OJcYq_$ehe" role="37wK5m">
                       <property role="3cmrfH" value="2" />
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="liA8E" id="6Fo9k$JySHu" role="2OqNvi">
+              <node concept="liA8E" id="7OJcYq_$ehf" role="2OqNvi">
                 <ref role="37wK5l" to="781x:~HttpClient$Builder.build()" resolve="build" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="6Fo9k$JySHv" role="3cqZAp" />
-        <node concept="3cpWs8" id="6Fo9k$JySHw" role="3cqZAp">
-          <node concept="3cpWsn" id="6Fo9k$JySHx" role="3cpWs9">
+        <node concept="3clFbH" id="7OJcYq_$ehg" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYq_$ehh" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_$ehi" role="3cpWs9">
             <property role="TrG5h" value="request" />
-            <node concept="3uibUv" id="6Fo9k$JySHy" role="1tU5fm">
+            <node concept="3uibUv" id="7OJcYq_$ehj" role="1tU5fm">
               <ref role="3uigEE" to="781x:~HttpRequest" resolve="HttpRequest" />
             </node>
-            <node concept="2OqwBi" id="6Fo9k$JySHz" role="33vP2m">
-              <node concept="2OqwBi" id="6Fo9k$JySH$" role="2Oq$k0">
-                <node concept="2YIFZM" id="6Fo9k$JySH_" role="2Oq$k0">
-                  <ref role="1Pybhc" to="781x:~HttpRequest" resolve="HttpRequest" />
+            <node concept="2OqwBi" id="7OJcYq_$ehk" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYq_$ehl" role="2Oq$k0">
+                <node concept="2YIFZM" id="7OJcYq_$ehm" role="2Oq$k0">
                   <ref role="37wK5l" to="781x:~HttpRequest.newBuilder(java.net.URI)" resolve="newBuilder" />
-                  <node concept="2YIFZM" id="6Fo9k$JySHA" role="37wK5m">
-                    <ref role="37wK5l" to="zf81:~URI.create(java.lang.String)" resolve="create" />
+                  <ref role="1Pybhc" to="781x:~HttpRequest" resolve="HttpRequest" />
+                  <node concept="2YIFZM" id="7OJcYq_$ehn" role="37wK5m">
                     <ref role="1Pybhc" to="zf81:~URI" resolve="URI" />
-                    <node concept="Xl_RD" id="6Fo9k$JySHB" role="37wK5m">
+                    <ref role="37wK5l" to="zf81:~URI.create(java.lang.String)" resolve="create" />
+                    <node concept="Xl_RD" id="7OJcYq_$eho" role="37wK5m">
                       <property role="Xl_RC" value="http://127.0.0.1:63320/lionweb/bulk?modelRef=r%3Ab9a0b9c9-f16d-406d-a198-bccf7ca08a89%28io.lionweb.mps.server.test.instanceModel%29" />
                     </node>
                   </node>
                 </node>
-                <node concept="liA8E" id="6Fo9k$JySHC" role="2OqNvi">
+                <node concept="liA8E" id="7OJcYq_$ehp" role="2OqNvi">
                   <ref role="37wK5l" to="781x:~HttpRequest$Builder.GET()" resolve="GET" />
                 </node>
               </node>
-              <node concept="liA8E" id="6Fo9k$JySHD" role="2OqNvi">
+              <node concept="liA8E" id="7OJcYq_$ehq" role="2OqNvi">
                 <ref role="37wK5l" to="781x:~HttpRequest$Builder.build()" resolve="build" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="6Fo9k$JySHE" role="3cqZAp">
-          <node concept="3cpWsn" id="6Fo9k$JySHF" role="3cpWs9">
+        <node concept="3cpWs8" id="7OJcYq_$ehr" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_$ehs" role="3cpWs9">
             <property role="TrG5h" value="response" />
-            <node concept="3uibUv" id="6Fo9k$JySHG" role="1tU5fm">
+            <node concept="3uibUv" id="7OJcYq_$eht" role="1tU5fm">
               <ref role="3uigEE" to="781x:~HttpResponse" resolve="HttpResponse" />
-              <node concept="3uibUv" id="6Fo9k$JySHH" role="11_B2D">
+              <node concept="3uibUv" id="7OJcYq_$ehu" role="11_B2D">
                 <ref role="3uigEE" to="guwi:~InputStream" resolve="InputStream" />
               </node>
             </node>
-            <node concept="2OqwBi" id="6Fo9k$JySHI" role="33vP2m">
-              <node concept="37vLTw" id="6Fo9k$JySHJ" role="2Oq$k0">
-                <ref role="3cqZAo" node="6Fo9k$JySHm" resolve="httpClient" />
+            <node concept="2OqwBi" id="7OJcYq_$ehv" role="33vP2m">
+              <node concept="37vLTw" id="7OJcYq_$ehw" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYq_$eh7" resolve="httpClient" />
               </node>
-              <node concept="liA8E" id="6Fo9k$JySHK" role="2OqNvi">
+              <node concept="liA8E" id="7OJcYq_$ehx" role="2OqNvi">
                 <ref role="37wK5l" to="781x:~HttpClient.send(java.net.http.HttpRequest,java.net.http.HttpResponse$BodyHandler)" resolve="send" />
-                <node concept="37vLTw" id="6Fo9k$JySHL" role="37wK5m">
-                  <ref role="3cqZAo" node="6Fo9k$JySHx" resolve="request" />
+                <node concept="37vLTw" id="7OJcYq_$ehy" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYq_$ehi" resolve="request" />
                 </node>
-                <node concept="2YIFZM" id="6Fo9k$JySHM" role="37wK5m">
+                <node concept="2YIFZM" id="7OJcYq_$ehz" role="37wK5m">
                   <ref role="1Pybhc" to="781x:~HttpResponse$BodyHandlers" resolve="HttpResponse.BodyHandlers" />
                   <ref role="37wK5l" to="781x:~HttpResponse$BodyHandlers.ofInputStream()" resolve="ofInputStream" />
                 </node>
@@ -1088,234 +609,1010 @@
             </node>
           </node>
         </node>
-        <node concept="3vlDli" id="6Fo9k$JySHN" role="3cqZAp">
-          <node concept="10M0yZ" id="6Fo9k$JySHO" role="3tpDZB">
-            <ref role="3cqZAo" to="zf81:~HttpURLConnection.HTTP_OK" resolve="HTTP_OK" />
+        <node concept="3vlDli" id="7OJcYq_$eh$" role="3cqZAp">
+          <node concept="10M0yZ" id="7OJcYq_$eh_" role="3tpDZB">
             <ref role="1PxDUh" to="zf81:~HttpURLConnection" resolve="HttpURLConnection" />
+            <ref role="3cqZAo" to="zf81:~HttpURLConnection.HTTP_OK" resolve="HTTP_OK" />
           </node>
-          <node concept="2OqwBi" id="6Fo9k$JySHP" role="3tpDZA">
-            <node concept="37vLTw" id="6Fo9k$JySHQ" role="2Oq$k0">
-              <ref role="3cqZAo" node="6Fo9k$JySHF" resolve="response" />
+          <node concept="2OqwBi" id="7OJcYq_$ehA" role="3tpDZA">
+            <node concept="37vLTw" id="7OJcYq_$ehB" role="2Oq$k0">
+              <ref role="3cqZAo" node="7OJcYq_$ehs" resolve="response" />
             </node>
-            <node concept="liA8E" id="6Fo9k$JySHR" role="2OqNvi">
+            <node concept="liA8E" id="7OJcYq_$ehC" role="2OqNvi">
               <ref role="37wK5l" to="781x:~HttpResponse.statusCode()" resolve="statusCode" />
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="6Fo9k$JySHU" role="3cqZAp" />
-        <node concept="3cpWs8" id="6Fo9k$JySHV" role="3cqZAp">
-          <node concept="3cpWsn" id="6Fo9k$JySHW" role="3cpWs9">
+        <node concept="3clFbH" id="7OJcYq_$ehD" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYq_$ehE" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_$ehF" role="3cpWs9">
             <property role="TrG5h" value="deserializer" />
-            <node concept="3uibUv" id="6Fo9k$JySHX" role="1tU5fm">
+            <node concept="3uibUv" id="7OJcYq_$ehG" role="1tU5fm">
               <ref role="3uigEE" to="6peh:z1IqfFwqda" resolve="Deserializer" />
             </node>
-            <node concept="2ShNRf" id="6Fo9k$JySHY" role="33vP2m">
-              <node concept="1pGfFk" id="6Fo9k$JySHZ" role="2ShVmc">
+            <node concept="2ShNRf" id="7OJcYq_$ehH" role="33vP2m">
+              <node concept="1pGfFk" id="7OJcYq_$ehI" role="2ShVmc">
                 <ref role="37wK5l" to="6peh:z1IqfFwqeg" resolve="Deserializer" />
-                <node concept="2OqwBi" id="6Fo9k$JySI0" role="37wK5m">
-                  <node concept="37vLTw" id="6Fo9k$JySI1" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6Fo9k$JySHF" resolve="response" />
+                <node concept="2OqwBi" id="7OJcYq_$ehJ" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYq_$ehK" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYq_$ehs" resolve="response" />
                   </node>
-                  <node concept="liA8E" id="6Fo9k$JySI2" role="2OqNvi">
+                  <node concept="liA8E" id="7OJcYq_$ehL" role="2OqNvi">
                     <ref role="37wK5l" to="781x:~HttpResponse.body()" resolve="body" />
                   </node>
                 </node>
-                <node concept="2ShNRf" id="5hsSXrmD6rv" role="37wK5m">
-                  <node concept="1pGfFk" id="5hsSXrmDcUm" role="2ShVmc">
+                <node concept="2ShNRf" id="7OJcYq_$ehM" role="37wK5m">
+                  <node concept="1pGfFk" id="7OJcYq_$ehN" role="2ShVmc">
                     <ref role="37wK5l" to="6peh:5JNiskj4SJa" resolve="JsonConstants" />
-                    <node concept="2YIFZM" id="5hsSXrmDeQ3" role="37wK5m">
-                      <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
+                    <node concept="2YIFZM" id="7OJcYq_$ehO" role="37wK5m">
                       <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                      <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
                     </node>
-                    <node concept="2ShNRf" id="7weWCFlyI7w" role="37wK5m">
-                      <node concept="HV5vD" id="7weWCFlyJjA" role="2ShVmc">
+                    <node concept="2ShNRf" id="7OJcYq_$ehP" role="37wK5m">
+                      <node concept="HV5vD" id="7OJcYq_$ehQ" role="2ShVmc">
                         <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
                       </node>
                     </node>
-                    <node concept="10Nm6u" id="7OJcYqxXlnt" role="37wK5m" />
+                    <node concept="2ShNRf" id="7OJcYq_$e$X" role="37wK5m">
+                      <node concept="1pGfFk" id="7OJcYq_$f39" role="2ShVmc">
+                        <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                        <node concept="2OqwBi" id="7OJcYq_$frz" role="37wK5m">
+                          <node concept="1jGwE1" id="7OJcYq_$fcd" role="2Oq$k0" />
+                          <node concept="liA8E" id="7OJcYq_$fCy" role="2OqNvi">
+                            <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="6Fo9k$JySI3" role="3cqZAp">
-          <node concept="3KEzu6" id="6Fo9k$JySI4" role="3cpWs9">
+        <node concept="3cpWs8" id="7OJcYq_$ehS" role="3cqZAp">
+          <node concept="3KEzu6" id="7OJcYq_$ehT" role="3cpWs9">
             <property role="TrG5h" value="roots" />
-            <node concept="2OqwBi" id="6Fo9k$JySI5" role="33vP2m">
-              <node concept="37vLTw" id="6Fo9k$JySI6" role="2Oq$k0">
-                <ref role="3cqZAo" node="6Fo9k$JySHW" resolve="deserializer" />
+            <node concept="2OqwBi" id="7OJcYq_$ehU" role="33vP2m">
+              <node concept="37vLTw" id="7OJcYq_$ehV" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYq_$ehF" resolve="deserializer" />
               </node>
-              <node concept="liA8E" id="6Fo9k$JySI7" role="2OqNvi">
+              <node concept="liA8E" id="7OJcYq_$ehW" role="2OqNvi">
                 <ref role="37wK5l" to="6peh:z1IqfFwqy3" resolve="deserialize" />
               </node>
             </node>
-            <node concept="PeGgZ" id="6Fo9k$JySI8" role="1tU5fm" />
+            <node concept="PeGgZ" id="7OJcYq_$ehX" role="1tU5fm" />
           </node>
         </node>
-        <node concept="3clFbH" id="6Fo9k$JySI9" role="3cqZAp" />
-        <node concept="3vFxKo" id="6Fo9k$JySIa" role="3cqZAp">
-          <node concept="2OqwBi" id="6Fo9k$JySIb" role="3vFALc">
-            <node concept="37vLTw" id="6Fo9k$JySIc" role="2Oq$k0">
-              <ref role="3cqZAo" node="6Fo9k$JySI4" resolve="roots" />
+        <node concept="3clFbH" id="7OJcYq_$ehY" role="3cqZAp" />
+        <node concept="3vFxKo" id="7OJcYq_$ehZ" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq_$ei0" role="3vFALc">
+            <node concept="37vLTw" id="7OJcYq_$ei1" role="2Oq$k0">
+              <ref role="3cqZAo" node="7OJcYq_$ehT" resolve="roots" />
             </node>
-            <node concept="1v1jN8" id="6Fo9k$JySId" role="2OqNvi" />
+            <node concept="1v1jN8" id="7OJcYq_$ei2" role="2OqNvi" />
           </node>
         </node>
-        <node concept="3clFbH" id="6Fo9k$JyWJS" role="3cqZAp" />
-        <node concept="3cpWs6" id="6Fo9k$JyWSO" role="3cqZAp">
-          <node concept="37vLTw" id="6Fo9k$JyX11" role="3cqZAk">
-            <ref role="3cqZAo" node="6Fo9k$JySI4" resolve="roots" />
+        <node concept="3clFbH" id="7OJcYq_$ei3" role="3cqZAp" />
+        <node concept="3cpWs6" id="7OJcYq_$ei4" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYq_$ei5" role="3cqZAk">
+            <ref role="3cqZAo" node="7OJcYq_$ehT" resolve="roots" />
           </node>
         </node>
       </node>
-      <node concept="3Tm6S6" id="6Fo9k$JySEz" role="1B3o_S" />
-      <node concept="3uibUv" id="6Fo9k$JyWjr" role="Sfmx6">
-        <ref role="3uigEE" to="wyt6:~InterruptedException" resolve="InterruptedException" />
-      </node>
-      <node concept="3uibUv" id="6Fo9k$JyWBw" role="Sfmx6">
-        <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
-      </node>
-      <node concept="_YKpA" id="6Fo9k$JyXgY" role="3clF45">
-        <node concept="3uibUv" id="6Fo9k$JyXh1" role="_ZDj9">
+      <node concept="3Tm6S6" id="7OJcYq_$egY" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYq_$eh0" role="3clF45">
+        <node concept="3uibUv" id="7OJcYq_$eh1" role="_ZDj9">
           <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
         </node>
       </node>
+      <node concept="3uibUv" id="7OJcYq_$GdC" role="Sfmx6">
+        <ref role="3uigEE" to="wyt6:~InterruptedException" resolve="InterruptedException" />
+      </node>
+      <node concept="3uibUv" id="7OJcYq_$GSh" role="Sfmx6">
+        <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
+      </node>
     </node>
-    <node concept="2tJIrI" id="3LyuSndQjys" role="jymVt" />
-    <node concept="3clFb_" id="3LyuSndQlB2" role="jymVt">
+    <node concept="2XrIbr" id="7OJcYq_$fKN" role="1qtyYc">
       <property role="TrG5h" value="write" />
-      <node concept="3clFbS" id="3LyuSndQlB5" role="3clF47">
-        <node concept="3cpWs8" id="3LyuSndQoXo" role="3cqZAp">
-          <node concept="3cpWsn" id="3LyuSndQoXp" role="3cpWs9">
+      <node concept="37vLTG" id="7OJcYq_$fMq" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="A3Dl8" id="7OJcYq_$fMr" role="1tU5fm">
+          <node concept="3uibUv" id="7OJcYq_$fMs" role="A3Ik2">
+            <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="7OJcYq_$fMn" role="3clF45" />
+      <node concept="3clFbS" id="7OJcYq_$fKP" role="3clF47">
+        <node concept="3cpWs8" id="7OJcYq_$fMB" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_$fMC" role="3cpWs9">
             <property role="TrG5h" value="writer" />
-            <node concept="3uibUv" id="3LyuSndQoXq" role="1tU5fm">
+            <node concept="3uibUv" id="7OJcYq_$fMD" role="1tU5fm">
               <ref role="3uigEE" to="guwi:~StringWriter" resolve="StringWriter" />
             </node>
-            <node concept="2ShNRf" id="3LyuSndQoXr" role="33vP2m">
-              <node concept="1pGfFk" id="3LyuSndQoXs" role="2ShVmc">
+            <node concept="2ShNRf" id="7OJcYq_$fME" role="33vP2m">
+              <node concept="1pGfFk" id="7OJcYq_$fMF" role="2ShVmc">
                 <ref role="37wK5l" to="guwi:~StringWriter.&lt;init&gt;()" resolve="StringWriter" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="3LyuSndQoXt" role="3cqZAp">
-          <node concept="2OqwBi" id="3LyuSndQoXu" role="3clFbG">
-            <node concept="2ShNRf" id="3LyuSndQoXv" role="2Oq$k0">
-              <node concept="1pGfFk" id="3LyuSndQoXw" role="2ShVmc">
+        <node concept="3clFbF" id="7OJcYq_$fMG" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq_$fMH" role="3clFbG">
+            <node concept="2ShNRf" id="7OJcYq_$fMI" role="2Oq$k0">
+              <node concept="1pGfFk" id="7OJcYq_$fMJ" role="2ShVmc">
                 <ref role="37wK5l" to="6peh:5s4Z0e0nc6h" resolve="M1Serializer" />
-                <node concept="37vLTw" id="3LyuSndQoXx" role="37wK5m">
-                  <ref role="3cqZAo" node="3LyuSndQoXp" resolve="writer" />
+                <node concept="37vLTw" id="7OJcYq_$fMK" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYq_$fMC" resolve="writer" />
                 </node>
-                <node concept="3clFbT" id="3LyuSndQoXy" role="37wK5m">
+                <node concept="3clFbT" id="7OJcYq_$fML" role="37wK5m">
                   <property role="3clFbU" value="true" />
                 </node>
               </node>
             </node>
-            <node concept="liA8E" id="3LyuSndQoXz" role="2OqNvi">
+            <node concept="liA8E" id="7OJcYq_$fMM" role="2OqNvi">
               <ref role="37wK5l" to="6peh:6VkSF6c$iAh" resolve="serialize" />
-              <node concept="37vLTw" id="3LyuSndQoX$" role="37wK5m">
-                <ref role="3cqZAo" node="3LyuSndQmvZ" resolve="nodes" />
+              <node concept="37vLTw" id="7OJcYq_$fMN" role="37wK5m">
+                <ref role="3cqZAo" node="7OJcYq_$fMq" resolve="nodes" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="3LyuSndQojj" role="3cqZAp" />
-        <node concept="3cpWs8" id="3LyuSndQn5L" role="3cqZAp">
-          <node concept="3cpWsn" id="3LyuSndQn5M" role="3cpWs9">
+        <node concept="3clFbH" id="7OJcYq_$fMO" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYq_$fMP" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_$fMQ" role="3cpWs9">
             <property role="TrG5h" value="httpClient" />
-            <node concept="3uibUv" id="3LyuSndQn5N" role="1tU5fm">
+            <node concept="3uibUv" id="7OJcYq_$fMR" role="1tU5fm">
               <ref role="3uigEE" to="781x:~HttpClient" resolve="HttpClient" />
             </node>
-            <node concept="2OqwBi" id="3LyuSndQn5O" role="33vP2m">
-              <node concept="2OqwBi" id="3LyuSndQn5P" role="2Oq$k0">
-                <node concept="2YIFZM" id="3LyuSndQn5Q" role="2Oq$k0">
-                  <ref role="37wK5l" to="781x:~HttpClient.newBuilder()" resolve="newBuilder" />
+            <node concept="2OqwBi" id="7OJcYq_$fMS" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYq_$fMT" role="2Oq$k0">
+                <node concept="2YIFZM" id="7OJcYq_$fMU" role="2Oq$k0">
                   <ref role="1Pybhc" to="781x:~HttpClient" resolve="HttpClient" />
+                  <ref role="37wK5l" to="781x:~HttpClient.newBuilder()" resolve="newBuilder" />
                 </node>
-                <node concept="liA8E" id="3LyuSndQn5R" role="2OqNvi">
+                <node concept="liA8E" id="7OJcYq_$fMV" role="2OqNvi">
                   <ref role="37wK5l" to="781x:~HttpClient$Builder.connectTimeout(java.time.Duration)" resolve="connectTimeout" />
-                  <node concept="2YIFZM" id="3LyuSndQn5S" role="37wK5m">
-                    <ref role="37wK5l" to="28m1:~Duration.ofSeconds(long)" resolve="ofSeconds" />
+                  <node concept="2YIFZM" id="7OJcYq_$fMW" role="37wK5m">
                     <ref role="1Pybhc" to="28m1:~Duration" resolve="Duration" />
-                    <node concept="3cmrfG" id="3LyuSndQn5T" role="37wK5m">
+                    <ref role="37wK5l" to="28m1:~Duration.ofSeconds(long)" resolve="ofSeconds" />
+                    <node concept="3cmrfG" id="7OJcYq_$fMX" role="37wK5m">
                       <property role="3cmrfH" value="2" />
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="liA8E" id="3LyuSndQn5U" role="2OqNvi">
+              <node concept="liA8E" id="7OJcYq_$fMY" role="2OqNvi">
                 <ref role="37wK5l" to="781x:~HttpClient$Builder.build()" resolve="build" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="3LyuSndQn5V" role="3cqZAp" />
-        <node concept="3cpWs8" id="3LyuSndQn5W" role="3cqZAp">
-          <node concept="3cpWsn" id="3LyuSndQn5X" role="3cpWs9">
+        <node concept="3clFbH" id="7OJcYq_$fMZ" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYq_$fN0" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_$fN1" role="3cpWs9">
             <property role="TrG5h" value="request" />
-            <node concept="3uibUv" id="3LyuSndQn5Y" role="1tU5fm">
+            <node concept="3uibUv" id="7OJcYq_$fN2" role="1tU5fm">
               <ref role="3uigEE" to="781x:~HttpRequest" resolve="HttpRequest" />
             </node>
-            <node concept="2OqwBi" id="3LyuSndQn5Z" role="33vP2m">
-              <node concept="2OqwBi" id="3LyuSndQn60" role="2Oq$k0">
-                <node concept="2YIFZM" id="3LyuSndQn61" role="2Oq$k0">
-                  <ref role="37wK5l" to="781x:~HttpRequest.newBuilder(java.net.URI)" resolve="newBuilder" />
+            <node concept="2OqwBi" id="7OJcYq_$fN3" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYq_$fN4" role="2Oq$k0">
+                <node concept="2YIFZM" id="7OJcYq_$fN5" role="2Oq$k0">
                   <ref role="1Pybhc" to="781x:~HttpRequest" resolve="HttpRequest" />
-                  <node concept="2YIFZM" id="3LyuSndQn62" role="37wK5m">
+                  <ref role="37wK5l" to="781x:~HttpRequest.newBuilder(java.net.URI)" resolve="newBuilder" />
+                  <node concept="2YIFZM" id="7OJcYq_$fN6" role="37wK5m">
                     <ref role="1Pybhc" to="zf81:~URI" resolve="URI" />
                     <ref role="37wK5l" to="zf81:~URI.create(java.lang.String)" resolve="create" />
-                    <node concept="Xl_RD" id="3LyuSndQn63" role="37wK5m">
+                    <node concept="Xl_RD" id="7OJcYq_$fN7" role="37wK5m">
                       <property role="Xl_RC" value="http://127.0.0.1:63320/lionweb/bulk?modelRef=r%3Ab9a0b9c9-f16d-406d-a198-bccf7ca08a89%28io.lionweb.mps.server.test.instanceModel%29" />
                     </node>
                   </node>
                 </node>
-                <node concept="liA8E" id="3LyuSndQn64" role="2OqNvi">
+                <node concept="liA8E" id="7OJcYq_$fN8" role="2OqNvi">
                   <ref role="37wK5l" to="781x:~HttpRequest$Builder.POST(java.net.http.HttpRequest$BodyPublisher)" resolve="POST" />
-                  <node concept="2YIFZM" id="3LyuSndQn65" role="37wK5m">
-                    <ref role="37wK5l" to="781x:~HttpRequest$BodyPublishers.ofString(java.lang.String)" resolve="ofString" />
+                  <node concept="2YIFZM" id="7OJcYq_$fN9" role="37wK5m">
                     <ref role="1Pybhc" to="781x:~HttpRequest$BodyPublishers" resolve="HttpRequest.BodyPublishers" />
-                    <node concept="2OqwBi" id="3LyuSndQn66" role="37wK5m">
-                      <node concept="2OqwBi" id="3LyuSndQn67" role="2Oq$k0">
-                        <node concept="37vLTw" id="3LyuSndQn68" role="2Oq$k0">
-                          <ref role="3cqZAo" node="3LyuSndQoXp" resolve="writer" />
+                    <ref role="37wK5l" to="781x:~HttpRequest$BodyPublishers.ofString(java.lang.String)" resolve="ofString" />
+                    <node concept="2OqwBi" id="7OJcYq_$fNa" role="37wK5m">
+                      <node concept="2OqwBi" id="7OJcYq_$fNb" role="2Oq$k0">
+                        <node concept="37vLTw" id="7OJcYq_$fNc" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7OJcYq_$fMC" resolve="writer" />
                         </node>
-                        <node concept="liA8E" id="3LyuSndQn69" role="2OqNvi">
+                        <node concept="liA8E" id="7OJcYq_$fNd" role="2OqNvi">
                           <ref role="37wK5l" to="guwi:~StringWriter.getBuffer()" resolve="getBuffer" />
                         </node>
                       </node>
-                      <node concept="liA8E" id="3LyuSndQn6a" role="2OqNvi">
+                      <node concept="liA8E" id="7OJcYq_$fNe" role="2OqNvi">
                         <ref role="37wK5l" to="wyt6:~StringBuffer.toString()" resolve="toString" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="liA8E" id="3LyuSndQn6b" role="2OqNvi">
+              <node concept="liA8E" id="7OJcYq_$fNf" role="2OqNvi">
                 <ref role="37wK5l" to="781x:~HttpRequest$Builder.build()" resolve="build" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="3LyuSndQn6c" role="3cqZAp">
-          <node concept="3cpWsn" id="3LyuSndQn6d" role="3cpWs9">
+        <node concept="3cpWs8" id="7OJcYq_$fNg" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq_$fNh" role="3cpWs9">
             <property role="TrG5h" value="response" />
-            <node concept="3uibUv" id="3LyuSndQn6e" role="1tU5fm">
+            <node concept="3uibUv" id="7OJcYq_$fNi" role="1tU5fm">
               <ref role="3uigEE" to="781x:~HttpResponse" resolve="HttpResponse" />
-              <node concept="3uibUv" id="3LyuSndQn6f" role="11_B2D">
+              <node concept="3uibUv" id="7OJcYq_$fNj" role="11_B2D">
                 <ref role="3uigEE" to="guwi:~InputStream" resolve="InputStream" />
               </node>
             </node>
-            <node concept="2OqwBi" id="3LyuSndQn6g" role="33vP2m">
-              <node concept="37vLTw" id="3LyuSndQn6h" role="2Oq$k0">
-                <ref role="3cqZAo" node="3LyuSndQn5M" resolve="httpClient" />
+            <node concept="2OqwBi" id="7OJcYq_$fNk" role="33vP2m">
+              <node concept="37vLTw" id="7OJcYq_$fNl" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYq_$fMQ" resolve="httpClient" />
               </node>
-              <node concept="liA8E" id="3LyuSndQn6i" role="2OqNvi">
+              <node concept="liA8E" id="7OJcYq_$fNm" role="2OqNvi">
                 <ref role="37wK5l" to="781x:~HttpClient.send(java.net.http.HttpRequest,java.net.http.HttpResponse$BodyHandler)" resolve="send" />
-                <node concept="37vLTw" id="3LyuSndQn6j" role="37wK5m">
-                  <ref role="3cqZAo" node="3LyuSndQn5X" resolve="request" />
+                <node concept="37vLTw" id="7OJcYq_$fNn" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYq_$fN1" resolve="request" />
                 </node>
-                <node concept="2YIFZM" id="3LyuSndQn6k" role="37wK5m">
+                <node concept="2YIFZM" id="7OJcYq_$fNo" role="37wK5m">
+                  <ref role="1Pybhc" to="781x:~HttpResponse$BodyHandlers" resolve="HttpResponse.BodyHandlers" />
+                  <ref role="37wK5l" to="781x:~HttpResponse$BodyHandlers.ofInputStream()" resolve="ofInputStream" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq_$fNp" role="3cqZAp" />
+        <node concept="3vlDli" id="7OJcYq_$fNq" role="3cqZAp">
+          <node concept="10M0yZ" id="7OJcYq_$fNr" role="3tpDZB">
+            <ref role="1PxDUh" to="zf81:~HttpURLConnection" resolve="HttpURLConnection" />
+            <ref role="3cqZAo" to="zf81:~HttpURLConnection.HTTP_OK" resolve="HTTP_OK" />
+          </node>
+          <node concept="2OqwBi" id="7OJcYq_$fNs" role="3tpDZA">
+            <node concept="37vLTw" id="7OJcYq_$fNt" role="2Oq$k0">
+              <ref role="3cqZAo" node="7OJcYq_$fNh" resolve="response" />
+            </node>
+            <node concept="liA8E" id="7OJcYq_$fNu" role="2OqNvi">
+              <ref role="37wK5l" to="781x:~HttpResponse.statusCode()" resolve="statusCode" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="7OJcYq_$fMj" role="1B3o_S" />
+      <node concept="3uibUv" id="7OJcYq_$MbW" role="Sfmx6">
+        <ref role="3uigEE" to="wyt6:~InterruptedException" resolve="InterruptedException" />
+      </node>
+      <node concept="3uibUv" id="7OJcYq_$MNq" role="Sfmx6">
+        <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
+      </node>
+    </node>
+  </node>
+  <node concept="2XOHcx" id="3ePT3MiXrx5">
+    <property role="2XOHcw" value="${lionweb-mps.home}" />
+  </node>
+  <node concept="1lH9Xt" id="7OJcYq__hO0">
+    <property role="TrG5h" value="LanguagesLionCore" />
+    <property role="26Nn1l" value="true" />
+    <node concept="1LZb2c" id="7OJcYq__op0" role="1SL9yI">
+      <property role="TrG5h" value="refToBuiltinPropertyType" />
+      <node concept="3cqZAl" id="7OJcYq__op1" role="3clF45" />
+      <node concept="3clFbS" id="7OJcYq__op5" role="3clF47">
+        <node concept="3cpWs8" id="7OJcYq__o_M" role="3cqZAp">
+          <node concept="3KEzu6" id="7OJcYq__o_N" role="3cpWs9">
+            <property role="TrG5h" value="roots" />
+            <node concept="2OqwBi" id="7OJcYq__yHs" role="33vP2m">
+              <node concept="2WthIp" id="7OJcYq__yHv" role="2Oq$k0" />
+              <node concept="2XshWL" id="7OJcYq__yHx" role="2OqNvi">
+                <ref role="2WH_rO" node="7OJcYq__iNQ" resolve="retrieveTestLang" />
+              </node>
+            </node>
+            <node concept="PeGgZ" id="7OJcYq__o_P" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq__o_Q" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYq__o_R" role="3cqZAp">
+          <node concept="3KEzu6" id="7OJcYq__o_S" role="3cpWs9">
+            <property role="TrG5h" value="stringProp" />
+            <node concept="2OqwBi" id="7OJcYq__o_T" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYq__Ba2" role="2Oq$k0">
+                <node concept="2WthIp" id="7OJcYq__Ba5" role="2Oq$k0" />
+                <node concept="2XshWL" id="7OJcYq__Ba7" role="2OqNvi">
+                  <ref role="2WH_rO" node="7OJcYq__iNE" resolve="filter" />
+                  <node concept="37vLTw" id="7OJcYq__o_V" role="2XxRq1">
+                    <ref role="3cqZAo" node="7OJcYq__o_N" resolve="roots" />
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYq__o_W" role="2XxRq1">
+                    <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
+                    <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.LanguageEntity)" resolve="from" />
+                    <node concept="2YIFZM" id="7OJcYq__o_X" role="37wK5m">
+                      <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+                      <ref role="37wK5l" to="cz4z:~LionCore.getProperty()" resolve="getProperty" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="7OJcYq__o_Y" role="2XxRq1">
+                    <property role="Xl_RC" value="stringProp" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1uHKPH" id="7OJcYq__o_Z" role="2OqNvi" />
+            </node>
+            <node concept="PeGgZ" id="7OJcYq__oA0" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq__oA1" role="3cqZAp" />
+        <node concept="2Hmddi" id="7OJcYq__oA2" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYq__oA3" role="2Hmdds">
+            <ref role="3cqZAo" node="7OJcYq__o_S" resolve="stringProp" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7OJcYq__oA4" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq__oA5" role="3cpWs9">
+            <property role="TrG5h" value="type" />
+            <node concept="3uibUv" id="7OJcYq__oA6" role="1tU5fm">
+              <ref role="3uigEE" to="xfsv:~SerializedReferenceValue" resolve="SerializedReferenceValue" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYq__oA7" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYq__oA8" role="2Oq$k0">
+                <node concept="2OqwBi" id="7OJcYq__oA9" role="2Oq$k0">
+                  <node concept="37vLTw" id="7OJcYq__oAa" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYq__o_S" resolve="stringProp" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYq__oAb" role="2OqNvi">
+                    <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getReferences()" resolve="getReferences" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="7OJcYq__oAc" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7OJcYq__oAd" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7OJcYq__oAe" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq__oAf" role="3tpDZA">
+            <node concept="2OqwBi" id="7OJcYq__oAg" role="2Oq$k0">
+              <node concept="2OqwBi" id="7OJcYq__oAh" role="2Oq$k0">
+                <node concept="2OqwBi" id="7OJcYq__oAi" role="2Oq$k0">
+                  <node concept="37vLTw" id="7OJcYq__oAj" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYq__oA5" resolve="type" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYq__oAk" role="2OqNvi">
+                    <ref role="37wK5l" to="xfsv:~SerializedReferenceValue.getValue()" resolve="getValue" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="7OJcYq__oAl" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7OJcYq__oAm" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7OJcYq__oAn" role="2OqNvi">
+              <ref role="37wK5l" to="xfsv:~SerializedReferenceValue$Entry.getResolveInfo()" resolve="getResolveInfo" />
+            </node>
+          </node>
+          <node concept="Xl_RD" id="7OJcYq__oAo" role="3tpDZB">
+            <property role="Xl_RC" value="String" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="7OJcYq__oAp" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq__oAq" role="3tpDZA">
+            <node concept="2OqwBi" id="7OJcYq__oAr" role="2Oq$k0">
+              <node concept="2OqwBi" id="7OJcYq__oAs" role="2Oq$k0">
+                <node concept="2OqwBi" id="7OJcYq__oAt" role="2Oq$k0">
+                  <node concept="37vLTw" id="7OJcYq__oAu" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYq__oA5" resolve="type" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYq__oAv" role="2OqNvi">
+                    <ref role="37wK5l" to="xfsv:~SerializedReferenceValue.getValue()" resolve="getValue" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="7OJcYq__oAw" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7OJcYq__oAx" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7OJcYq__oAy" role="2OqNvi">
+              <ref role="37wK5l" to="xfsv:~SerializedReferenceValue$Entry.getReference()" resolve="getReference" />
+            </node>
+          </node>
+          <node concept="Xl_RD" id="7OJcYq__oAz" role="3tpDZB">
+            <property role="Xl_RC" value="LionCore-builtins-String" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="7OJcYq__qfv" role="1SL9yI">
+      <property role="TrG5h" value="refToBuiltinNode" />
+      <node concept="3cqZAl" id="7OJcYq__qfw" role="3clF45" />
+      <node concept="3clFbS" id="7OJcYq__qf$" role="3clF47">
+        <node concept="3cpWs8" id="7OJcYq__qEE" role="3cqZAp">
+          <node concept="3KEzu6" id="7OJcYq__qEF" role="3cpWs9">
+            <property role="TrG5h" value="roots" />
+            <node concept="2OqwBi" id="7OJcYq__zzx" role="33vP2m">
+              <node concept="2WthIp" id="7OJcYq__zz$" role="2Oq$k0" />
+              <node concept="2XshWL" id="7OJcYq__zzA" role="2OqNvi">
+                <ref role="2WH_rO" node="7OJcYq__iNQ" resolve="retrieveTestLang" />
+              </node>
+            </node>
+            <node concept="PeGgZ" id="7OJcYq__qEH" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq__qEI" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYq__qEJ" role="3cqZAp">
+          <node concept="3KEzu6" id="7OJcYq__qEK" role="3cpWs9">
+            <property role="TrG5h" value="stringProp" />
+            <node concept="2OqwBi" id="7OJcYq__qEL" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYq__E6Y" role="2Oq$k0">
+                <node concept="2WthIp" id="7OJcYq__E71" role="2Oq$k0" />
+                <node concept="2XshWL" id="7OJcYq__E73" role="2OqNvi">
+                  <ref role="2WH_rO" node="7OJcYq__iNE" resolve="filter" />
+                  <node concept="37vLTw" id="7OJcYq__qEN" role="2XxRq1">
+                    <ref role="3cqZAo" node="7OJcYq__qEF" resolve="roots" />
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYq__qEO" role="2XxRq1">
+                    <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
+                    <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.LanguageEntity)" resolve="from" />
+                    <node concept="2YIFZM" id="7OJcYq__qEP" role="37wK5m">
+                      <ref role="37wK5l" to="cz4z:~LionCore.getContainment()" resolve="getContainment" />
+                      <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="7OJcYq__qEQ" role="2XxRq1">
+                    <property role="Xl_RC" value="anything" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1uHKPH" id="7OJcYq__qER" role="2OqNvi" />
+            </node>
+            <node concept="PeGgZ" id="7OJcYq__qES" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq__qET" role="3cqZAp" />
+        <node concept="2Hmddi" id="7OJcYq__qEU" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYq__qEV" role="2Hmdds">
+            <ref role="3cqZAo" node="7OJcYq__qEK" resolve="stringProp" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7OJcYq__qEW" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq__qEX" role="3cpWs9">
+            <property role="TrG5h" value="type" />
+            <node concept="3uibUv" id="7OJcYq__qEY" role="1tU5fm">
+              <ref role="3uigEE" to="xfsv:~SerializedReferenceValue" resolve="SerializedReferenceValue" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYq__qEZ" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYq__qF0" role="2Oq$k0">
+                <node concept="2OqwBi" id="7OJcYq__qF1" role="2Oq$k0">
+                  <node concept="37vLTw" id="7OJcYq__qF2" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYq__qEK" resolve="stringProp" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYq__qF3" role="2OqNvi">
+                    <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getReferences()" resolve="getReferences" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="7OJcYq__qF4" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7OJcYq__qF5" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="7OJcYq__qF6" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq__qF7" role="3tpDZA">
+            <node concept="2OqwBi" id="7OJcYq__qF8" role="2Oq$k0">
+              <node concept="2OqwBi" id="7OJcYq__qF9" role="2Oq$k0">
+                <node concept="2OqwBi" id="7OJcYq__qFa" role="2Oq$k0">
+                  <node concept="37vLTw" id="7OJcYq__qFb" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYq__qEX" resolve="type" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYq__qFc" role="2OqNvi">
+                    <ref role="37wK5l" to="xfsv:~SerializedReferenceValue.getValue()" resolve="getValue" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="7OJcYq__qFd" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7OJcYq__qFe" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7OJcYq__qFf" role="2OqNvi">
+              <ref role="37wK5l" to="xfsv:~SerializedReferenceValue$Entry.getResolveInfo()" resolve="getResolveInfo" />
+            </node>
+          </node>
+          <node concept="Xl_RD" id="7OJcYq__qFg" role="3tpDZB">
+            <property role="Xl_RC" value="Node" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="7OJcYq__qFh" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq__qFi" role="3tpDZA">
+            <node concept="2OqwBi" id="7OJcYq__qFj" role="2Oq$k0">
+              <node concept="2OqwBi" id="7OJcYq__qFk" role="2Oq$k0">
+                <node concept="2OqwBi" id="7OJcYq__qFl" role="2Oq$k0">
+                  <node concept="37vLTw" id="7OJcYq__qFm" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYq__qEX" resolve="type" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYq__qFn" role="2OqNvi">
+                    <ref role="37wK5l" to="xfsv:~SerializedReferenceValue.getValue()" resolve="getValue" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="7OJcYq__qFo" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7OJcYq__qFp" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7OJcYq__qFq" role="2OqNvi">
+              <ref role="37wK5l" to="xfsv:~SerializedReferenceValue$Entry.getReference()" resolve="getReference" />
+            </node>
+          </node>
+          <node concept="Xl_RD" id="7OJcYq__qFr" role="3tpDZB">
+            <property role="Xl_RC" value="LionCore-builtins-Node" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="7OJcYq__sx6" role="1SL9yI">
+      <property role="TrG5h" value="refToBuiltinINamed" />
+      <node concept="3cqZAl" id="7OJcYq__sx7" role="3clF45" />
+      <node concept="3clFbS" id="7OJcYq__sxb" role="3clF47">
+        <node concept="3cpWs8" id="7OJcYq__taE" role="3cqZAp">
+          <node concept="3KEzu6" id="7OJcYq__taF" role="3cpWs9">
+            <property role="TrG5h" value="roots" />
+            <node concept="2OqwBi" id="7OJcYq__$py" role="33vP2m">
+              <node concept="2WthIp" id="7OJcYq__$p_" role="2Oq$k0" />
+              <node concept="2XshWL" id="7OJcYq__$pB" role="2OqNvi">
+                <ref role="2WH_rO" node="7OJcYq__iNQ" resolve="retrieveTestLang" />
+              </node>
+            </node>
+            <node concept="PeGgZ" id="7OJcYq__taH" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq__taI" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYq__taJ" role="3cqZAp">
+          <node concept="3KEzu6" id="7OJcYq__taK" role="3cpWs9">
+            <property role="TrG5h" value="stringProp" />
+            <node concept="2OqwBi" id="7OJcYq__taL" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYq__GVT" role="2Oq$k0">
+                <node concept="2WthIp" id="7OJcYq__GVW" role="2Oq$k0" />
+                <node concept="2XshWL" id="7OJcYq__GVY" role="2OqNvi">
+                  <ref role="2WH_rO" node="7OJcYq__iNE" resolve="filter" />
+                  <node concept="37vLTw" id="7OJcYq__taN" role="2XxRq1">
+                    <ref role="3cqZAo" node="7OJcYq__taF" resolve="roots" />
+                  </node>
+                  <node concept="2YIFZM" id="7OJcYq__taO" role="2XxRq1">
+                    <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
+                    <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.LanguageEntity)" resolve="from" />
+                    <node concept="2YIFZM" id="7OJcYq__taP" role="37wK5m">
+                      <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+                      <ref role="37wK5l" to="cz4z:~LionCore.getInterface()" resolve="getInterface" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="7OJcYq__taQ" role="2XxRq1">
+                    <property role="Xl_RC" value="TestInterfaceExtends3" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1uHKPH" id="7OJcYq__taR" role="2OqNvi" />
+            </node>
+            <node concept="PeGgZ" id="7OJcYq__taS" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq__taT" role="3cqZAp" />
+        <node concept="2Hmddi" id="7OJcYq__taU" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYq__taV" role="2Hmdds">
+            <ref role="3cqZAo" node="7OJcYq__taK" resolve="stringProp" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7OJcYq__taW" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq__taX" role="3cpWs9">
+            <property role="TrG5h" value="type" />
+            <node concept="3uibUv" id="7OJcYq__taY" role="1tU5fm">
+              <ref role="3uigEE" to="xfsv:~SerializedReferenceValue" resolve="SerializedReferenceValue" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYq__taZ" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYq__tb0" role="2Oq$k0">
+                <node concept="2OqwBi" id="7OJcYq__tb1" role="2Oq$k0">
+                  <node concept="37vLTw" id="7OJcYq__tb2" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYq__taK" resolve="stringProp" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYq__tb3" role="2OqNvi">
+                    <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getReferences()" resolve="getReferences" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="7OJcYq__tb4" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7OJcYq__tb5" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7OJcYq__tb6" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq__tb7" role="3cpWs9">
+            <property role="TrG5h" value="named" />
+            <node concept="3uibUv" id="7OJcYq__tb8" role="1tU5fm">
+              <ref role="3uigEE" to="xfsv:~SerializedReferenceValue$Entry" resolve="SerializedReferenceValue.Entry" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYq__tb9" role="33vP2m">
+              <node concept="1eOMI4" id="7OJcYq__tba" role="2Oq$k0">
+                <node concept="10QFUN" id="7OJcYq__tbb" role="1eOMHV">
+                  <node concept="2OqwBi" id="7OJcYq__tbc" role="10QFUP">
+                    <node concept="37vLTw" id="7OJcYq__tbd" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7OJcYq__taX" resolve="type" />
+                    </node>
+                    <node concept="liA8E" id="7OJcYq__tbe" role="2OqNvi">
+                      <ref role="37wK5l" to="xfsv:~SerializedReferenceValue.getValue()" resolve="getValue" />
+                    </node>
+                  </node>
+                  <node concept="_YKpA" id="7OJcYq__tbf" role="10QFUM">
+                    <node concept="3uibUv" id="7OJcYq__tbg" role="_ZDj9">
+                      <ref role="3uigEE" to="xfsv:~SerializedReferenceValue$Entry" resolve="SerializedReferenceValue.Entry" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1z4cxt" id="7OJcYq__tbh" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYq__tbi" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYq__tbj" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYq__tbk" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYq__tbl" role="3clFbG">
+                        <node concept="2OqwBi" id="7OJcYq__tbm" role="3uHU7B">
+                          <node concept="37vLTw" id="7OJcYq__tbn" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYq__tbq" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYq__tbo" role="2OqNvi">
+                            <ref role="37wK5l" to="xfsv:~SerializedReferenceValue$Entry.getReference()" resolve="getReference" />
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="7OJcYq__tbp" role="3uHU7w">
+                          <property role="Xl_RC" value="LionCore-builtins-INamed" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYq__tbq" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYq__tbr" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Hmddi" id="7OJcYq__tbs" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYq__tbt" role="2Hmdds">
+            <ref role="3cqZAo" node="7OJcYq__tb7" resolve="named" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="7OJcYq__tbu" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq__tbv" role="3tpDZA">
+            <node concept="37vLTw" id="7OJcYq__tbw" role="2Oq$k0">
+              <ref role="3cqZAo" node="7OJcYq__tb7" resolve="named" />
+            </node>
+            <node concept="liA8E" id="7OJcYq__tbx" role="2OqNvi">
+              <ref role="37wK5l" to="xfsv:~SerializedReferenceValue$Entry.getResolveInfo()" resolve="getResolveInfo" />
+            </node>
+          </node>
+          <node concept="Xl_RD" id="7OJcYq__tby" role="3tpDZB">
+            <property role="Xl_RC" value="INamed" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2XrIbr" id="7OJcYq__iNy" role="1qtyYc">
+      <property role="TrG5h" value="nameMp" />
+      <node concept="3uibUv" id="7OJcYq__iOt" role="3clF45">
+        <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
+      </node>
+      <node concept="3clFbS" id="7OJcYq__iN$" role="3clF47">
+        <node concept="3cpWs6" id="7OJcYq__j1F" role="3cqZAp">
+          <node concept="2YIFZM" id="7OJcYq__j1G" role="3cqZAk">
+            <ref role="37wK5l" to="xfsv:~MetaPointer.from(io.lionweb.lioncore.java.language.Feature)" resolve="from" />
+            <ref role="1Pybhc" to="xfsv:~MetaPointer" resolve="MetaPointer" />
+            <node concept="2OqwBi" id="7OJcYq__j1H" role="37wK5m">
+              <node concept="2OqwBi" id="7OJcYq__j1I" role="2Oq$k0">
+                <node concept="2OqwBi" id="7OJcYq__j1J" role="2Oq$k0">
+                  <node concept="liA8E" id="7OJcYq__j1K" role="2OqNvi">
+                    <ref role="37wK5l" to="imb3:~Classifier.allProperties()" resolve="allProperties" />
+                  </node>
+                  <node concept="2OqwBi" id="7OJcYq__Qq_" role="2Oq$k0">
+                    <node concept="2OqwBi" id="7OJcYq__j1L" role="2Oq$k0">
+                      <node concept="2ShNRf" id="7OJcYq__j1M" role="2Oq$k0">
+                        <node concept="1pGfFk" id="7OJcYq__j1N" role="2ShVmc">
+                          <ref role="37wK5l" to="6peh:5JNiskj4SJa" resolve="JsonConstants" />
+                          <node concept="2YIFZM" id="7OJcYq__j1O" role="37wK5m">
+                            <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                            <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
+                          </node>
+                          <node concept="2ShNRf" id="7OJcYq__j1P" role="37wK5m">
+                            <node concept="HV5vD" id="7OJcYq__j1Q" role="2ShVmc">
+                              <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                            </node>
+                          </node>
+                          <node concept="2ShNRf" id="7OJcYq__I_B" role="37wK5m">
+                            <node concept="1pGfFk" id="7OJcYq__Kxl" role="2ShVmc">
+                              <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                              <node concept="2OqwBi" id="7OJcYq__NhU" role="37wK5m">
+                                <node concept="1jGwE1" id="7OJcYq__M7i" role="2Oq$k0" />
+                                <node concept="liA8E" id="7OJcYq__OLN" role="2OqNvi">
+                                  <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="7OJcYq__j1S" role="2OqNvi">
+                        <ref role="37wK5l" to="6peh:7OJcYqxTGtE" resolve="getINamed" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="7OJcYq__RR6" role="2OqNvi">
+                      <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="7OJcYq__j1T" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7OJcYq__j1U" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="7OJcYq__iNC" role="1B3o_S" />
+    </node>
+    <node concept="2XrIbr" id="7OJcYq__iNE" role="1qtyYc">
+      <property role="TrG5h" value="filter" />
+      <node concept="37vLTG" id="7OJcYq__k2C" role="3clF46">
+        <property role="TrG5h" value="roots" />
+        <node concept="A3Dl8" id="7OJcYq__k2D" role="1tU5fm">
+          <node concept="3uibUv" id="7OJcYq__k2E" role="A3Ik2">
+            <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYq__k2F" role="3clF46">
+        <property role="TrG5h" value="concept" />
+        <node concept="3uibUv" id="7OJcYq__k2G" role="1tU5fm">
+          <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="7OJcYq__k2H" role="3clF46">
+        <property role="TrG5h" value="name" />
+        <node concept="17QB3L" id="7OJcYq__k2I" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="7OJcYq__iNG" role="3clF47">
+        <node concept="3clFbF" id="7OJcYq__kcB" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq__kcC" role="3clFbG">
+            <node concept="2OqwBi" id="7OJcYq__kcD" role="2Oq$k0">
+              <node concept="37vLTw" id="7OJcYq__kcE" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYq__k2C" resolve="roots" />
+              </node>
+              <node concept="3zZkjj" id="7OJcYq__kcF" role="2OqNvi">
+                <node concept="1bVj0M" id="7OJcYq__kcG" role="23t8la">
+                  <node concept="3clFbS" id="7OJcYq__kcH" role="1bW5cS">
+                    <node concept="3clFbF" id="7OJcYq__kcI" role="3cqZAp">
+                      <node concept="17R0WA" id="7OJcYq__kcJ" role="3clFbG">
+                        <node concept="37vLTw" id="7OJcYq__kcK" role="3uHU7w">
+                          <ref role="3cqZAo" node="7OJcYq__k2F" resolve="concept" />
+                        </node>
+                        <node concept="2OqwBi" id="7OJcYq__kcL" role="3uHU7B">
+                          <node concept="37vLTw" id="7OJcYq__kcM" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7OJcYq__kcO" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="7OJcYq__kcN" role="2OqNvi">
+                            <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getClassifier()" resolve="getClassifier" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="7OJcYq__kcO" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7OJcYq__kcP" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3zZkjj" id="7OJcYq__kcQ" role="2OqNvi">
+              <node concept="1bVj0M" id="7OJcYq__kcR" role="23t8la">
+                <node concept="3clFbS" id="7OJcYq__kcS" role="1bW5cS">
+                  <node concept="3clFbF" id="7OJcYq__kcT" role="3cqZAp">
+                    <node concept="2OqwBi" id="7OJcYq__kcU" role="3clFbG">
+                      <node concept="2OqwBi" id="7OJcYq__kcV" role="2Oq$k0">
+                        <node concept="2OqwBi" id="7OJcYq__kcW" role="2Oq$k0">
+                          <node concept="1eOMI4" id="7OJcYq__kcX" role="2Oq$k0">
+                            <node concept="10QFUN" id="7OJcYq__kcY" role="1eOMHV">
+                              <node concept="2OqwBi" id="7OJcYq__kcZ" role="10QFUP">
+                                <node concept="37vLTw" id="7OJcYq__kd0" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7OJcYq__kdr" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="7OJcYq__kd1" role="2OqNvi">
+                                  <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getProperties()" resolve="getProperties" />
+                                </node>
+                              </node>
+                              <node concept="_YKpA" id="7OJcYq__kd2" role="10QFUM">
+                                <node concept="3uibUv" id="7OJcYq__kd3" role="_ZDj9">
+                                  <ref role="3uigEE" to="xfsv:~SerializedPropertyValue" resolve="SerializedPropertyValue" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3zZkjj" id="7OJcYq__kd4" role="2OqNvi">
+                            <node concept="1bVj0M" id="7OJcYq__kd5" role="23t8la">
+                              <node concept="3clFbS" id="7OJcYq__kd6" role="1bW5cS">
+                                <node concept="3clFbF" id="7OJcYq__kd7" role="3cqZAp">
+                                  <node concept="17R0WA" id="7OJcYq__kd8" role="3clFbG">
+                                    <node concept="2OqwBi" id="7OJcYq__nLD" role="3uHU7w">
+                                      <node concept="2WthIp" id="7OJcYq__nLG" role="2Oq$k0" />
+                                      <node concept="2XshWL" id="7OJcYq__nLI" role="2OqNvi">
+                                        <ref role="2WH_rO" node="7OJcYq__iNy" resolve="nameMp" />
+                                      </node>
+                                    </node>
+                                    <node concept="2OqwBi" id="7OJcYq__kda" role="3uHU7B">
+                                      <node concept="37vLTw" id="7OJcYq__kdb" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="7OJcYq__kdd" resolve="it" />
+                                      </node>
+                                      <node concept="liA8E" id="7OJcYq__kdc" role="2OqNvi">
+                                        <ref role="37wK5l" to="xfsv:~SerializedPropertyValue.getMetaPointer()" resolve="getMetaPointer" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="Rh6nW" id="7OJcYq__kdd" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="7OJcYq__kde" role="1tU5fm" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3zZkjj" id="7OJcYq__kdf" role="2OqNvi">
+                          <node concept="1bVj0M" id="7OJcYq__kdg" role="23t8la">
+                            <node concept="3clFbS" id="7OJcYq__kdh" role="1bW5cS">
+                              <node concept="3clFbF" id="7OJcYq__kdi" role="3cqZAp">
+                                <node concept="17R0WA" id="7OJcYq__kdj" role="3clFbG">
+                                  <node concept="2OqwBi" id="7OJcYq__kdk" role="3uHU7B">
+                                    <node concept="37vLTw" id="7OJcYq__kdl" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="7OJcYq__kdo" resolve="it" />
+                                    </node>
+                                    <node concept="liA8E" id="7OJcYq__kdm" role="2OqNvi">
+                                      <ref role="37wK5l" to="xfsv:~SerializedPropertyValue.getValue()" resolve="getValue" />
+                                    </node>
+                                  </node>
+                                  <node concept="37vLTw" id="7OJcYq__kdn" role="3uHU7w">
+                                    <ref role="3cqZAo" node="7OJcYq__k2H" resolve="name" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="Rh6nW" id="7OJcYq__kdo" role="1bW2Oz">
+                              <property role="TrG5h" value="it" />
+                              <node concept="2jxLKc" id="7OJcYq__kdp" role="1tU5fm" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3GX2aA" id="7OJcYq__kdq" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="7OJcYq__kdr" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="7OJcYq__kds" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="7OJcYq__iNH" role="1B3o_S" />
+      <node concept="A3Dl8" id="7OJcYq__k2q" role="3clF45">
+        <node concept="3uibUv" id="7OJcYq__k2r" role="A3Ik2">
+          <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
+        </node>
+      </node>
+    </node>
+    <node concept="2XrIbr" id="7OJcYq__iNQ" role="1qtyYc">
+      <property role="TrG5h" value="retrieveTestLang" />
+      <node concept="3clFbS" id="7OJcYq__iNS" role="3clF47">
+        <node concept="3cpWs8" id="7OJcYq__kDC" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq__kDD" role="3cpWs9">
+            <property role="TrG5h" value="httpClient" />
+            <node concept="3uibUv" id="7OJcYq__kDE" role="1tU5fm">
+              <ref role="3uigEE" to="781x:~HttpClient" resolve="HttpClient" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYq__kDF" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYq__kDG" role="2Oq$k0">
+                <node concept="2YIFZM" id="7OJcYq__kDH" role="2Oq$k0">
+                  <ref role="1Pybhc" to="781x:~HttpClient" resolve="HttpClient" />
+                  <ref role="37wK5l" to="781x:~HttpClient.newBuilder()" resolve="newBuilder" />
+                </node>
+                <node concept="liA8E" id="7OJcYq__kDI" role="2OqNvi">
+                  <ref role="37wK5l" to="781x:~HttpClient$Builder.connectTimeout(java.time.Duration)" resolve="connectTimeout" />
+                  <node concept="2YIFZM" id="7OJcYq__kDJ" role="37wK5m">
+                    <ref role="1Pybhc" to="28m1:~Duration" resolve="Duration" />
+                    <ref role="37wK5l" to="28m1:~Duration.ofSeconds(long)" resolve="ofSeconds" />
+                    <node concept="3cmrfG" id="7OJcYq__kDK" role="37wK5m">
+                      <property role="3cmrfH" value="2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="7OJcYq__kDL" role="2OqNvi">
+                <ref role="37wK5l" to="781x:~HttpClient$Builder.build()" resolve="build" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq__kDM" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYq__kDN" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq__kDO" role="3cpWs9">
+            <property role="TrG5h" value="request" />
+            <node concept="3uibUv" id="7OJcYq__kDP" role="1tU5fm">
+              <ref role="3uigEE" to="781x:~HttpRequest" resolve="HttpRequest" />
+            </node>
+            <node concept="2OqwBi" id="7OJcYq__kDQ" role="33vP2m">
+              <node concept="2OqwBi" id="7OJcYq__kDR" role="2Oq$k0">
+                <node concept="2YIFZM" id="7OJcYq__kDS" role="2Oq$k0">
+                  <ref role="1Pybhc" to="781x:~HttpRequest" resolve="HttpRequest" />
+                  <ref role="37wK5l" to="781x:~HttpRequest.newBuilder(java.net.URI)" resolve="newBuilder" />
+                  <node concept="2YIFZM" id="7OJcYq__kDT" role="37wK5m">
+                    <ref role="37wK5l" to="zf81:~URI.create(java.lang.String)" resolve="create" />
+                    <ref role="1Pybhc" to="zf81:~URI" resolve="URI" />
+                    <node concept="Xl_RD" id="7OJcYq__kDU" role="37wK5m">
+                      <property role="Xl_RC" value="http://127.0.0.1:63320/lionweb/language?moduleRef=08caad75-8246-4427-bb4d-8444b6c5c729()" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="7OJcYq__kDV" role="2OqNvi">
+                  <ref role="37wK5l" to="781x:~HttpRequest$Builder.GET()" resolve="GET" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7OJcYq__kDW" role="2OqNvi">
+                <ref role="37wK5l" to="781x:~HttpRequest$Builder.build()" resolve="build" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7OJcYq__kDX" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq__kDY" role="3cpWs9">
+            <property role="TrG5h" value="response" />
+            <node concept="3uibUv" id="7OJcYq__kDZ" role="1tU5fm">
+              <ref role="3uigEE" to="781x:~HttpResponse" resolve="HttpResponse" />
+              <node concept="3uibUv" id="7OJcYq__kE0" role="11_B2D">
+                <ref role="3uigEE" to="guwi:~InputStream" resolve="InputStream" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7OJcYq__kE1" role="33vP2m">
+              <node concept="37vLTw" id="7OJcYq__kE2" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYq__kDD" resolve="httpClient" />
+              </node>
+              <node concept="liA8E" id="7OJcYq__kE3" role="2OqNvi">
+                <ref role="37wK5l" to="781x:~HttpClient.send(java.net.http.HttpRequest,java.net.http.HttpResponse$BodyHandler)" resolve="send" />
+                <node concept="37vLTw" id="7OJcYq__kE4" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYq__kDO" resolve="request" />
+                </node>
+                <node concept="2YIFZM" id="7OJcYq__kE5" role="37wK5m">
                   <ref role="37wK5l" to="781x:~HttpResponse$BodyHandlers.ofInputStream()" resolve="ofInputStream" />
                   <ref role="1Pybhc" to="781x:~HttpResponse$BodyHandlers" resolve="HttpResponse.BodyHandlers" />
                 </node>
@@ -1323,321 +1620,108 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="3LyuSndQn6l" role="3cqZAp" />
-        <node concept="3vlDli" id="3LyuSndQn6m" role="3cqZAp">
-          <node concept="10M0yZ" id="3LyuSndQn6n" role="3tpDZB">
-            <ref role="3cqZAo" to="zf81:~HttpURLConnection.HTTP_OK" resolve="HTTP_OK" />
+        <node concept="3vlDli" id="7OJcYq__kE6" role="3cqZAp">
+          <node concept="10M0yZ" id="7OJcYq__kE7" role="3tpDZB">
             <ref role="1PxDUh" to="zf81:~HttpURLConnection" resolve="HttpURLConnection" />
+            <ref role="3cqZAo" to="zf81:~HttpURLConnection.HTTP_OK" resolve="HTTP_OK" />
           </node>
-          <node concept="2OqwBi" id="3LyuSndQn6o" role="3tpDZA">
-            <node concept="37vLTw" id="3LyuSndQn6p" role="2Oq$k0">
-              <ref role="3cqZAo" node="3LyuSndQn6d" resolve="response" />
+          <node concept="2OqwBi" id="7OJcYq__kE8" role="3tpDZA">
+            <node concept="37vLTw" id="7OJcYq__kE9" role="2Oq$k0">
+              <ref role="3cqZAo" node="7OJcYq__kDY" resolve="response" />
             </node>
-            <node concept="liA8E" id="3LyuSndQn6q" role="2OqNvi">
+            <node concept="liA8E" id="7OJcYq__kEa" role="2OqNvi">
               <ref role="37wK5l" to="781x:~HttpResponse.statusCode()" resolve="statusCode" />
             </node>
           </node>
         </node>
-      </node>
-      <node concept="3Tm6S6" id="3LyuSndQkOF" role="1B3o_S" />
-      <node concept="3cqZAl" id="3LyuSndQl_T" role="3clF45" />
-      <node concept="37vLTG" id="3LyuSndQmvZ" role="3clF46">
-        <property role="TrG5h" value="nodes" />
-        <node concept="A3Dl8" id="3LyuSndQqVO" role="1tU5fm">
-          <node concept="3uibUv" id="3LyuSndQqVP" role="A3Ik2">
-            <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
+        <node concept="3clFbH" id="7OJcYq__kEb" role="3cqZAp" />
+        <node concept="3cpWs8" id="7OJcYq__kEc" role="3cqZAp">
+          <node concept="3cpWsn" id="7OJcYq__kEd" role="3cpWs9">
+            <property role="TrG5h" value="unserializer" />
+            <node concept="3uibUv" id="7OJcYq__kEe" role="1tU5fm">
+              <ref role="3uigEE" to="6peh:z1IqfFwqda" resolve="Deserializer" />
+            </node>
+            <node concept="2ShNRf" id="7OJcYq__kEf" role="33vP2m">
+              <node concept="1pGfFk" id="7OJcYq__kEg" role="2ShVmc">
+                <ref role="37wK5l" to="6peh:z1IqfFwqeg" resolve="Deserializer" />
+                <node concept="2OqwBi" id="7OJcYq__kEh" role="37wK5m">
+                  <node concept="37vLTw" id="7OJcYq__kEi" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYq__kDY" resolve="response" />
+                  </node>
+                  <node concept="liA8E" id="7OJcYq__kEj" role="2OqNvi">
+                    <ref role="37wK5l" to="781x:~HttpResponse.body()" resolve="body" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="7OJcYq__kEk" role="37wK5m">
+                  <node concept="1pGfFk" id="7OJcYq__kEl" role="2ShVmc">
+                    <ref role="37wK5l" to="6peh:5JNiskj4SJa" resolve="JsonConstants" />
+                    <node concept="2YIFZM" id="7OJcYq__kEm" role="37wK5m">
+                      <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
+                      <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                    </node>
+                    <node concept="2ShNRf" id="7OJcYq__kEn" role="37wK5m">
+                      <node concept="HV5vD" id="7OJcYq__kEo" role="2ShVmc">
+                        <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                      </node>
+                    </node>
+                    <node concept="2ShNRf" id="7OJcYq__mw_" role="37wK5m">
+                      <node concept="1pGfFk" id="7OJcYq__mZB" role="2ShVmc">
+                        <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                        <node concept="2OqwBi" id="7OJcYq__lsl" role="37wK5m">
+                          <node concept="1jGwE1" id="7OJcYq__lbj" role="2Oq$k0" />
+                          <node concept="liA8E" id="7OJcYq__lID" role="2OqNvi">
+                            <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7OJcYq__kEq" role="3cqZAp">
+          <node concept="3KEzu6" id="7OJcYq__kEr" role="3cpWs9">
+            <property role="TrG5h" value="roots" />
+            <node concept="2OqwBi" id="7OJcYq__kEs" role="33vP2m">
+              <node concept="37vLTw" id="7OJcYq__kEt" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYq__kEd" resolve="unserializer" />
+              </node>
+              <node concept="liA8E" id="7OJcYq__kEu" role="2OqNvi">
+                <ref role="37wK5l" to="6peh:z1IqfFwqy3" resolve="deserialize" />
+              </node>
+            </node>
+            <node concept="PeGgZ" id="7OJcYq__kEv" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq__kEw" role="3cqZAp" />
+        <node concept="3vFxKo" id="7OJcYq__kEx" role="3cqZAp">
+          <node concept="2OqwBi" id="7OJcYq__kEy" role="3vFALc">
+            <node concept="37vLTw" id="7OJcYq__kEz" role="2Oq$k0">
+              <ref role="3cqZAo" node="7OJcYq__kEr" resolve="roots" />
+            </node>
+            <node concept="1v1jN8" id="7OJcYq__kE$" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="7OJcYq__kE_" role="3cqZAp" />
+        <node concept="3cpWs6" id="7OJcYq__kEA" role="3cqZAp">
+          <node concept="37vLTw" id="7OJcYq__kEB" role="3cqZAk">
+            <ref role="3cqZAo" node="7OJcYq__kEr" resolve="roots" />
           </node>
         </node>
       </node>
-      <node concept="3uibUv" id="3LyuSndQvmf" role="Sfmx6">
-        <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
+      <node concept="3Tm6S6" id="7OJcYq__iNT" role="1B3o_S" />
+      <node concept="_YKpA" id="7OJcYq__kDq" role="3clF45">
+        <node concept="3uibUv" id="7OJcYq__kDr" role="_ZDj9">
+          <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
+        </node>
       </node>
-      <node concept="3uibUv" id="3LyuSndQw3J" role="Sfmx6">
+      <node concept="3uibUv" id="7OJcYq__n9t" role="Sfmx6">
         <ref role="3uigEE" to="wyt6:~InterruptedException" resolve="InterruptedException" />
       </node>
-    </node>
-    <node concept="3Tm1VV" id="6Fo9k$JyLNt" role="1B3o_S" />
-    <node concept="3s_gsd" id="6Fo9k$JyLNu" role="3s_ewO">
-      <node concept="3s$Bmu" id="6Fo9k$JyRli" role="3s_gse">
-        <property role="3s$Bm0" value="readInstanceFromServer" />
-        <node concept="3cqZAl" id="6Fo9k$JyRlj" role="3clF45" />
-        <node concept="3Tm1VV" id="6Fo9k$JyRlk" role="1B3o_S" />
-        <node concept="3clFbS" id="6Fo9k$JyRll" role="3clF47">
-          <node concept="3cpWs8" id="6Fo9k$Jz1th" role="3cqZAp">
-            <node concept="3cpWsn" id="6Fo9k$Jz1ti" role="3cpWs9">
-              <property role="TrG5h" value="instances" />
-              <node concept="_YKpA" id="6Fo9k$Jz1pj" role="1tU5fm">
-                <node concept="3uibUv" id="6Fo9k$Jz1pm" role="_ZDj9">
-                  <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
-                </node>
-              </node>
-              <node concept="1rXfSq" id="6Fo9k$Jz1tj" role="33vP2m">
-                <ref role="37wK5l" node="6Fo9k$JySGH" resolve="read" />
-              </node>
-            </node>
-          </node>
-          <node concept="3vlDli" id="6Fo9k$Jz1xP" role="3cqZAp">
-            <node concept="2OqwBi" id="6Fo9k$Jz213" role="3tpDZA">
-              <node concept="37vLTw" id="6Fo9k$Jz1Ai" role="2Oq$k0">
-                <ref role="3cqZAo" node="6Fo9k$Jz1ti" resolve="instances" />
-              </node>
-              <node concept="34oBXx" id="6Fo9k$Jz2zk" role="2OqNvi" />
-            </node>
-            <node concept="3cmrfG" id="6Fo9k$JzqgJ" role="3tpDZB">
-              <property role="3cmrfH" value="3" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3s$Bmu" id="6Fo9k$JyLOt" role="3s_gse">
-        <property role="3s$Bm0" value="writeUnchangedToServer" />
-        <node concept="3cqZAl" id="6Fo9k$JyLOu" role="3clF45" />
-        <node concept="3Tm1VV" id="6Fo9k$JyLOv" role="1B3o_S" />
-        <node concept="3clFbS" id="6Fo9k$JyLOw" role="3clF47">
-          <node concept="3cpWs8" id="6Fo9k$Jz2DF" role="3cqZAp">
-            <node concept="3cpWsn" id="6Fo9k$Jz2DG" role="3cpWs9">
-              <property role="TrG5h" value="originalInstances" />
-              <node concept="_YKpA" id="6Fo9k$Jz2DH" role="1tU5fm">
-                <node concept="3uibUv" id="6Fo9k$Jz2DI" role="_ZDj9">
-                  <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
-                </node>
-              </node>
-              <node concept="1rXfSq" id="6Fo9k$Jz2DJ" role="33vP2m">
-                <ref role="37wK5l" node="6Fo9k$JySGH" resolve="read" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="6Fo9k$Jz2_8" role="3cqZAp" />
-          <node concept="3clFbF" id="3LyuSndQxsE" role="3cqZAp">
-            <node concept="1rXfSq" id="3LyuSndQxsC" role="3clFbG">
-              <ref role="37wK5l" node="3LyuSndQlB2" resolve="write" />
-              <node concept="37vLTw" id="3LyuSndQxL7" role="37wK5m">
-                <ref role="3cqZAo" node="6Fo9k$Jz2DG" resolve="originalInstances" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="3LyuSndQwO7" role="3cqZAp" />
-          <node concept="3cpWs8" id="6Fo9k$JzGdE" role="3cqZAp">
-            <node concept="3cpWsn" id="6Fo9k$JzGdF" role="3cpWs9">
-              <property role="TrG5h" value="newInstances" />
-              <node concept="_YKpA" id="6Fo9k$JzGdG" role="1tU5fm">
-                <node concept="3uibUv" id="6Fo9k$JzGdH" role="_ZDj9">
-                  <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
-                </node>
-              </node>
-              <node concept="1rXfSq" id="6Fo9k$JzGdI" role="33vP2m">
-                <ref role="37wK5l" node="6Fo9k$JySGH" resolve="read" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="6Fo9k$JzGQg" role="3cqZAp" />
-          <node concept="3vlDli" id="6Fo9k$JzH10" role="3cqZAp">
-            <node concept="2ShNRf" id="6Fo9k$JzJ0U" role="3tpDZB">
-              <node concept="2i4dXS" id="6Fo9k$JzJsz" role="2ShVmc">
-                <node concept="37vLTw" id="6Fo9k$JzJYY" role="I$8f6">
-                  <ref role="3cqZAo" node="6Fo9k$Jz2DG" resolve="originalInstances" />
-                </node>
-              </node>
-            </node>
-            <node concept="2ShNRf" id="6Fo9k$JzK_L" role="3tpDZA">
-              <node concept="2i4dXS" id="6Fo9k$JzL2l" role="2ShVmc">
-                <node concept="37vLTw" id="6Fo9k$JzM3Y" role="I$8f6">
-                  <ref role="3cqZAo" node="6Fo9k$JzGdF" resolve="newInstances" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3s$Bmu" id="3LyuSndPfxX" role="3s_gse">
-        <property role="3s$Bm0" value="writeChangedToServer" />
-        <node concept="3cqZAl" id="3LyuSndPfxY" role="3clF45" />
-        <node concept="3Tm1VV" id="3LyuSndPfxZ" role="1B3o_S" />
-        <node concept="3clFbS" id="3LyuSndPfy0" role="3clF47">
-          <node concept="3cpWs8" id="3LyuSndPfy1" role="3cqZAp">
-            <node concept="3cpWsn" id="3LyuSndPfy2" role="3cpWs9">
-              <property role="TrG5h" value="originalInstances" />
-              <node concept="_YKpA" id="3LyuSndPfy3" role="1tU5fm">
-                <node concept="3uibUv" id="3LyuSndPfy4" role="_ZDj9">
-                  <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
-                </node>
-              </node>
-              <node concept="1rXfSq" id="3LyuSndPfy5" role="33vP2m">
-                <ref role="37wK5l" node="6Fo9k$JySGH" resolve="read" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="3LyuSndPfy6" role="3cqZAp" />
-          <node concept="3cpWs8" id="3LyuSndQd9E" role="3cqZAp">
-            <node concept="3cpWsn" id="3LyuSndQd9F" role="3cpWs9">
-              <property role="TrG5h" value="libNode" />
-              <node concept="3uibUv" id="3LyuSndQd9G" role="1tU5fm">
-                <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
-              </node>
-              <node concept="10Nm6u" id="3LyuSndQi13" role="33vP2m" />
-            </node>
-          </node>
-          <node concept="3cpWs8" id="3LyuSndPSvF" role="3cqZAp">
-            <node concept="3cpWsn" id="3LyuSndPSvG" role="3cpWs9">
-              <property role="TrG5h" value="libNameProperty" />
-              <node concept="3uibUv" id="3LyuSndPSqu" role="1tU5fm">
-                <ref role="3uigEE" to="xfsv:~SerializedPropertyValue" resolve="SerializedPropertyValue" />
-              </node>
-              <node concept="10Nm6u" id="3LyuSndQhuJ" role="33vP2m" />
-            </node>
-          </node>
-          <node concept="2Gpval" id="3LyuSndQ0Z7" role="3cqZAp">
-            <node concept="2GrKxI" id="3LyuSndQ0Z9" role="2Gsz3X">
-              <property role="TrG5h" value="origInstance" />
-            </node>
-            <node concept="37vLTw" id="3LyuSndQ1Vs" role="2GsD0m">
-              <ref role="3cqZAo" node="3LyuSndPfy2" resolve="originalInstances" />
-            </node>
-            <node concept="3clFbS" id="3LyuSndQ0Zd" role="2LFqv$">
-              <node concept="2Gpval" id="3LyuSndQ2u$" role="3cqZAp">
-                <node concept="2GrKxI" id="3LyuSndQ2u_" role="2Gsz3X">
-                  <property role="TrG5h" value="prop" />
-                </node>
-                <node concept="2OqwBi" id="3LyuSndQ3Gj" role="2GsD0m">
-                  <node concept="2GrUjf" id="3LyuSndQ38e" role="2Oq$k0">
-                    <ref role="2Gs0qQ" node="3LyuSndQ0Z9" resolve="origInstance" />
-                  </node>
-                  <node concept="liA8E" id="3LyuSndQ48S" role="2OqNvi">
-                    <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getProperties()" resolve="getProperties" />
-                  </node>
-                </node>
-                <node concept="3clFbS" id="3LyuSndQ2uB" role="2LFqv$">
-                  <node concept="3clFbJ" id="3LyuSndQ4Kf" role="3cqZAp">
-                    <node concept="17R0WA" id="3LyuSndQ7ia" role="3clFbw">
-                      <node concept="Xl_RD" id="3LyuSndQ81d" role="3uHU7w">
-                        <property role="Xl_RC" value="MyLib" />
-                      </node>
-                      <node concept="2OqwBi" id="3LyuSndQ5Dk" role="3uHU7B">
-                        <node concept="2GrUjf" id="3LyuSndQ5aI" role="2Oq$k0">
-                          <ref role="2Gs0qQ" node="3LyuSndQ2u_" resolve="prop" />
-                        </node>
-                        <node concept="liA8E" id="3LyuSndQ6uq" role="2OqNvi">
-                          <ref role="37wK5l" to="xfsv:~SerializedPropertyValue.getValue()" resolve="getValue" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbS" id="3LyuSndQ4Kh" role="3clFbx">
-                      <node concept="3clFbF" id="3LyuSndQeSk" role="3cqZAp">
-                        <node concept="37vLTI" id="3LyuSndQfAD" role="3clFbG">
-                          <node concept="2GrUjf" id="3LyuSndQg1X" role="37vLTx">
-                            <ref role="2Gs0qQ" node="3LyuSndQ0Z9" resolve="origInstance" />
-                          </node>
-                          <node concept="37vLTw" id="3LyuSndQeSi" role="37vLTJ">
-                            <ref role="3cqZAo" node="3LyuSndQd9F" resolve="libNode" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbF" id="3LyuSndQ8QI" role="3cqZAp">
-                        <node concept="37vLTI" id="3LyuSndQaRz" role="3clFbG">
-                          <node concept="2GrUjf" id="3LyuSndQbtn" role="37vLTx">
-                            <ref role="2Gs0qQ" node="3LyuSndQ2u_" resolve="prop" />
-                          </node>
-                          <node concept="37vLTw" id="3LyuSndQapP" role="37vLTJ">
-                            <ref role="3cqZAo" node="3LyuSndPSvG" resolve="libNameProperty" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="3LyuSndPVal" role="3cqZAp">
-            <node concept="2OqwBi" id="3LyuSndPVCv" role="3clFbG">
-              <node concept="37vLTw" id="3LyuSndPVaj" role="2Oq$k0">
-                <ref role="3cqZAo" node="3LyuSndPSvG" resolve="libNameProperty" />
-              </node>
-              <node concept="liA8E" id="3LyuSndPWfZ" role="2OqNvi">
-                <ref role="37wK5l" to="xfsv:~SerializedPropertyValue.setValue(java.lang.String)" resolve="setValue" />
-                <node concept="Xl_RD" id="3LyuSndPWYH" role="37wK5m">
-                  <property role="Xl_RC" value="NewLib" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="3LyuSndPwdR" role="3cqZAp" />
-          <node concept="3clFbF" id="3LyuSndQzqe" role="3cqZAp">
-            <node concept="1rXfSq" id="3LyuSndQzqc" role="3clFbG">
-              <ref role="37wK5l" node="3LyuSndQlB2" resolve="write" />
-              <node concept="2ShNRf" id="3LyuSndQzLQ" role="37wK5m">
-                <node concept="2HTt$P" id="3LyuSndQ$Cj" role="2ShVmc">
-                  <node concept="3uibUv" id="3LyuSndQ$UQ" role="2HTBi0">
-                    <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
-                  </node>
-                  <node concept="37vLTw" id="3LyuSndQ_ip" role="2HTEbv">
-                    <ref role="3cqZAo" node="3LyuSndQd9F" resolve="libNode" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="3LyuSndQz6l" role="3cqZAp" />
-          <node concept="3cpWs8" id="3LyuSndPfzg" role="3cqZAp">
-            <node concept="3cpWsn" id="3LyuSndPfzh" role="3cpWs9">
-              <property role="TrG5h" value="newInstances" />
-              <node concept="_YKpA" id="3LyuSndPfzi" role="1tU5fm">
-                <node concept="3uibUv" id="3LyuSndPfzj" role="_ZDj9">
-                  <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
-                </node>
-              </node>
-              <node concept="1rXfSq" id="3LyuSndPfzk" role="33vP2m">
-                <ref role="37wK5l" node="6Fo9k$JySGH" resolve="read" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="3LyuSndPfzl" role="3cqZAp" />
-          <node concept="3vlDli" id="3LyuSndPfzm" role="3cqZAp">
-            <node concept="2ShNRf" id="3LyuSndPfzn" role="3tpDZB">
-              <node concept="2i4dXS" id="3LyuSndPfzo" role="2ShVmc">
-                <node concept="37vLTw" id="3LyuSndPfzp" role="I$8f6">
-                  <ref role="3cqZAo" node="3LyuSndPfy2" resolve="originalInstances" />
-                </node>
-              </node>
-            </node>
-            <node concept="2ShNRf" id="3LyuSndPfzq" role="3tpDZA">
-              <node concept="2i4dXS" id="3LyuSndPfzr" role="2ShVmc">
-                <node concept="37vLTw" id="3LyuSndPfzs" role="I$8f6">
-                  <ref role="3cqZAo" node="3LyuSndPfzh" resolve="newInstances" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbH" id="3LyuSndQAiL" role="3cqZAp" />
-          <node concept="3clFbF" id="3LyuSndQAxj" role="3cqZAp">
-            <node concept="2OqwBi" id="3LyuSndQALn" role="3clFbG">
-              <node concept="37vLTw" id="3LyuSndQAxh" role="2Oq$k0">
-                <ref role="3cqZAo" node="3LyuSndPSvG" resolve="libNameProperty" />
-              </node>
-              <node concept="liA8E" id="3LyuSndQBgx" role="2OqNvi">
-                <ref role="37wK5l" to="xfsv:~SerializedPropertyValue.setValue(java.lang.String)" resolve="setValue" />
-                <node concept="Xl_RD" id="3LyuSndQBDg" role="37wK5m">
-                  <property role="Xl_RC" value="MyLib" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="3LyuSndQCdV" role="3cqZAp">
-            <node concept="1rXfSq" id="3LyuSndQCdW" role="3clFbG">
-              <ref role="37wK5l" node="3LyuSndQlB2" resolve="write" />
-              <node concept="2ShNRf" id="3LyuSndQCdX" role="37wK5m">
-                <node concept="2HTt$P" id="3LyuSndQCdY" role="2ShVmc">
-                  <node concept="3uibUv" id="3LyuSndQCdZ" role="2HTBi0">
-                    <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
-                  </node>
-                  <node concept="37vLTw" id="3LyuSndQCe0" role="2HTEbv">
-                    <ref role="3cqZAo" node="3LyuSndQd9F" resolve="libNode" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
+      <node concept="3uibUv" id="7OJcYq__npT" role="Sfmx6">
+        <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
       </node>
     </node>
   </node>

--- a/solutions/io.lionweb.mps.server.test/models/io.lionweb.mps.server.test.language@tests.mps
+++ b/solutions/io.lionweb.mps.server.test/models/io.lionweb.mps.server.test.language@tests.mps
@@ -18,6 +18,8 @@
     <import index="imb3" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.language(io.lionweb.lioncore.java/)" />
     <import index="cz4z" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.self(io.lionweb.lioncore.java/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="ofrr" ref="r:6a974d9b-2388-4f82-8f03-f540b2d0448e(io.lionweb.mps.json.test.json2lioncore@tests)" />
+    <import index="y7p" ref="r:3303ef0b-a58e-4f50-b3cb-bd3d7aaf3653(io.lionweb.mps.m3.runtime)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -334,6 +336,7 @@
                         <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
                       </node>
                     </node>
+                    <node concept="10Nm6u" id="7OJcYqxXqvw" role="37wK5m" />
                   </node>
                 </node>
               </node>
@@ -824,6 +827,7 @@
                             <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
                           </node>
                         </node>
+                        <node concept="10Nm6u" id="7OJcYqxXtXS" role="37wK5m" />
                       </node>
                     </node>
                     <node concept="liA8E" id="5TNjoy1x3nU" role="2OqNvi">
@@ -1128,6 +1132,7 @@
                         <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
                       </node>
                     </node>
+                    <node concept="10Nm6u" id="7OJcYqxXlnt" role="37wK5m" />
                   </node>
                 </node>
               </node>


### PR DESCRIPTION
Refactored how representations of the same thing in different metamodels are stapled together (`IKeyedStaple`/`IJsonStaple`).

Fixes a bug where `jetbrains.mps.lang.core` would be exported with invalid key.

Still open: #100.