### PR TITLE
Merge/extend export tests 2021.1 from main

### DIFF
--- a/.mps/modules.xml
+++ b/.mps/modules.xml
@@ -9,6 +9,8 @@
       <modulePath path="$PROJECT_DIR$/languages/io.lionweb.mps.converter.TestComputedProperty/io.lionweb.mps.converter.TestComputedProperty.mpl" folder="test.langs" />
       <modulePath path="$PROJECT_DIR$/languages/io.lionweb.mps.converter.TestCoreRefLang/io.lionweb.mps.converter.TestCoreRefLang.mpl" folder="test.langs" />
       <modulePath path="$PROJECT_DIR$/languages/io.lionweb.mps.converter.TestCustomDatatype/io.lionweb.mps.converter.TestCustomDatatype.mpl" folder="test.langs" />
+      <modulePath path="$PROJECT_DIR$/languages/io.lionweb.mps.converter.TestDeprecated/io.lionweb.mps.converter.TestDeprecated.mpl" folder="test.langs" />
+      <modulePath path="$PROJECT_DIR$/languages/io.lionweb.mps.converter.TestEnum/io.lionweb.mps.converter.TestEnum.mpl" folder="test.langs" />
       <modulePath path="$PROJECT_DIR$/languages/io.lionweb.mps.converter.TestLang/io.lionweb.mps.converter.TestLang.mpl" folder="test.langs" />
       <modulePath path="$PROJECT_DIR$/languages/io.lionweb.mps.converter.TestLang2/io.lionweb.mps.converter.TestLang2.mpl" folder="test.langs" />
       <modulePath path="$PROJECT_DIR$/languages/io.lionweb.mps.converter.TestLang3/io.lionweb.mps.converter.TestLang3.mpl" folder="test.langs" />

--- a/build.xml
+++ b/build.xml
@@ -219,6 +219,7 @@
           <module ref="9abaaae2-decf-4e97-bf80-9109e8b759cc(jetbrains.mps.lang.messages.api)" kind="rt" />
           <module ref="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" kind="rt" />
           <module ref="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" kind="rt" />
+          <module ref="7350a1d7-537e-4f0d-9965-e91c82522d7d(io.lionweb.mps.m3.runtime)" kind="cl" />
           <module ref="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" kind="cl" />
           <module ref="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" kind="cl" />
           <module ref="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" kind="cl" />
@@ -2761,6 +2762,124 @@
       <zipfileset file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLanguageAnnotation/io.lionweb.mps.converter.TestLanguageAnnotation.mpl" prefix="module" />
       <zipfileset dir="${build.tmp}/customProcessors/copyModels/languages-io.lionweb.mps.converter.TestLanguageAnnotation-models" prefix="module/models" />
     </jar>
+    <mkdir dir="${build.tmp}/default/io.lionweb.mps.converter.TestDeprecated.jar" />
+    <mkdir dir="${build.tmp}/default/io.lionweb.mps.converter.TestDeprecated.jar/META-INF" />
+    <echoxml file="${build.tmp}/default/io.lionweb.mps.converter.TestDeprecated.jar/META-INF/module.xml">
+      <module namespace="io.lionweb.mps.converter.TestDeprecated" type="language" uuid="09360184-8598-44e7-9bf5-fb1ce45a480a">
+        <dependencies>
+          <module ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" kind="rt" />
+          <module ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" kind="rt" />
+          <module ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" kind="rt" />
+          <module ref="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" kind="rt" />
+          <module ref="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" kind="rt" />
+          <module ref="a3e4657f-a76c-45bb-bbda-c764596ecc65(jetbrains.mps.baseLanguage.logging.runtime)" kind="rt" />
+          <module ref="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" kind="rt" />
+          <module ref="d44dab97-aaac-44cb-9745-8a14db674c03(jetbrains.mps.baseLanguage.tuples.runtime)" kind="rt" />
+          <module ref="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" kind="rt" />
+          <module ref="d936855b-48da-4812-a8a0-2bfddd633ac4(jetbrains.mps.lang.behavior.runtime)" kind="rt" />
+          <module ref="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" kind="rt" />
+          <module ref="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" kind="cl" />
+        </dependencies>
+        <uses>
+          <language id="l:411e5b27-8a76-482e-8af8-1704262b4468:io.lionweb.mps.structure.attribute" />
+          <language id="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" />
+          <language id="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" />
+          <language id="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" />
+          <language id="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" />
+          <language id="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" />
+          <language id="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" />
+          <language id="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" />
+          <language id="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" />
+          <language id="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" />
+          <language id="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" />
+          <language id="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" />
+          <language id="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" />
+          <language id="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" />
+        </uses>
+        <classpath>
+          <entry path="." />
+        </classpath>
+        <sources jar="io.lionweb.mps.converter.TestDeprecated-src.jar" descriptor="io.lionweb.mps.converter.TestDeprecated.mpl" />
+      </module>
+    </echoxml>
+    <jar destfile="${build.layout}/io.lionweb.mps.tests.contributions/languages/lionweb-mps-tests.contributions/io.lionweb.mps.converter.TestDeprecated.jar" duplicate="preserve">
+      <fileset dir="${build.tmp}/java/out/io.lionweb.mps.converter.TestDeprecated" />
+      <fileset dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestDeprecated" includes="icons/**, resources/**" />
+      <fileset dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestDeprecated/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
+      <fileset dir="${build.tmp}/default/io.lionweb.mps.converter.TestDeprecated.jar" />
+    </jar>
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/languages-io.lionweb.mps.converter.TestDeprecated-models">
+      <fileset dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestDeprecated/models" includes="**/*.mps, **/*.mpsr, **/.model" />
+    </copyModels>
+    <jar destfile="${build.layout}/io.lionweb.mps.tests.contributions/languages/lionweb-mps-tests.contributions/io.lionweb.mps.converter.TestDeprecated-src.jar" duplicate="preserve">
+      <fileset dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestDeprecated/source_gen">
+        <exclude name="**/trace.info" />
+        <exclude name="**/exports" />
+        <exclude name="**/checkpoints" />
+        <exclude name="**/*.mps" />
+      </fileset>
+      <zipfileset file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestDeprecated/io.lionweb.mps.converter.TestDeprecated.mpl" prefix="module" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/languages-io.lionweb.mps.converter.TestDeprecated-models" prefix="module/models" />
+    </jar>
+    <mkdir dir="${build.tmp}/default/io.lionweb.mps.converter.TestEnum.jar" />
+    <mkdir dir="${build.tmp}/default/io.lionweb.mps.converter.TestEnum.jar/META-INF" />
+    <echoxml file="${build.tmp}/default/io.lionweb.mps.converter.TestEnum.jar/META-INF/module.xml">
+      <module namespace="io.lionweb.mps.converter.TestEnum" type="language" uuid="1ec6d5e7-6402-4c18-95d0-6e0906eb1ff1">
+        <dependencies>
+          <module ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" kind="rt" />
+          <module ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" kind="rt" />
+          <module ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" kind="rt" />
+          <module ref="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" kind="rt" />
+          <module ref="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" kind="rt" />
+          <module ref="a3e4657f-a76c-45bb-bbda-c764596ecc65(jetbrains.mps.baseLanguage.logging.runtime)" kind="rt" />
+          <module ref="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" kind="rt" />
+          <module ref="d44dab97-aaac-44cb-9745-8a14db674c03(jetbrains.mps.baseLanguage.tuples.runtime)" kind="rt" />
+          <module ref="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" kind="rt" />
+          <module ref="d936855b-48da-4812-a8a0-2bfddd633ac4(jetbrains.mps.lang.behavior.runtime)" kind="rt" />
+          <module ref="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" kind="rt" />
+          <module ref="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" kind="cl" />
+        </dependencies>
+        <uses>
+          <language id="l:411e5b27-8a76-482e-8af8-1704262b4468:io.lionweb.mps.structure.attribute" />
+          <language id="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" />
+          <language id="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" />
+          <language id="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" />
+          <language id="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" />
+          <language id="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" />
+          <language id="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" />
+          <language id="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" />
+          <language id="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" />
+          <language id="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" />
+          <language id="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" />
+          <language id="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" />
+          <language id="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" />
+          <language id="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" />
+        </uses>
+        <classpath>
+          <entry path="." />
+        </classpath>
+        <sources jar="io.lionweb.mps.converter.TestEnum-src.jar" descriptor="io.lionweb.mps.converter.TestEnum.mpl" />
+      </module>
+    </echoxml>
+    <jar destfile="${build.layout}/io.lionweb.mps.tests.contributions/languages/lionweb-mps-tests.contributions/io.lionweb.mps.converter.TestEnum.jar" duplicate="preserve">
+      <fileset dir="${build.tmp}/java/out/io.lionweb.mps.converter.TestEnum" />
+      <fileset dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestEnum" includes="icons/**, resources/**" />
+      <fileset dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestEnum/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
+      <fileset dir="${build.tmp}/default/io.lionweb.mps.converter.TestEnum.jar" />
+    </jar>
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/languages-io.lionweb.mps.converter.TestEnum-models">
+      <fileset dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestEnum/models" includes="**/*.mps, **/*.mpsr, **/.model" />
+    </copyModels>
+    <jar destfile="${build.layout}/io.lionweb.mps.tests.contributions/languages/lionweb-mps-tests.contributions/io.lionweb.mps.converter.TestEnum-src.jar" duplicate="preserve">
+      <fileset dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestEnum/source_gen">
+        <exclude name="**/trace.info" />
+        <exclude name="**/exports" />
+        <exclude name="**/checkpoints" />
+        <exclude name="**/*.mps" />
+      </fileset>
+      <zipfileset file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestEnum/io.lionweb.mps.converter.TestEnum.mpl" prefix="module" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/languages-io.lionweb.mps.converter.TestEnum-models" prefix="module/models" />
+    </jar>
     <mkdir dir="${build.tmp}/default/io.lionweb.mps.converter.test.support.jar" />
     <mkdir dir="${build.tmp}/default/io.lionweb.mps.converter.test.support.jar/META-INF" />
     <echoxml file="${build.tmp}/default/io.lionweb.mps.converter.test.support.jar/META-INF/module.xml">
@@ -2989,6 +3108,7 @@
           <module ref="4d96f781-5fa4-4d94-817a-c51f74fdf43f(io.lionweb.mps.converter)" kind="cl" />
           <module ref="3ecd737b-418b-4a70-a991-f6b83f0e3247(io.lionweb.mps.converter.TestAbstract)" kind="cl" />
           <module ref="60791ea2-7a1d-4862-a1ef-f87878cc3b6e(io.lionweb.mps.converter.TestComputedProperty)" kind="cl" />
+          <module ref="1ec6d5e7-6402-4c18-95d0-6e0906eb1ff1(io.lionweb.mps.converter.TestEnum)" kind="cl" />
           <module ref="08caad75-8246-4427-bb4d-8444b6c5c729(io.lionweb.mps.converter.TestLang)" kind="cl" />
           <module ref="48d0f6eb-6186-4cec-83d1-7caedb05a494(io.lionweb.mps.converter.TestLang2)" kind="cl" />
           <module ref="099490a3-1e39-4ed1-bebc-8027665cecf9(io.lionweb.mps.converter.TestLang3)" kind="cl" />
@@ -3008,6 +3128,7 @@
           <language id="l:afd6d8a2-5e3b-49d1-ab82-c9cb7dc063bb:io.lionweb.mps.converter.TestAnnotation" />
           <language id="l:60791ea2-7a1d-4862-a1ef-f87878cc3b6e:io.lionweb.mps.converter.TestComputedProperty" />
           <language id="l:11541b24-a02a-4586-a931-92521b3f6166:io.lionweb.mps.converter.TestCustomDatatype" />
+          <language id="l:1ec6d5e7-6402-4c18-95d0-6e0906eb1ff1:io.lionweb.mps.converter.TestEnum" />
           <language id="l:08caad75-8246-4427-bb4d-8444b6c5c729:io.lionweb.mps.converter.TestLang" />
           <language id="l:48d0f6eb-6186-4cec-83d1-7caedb05a494:io.lionweb.mps.converter.TestLang2" />
           <language id="l:099490a3-1e39-4ed1-bebc-8027665cecf9:io.lionweb.mps.converter.TestLang3" />
@@ -3149,7 +3270,7 @@
     <delete dir="${build.layout}" />
   </target>
   
-  <target name="compileJava" depends="java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.m3.runtime, java.compile.io.lionweb.mps.structure.attribute, java.compile.io.lionweb.mps.specific, java.compile.io.lionweb.mps.server.plugin, java.compile.io.lionweb.mps.converter, java.compile.io.lionweb.mps.json, java.compile.java.modules.cycle.1, java.compile.io.lionweb.mps.converter.lang, java.compile.io.lionweb.mps.converter.lang.runtime, java.compile.io.lionweb.mps.client.connector, java.compile.io.lionweb.mps.client.ideaPlugin, java.compile.io.lionweb.mps.client.persistence, java.compile.io.lionweb.mps.cmdline, java.compile.io.lionweb.mps.build, java.compile.io.lionweb.mps.converter.TestAllBuiltins, java.compile.io.lionweb.mps.testsupport, java.compile.io.lionweb.mps.testsupport.generator, java.compile.io.lionweb.mps.converter.TestLang, java.compile.io.lionweb.mps.converter.TestLang2, java.compile.io.lionweb.mps.converter.TestLang3, java.compile.library, java.compile.MultiRefLang, java.compile.io.lionweb.mps.converter.TestCoreRefLang, java.compile.io.lionweb.mps.converter.TestCustomDatatype, java.compile.io.lionweb.mps.converter.TestAnnotation, java.compile.io.lionweb.mps.converter.TestRefs, java.compile.io.lionweb.mps.converter.deps.AnnotationAnnotates, java.compile.io.lionweb.mps.converter.deps.AnnotationAnnotates_Node, java.compile.io.lionweb.mps.converter.deps.AnnotationExtends, java.compile.io.lionweb.mps.converter.deps.AnnotationImplements, java.compile.io.lionweb.mps.converter.deps.ConceptExtends, java.compile.io.lionweb.mps.converter.deps.ConceptImplements, java.compile.io.lionweb.mps.converter.deps.ContainmentType, java.compile.io.lionweb.mps.converter.deps.InterfaceExtends, java.compile.io.lionweb.mps.converter.deps.LanguageDepends, java.compile.io.lionweb.mps.converter.deps.OnlyBuiltins, java.compile.io.lionweb.mps.converter.deps.PropertyType, java.compile.io.lionweb.mps.converter.deps.ReferenceType, java.compile.io.lionweb.mps.converter.deps.SmartReferenceType, java.compile.io.lionweb.mps.converter.deps.Standalone, java.compile.io.lionweb.mps.converter.deps.AvoidMultipleConcepts, java.compile.io.lionweb.mps.converter.TestAbstract, java.compile.io.lionweb.mps.converter.TestComputedProperty, java.compile.io.lionweb.mps.converter.TestLanguageAnnotation, java.compile.io.lionweb.mps.converter.test.support, java.compile.io.lionweb.mps.json.test.support, java.compile.io.lionweb.mps.lang.test, java.compile.io.lionweb.mps.json.test, java.compile.io.lionweb.mps.converter.test" />
+  <target name="compileJava" depends="java.compile.io.lionweb.mps.m3, java.compile.java.modules.cycle.1, java.compile.io.lionweb.mps.m3.runtime, java.compile.io.lionweb.mps.structure.attribute, java.compile.io.lionweb.mps.specific, java.compile.io.lionweb.mps.server.plugin, java.compile.io.lionweb.mps.converter, java.compile.io.lionweb.mps.json, java.compile.java.modules.cycle.2, java.compile.io.lionweb.mps.converter.lang, java.compile.io.lionweb.mps.converter.lang.runtime, java.compile.io.lionweb.mps.client.connector, java.compile.io.lionweb.mps.client.ideaPlugin, java.compile.io.lionweb.mps.client.persistence, java.compile.io.lionweb.mps.cmdline, java.compile.io.lionweb.mps.build, java.compile.io.lionweb.mps.converter.TestAllBuiltins, java.compile.io.lionweb.mps.testsupport, java.compile.io.lionweb.mps.testsupport.generator, java.compile.io.lionweb.mps.converter.TestLang, java.compile.io.lionweb.mps.converter.TestLang2, java.compile.io.lionweb.mps.converter.TestLang3, java.compile.library, java.compile.MultiRefLang, java.compile.io.lionweb.mps.converter.TestCoreRefLang, java.compile.io.lionweb.mps.converter.TestCustomDatatype, java.compile.io.lionweb.mps.converter.TestAnnotation, java.compile.io.lionweb.mps.converter.TestRefs, java.compile.io.lionweb.mps.converter.deps.AnnotationAnnotates, java.compile.io.lionweb.mps.converter.deps.AnnotationAnnotates_Node, java.compile.io.lionweb.mps.converter.deps.AnnotationExtends, java.compile.io.lionweb.mps.converter.deps.AnnotationImplements, java.compile.io.lionweb.mps.converter.deps.ConceptExtends, java.compile.io.lionweb.mps.converter.deps.ConceptImplements, java.compile.io.lionweb.mps.converter.deps.ContainmentType, java.compile.io.lionweb.mps.converter.deps.InterfaceExtends, java.compile.io.lionweb.mps.converter.deps.LanguageDepends, java.compile.io.lionweb.mps.converter.deps.OnlyBuiltins, java.compile.io.lionweb.mps.converter.deps.PropertyType, java.compile.io.lionweb.mps.converter.deps.ReferenceType, java.compile.io.lionweb.mps.converter.deps.SmartReferenceType, java.compile.io.lionweb.mps.converter.deps.Standalone, java.compile.io.lionweb.mps.converter.deps.AvoidMultipleConcepts, java.compile.io.lionweb.mps.converter.TestAbstract, java.compile.io.lionweb.mps.converter.TestComputedProperty, java.compile.io.lionweb.mps.converter.TestLanguageAnnotation, java.compile.io.lionweb.mps.converter.TestDeprecated, java.compile.io.lionweb.mps.converter.TestEnum, java.compile.io.lionweb.mps.converter.test.support, java.compile.io.lionweb.mps.json.test.support, java.compile.io.lionweb.mps.lang.test, java.compile.io.lionweb.mps.json.test, java.compile.io.lionweb.mps.converter.test" />
   
   <target name="processResources" />
   
@@ -3294,6 +3415,9 @@
         <module file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLang/io.lionweb.mps.converter.TestLang.mpl" />
         <module file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLanguageAnnotation/io.lionweb.mps.converter.TestLanguageAnnotation.mpl" bootstrap="true" />
         <module file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.deps.AvoidMultipleConcepts/io.lionweb.mps.converter.deps.AvoidMultipleConcepts.mpl" />
+        <module file="${lionweb-mps.home}/languages/io.lionweb.mps.m3/io.lionweb.mps.m3.mpl" bootstrap="true" />
+        <module file="${lionweb-mps.home}/solutions/io.lionweb.mps.m3.runtime/io.lionweb.mps.m3.runtime.msd" />
+        <module file="${lionweb-mps.home}/languages/io.lionweb.mps.specific/io.lionweb.mps.specific.mpl" bootstrap="true" />
         <module file="${lionweb-mps.home}/languages/io.lionweb.mps.structure.attribute/io.lionweb.mps.structure.attribute.mpl" />
         <module file="${lionweb-mps.home}/languages/io.lionweb.mps.testsupport/io.lionweb.mps.testsupport.mpl" />
         <module file="${lionweb-mps.home}/languages/library/library.mpl" />
@@ -3310,6 +3434,8 @@
         <module file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestAnnotation/io.lionweb.mps.converter.TestAnnotation.mpl" />
         <module file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestComputedProperty/io.lionweb.mps.converter.TestComputedProperty.mpl" />
         <module file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestCustomDatatype/io.lionweb.mps.converter.TestCustomDatatype.mpl" />
+        <module file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestDeprecated/io.lionweb.mps.converter.TestDeprecated.mpl" />
+        <module file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestEnum/io.lionweb.mps.converter.TestEnum.mpl" />
         <module file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLang2/io.lionweb.mps.converter.TestLang2.mpl" />
         <module file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLang3/io.lionweb.mps.converter.TestLang3.mpl" />
         <module file="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestRefs/io.lionweb.mps.converter.TestRefs.mpl" />
@@ -3332,15 +3458,12 @@
         <module file="${lionweb-mps.home}/solutions/io.lionweb.mps.converter.test.support/io.lionweb.mps.converter.test.support.msd" />
         <module file="${lionweb-mps.home}/solutions/io.lionweb.mps.json/io.lionweb.mps.json.msd" />
         <module file="${lionweb-mps.home}/solutions/io.lionweb.mps.json.test.support/io.lionweb.mps.json.test.support.msd" />
-        <module file="${lionweb-mps.home}/languages/io.lionweb.mps.m3/io.lionweb.mps.m3.mpl" />
-        <module file="${lionweb-mps.home}/solutions/io.lionweb.mps.m3.runtime/io.lionweb.mps.m3.runtime.msd" />
+        <module file="${lionweb-mps.home}/solutions/io.lionweb.mps.lang.test/io.lionweb.mps.lang.test.msd" />
         <module file="${lionweb-mps.home}/solutions/io.lionweb.mps.server.plugin/io.lionweb.mps.server.plugin.msd" />
-        <module file="${lionweb-mps.home}/languages/io.lionweb.mps.specific/io.lionweb.mps.specific.mpl" />
       </chunk>
       <chunk>
         <module file="${lionweb-mps.home}/solutions/io.lionweb.mps.converter.test/io.lionweb.mps.converter.test.msd" />
         <module file="${lionweb-mps.home}/solutions/io.lionweb.mps.json.test/io.lionweb.mps.json.test.msd" />
-        <module file="${lionweb-mps.home}/solutions/io.lionweb.mps.lang.test/io.lionweb.mps.lang.test.msd" />
       </chunk>
       <jvmargs>
         <arg value="-ea" />
@@ -3416,75 +3539,12 @@
     </copy>
   </target>
   
-  <target name="java.compile.io.lionweb.mps.m3.runtime" depends="java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.specific, java.compile.io.lionweb.mps.structure.attribute, fetchDependencies">
-    <mkdir dir="${lionweb-mps.home}/solutions/io.lionweb.mps.m3.runtime/source_gen" />
-    <mkdir dir="${build.tmp}/java/out/io.lionweb.mps.m3.runtime" />
-    <javac destdir="${build.tmp}/java/out/io.lionweb.mps.m3.runtime" fork="false" encoding="utf8" includeantruntime="false" debug="true">
+  <target name="java.compile.java.modules.cycle.1" depends="java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.specific, fetchDependencies">
+    <mkdir dir="${build.tmp}/java.modules.cycle.1" />
+    <javac destdir="${build.tmp}/java.modules.cycle.1" fork="false" encoding="utf8" nowarn="true" includeantruntime="false">
       <compilerarg value="-Xlint:none" />
       <src>
         <path location="${lionweb-mps.home}/solutions/io.lionweb.mps.m3.runtime/source_gen" />
-      </src>
-      <classpath>
-        <fileset file="${artifacts.mps}/lib/mps-core.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-annotations.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-openapi.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-context.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-constraints-runtime.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-problem.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-feedback-api.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-platform.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-messages-api.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-messages-for-rules.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-behavior-api.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-behavior-runtime.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-closures.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-collections.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-logging.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-tuples.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-references.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-messaging.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-boot-util.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-editor.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-editor-api.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-editor-runtime.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-generator.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-persistence.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-environment.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-project-check.jar" />
-        <fileset file="${artifacts.mps}/lib/mps-textgen.jar" />
-        <pathelement path="${build.tmp}/java/out/io.lionweb.mps.m3" />
-        <pathelement path="${build.tmp}/java/out/io.lionweb.mps.specific" />
-        <pathelement path="${build.tmp}/java/out/io.lionweb.mps.structure.attribute" />
-        <fileset file="${artifacts.IDEA}/lib/annotations.jar" />
-        <fileset dir="${artifacts.IDEA}/lib" includes="*.jar" />
-        <fileset file="${artifacts.IDEA}/lib/log4j.jar" />
-        <fileset file="${artifacts.IDEA}/lib/jdom.jar" />
-        <fileset file="${artifacts.IDEA}/lib/trove4j.jar" />
-        <fileset file="${artifacts.IDEA}/lib/ecj-4.16.jar" />
-        <fileset file="${artifacts.IDEA}/plugins/java/lib/ecj-4.16.jar" />
-        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.jar" />
-        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.closures.jar" />
-        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.collections.jar" />
-        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.scopes.jar" />
-        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.core.jar" />
-        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.modelapi.jar" />
-        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.scopes.runtime.jar" />
-        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.smodel.jar" />
-        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.structure.jar" />
-        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.traceable.jar" />
-      </classpath>
-    </javac>
-    <copy todir="${build.tmp}/java/out/io.lionweb.mps.m3.runtime">
-      <fileset dir="${lionweb-mps.home}/solutions/io.lionweb.mps.m3.runtime/source_gen" excludes="**/*.java" />
-    </copy>
-  </target>
-  
-  <target name="java.compile.io.lionweb.mps.structure.attribute" depends="fetchDependencies">
-    <mkdir dir="${lionweb-mps.home}/languages/io.lionweb.mps.structure.attribute/source_gen" />
-    <mkdir dir="${build.tmp}/java/out/io.lionweb.mps.structure.attribute" />
-    <javac destdir="${build.tmp}/java/out/io.lionweb.mps.structure.attribute" fork="false" encoding="utf8" includeantruntime="false" debug="true">
-      <compilerarg value="-Xlint:none" />
-      <src>
         <path location="${lionweb-mps.home}/languages/io.lionweb.mps.structure.attribute/source_gen" />
       </src>
       <classpath>
@@ -3522,12 +3582,138 @@
         <fileset file="${artifacts.IDEA}/lib/trove4j.jar" />
         <fileset file="${artifacts.IDEA}/lib/ecj-4.16.jar" />
         <fileset file="${artifacts.IDEA}/plugins/java/lib/ecj-4.16.jar" />
+        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.jar" />
+        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.closures.jar" />
+        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.collections.jar" />
+        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.scopes.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.core.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.modelapi.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.scopes.runtime.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.smodel.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.structure.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.traceable.jar" />
+        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.logging.runtime.jar" />
+        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.regexp.runtime.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.descriptor.aspects.jar" />
+        <pathelement path="${build.tmp}/java/out/io.lionweb.mps.m3" />
+        <pathelement path="${build.tmp}/java/out/io.lionweb.mps.specific" />
+      </classpath>
+    </javac>
+  </target>
+  
+  <target name="java.compile.io.lionweb.mps.m3.runtime" depends="java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.specific, java.compile.java.modules.cycle.1, fetchDependencies">
+    <mkdir dir="${lionweb-mps.home}/solutions/io.lionweb.mps.m3.runtime/source_gen" />
+    <mkdir dir="${build.tmp}/java/out/io.lionweb.mps.m3.runtime" />
+    <javac destdir="${build.tmp}/java/out/io.lionweb.mps.m3.runtime" fork="false" encoding="utf8" includeantruntime="false" debug="true">
+      <compilerarg value="-Xlint:none" />
+      <src>
+        <path location="${lionweb-mps.home}/solutions/io.lionweb.mps.m3.runtime/source_gen" />
+      </src>
+      <classpath>
+        <fileset file="${artifacts.mps}/lib/mps-core.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-annotations.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-openapi.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-context.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-constraints-runtime.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-problem.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-feedback-api.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-platform.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-messages-api.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-messages-for-rules.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-behavior-api.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-behavior-runtime.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-closures.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-collections.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-logging.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-tuples.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-references.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-messaging.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-boot-util.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-editor.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-editor-api.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-editor-runtime.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-generator.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-persistence.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-environment.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-project-check.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-textgen.jar" />
+        <pathelement path="${build.tmp}/java/out/io.lionweb.mps.m3" />
+        <pathelement path="${build.tmp}/java/out/io.lionweb.mps.specific" />
+        <fileset file="${artifacts.IDEA}/lib/annotations.jar" />
+        <fileset dir="${artifacts.IDEA}/lib" includes="*.jar" />
+        <fileset file="${artifacts.IDEA}/lib/log4j.jar" />
+        <fileset file="${artifacts.IDEA}/lib/jdom.jar" />
+        <fileset file="${artifacts.IDEA}/lib/trove4j.jar" />
+        <fileset file="${artifacts.IDEA}/lib/ecj-4.16.jar" />
+        <fileset file="${artifacts.IDEA}/plugins/java/lib/ecj-4.16.jar" />
+        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.jar" />
+        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.closures.jar" />
+        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.collections.jar" />
+        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.scopes.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.core.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.modelapi.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.scopes.runtime.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.smodel.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.structure.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.traceable.jar" />
+        <pathelement path="${build.tmp}/java.modules.cycle.1" />
+      </classpath>
+    </javac>
+    <copy todir="${build.tmp}/java/out/io.lionweb.mps.m3.runtime">
+      <fileset dir="${lionweb-mps.home}/solutions/io.lionweb.mps.m3.runtime/source_gen" excludes="**/*.java" />
+    </copy>
+  </target>
+  
+  <target name="java.compile.io.lionweb.mps.structure.attribute" depends="java.compile.java.modules.cycle.1, fetchDependencies">
+    <mkdir dir="${lionweb-mps.home}/languages/io.lionweb.mps.structure.attribute/source_gen" />
+    <mkdir dir="${build.tmp}/java/out/io.lionweb.mps.structure.attribute" />
+    <javac destdir="${build.tmp}/java/out/io.lionweb.mps.structure.attribute" fork="false" encoding="utf8" includeantruntime="false" debug="true">
+      <compilerarg value="-Xlint:none" />
+      <src>
+        <path location="${lionweb-mps.home}/languages/io.lionweb.mps.structure.attribute/source_gen" />
+      </src>
+      <classpath>
+        <fileset file="${artifacts.mps}/lib/mps-core.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-annotations.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-behavior-api.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-behavior-runtime.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-closures.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-collections.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-generator.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-openapi.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-logging.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-tuples.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-references.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-messaging.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-boot-util.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-context.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-constraints-runtime.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-persistence.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-project-check.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-textgen.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-problem.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-feedback-api.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-platform.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-messages-api.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-messages-for-rules.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-editor.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-editor-api.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-editor-runtime.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-environment.jar" />
+        <fileset file="${artifacts.IDEA}/lib/annotations.jar" />
+        <fileset file="${artifacts.IDEA}/lib/log4j.jar" />
+        <fileset file="${artifacts.IDEA}/lib/jdom.jar" />
+        <fileset file="${artifacts.IDEA}/lib/trove4j.jar" />
+        <fileset file="${artifacts.IDEA}/lib/ecj-4.16.jar" />
+        <fileset file="${artifacts.IDEA}/plugins/java/lib/ecj-4.16.jar" />
+        <fileset dir="${artifacts.IDEA}/lib" includes="*.jar" />
         <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.logging.runtime.jar" />
         <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.regexp.runtime.jar" />
         <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.core.jar" />
         <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.descriptor.aspects.jar" />
         <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.scopes.runtime.jar" />
         <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.structure.jar" />
+        <pathelement path="${build.tmp}/java.modules.cycle.1" />
       </classpath>
     </javac>
     <copy todir="${build.tmp}/java/out/io.lionweb.mps.structure.attribute">
@@ -3753,9 +3939,9 @@
     </copy>
   </target>
   
-  <target name="java.compile.java.modules.cycle.1" depends="java.compile.io.lionweb.mps.converter, java.compile.io.lionweb.mps.json, java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.m3.runtime, fetchDependencies">
-    <mkdir dir="${build.tmp}/java.modules.cycle.1" />
-    <javac destdir="${build.tmp}/java.modules.cycle.1" fork="false" encoding="utf8" nowarn="true" includeantruntime="false">
+  <target name="java.compile.java.modules.cycle.2" depends="java.compile.io.lionweb.mps.converter, java.compile.io.lionweb.mps.json, java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.m3.runtime, fetchDependencies">
+    <mkdir dir="${build.tmp}/java.modules.cycle.2" />
+    <javac destdir="${build.tmp}/java.modules.cycle.2" fork="false" encoding="utf8" nowarn="true" includeantruntime="false">
       <compilerarg value="-Xlint:none" />
       <src>
         <path location="${lionweb-mps.home}/languages/io.lionweb.mps.converter.lang/source_gen" />
@@ -3820,7 +4006,7 @@
     </javac>
   </target>
   
-  <target name="java.compile.io.lionweb.mps.converter.lang" depends="java.compile.io.lionweb.mps.converter, java.compile.io.lionweb.mps.json, java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.m3.runtime, java.compile.java.modules.cycle.1, fetchDependencies">
+  <target name="java.compile.io.lionweb.mps.converter.lang" depends="java.compile.io.lionweb.mps.converter, java.compile.io.lionweb.mps.json, java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.m3.runtime, java.compile.java.modules.cycle.2, fetchDependencies">
     <mkdir dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.lang/source_gen" />
     <mkdir dir="${build.tmp}/java/out/io.lionweb.mps.converter.lang" />
     <javac destdir="${build.tmp}/java/out/io.lionweb.mps.converter.lang" fork="false" encoding="utf8" includeantruntime="false" debug="true">
@@ -3883,7 +4069,7 @@
         <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.smodel.jar" />
         <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.structure.jar" />
         <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.traceable.jar" />
-        <pathelement path="${build.tmp}/java.modules.cycle.1" />
+        <pathelement path="${build.tmp}/java.modules.cycle.2" />
       </classpath>
     </javac>
     <copy todir="${build.tmp}/java/out/io.lionweb.mps.converter.lang">
@@ -3891,7 +4077,7 @@
     </copy>
   </target>
   
-  <target name="java.compile.io.lionweb.mps.converter.lang.runtime" depends="java.compile.io.lionweb.mps.converter, java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.m3.runtime, java.compile.java.modules.cycle.1, fetchDependencies">
+  <target name="java.compile.io.lionweb.mps.converter.lang.runtime" depends="java.compile.io.lionweb.mps.converter, java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.m3.runtime, java.compile.java.modules.cycle.2, fetchDependencies">
     <mkdir dir="${lionweb-mps.home}/solutions/io.lionweb.mps.converter.lang.runtime/source_gen" />
     <mkdir dir="${build.tmp}/java/out/io.lionweb.mps.converter.lang.runtime" />
     <javac destdir="${build.tmp}/java/out/io.lionweb.mps.converter.lang.runtime" fork="false" encoding="utf8" includeantruntime="false" debug="true">
@@ -3950,7 +4136,7 @@
         <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.smodel.jar" />
         <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.structure.jar" />
         <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.traceable.jar" />
-        <pathelement path="${build.tmp}/java.modules.cycle.1" />
+        <pathelement path="${build.tmp}/java.modules.cycle.2" />
       </classpath>
     </javac>
     <copy todir="${build.tmp}/java/out/io.lionweb.mps.converter.lang.runtime">
@@ -5528,6 +5714,92 @@
     </copy>
   </target>
   
+  <target name="java.compile.io.lionweb.mps.converter.TestDeprecated" depends="fetchDependencies">
+    <mkdir dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestDeprecated/source_gen" />
+    <mkdir dir="${build.tmp}/java/out/io.lionweb.mps.converter.TestDeprecated" />
+    <javac destdir="${build.tmp}/java/out/io.lionweb.mps.converter.TestDeprecated" fork="false" encoding="utf8" includeantruntime="false" debug="true">
+      <compilerarg value="-Xlint:none" />
+      <src>
+        <path location="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestDeprecated/source_gen" />
+      </src>
+      <classpath>
+        <fileset file="${artifacts.mps}/lib/mps-core.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-annotations.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-behavior-api.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-behavior-runtime.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-closures.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-collections.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-generator.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-openapi.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-logging.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-tuples.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-references.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-messaging.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-boot-util.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-context.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-constraints-runtime.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-persistence.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-project-check.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-textgen.jar" />
+        <fileset file="${artifacts.IDEA}/lib/annotations.jar" />
+        <fileset file="${artifacts.IDEA}/lib/log4j.jar" />
+        <fileset file="${artifacts.IDEA}/lib/jdom.jar" />
+        <fileset file="${artifacts.IDEA}/lib/trove4j.jar" />
+        <fileset file="${artifacts.IDEA}/lib/ecj-4.16.jar" />
+        <fileset file="${artifacts.IDEA}/plugins/java/lib/ecj-4.16.jar" />
+        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.logging.runtime.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.core.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.descriptor.aspects.jar" />
+      </classpath>
+    </javac>
+    <copy todir="${build.tmp}/java/out/io.lionweb.mps.converter.TestDeprecated">
+      <fileset dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestDeprecated/source_gen" excludes="**/*.java" />
+    </copy>
+  </target>
+  
+  <target name="java.compile.io.lionweb.mps.converter.TestEnum" depends="fetchDependencies">
+    <mkdir dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestEnum/source_gen" />
+    <mkdir dir="${build.tmp}/java/out/io.lionweb.mps.converter.TestEnum" />
+    <javac destdir="${build.tmp}/java/out/io.lionweb.mps.converter.TestEnum" fork="false" encoding="utf8" includeantruntime="false" debug="true">
+      <compilerarg value="-Xlint:none" />
+      <src>
+        <path location="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestEnum/source_gen" />
+      </src>
+      <classpath>
+        <fileset file="${artifacts.mps}/lib/mps-core.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-annotations.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-behavior-api.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-behavior-runtime.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-closures.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-collections.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-generator.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-openapi.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-logging.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-tuples.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-references.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-messaging.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-boot-util.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-context.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-constraints-runtime.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-persistence.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-project-check.jar" />
+        <fileset file="${artifacts.mps}/lib/mps-textgen.jar" />
+        <fileset file="${artifacts.IDEA}/lib/annotations.jar" />
+        <fileset file="${artifacts.IDEA}/lib/log4j.jar" />
+        <fileset file="${artifacts.IDEA}/lib/jdom.jar" />
+        <fileset file="${artifacts.IDEA}/lib/trove4j.jar" />
+        <fileset file="${artifacts.IDEA}/lib/ecj-4.16.jar" />
+        <fileset file="${artifacts.IDEA}/plugins/java/lib/ecj-4.16.jar" />
+        <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.logging.runtime.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.core.jar" />
+        <fileset file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.descriptor.aspects.jar" />
+      </classpath>
+    </javac>
+    <copy todir="${build.tmp}/java/out/io.lionweb.mps.converter.TestEnum">
+      <fileset dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestEnum/source_gen" excludes="**/*.java" />
+    </copy>
+  </target>
+  
   <target name="java.compile.io.lionweb.mps.converter.test.support" depends="java.compile.io.lionweb.mps.converter, java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.m3.runtime, fetchDependencies">
     <mkdir dir="${lionweb-mps.home}/solutions/io.lionweb.mps.converter.test.support/source_gen" />
     <mkdir dir="${build.tmp}/java/out/io.lionweb.mps.converter.test.support" />
@@ -5703,7 +5975,7 @@
     </copy>
   </target>
   
-  <target name="java.compile.io.lionweb.mps.json.test" depends="java.compile.MultiRefLang, java.compile.io.lionweb.mps.converter, java.compile.io.lionweb.mps.converter.TestAbstract, java.compile.io.lionweb.mps.converter.TestComputedProperty, java.compile.io.lionweb.mps.converter.TestLang, java.compile.io.lionweb.mps.converter.TestLang2, java.compile.io.lionweb.mps.converter.TestLang3, java.compile.io.lionweb.mps.converter.TestRefs, java.compile.io.lionweb.mps.converter.lang.runtime, java.compile.io.lionweb.mps.converter.test.support, java.compile.io.lionweb.mps.json, java.compile.io.lionweb.mps.json.test.support, java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.m3.runtime, java.compile.io.lionweb.mps.testsupport, java.compile.library, fetchDependencies">
+  <target name="java.compile.io.lionweb.mps.json.test" depends="java.compile.MultiRefLang, java.compile.io.lionweb.mps.converter, java.compile.io.lionweb.mps.converter.TestAbstract, java.compile.io.lionweb.mps.converter.TestComputedProperty, java.compile.io.lionweb.mps.converter.TestEnum, java.compile.io.lionweb.mps.converter.TestLang, java.compile.io.lionweb.mps.converter.TestLang2, java.compile.io.lionweb.mps.converter.TestLang3, java.compile.io.lionweb.mps.converter.TestRefs, java.compile.io.lionweb.mps.converter.lang.runtime, java.compile.io.lionweb.mps.converter.test.support, java.compile.io.lionweb.mps.json, java.compile.io.lionweb.mps.json.test.support, java.compile.io.lionweb.mps.m3, java.compile.io.lionweb.mps.m3.runtime, java.compile.io.lionweb.mps.testsupport, java.compile.library, fetchDependencies">
     <mkdir dir="${lionweb-mps.home}/solutions/io.lionweb.mps.json.test/test_gen" />
     <mkdir dir="${build.tmp}/java/out/io.lionweb.mps.json.test" />
     <javac destdir="${build.tmp}/java/out/io.lionweb.mps.json.test" fork="false" encoding="utf8" includeantruntime="false" debug="true">
@@ -5744,6 +6016,7 @@
         <fileset file="${artifacts.mps}/lib/mps-messages-api.jar" />
         <fileset file="${artifacts.mps}/lib/mps-messages-for-rules.jar" />
         <pathelement path="${build.tmp}/java/out/io.lionweb.mps.converter.TestComputedProperty" />
+        <pathelement path="${build.tmp}/java/out/io.lionweb.mps.converter.TestEnum" />
         <pathelement path="${build.tmp}/java/out/io.lionweb.mps.converter.TestLang" />
         <pathelement path="${build.tmp}/java/out/io.lionweb.mps.converter.TestLang2" />
         <pathelement path="${build.tmp}/java/out/io.lionweb.mps.converter.TestLang3" />
@@ -5996,6 +6269,7 @@
       <pathelement location="${build.layout}/io.lionweb.mps.tests.contributions/languages/lionweb-mps-tests.contributions/io.lionweb.mps.converter.TestComputedProperty.jar" />
       <pathelement location="${build.layout}/io.lionweb.mps.tests.contributions/languages/lionweb-mps-tests.contributions/io.lionweb.mps.converter.TestCoreRefLang.jar" />
       <pathelement location="${build.layout}/io.lionweb.mps.tests.contributions/languages/lionweb-mps-tests.contributions/io.lionweb.mps.converter.TestCustomDatatype.jar" />
+      <pathelement location="${build.layout}/io.lionweb.mps.tests.contributions/languages/lionweb-mps-tests.contributions/io.lionweb.mps.converter.TestEnum.jar" />
       <pathelement location="${build.layout}/io.lionweb.mps.tests.contributions/languages/lionweb-mps-tests.contributions/io.lionweb.mps.converter.TestLang.jar" />
       <pathelement location="${build.layout}/io.lionweb.mps.tests.contributions/languages/lionweb-mps-tests.contributions/io.lionweb.mps.converter.TestLang2.jar" />
       <pathelement location="${build.layout}/io.lionweb.mps.tests.contributions/languages/lionweb-mps-tests.contributions/io.lionweb.mps.converter.TestLang3.jar" />
@@ -6090,6 +6364,8 @@
     <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestAnnotation/source_gen" />
     <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestComputedProperty/source_gen" />
     <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestCustomDatatype/source_gen" />
+    <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestDeprecated/source_gen" />
+    <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestEnum/source_gen" />
     <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLang2/source_gen" />
     <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestLang3/source_gen" />
     <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.converter.TestRefs/source_gen" />
@@ -6112,15 +6388,12 @@
     <delete dir="${lionweb-mps.home}/solutions/io.lionweb.mps.converter.test.support/source_gen" />
     <delete dir="${lionweb-mps.home}/solutions/io.lionweb.mps.json/source_gen" />
     <delete dir="${lionweb-mps.home}/solutions/io.lionweb.mps.json.test.support/source_gen" />
-    <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.m3/source_gen" />
-    <delete dir="${lionweb-mps.home}/solutions/io.lionweb.mps.m3.runtime/source_gen" />
+    <delete dir="${lionweb-mps.home}/solutions/io.lionweb.mps.lang.test/test_gen" />
     <delete dir="${lionweb-mps.home}/solutions/io.lionweb.mps.server.plugin/source_gen" />
-    <delete dir="${lionweb-mps.home}/languages/io.lionweb.mps.specific/source_gen" />
     <delete dir="${lionweb-mps.home}/solutions/io.lionweb.mps.converter.test/test_gen" />
     <delete dir="${lionweb-mps.home}/solutions/io.lionweb.mps.json.test/test_gen" />
     <delete dir="${lionweb-mps.home}/solutions/io.lionweb.mps.lang.test/test_gen" />
     <delete dir="${lionweb-mps.home}/solutions/io.lionweb.mps.converter.test/test_gen" />
     <delete dir="${lionweb-mps.home}/solutions/io.lionweb.mps.json.test/test_gen" />
-    <delete dir="${lionweb-mps.home}/solutions/io.lionweb.mps.lang.test/test_gen" />
   </target>
 </project>

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 * Added optional `version` to LionWeb Language root in structure aspect.
   This value, if set, takes precendence over the language's version.
+* Set up testing of commandline export of languages.
 
 ## 0.2.9-2023.1
 
@@ -12,6 +13,7 @@
 * Added export of deprecation annotations.
 
 ## Up to 0.2.7-2023.1
+
 * Optionally export computed property values of instances to LionWeb JSON.
 
 * For concepts with alias and/or short description, optinally export annotation with that information.  

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 # Changelog for LionWeb-MPS
 
+## 0.2.10-2023.1
+
+* Added optional `version` to LionWeb Language root in structure aspect.
+  This value, if set, takes precendence over the language's version.
+
+## 0.2.9-2023.1
+
+* Fixed using enumeration literal's key in all cases.
+
+* Added export of deprecation annotations.
+
 ## Up to 0.2.7-2023.1
 * Optionally export computed property values of instances to LionWeb JSON.
 

--- a/docs/reference/converter-lang.adoc
+++ b/docs/reference/converter-lang.adoc
@@ -48,6 +48,16 @@ Converts all listed languages completely.
 If any element in the listed languages uses an element from a non-listed language, we include the element of the non-listed language -- but not any other elements of that non-listed language.
 We apply this strategy (known as _tree shaking_) transitively until we included all used elements.
 
+We can set some flags for special annotation handling:
+
+[horizontal]
+export description annotations::
+Whether concept descriptions should be exported as instances of `io.lionweb.mps.specific.lang.MPS-specific annotations.ConceptDescription`.
+
+export special annotations::
+Whether special concept annotations should be exported:
++
+* `jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation` -> `io.lionweb.mps.specific.lang.MPS-specific annotations.Deprecated`
 
 [[instance-json]]
 == MPS Instance Model &harr; JSON

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.2.9-SNAPSHOT
+version=0.2.10-SNAPSHOT
 lionwebRelease=2023.1
 lionwebJavaVersion=0.2.14
 mpsVersionSuffix=2021.1

--- a/languages/MultiRefLang/models/MultiRefLang.structure.mps
+++ b/languages/MultiRefLang/models/MultiRefLang.structure.mps
@@ -41,7 +41,7 @@
       </concept>
     </language>
     <language id="411e5b27-8a76-482e-8af8-1704262b4468" name="io.lionweb.mps.structure.attribute">
-      <concept id="7205279169712116346" name="io.lionweb.mps.structure.attribute.structure.LionWebLanguageKey" flags="ng" index="2DM1_0" />
+      <concept id="7205279169712116346" name="io.lionweb.mps.structure.attribute.structure.LionWebLanguage" flags="ng" index="2DM1_0" />
       <concept id="7205279169712116353" name="io.lionweb.mps.structure.attribute.structure.ILionWebKey" flags="ng" index="2DM1AV">
         <property id="7205279169712116354" name="key" index="2DM1AS" />
       </concept>

--- a/languages/io.lionweb.mps.converter.TestDeprecated/io.lionweb.mps.converter.TestDeprecated.mpl
+++ b/languages/io.lionweb.mps.converter.TestDeprecated/io.lionweb.mps.converter.TestDeprecated.mpl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language namespace="io.lionweb.mps.converter.TestDeprecated" uuid="09360184-8598-44e7-9bf5-fb1ce45a480a" languageVersion="0" moduleVersion="0">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <accessoryModels />
+  <sourcePath />
+  <languageVersions>
+    <language slang="l:411e5b27-8a76-482e-8af8-1704262b4468:io.lionweb.mps.structure.attribute" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="09360184-8598-44e7-9bf5-fb1ce45a480a(io.lionweb.mps.converter.TestDeprecated)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+  </dependencyVersions>
+  <extendedLanguages />
+</language>
+

--- a/languages/io.lionweb.mps.converter.TestDeprecated/models/io.lionweb.mps.converter.TestDeprecated.behavior.mps
+++ b/languages/io.lionweb.mps.converter.TestDeprecated/models/io.lionweb.mps.converter.TestDeprecated.behavior.mps
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:61fc58ed-083c-441a-a576-e58049d4485c(io.lionweb.mps.converter.TestDeprecated.behavior)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/languages/io.lionweb.mps.converter.TestDeprecated/models/io.lionweb.mps.converter.TestDeprecated.structure.mps
+++ b/languages/io.lionweb.mps.converter.TestDeprecated/models/io.lionweb.mps.converter.TestDeprecated.structure.mps
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:3a8b47e5-fb10-4397-85b3-d41b7aa24493(io.lionweb.mps.converter.TestDeprecated.structure)">
+  <persistence version="9" />
+  <languages>
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <use id="411e5b27-8a76-482e-8af8-1704262b4468" name="io.lionweb.mps.structure.attribute" version="0" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
+  </languages>
+  <imports>
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="3348158742936976480" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration" flags="ng" index="25R33">
+        <property id="1421157252384165432" name="memberId" index="3tVfz5" />
+      </concept>
+      <concept id="3348158742936976479" name="jetbrains.mps.lang.structure.structure.EnumerationDeclaration" flags="ng" index="25R3W">
+        <child id="3348158742936976577" name="members" index="25R1y" />
+      </concept>
+      <concept id="1224240836180" name="jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation" flags="ig" index="asaX9">
+        <property id="1225118929411" name="build" index="YLPcu" />
+        <property id="1225118933224" name="comment" index="YLQ7P" />
+      </concept>
+      <concept id="1082978164218" name="jetbrains.mps.lang.structure.structure.DataTypeDeclaration" flags="ng" index="AxPO6">
+        <property id="7791109065626895363" name="datatypeId" index="3F6X1D" />
+      </concept>
+      <concept id="1082978499127" name="jetbrains.mps.lang.structure.structure.ConstrainedDataTypeDeclaration" flags="ng" index="Az7Fb">
+        <property id="1083066089218" name="constraint" index="FLfZY" />
+      </concept>
+      <concept id="2992811758677295509" name="jetbrains.mps.lang.structure.structure.AttributeInfo" flags="ng" index="M6xJ_" />
+      <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
+        <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
+      </concept>
+      <concept id="1169125989551" name="jetbrains.mps.lang.structure.structure.InterfaceConceptDeclaration" flags="ig" index="PlHQZ" />
+      <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <reference id="1071489389519" name="extends" index="1TJDcQ" />
+      </concept>
+      <concept id="1071489288299" name="jetbrains.mps.lang.structure.structure.PropertyDeclaration" flags="ig" index="1TJgyi">
+        <property id="241647608299431129" name="propertyId" index="IQ2nx" />
+        <reference id="1082985295845" name="dataType" index="AX2Wp" />
+      </concept>
+      <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
+        <property id="1071599776563" name="role" index="20kJfa" />
+        <property id="1071599893252" name="sourceCardinality" index="20lbJX" />
+        <property id="1071599937831" name="metaClass" index="20lmBu" />
+        <property id="241647608299431140" name="linkId" index="IQ2ns" />
+        <reference id="1071599976176" name="target" index="20lvS9" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1TIwiD" id="6LPkCA$4tpA">
+    <property role="EcuMT" value="7815243479487993446" />
+    <property role="TrG5h" value="DeprConcept" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="6LPkCA$4tpD" role="1TKVEl">
+      <property role="IQ2nx" value="7815243479487993449" />
+      <property role="TrG5h" value="deprProp" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+      <node concept="asaX9" id="6LPkCA$4tpF" role="lGtFl">
+        <property role="YLQ7P" value="deprProp comment" />
+        <property role="YLPcu" value="deprProp build" />
+      </node>
+    </node>
+    <node concept="asaX9" id="6LPkCA$4tpB" role="lGtFl">
+      <property role="YLQ7P" value="deprConcept comment" />
+      <property role="YLPcu" value="deprConcept build" />
+    </node>
+    <node concept="1TJgyj" id="6LPkCA$4tpH" role="1TKVEi">
+      <property role="IQ2ns" value="7815243479487993453" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="deprChild" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="6LPkCA$4tpJ" resolve="DeprIface" />
+      <node concept="asaX9" id="6LPkCA$4tpV" role="lGtFl">
+        <property role="YLQ7P" value="deprChild comment" />
+        <property role="YLPcu" value="deprChild build" />
+      </node>
+    </node>
+    <node concept="1TJgyj" id="6LPkCA$4tpM" role="1TKVEi">
+      <property role="IQ2ns" value="7815243479487993458" />
+      <property role="20kJfa" value="deprRef" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6LPkCA$4tpP" resolve="DeprAnnotation" />
+      <node concept="asaX9" id="6LPkCA$4tpX" role="lGtFl">
+        <property role="YLQ7P" value="deprRef comment" />
+        <property role="YLPcu" value="deprRef build" />
+      </node>
+    </node>
+  </node>
+  <node concept="PlHQZ" id="6LPkCA$4tpJ">
+    <property role="EcuMT" value="7815243479487993455" />
+    <property role="TrG5h" value="DeprIface" />
+    <node concept="asaX9" id="6LPkCA$4tpK" role="lGtFl">
+      <property role="YLQ7P" value="deprIface comment" />
+      <property role="YLPcu" value="deprIface build" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="6LPkCA$4tpP">
+    <property role="EcuMT" value="7815243479487993461" />
+    <property role="TrG5h" value="DeprAnnotation" />
+    <ref role="1TJDcQ" to="tpck:2ULFgo8_XDk" resolve="NodeAttribute" />
+    <node concept="M6xJ_" id="6LPkCA$4tpQ" role="lGtFl" />
+    <node concept="asaX9" id="6LPkCA$4tpS" role="lGtFl">
+      <property role="YLQ7P" value="deprAnnotation comment" />
+      <property role="YLPcu" value="deprAnnotation build" />
+    </node>
+  </node>
+  <node concept="25R3W" id="6LPkCA$4tpZ">
+    <property role="3F6X1D" value="7815243479487993471" />
+    <property role="TrG5h" value="DeprEnum" />
+    <node concept="25R33" id="6LPkCA$4tq0" role="25R1y">
+      <property role="3tVfz5" value="7815243479487993472" />
+      <property role="TrG5h" value="A" />
+    </node>
+    <node concept="25R33" id="6LPkCA$4tq3" role="25R1y">
+      <property role="3tVfz5" value="7815243479487993475" />
+      <property role="TrG5h" value="B" />
+    </node>
+    <node concept="asaX9" id="6LPkCA$4tq1" role="lGtFl">
+      <property role="YLQ7P" value="deprEnum comment" />
+      <property role="YLPcu" value="deprEnum build" />
+    </node>
+  </node>
+  <node concept="Az7Fb" id="6LPkCA$4tqc">
+    <property role="3F6X1D" value="7815243479487993484" />
+    <property role="TrG5h" value="DeprDatatype" />
+    <property role="FLfZY" value=".*" />
+    <node concept="asaX9" id="6LPkCA$4tqd" role="lGtFl">
+      <property role="YLQ7P" value="deprDatatype comment" />
+      <property role="YLPcu" value="deprDatatype build" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="6LPkCA_fd3p">
+    <property role="EcuMT" value="7815243479507587289" />
+    <property role="TrG5h" value="DeprNoComment" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="asaX9" id="6LPkCA_fd8U" role="lGtFl" />
+  </node>
+</model>
+

--- a/languages/io.lionweb.mps.converter.TestEnum/io.lionweb.mps.converter.TestEnum.mpl
+++ b/languages/io.lionweb.mps.converter.TestEnum/io.lionweb.mps.converter.TestEnum.mpl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language namespace="io.lionweb.mps.converter.TestEnum" uuid="1ec6d5e7-6402-4c18-95d0-6e0906eb1ff1" languageVersion="0" moduleVersion="0">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <accessoryModels />
+  <sourcePath />
+  <languageVersions>
+    <language slang="l:411e5b27-8a76-482e-8af8-1704262b4468:io.lionweb.mps.structure.attribute" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="1ec6d5e7-6402-4c18-95d0-6e0906eb1ff1(io.lionweb.mps.converter.TestEnum)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+  </dependencyVersions>
+  <extendedLanguages />
+</language>
+

--- a/languages/io.lionweb.mps.converter.TestEnum/models/io.lionweb.mps.converter.TestEnum.behavior.mps
+++ b/languages/io.lionweb.mps.converter.TestEnum/models/io.lionweb.mps.converter.TestEnum.behavior.mps
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:79697d29-a569-4a38-a965-031f7ea3c209(io.lionweb.mps.converter.TestEnum.behavior)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/languages/io.lionweb.mps.converter.TestEnum/models/io.lionweb.mps.converter.TestEnum.structure.mps
+++ b/languages/io.lionweb.mps.converter.TestEnum/models/io.lionweb.mps.converter.TestEnum.structure.mps
@@ -1,0 +1,331 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:45d4cca0-b85a-4b49-8b0a-a764324dd84b(io.lionweb.mps.converter.TestEnum.structure)">
+  <persistence version="9" />
+  <languages>
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <use id="411e5b27-8a76-482e-8af8-1704262b4468" name="io.lionweb.mps.structure.attribute" version="0" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
+  </languages>
+  <imports>
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="3348158742936976480" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration" flags="ng" index="25R33">
+        <property id="1421157252384165432" name="memberId" index="3tVfz5" />
+      </concept>
+      <concept id="3348158742936976479" name="jetbrains.mps.lang.structure.structure.EnumerationDeclaration" flags="ng" index="25R3W">
+        <reference id="1075010451642646892" name="defaultMember" index="1H5jkz" />
+        <child id="3348158742936976577" name="members" index="25R1y" />
+      </concept>
+      <concept id="1082978164218" name="jetbrains.mps.lang.structure.structure.DataTypeDeclaration" flags="ng" index="AxPO6">
+        <property id="7791109065626895363" name="datatypeId" index="3F6X1D" />
+      </concept>
+      <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
+      </concept>
+      <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
+        <reference id="1169127628841" name="intfc" index="PrY4T" />
+      </concept>
+      <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <property id="1096454100552" name="rootable" index="19KtqR" />
+        <reference id="1071489389519" name="extends" index="1TJDcQ" />
+        <child id="1169129564478" name="implements" index="PzmwI" />
+      </concept>
+      <concept id="1071489288299" name="jetbrains.mps.lang.structure.structure.PropertyDeclaration" flags="ig" index="1TJgyi">
+        <property id="241647608299431129" name="propertyId" index="IQ2nx" />
+        <reference id="1082985295845" name="dataType" index="AX2Wp" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="411e5b27-8a76-482e-8af8-1704262b4468" name="io.lionweb.mps.structure.attribute">
+      <concept id="7205279169712116353" name="io.lionweb.mps.structure.attribute.structure.ILionWebKey" flags="ng" index="2DM1AV">
+        <property id="7205279169712116354" name="key" index="2DM1AS" />
+      </concept>
+      <concept id="7205279169712116358" name="io.lionweb.mps.structure.attribute.structure.LionWebEntityKey" flags="ng" index="2DM1AW" />
+      <concept id="6461713321120959611" name="io.lionweb.mps.structure.attribute.structure.LionWebOptionalProperty" flags="ng" index="3KvT9W">
+        <property id="6461713321120959618" name="optional" index="3KvTa5" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1TIwiD" id="2NSuNu8iabL">
+    <property role="EcuMT" value="3240475410332951281" />
+    <property role="TrG5h" value="EnumHostWithKeyOptional" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="2NSuNu8iais" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332951708" />
+      <property role="TrG5h" value="defaultWithKey" />
+      <ref role="AX2Wp" node="2NSuNu8iai3" resolve="EnumWithKeyDefaultWithKey" />
+      <node concept="3KvT9W" id="2NSuNu8iaiu" role="lGtFl">
+        <property role="3KvTa5" value="true" />
+      </node>
+    </node>
+    <node concept="1TJgyi" id="2NSuNu8iaiw" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332951712" />
+      <property role="TrG5h" value="defaultWithoutKey" />
+      <ref role="AX2Wp" node="2NSuNu8iai8" resolve="EnumWithKeyDefaultWithoutKey" />
+      <node concept="3KvT9W" id="2NSuNu8iaix" role="lGtFl">
+        <property role="3KvTa5" value="true" />
+      </node>
+    </node>
+    <node concept="1TJgyi" id="2NSuNu8iaiA" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332951718" />
+      <property role="TrG5h" value="noDefault" />
+      <ref role="AX2Wp" node="2NSuNu8iabO" resolve="EnumWithKeyNoDefault" />
+      <node concept="3KvT9W" id="2NSuNu8iaiB" role="lGtFl">
+        <property role="3KvTa5" value="true" />
+      </node>
+    </node>
+    <node concept="PrWs8" id="2NSuNu8iabM" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="25R3W" id="2NSuNu8iabO">
+    <property role="3F6X1D" value="3240475410332951284" />
+    <property role="TrG5h" value="EnumWithKeyNoDefault" />
+    <node concept="25R33" id="2NSuNu8iabP" role="25R1y">
+      <property role="3tVfz5" value="3240475410332951285" />
+      <property role="TrG5h" value="literalWithKey" />
+      <node concept="2DM1AW" id="2NSuNu8iai1" role="lGtFl">
+        <property role="2DM1AS" value="key-literalWithKey" />
+      </node>
+    </node>
+    <node concept="25R33" id="2NSuNu8iabQ" role="25R1y">
+      <property role="3tVfz5" value="3240475410332951286" />
+      <property role="TrG5h" value="literalWithoutKey" />
+    </node>
+    <node concept="2DM1AW" id="2NSuNu8iahZ" role="lGtFl">
+      <property role="2DM1AS" value="key-EnumWithKeyNoDefault" />
+    </node>
+  </node>
+  <node concept="25R3W" id="2NSuNu8iai3">
+    <property role="3F6X1D" value="3240475410332951683" />
+    <property role="TrG5h" value="EnumWithKeyDefaultWithKey" />
+    <ref role="1H5jkz" node="2NSuNu8iai4" resolve="literalWithKey" />
+    <node concept="25R33" id="2NSuNu8iai4" role="25R1y">
+      <property role="3tVfz5" value="3240475410332951684" />
+      <property role="TrG5h" value="literalWithKey" />
+      <node concept="2DM1AW" id="2NSuNu8iai5" role="lGtFl">
+        <property role="2DM1AS" value="key-literalWithKey" />
+      </node>
+    </node>
+    <node concept="25R33" id="2NSuNu8iai6" role="25R1y">
+      <property role="3tVfz5" value="3240475410332951686" />
+      <property role="TrG5h" value="literalWithoutKey" />
+    </node>
+    <node concept="2DM1AW" id="2NSuNu8iai7" role="lGtFl">
+      <property role="2DM1AS" value="key-EnumWithKeyDefaultWithKey" />
+    </node>
+  </node>
+  <node concept="25R3W" id="2NSuNu8iai8">
+    <property role="3F6X1D" value="3240475410332951688" />
+    <property role="TrG5h" value="EnumWithKeyDefaultWithoutKey" />
+    <ref role="1H5jkz" node="2NSuNu8iaib" resolve="literalWithoutKey" />
+    <node concept="25R33" id="2NSuNu8iai9" role="25R1y">
+      <property role="3tVfz5" value="3240475410332951689" />
+      <property role="TrG5h" value="literalWithKey" />
+      <node concept="2DM1AW" id="2NSuNu8iaia" role="lGtFl">
+        <property role="2DM1AS" value="key-literalWithKey" />
+      </node>
+    </node>
+    <node concept="25R33" id="2NSuNu8iaib" role="25R1y">
+      <property role="3tVfz5" value="3240475410332951691" />
+      <property role="TrG5h" value="literalWithoutKey" />
+    </node>
+    <node concept="2DM1AW" id="2NSuNu8iaic" role="lGtFl">
+      <property role="2DM1AS" value="key-EnumWithKeyDefaultWithoutKey" />
+    </node>
+  </node>
+  <node concept="25R3W" id="2NSuNu8iaid">
+    <property role="3F6X1D" value="3240475410332951693" />
+    <property role="TrG5h" value="EnumWithoutKeyDefaultWithKey" />
+    <ref role="1H5jkz" node="2NSuNu8iaie" resolve="literalWithKey" />
+    <node concept="25R33" id="2NSuNu8iaie" role="25R1y">
+      <property role="3tVfz5" value="3240475410332951694" />
+      <property role="TrG5h" value="literalWithKey" />
+      <node concept="2DM1AW" id="2NSuNu8iaif" role="lGtFl">
+        <property role="2DM1AS" value="key-literalWithKey" />
+      </node>
+    </node>
+    <node concept="25R33" id="2NSuNu8iaig" role="25R1y">
+      <property role="3tVfz5" value="3240475410332951696" />
+      <property role="TrG5h" value="literalWithoutKey" />
+    </node>
+  </node>
+  <node concept="25R3W" id="2NSuNu8iaii">
+    <property role="3F6X1D" value="3240475410332951698" />
+    <property role="TrG5h" value="EnumWithoutKeyDefaultWithoutKey" />
+    <ref role="1H5jkz" node="2NSuNu8iail" resolve="literalWithoutKey" />
+    <node concept="25R33" id="2NSuNu8iaij" role="25R1y">
+      <property role="3tVfz5" value="3240475410332951699" />
+      <property role="TrG5h" value="literalWithKey" />
+      <node concept="2DM1AW" id="2NSuNu8iaik" role="lGtFl">
+        <property role="2DM1AS" value="key-literalWithKey" />
+      </node>
+    </node>
+    <node concept="25R33" id="2NSuNu8iail" role="25R1y">
+      <property role="3tVfz5" value="3240475410332951701" />
+      <property role="TrG5h" value="literalWithoutKey" />
+    </node>
+  </node>
+  <node concept="25R3W" id="2NSuNu8iain">
+    <property role="3F6X1D" value="3240475410332951703" />
+    <property role="TrG5h" value="EnumWithoutKeyNoDefault" />
+    <node concept="25R33" id="2NSuNu8iaio" role="25R1y">
+      <property role="3tVfz5" value="3240475410332951704" />
+      <property role="TrG5h" value="literalWithKey" />
+      <node concept="2DM1AW" id="2NSuNu8iaip" role="lGtFl">
+        <property role="2DM1AS" value="key-literalWithKey" />
+      </node>
+    </node>
+    <node concept="25R33" id="2NSuNu8iaiq" role="25R1y">
+      <property role="3tVfz5" value="3240475410332951706" />
+      <property role="TrG5h" value="literalWithoutKey" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2NSuNu8iaiI">
+    <property role="EcuMT" value="3240475410332951726" />
+    <property role="TrG5h" value="EnumHostWithKeyRequired" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="2NSuNu8iaiJ" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332951727" />
+      <property role="TrG5h" value="defaultWithKey" />
+      <ref role="AX2Wp" node="2NSuNu8iai3" resolve="EnumWithKeyDefaultWithKey" />
+      <node concept="3KvT9W" id="2NSuNu8iaiK" role="lGtFl" />
+    </node>
+    <node concept="1TJgyi" id="2NSuNu8iaiL" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332951729" />
+      <property role="TrG5h" value="defaultWithoutKey" />
+      <ref role="AX2Wp" node="2NSuNu8iai8" resolve="EnumWithKeyDefaultWithoutKey" />
+      <node concept="3KvT9W" id="2NSuNu8iaiM" role="lGtFl" />
+    </node>
+    <node concept="1TJgyi" id="2NSuNu8iaiN" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332951731" />
+      <property role="TrG5h" value="noDefault" />
+      <ref role="AX2Wp" node="2NSuNu8iabO" resolve="EnumWithKeyNoDefault" />
+      <node concept="3KvT9W" id="2NSuNu8iaiO" role="lGtFl" />
+    </node>
+    <node concept="PrWs8" id="2NSuNu8iaiP" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2NSuNu8iaiQ">
+    <property role="EcuMT" value="3240475410332951734" />
+    <property role="TrG5h" value="EnumHostWithoutKeyOptional" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="2NSuNu8iaiR" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332951735" />
+      <property role="TrG5h" value="defaultWithKey" />
+      <ref role="AX2Wp" node="2NSuNu8iaid" resolve="EnumWithoutKeyDefaultWithKey" />
+      <node concept="3KvT9W" id="2NSuNu8iaiS" role="lGtFl">
+        <property role="3KvTa5" value="true" />
+      </node>
+    </node>
+    <node concept="1TJgyi" id="2NSuNu8iaiT" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332951737" />
+      <property role="TrG5h" value="defaultWithoutKey" />
+      <ref role="AX2Wp" node="2NSuNu8iaii" resolve="EnumWithoutKeyDefaultWithoutKey" />
+      <node concept="3KvT9W" id="2NSuNu8iaiU" role="lGtFl">
+        <property role="3KvTa5" value="true" />
+      </node>
+    </node>
+    <node concept="1TJgyi" id="2NSuNu8iaiV" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332951739" />
+      <property role="TrG5h" value="noDefault" />
+      <ref role="AX2Wp" node="2NSuNu8iain" resolve="EnumWithoutKeyNoDefault" />
+      <node concept="3KvT9W" id="2NSuNu8iaiW" role="lGtFl">
+        <property role="3KvTa5" value="true" />
+      </node>
+    </node>
+    <node concept="PrWs8" id="2NSuNu8iaiX" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2NSuNu8iaiY">
+    <property role="EcuMT" value="3240475410332951742" />
+    <property role="TrG5h" value="EnumHostWithoutKeyRequired" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="2NSuNu8iaiZ" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332951743" />
+      <property role="TrG5h" value="defaultWithKey" />
+      <ref role="AX2Wp" node="2NSuNu8iaid" resolve="EnumWithoutKeyDefaultWithKey" />
+      <node concept="3KvT9W" id="2NSuNu8iaj0" role="lGtFl" />
+    </node>
+    <node concept="1TJgyi" id="2NSuNu8iaj1" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332951745" />
+      <property role="TrG5h" value="defaultWithoutKey" />
+      <ref role="AX2Wp" node="2NSuNu8iaii" resolve="EnumWithoutKeyDefaultWithoutKey" />
+      <node concept="3KvT9W" id="2NSuNu8iaj2" role="lGtFl" />
+    </node>
+    <node concept="1TJgyi" id="2NSuNu8iaj3" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332951747" />
+      <property role="TrG5h" value="noDefault" />
+      <ref role="AX2Wp" node="2NSuNu8iain" resolve="EnumWithoutKeyNoDefault" />
+      <node concept="3KvT9W" id="2NSuNu8iaj4" role="lGtFl" />
+    </node>
+    <node concept="PrWs8" id="2NSuNu8iaj5" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2NSuNu8iksT">
+    <property role="EcuMT" value="3240475410332993337" />
+    <property role="TrG5h" value="EnumHostWithKeyUnset" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="2NSuNu8iksU" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332993338" />
+      <property role="TrG5h" value="defaultWithKey" />
+      <ref role="AX2Wp" node="2NSuNu8iai3" resolve="EnumWithKeyDefaultWithKey" />
+    </node>
+    <node concept="1TJgyi" id="2NSuNu8iksW" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332993340" />
+      <property role="TrG5h" value="defaultWithoutKey" />
+      <ref role="AX2Wp" node="2NSuNu8iai8" resolve="EnumWithKeyDefaultWithoutKey" />
+    </node>
+    <node concept="1TJgyi" id="2NSuNu8iksY" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332993342" />
+      <property role="TrG5h" value="noDefault" />
+      <ref role="AX2Wp" node="2NSuNu8iabO" resolve="EnumWithKeyNoDefault" />
+    </node>
+    <node concept="PrWs8" id="2NSuNu8ikt0" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2NSuNu8ikt9">
+    <property role="EcuMT" value="3240475410332993353" />
+    <property role="TrG5h" value="EnumHostWithoutKeyUnset" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="2NSuNu8ikta" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332993354" />
+      <property role="TrG5h" value="defaultWithKey" />
+      <ref role="AX2Wp" node="2NSuNu8iaid" resolve="EnumWithoutKeyDefaultWithKey" />
+    </node>
+    <node concept="1TJgyi" id="2NSuNu8iktc" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332993356" />
+      <property role="TrG5h" value="defaultWithoutKey" />
+      <ref role="AX2Wp" node="2NSuNu8iaii" resolve="EnumWithoutKeyDefaultWithoutKey" />
+    </node>
+    <node concept="1TJgyi" id="2NSuNu8ikte" role="1TKVEl">
+      <property role="IQ2nx" value="3240475410332993358" />
+      <property role="TrG5h" value="noDefault" />
+      <ref role="AX2Wp" node="2NSuNu8iain" resolve="EnumWithoutKeyNoDefault" />
+    </node>
+    <node concept="PrWs8" id="2NSuNu8iktg" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+</model>
+

--- a/languages/io.lionweb.mps.converter.TestLang3/models/io.lionweb.mps.converter.TestLang3.structure.mps
+++ b/languages/io.lionweb.mps.converter.TestLang3/models/io.lionweb.mps.converter.TestLang3.structure.mps
@@ -63,7 +63,9 @@
       </concept>
     </language>
     <language id="411e5b27-8a76-482e-8af8-1704262b4468" name="io.lionweb.mps.structure.attribute">
-      <concept id="7205279169712116346" name="io.lionweb.mps.structure.attribute.structure.LionWebLanguageKey" flags="ng" index="2DM1_0" />
+      <concept id="7205279169712116346" name="io.lionweb.mps.structure.attribute.structure.LionWebLanguage" flags="ng" index="2DM1_0">
+        <property id="7263087982341810717" name="version" index="2NbWok" />
+      </concept>
       <concept id="7205279169712116353" name="io.lionweb.mps.structure.attribute.structure.ILionWebKey" flags="ng" index="2DM1AV">
         <property id="7205279169712116354" name="key" index="2DM1AS" />
       </concept>
@@ -321,6 +323,7 @@
   </node>
   <node concept="2DM1_0" id="5AGBwuDAKCg">
     <property role="2DM1AS" value="My-TestLang3" />
+    <property role="2NbWok" value="00 my! VERSION 😀" />
   </node>
   <node concept="1TIwiD" id="6jI_U5eOwrW">
     <property role="EcuMT" value="7272917167317845756" />

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.editor.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.editor.mps
@@ -257,6 +257,15 @@
             <ref role="1NtTu8" to="d0tf:5M8g5cT5W10" resolve="exportDescriptionAnnotations" />
           </node>
         </node>
+        <node concept="3EZMnI" id="6LPkCA_dTgd" role="3EZMnx">
+          <node concept="3F0ifn" id="6LPkCA_dTge" role="3EZMnx">
+            <property role="3F0ifm" value="Export special annotations:" />
+          </node>
+          <node concept="2iRfu4" id="6LPkCA_dTgf" role="2iSdaV" />
+          <node concept="3F0A7n" id="6LPkCA_dTgg" role="3EZMnx">
+            <ref role="1NtTu8" to="d0tf:6LPkCA_dTg9" resolve="exportSpecialAnnotations" />
+          </node>
+        </node>
       </node>
       <node concept="3F0ifn" id="1q44RFSZQQ1" role="3EZMnx" />
       <node concept="3F0ifn" id="4Yo3buYkNTb" role="3EZMnx">

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.intentions.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.intentions.mps
@@ -43,6 +43,12 @@
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
       <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
         <reference id="2820489544401957798" name="classifier" index="HV5vE" />
       </concept>
@@ -67,6 +73,9 @@
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
+      </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
@@ -84,6 +93,12 @@
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
       <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
@@ -105,6 +120,7 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
@@ -113,6 +129,10 @@
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -125,6 +145,9 @@
         <child id="8276990574895933172" name="throwable" index="1zc67B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
       <concept id="5351203823916832286" name="jetbrains.mps.baseLanguage.structure.ResourceVariable" flags="ng" index="3J1hQo" />
       <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
@@ -135,6 +158,11 @@
         <child id="1163668914799" name="condition" index="3K4Cdx" />
         <child id="1163668922816" name="ifTrue" index="3K4E3e" />
         <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
       </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
@@ -1850,13 +1878,38 @@
                   <ref role="3uigEE" to="6peh:4R9posp5N7h" resolve="JsonToM1" />
                 </node>
                 <node concept="2ShNRf" id="18UigYOS37i" role="33vP2m">
-                  <node concept="1pGfFk" id="18UigYOS37j" role="2ShVmc">
-                    <ref role="37wK5l" to="6peh:4R9posp5Osb" resolve="JsonToM1" />
-                    <node concept="37vLTw" id="18UigYOS37k" role="37wK5m">
-                      <ref role="3cqZAo" node="5M3rB6BZyeP" resolve="repository" />
-                    </node>
-                    <node concept="37vLTw" id="18UigYOS37l" role="37wK5m">
-                      <ref role="3cqZAo" node="7W6jYlyR0iK" resolve="jsonNodes" />
+                  <node concept="YeOm9" id="6jbF0BoEZqE" role="2ShVmc">
+                    <node concept="1Y3b0j" id="6jbF0BoEZqH" role="YeSDq">
+                      <property role="2bfB8j" value="true" />
+                      <ref role="37wK5l" to="6peh:4R9posp5Osb" resolve="JsonToM1" />
+                      <ref role="1Y3XeK" to="6peh:4R9posp5N7h" resolve="JsonToM1" />
+                      <node concept="3Tm1VV" id="6jbF0BoEZqI" role="1B3o_S" />
+                      <node concept="37vLTw" id="18UigYOS37k" role="37wK5m">
+                        <ref role="3cqZAo" node="5M3rB6BZyeP" resolve="repository" />
+                      </node>
+                      <node concept="37vLTw" id="18UigYOS37l" role="37wK5m">
+                        <ref role="3cqZAo" node="7W6jYlyR0iK" resolve="jsonNodes" />
+                      </node>
+                      <node concept="3clFb_" id="6jbF0BoEZvp" role="jymVt">
+                        <property role="TrG5h" value="logWarning" />
+                        <node concept="3cqZAl" id="6jbF0BoEZvq" role="3clF45" />
+                        <node concept="3Tmbuc" id="6jbF0BoEZvr" role="1B3o_S" />
+                        <node concept="37vLTG" id="6jbF0BoEZvs" role="3clF46">
+                          <property role="TrG5h" value="message" />
+                          <node concept="17QB3L" id="6jbF0BoEZvt" role="1tU5fm" />
+                        </node>
+                        <node concept="3clFbS" id="6jbF0BoEZvA" role="3clF47">
+                          <node concept="2xdQw9" id="6jbF0BoF0s8" role="3cqZAp">
+                            <property role="2xdLsb" value="gZ5fksE/warn" />
+                            <node concept="37vLTw" id="6jbF0BoF0AO" role="9lYJi">
+                              <ref role="3cqZAo" node="6jbF0BoEZvs" resolve="message" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2AHcQZ" id="6jbF0BoEZvB" role="2AJF6D">
+                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -2170,6 +2223,22 @@
                     <node concept="2Sf5sV" id="5M8g5cT5XG_" role="2Oq$k0" />
                     <node concept="3TrcHB" id="5M8g5cT5Y8A" role="2OqNvi">
                       <ref role="3TsBF5" to="d0tf:5M8g5cT5W10" resolve="exportDescriptionAnnotations" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="6LPkCA_dUlM" role="3cqZAp">
+              <node concept="2OqwBi" id="6LPkCA_dULJ" role="3clFbG">
+                <node concept="37vLTw" id="6LPkCA_dUlK" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1q44RFT01lB" resolve="converter" />
+                </node>
+                <node concept="liA8E" id="6LPkCA_dUY9" role="2OqNvi">
+                  <ref role="37wK5l" to="6peh:6LPkCA$Ryk5" resolve="setExportSpecialAnnotations" />
+                  <node concept="2OqwBi" id="6LPkCA_dVng" role="37wK5m">
+                    <node concept="2Sf5sV" id="6LPkCA_dVbO" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="6LPkCA_dVBV" role="2OqNvi">
+                      <ref role="3TsBF5" to="d0tf:6LPkCA_dTg9" resolve="exportSpecialAnnotations" />
                     </node>
                   </node>
                 </node>

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.structure.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.structure.mps
@@ -228,6 +228,11 @@
       <property role="TrG5h" value="exportDescriptionAnnotations" />
       <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
+    <node concept="1TJgyi" id="6LPkCA_dTg9" role="1TKVEl">
+      <property role="IQ2nx" value="7815243479507244041" />
+      <property role="TrG5h" value="exportSpecialAnnotations" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
     <node concept="PrWs8" id="1q44RFSZQBV" role="PzmwI">
       <ref role="PrY4T" node="1q44RFSZQFB" resolve="ILanguageIdentityContainer" />
     </node>

--- a/languages/io.lionweb.mps.m3/models/io.lionweb.mps.m3.builtin.mps
+++ b/languages/io.lionweb.mps.m3/models/io.lionweb.mps.m3.builtin.mps
@@ -35,7 +35,7 @@
   </registry>
   <node concept="2RzRRF" id="2ju2syjnJjW">
     <property role="TrG5h" value="Built-in DataTypes" />
-    <property role="3HH78N" value="1" />
+    <property role="3HH78N" value="2023.1" />
     <property role="2RzON1" value="LionCore-builtins" />
     <node concept="2RzSJf" id="2ju2syjnJjX" role="2RzR6B">
       <property role="2RzON1" value="LionCore-builtins-String" />

--- a/languages/io.lionweb.mps.m3/models/io.lionweb.mps.m3.structure.mps
+++ b/languages/io.lionweb.mps.m3/models/io.lionweb.mps.m3.structure.mps
@@ -62,7 +62,9 @@
       </concept>
     </language>
     <language id="411e5b27-8a76-482e-8af8-1704262b4468" name="io.lionweb.mps.structure.attribute">
-      <concept id="7205279169712116346" name="io.lionweb.mps.structure.attribute.structure.LionWebLanguageKey" flags="ng" index="2DM1_0" />
+      <concept id="7205279169712116346" name="io.lionweb.mps.structure.attribute.structure.LionWebLanguage" flags="ng" index="2DM1_0">
+        <property id="7263087982341810717" name="version" index="2NbWok" />
+      </concept>
       <concept id="7205279169712116353" name="io.lionweb.mps.structure.attribute.structure.ILionWebKey" flags="ng" index="2DM1AV">
         <property id="7205279169712116354" name="key" index="2DM1AS" />
       </concept>
@@ -443,6 +445,7 @@
   </node>
   <node concept="2DM1_0" id="5AGBwuDAKCg">
     <property role="2DM1AS" value="LionCore-M3" />
+    <property role="2NbWok" value="2023.1" />
   </node>
   <node concept="1TIwiD" id="18UigYQyrxa">
     <property role="EcuMT" value="1313442573167736906" />

--- a/languages/io.lionweb.mps.specific/models/io.lionweb.mps.specific.lang.mps
+++ b/languages/io.lionweb.mps.specific/models/io.lionweb.mps.specific.lang.mps
@@ -85,6 +85,23 @@
         <ref role="2Rx9Fl" to="2pzz:2ju2syjnJjX" resolve="String" />
       </node>
     </node>
+    <node concept="2$GZ55" id="6LPkCA$5hYZ" role="2RzR6B">
+      <property role="2RzON1" value="Deprecated" />
+      <property role="TrG5h" value="Deprecated" />
+      <ref role="2$GZ54" to="i2js:19nRYgR_pax" resolve="IKeyed" />
+      <node concept="2RzOeU" id="6LPkCA$5hZ9" role="2RzPPN">
+        <property role="2RzON1" value="Deprecated-comment" />
+        <property role="TrG5h" value="comment" />
+        <property role="2RzO1C" value="true" />
+        <ref role="2Rx9Fl" to="2pzz:2ju2syjnJjX" resolve="String" />
+      </node>
+      <node concept="2RzOeU" id="6LPkCA$5hZe" role="2RzPPN">
+        <property role="2RzON1" value="Deprecated-build" />
+        <property role="TrG5h" value="build" />
+        <property role="2RzO1C" value="true" />
+        <ref role="2Rx9Fl" to="2pzz:2ju2syjnJjX" resolve="String" />
+      </node>
+    </node>
     <node concept="2RzRkq" id="34Q84zMP1Uw" role="2RzRcN">
       <ref role="2RzRkr" to="i2js:5sACIIs$PgG" resolve="LionCore_M3" />
     </node>

--- a/languages/io.lionweb.mps.specific/models/io.lionweb.mps.specific.structure.mps
+++ b/languages/io.lionweb.mps.specific/models/io.lionweb.mps.specific.structure.mps
@@ -141,5 +141,34 @@
       <property role="2DM1AS" value="ConceptDescription" />
     </node>
   </node>
+  <node concept="1TIwiD" id="6LPkCA$4zbt">
+    <property role="EcuMT" value="7815243479488017117" />
+    <property role="TrG5h" value="Deprecated" />
+    <ref role="1TJDcQ" to="tpck:2ULFgo8_XDk" resolve="NodeAttribute" />
+    <node concept="M6xJ_" id="6LPkCA$4zbu" role="lGtFl">
+      <node concept="trNpa" id="6LPkCA$4_PR" role="EQaZv">
+        <ref role="trN6q" to="tpce:1ob16QT2yIl" resolve="INamedStructureElement" />
+      </node>
+    </node>
+    <node concept="1TJgyi" id="6LPkCA$4_PT" role="1TKVEl">
+      <property role="IQ2nx" value="7815243479488028025" />
+      <property role="TrG5h" value="comment" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+      <node concept="2DM1AW" id="6LPkCA$4_PZ" role="lGtFl">
+        <property role="2DM1AS" value="Deprecated-comment" />
+      </node>
+    </node>
+    <node concept="1TJgyi" id="6LPkCA$4_PV" role="1TKVEl">
+      <property role="IQ2nx" value="7815243479488028027" />
+      <property role="TrG5h" value="build" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+      <node concept="2DM1AW" id="6LPkCA$4_Q0" role="lGtFl">
+        <property role="2DM1AS" value="Deprecated-build" />
+      </node>
+    </node>
+    <node concept="2DM1AW" id="6LPkCA$4_PY" role="lGtFl">
+      <property role="2DM1AS" value="Deprecated" />
+    </node>
+  </node>
 </model>
 

--- a/languages/io.lionweb.mps.structure.attribute/io.lionweb.mps.structure.attribute.mpl
+++ b/languages/io.lionweb.mps.structure.attribute/io.lionweb.mps.structure.attribute.mpl
@@ -15,6 +15,7 @@
   <dependencies>
     <dependency reexport="false">c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)</dependency>
     <dependency reexport="false">2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)</dependency>
+    <dependency reexport="false">7350a1d7-537e-4f0d-9965-e91c82522d7d(io.lionweb.mps.m3.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
@@ -59,6 +60,7 @@
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="7350a1d7-537e-4f0d-9965-e91c82522d7d(io.lionweb.mps.m3.runtime)" version="0" />
     <module reference="411e5b27-8a76-482e-8af8-1704262b4468(io.lionweb.mps.structure.attribute)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />

--- a/languages/io.lionweb.mps.structure.attribute/models/io.lionweb.mps.structure.attribute.behavior.mps
+++ b/languages/io.lionweb.mps.structure.attribute/models/io.lionweb.mps.structure.attribute.behavior.mps
@@ -59,7 +59,7 @@
     </language>
   </registry>
   <node concept="13h7C7" id="3M8YG$9uJLd">
-    <ref role="13h7C2" to="234s:6fYiNFad_9U" resolve="LionWebLanguageKey" />
+    <ref role="13h7C2" to="234s:6fYiNFad_9U" resolve="LionWebLanguage" />
     <node concept="13hLZK" id="3M8YG$9uJLe" role="13h7CW">
       <node concept="3clFbS" id="3M8YG$9uJLf" role="2VODD2" />
     </node>

--- a/languages/io.lionweb.mps.structure.attribute/models/io.lionweb.mps.structure.attribute.editor.mps
+++ b/languages/io.lionweb.mps.structure.attribute/models/io.lionweb.mps.structure.attribute.editor.mps
@@ -39,6 +39,7 @@
       </concept>
       <concept id="1088185857835" name="jetbrains.mps.lang.editor.structure.InlineEditorComponent" flags="ig" index="1sVBvm" />
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <property id="1140114345053" name="allowEmptyText" index="1O74Pk" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
@@ -101,7 +102,7 @@
     </language>
   </registry>
   <node concept="24kQdi" id="6fYiNFad_f3">
-    <ref role="1XX52x" to="234s:6fYiNFad_9U" resolve="LionWebLanguageKey" />
+    <ref role="1XX52x" to="234s:6fYiNFad_9U" resolve="LionWebLanguage" />
     <node concept="3EZMnI" id="3M8YG$9urTp" role="2wV5jI">
       <node concept="3EZMnI" id="3M8YG$9urTH" role="3EZMnx">
         <ref role="1k5W1q" to="tpch:24YP6ZDyde4" resolve="Keyword" />
@@ -116,10 +117,39 @@
           </node>
         </node>
       </node>
-      <node concept="3F0A7n" id="3M8YG$9urTr" role="3EZMnx">
-        <ref role="1NtTu8" to="234s:6fYiNFad_a2" resolve="key" />
+      <node concept="3EZMnI" id="6jbF0BnTw3u" role="3EZMnx">
+        <node concept="VPM3Z" id="6jbF0BnTw3w" role="3F10Kt" />
+        <node concept="3XFhqQ" id="6jbF0BnTw3I" role="3EZMnx" />
+        <node concept="3EZMnI" id="6jbF0BnTw3O" role="3EZMnx">
+          <node concept="VPM3Z" id="6jbF0BnTw3Q" role="3F10Kt" />
+          <node concept="3EZMnI" id="6jbF0BnTw3Z" role="3EZMnx">
+            <node concept="VPM3Z" id="6jbF0BnTw41" role="3F10Kt" />
+            <node concept="3F0ifn" id="6jbF0BnTw49" role="3EZMnx">
+              <property role="3F0ifm" value="key" />
+            </node>
+            <node concept="3XFhqQ" id="6jbF0BnTw4f" role="3EZMnx" />
+            <node concept="3F0A7n" id="6jbF0BnTw4s" role="3EZMnx">
+              <ref role="1NtTu8" to="234s:6fYiNFad_a2" resolve="key" />
+            </node>
+            <node concept="2iRfu4" id="6jbF0BnTw44" role="2iSdaV" />
+          </node>
+          <node concept="3EZMnI" id="6jbF0BnTw4x" role="3EZMnx">
+            <node concept="VPM3Z" id="6jbF0BnTw4y" role="3F10Kt" />
+            <node concept="3F0ifn" id="6jbF0BnTw4z" role="3EZMnx">
+              <property role="3F0ifm" value="version" />
+            </node>
+            <node concept="3XFhqQ" id="6jbF0BnTw4$" role="3EZMnx" />
+            <node concept="3F0A7n" id="6jbF0BnTw4_" role="3EZMnx">
+              <property role="1O74Pk" value="true" />
+              <ref role="1NtTu8" to="234s:6jbF0BnT6Ct" resolve="version" />
+            </node>
+            <node concept="2iRfu4" id="6jbF0BnTw4A" role="2iSdaV" />
+          </node>
+          <node concept="2iRkQZ" id="6jbF0BnTw3T" role="2iSdaV" />
+        </node>
+        <node concept="2iRfu4" id="6jbF0BnTw3z" role="2iSdaV" />
       </node>
-      <node concept="2iRfu4" id="3M8YG$9urTs" role="2iSdaV" />
+      <node concept="2iRkQZ" id="6jbF0BnTw3k" role="2iSdaV" />
     </node>
   </node>
   <node concept="PKFIW" id="6fYiNFatshQ">

--- a/languages/io.lionweb.mps.structure.attribute/models/io.lionweb.mps.structure.attribute.intentions.mps
+++ b/languages/io.lionweb.mps.structure.attribute/models/io.lionweb.mps.structure.attribute.intentions.mps
@@ -6,16 +6,23 @@
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
+    <import index="y7p" ref="r:3303ef0b-a58e-4f50-b3cb-bd3d7aaf3653(io.lionweb.mps.m3.runtime)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
     <import index="234s" ref="r:c798b861-d641-45c1-bec6-e39cbda50960(io.lionweb.mps.structure.attribute.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -26,9 +33,14 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271369338" name="jetbrains.mps.baseLanguage.structure.IsEmptyOperation" flags="nn" index="17RlXB" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -44,6 +56,10 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
@@ -58,11 +74,13 @@
     <language id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions">
       <concept id="1192794744107" name="jetbrains.mps.lang.intentions.structure.IntentionDeclaration" flags="ig" index="2S6QgY" />
       <concept id="1192794782375" name="jetbrains.mps.lang.intentions.structure.DescriptionBlock" flags="in" index="2S6ZIM" />
+      <concept id="1192795771125" name="jetbrains.mps.lang.intentions.structure.IsApplicableBlock" flags="in" index="2SaL7w" />
       <concept id="1192795911897" name="jetbrains.mps.lang.intentions.structure.ExecuteBlock" flags="in" index="2Sbjvc" />
       <concept id="1192796902958" name="jetbrains.mps.lang.intentions.structure.ConceptFunctionParameter_node" flags="nn" index="2Sf5sV" />
       <concept id="2522969319638091381" name="jetbrains.mps.lang.intentions.structure.BaseIntentionDeclaration" flags="ig" index="2ZfUlf">
         <reference id="2522969319638198290" name="forConcept" index="2ZfgGC" />
         <child id="2522969319638198291" name="executeFunction" index="2ZfgGD" />
+        <child id="2522969319638093995" name="isApplicableFunction" index="2ZfVeh" />
         <child id="2522969319638093993" name="descriptionFunction" index="2ZfVej" />
       </concept>
     </language>
@@ -96,6 +114,9 @@
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC" />
       <concept id="1173122760281" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorsOperation" flags="nn" index="z$bX8" />
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
+      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
+        <child id="1145404616321" name="leftExpression" index="2JrQYb" />
+      </concept>
       <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7">
         <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
       </concept>
@@ -387,7 +408,7 @@
   </node>
   <node concept="2S6QgY" id="4Yo3buYlC$q">
     <property role="TrG5h" value="addNamesAsKeys" />
-    <ref role="2ZfgGC" to="234s:6fYiNFad_9U" resolve="LionWebLanguageKey" />
+    <ref role="2ZfgGC" to="234s:6fYiNFad_9U" resolve="LionWebLanguage" />
     <node concept="2S6ZIM" id="4Yo3buYlC$r" role="2ZfVej">
       <node concept="3clFbS" id="4Yo3buYlC$s" role="2VODD2">
         <node concept="3clFbF" id="4Yo3buYlCDq" role="3cqZAp">
@@ -527,7 +548,7 @@
   </node>
   <node concept="2S6QgY" id="4Yo3buYmccd">
     <property role="TrG5h" value="replaceNamesAsKeys" />
-    <ref role="2ZfgGC" to="234s:6fYiNFad_9U" resolve="LionWebLanguageKey" />
+    <ref role="2ZfgGC" to="234s:6fYiNFad_9U" resolve="LionWebLanguage" />
     <node concept="2S6ZIM" id="4Yo3buYmcce" role="2ZfVej">
       <node concept="3clFbS" id="4Yo3buYmccf" role="2VODD2">
         <node concept="3clFbF" id="4Yo3buYmce6" role="3cqZAp">
@@ -633,6 +654,72 @@
                 </node>
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2S6QgY" id="6jbF0BnTwAj">
+    <property role="TrG5h" value="copyLanguageVersion" />
+    <ref role="2ZfgGC" to="234s:6fYiNFad_9U" resolve="LionWebLanguage" />
+    <node concept="2S6ZIM" id="6jbF0BnTwAk" role="2ZfVej">
+      <node concept="3clFbS" id="6jbF0BnTwAl" role="2VODD2">
+        <node concept="3clFbF" id="6jbF0BnTwFj" role="3cqZAp">
+          <node concept="Xl_RD" id="6jbF0BnTwFi" role="3clFbG">
+            <property role="Xl_RC" value="Copy Language Version" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="6jbF0BnTwAm" role="2ZfgGD">
+      <node concept="3clFbS" id="6jbF0BnTwAn" role="2VODD2">
+        <node concept="3clFbF" id="6jbF0BnTxTq" role="3cqZAp">
+          <node concept="37vLTI" id="6jbF0BnTxVF" role="3clFbG">
+            <node concept="2YIFZM" id="6jbF0BnTyEr" role="37vLTx">
+              <ref role="37wK5l" to="y7p:34Q84zMXVAC" resolve="getLanguageVersionString" />
+              <ref role="1Pybhc" to="y7p:6jTTMHD72IS" resolve="MpsLanguageUtil" />
+              <node concept="2OqwBi" id="6jbF0BnT$7V" role="37wK5m">
+                <node concept="2YIFZM" id="6jbF0BnT$1z" role="2Oq$k0">
+                  <ref role="37wK5l" to="y7p:39$JcGGnzni" resolve="getInstance" />
+                  <ref role="1Pybhc" to="y7p:39$JcGGnjRO" resolve="MpsLanguageConverter" />
+                </node>
+                <node concept="liA8E" id="6jbF0BnT$j4" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:39$JcGGnA1k" resolve="toSLanguage" />
+                  <node concept="2OqwBi" id="6jbF0BnTzr8" role="37wK5m">
+                    <node concept="2JrnkZ" id="6jbF0BnTzks" role="2Oq$k0">
+                      <node concept="2OqwBi" id="6jbF0BnTyP6" role="2JrQYb">
+                        <node concept="2Sf5sV" id="6jbF0BnTyF5" role="2Oq$k0" />
+                        <node concept="I4A8Y" id="6jbF0BnTz4C" role="2OqNvi" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="6jbF0BnTzBB" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6jbF0BnTxTC" role="37vLTJ">
+              <node concept="2Sf5sV" id="6jbF0BnTxTp" role="2Oq$k0" />
+              <node concept="3TrcHB" id="6jbF0BnTxUz" role="2OqNvi">
+                <ref role="3TsBF5" to="234s:6jbF0BnT6Ct" resolve="version" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2SaL7w" id="6jbF0BnTwM0" role="2ZfVeh">
+      <node concept="3clFbS" id="6jbF0BnTwM1" role="2VODD2">
+        <node concept="3clFbF" id="6jbF0BnTwQ0" role="3cqZAp">
+          <node concept="2OqwBi" id="6jbF0BnTx_x" role="3clFbG">
+            <node concept="2OqwBi" id="6jbF0BnTx3q" role="2Oq$k0">
+              <node concept="2Sf5sV" id="6jbF0BnTwPZ" role="2Oq$k0" />
+              <node concept="3TrcHB" id="6jbF0BnTxcw" role="2OqNvi">
+                <ref role="3TsBF5" to="234s:6jbF0BnT6Ct" resolve="version" />
+              </node>
+            </node>
+            <node concept="17RlXB" id="6jbF0BnTxP5" role="2OqNvi" />
           </node>
         </node>
       </node>

--- a/languages/io.lionweb.mps.structure.attribute/models/io.lionweb.mps.structure.attribute.structure.mps
+++ b/languages/io.lionweb.mps.structure.attribute/models/io.lionweb.mps.structure.attribute.structure.mps
@@ -67,11 +67,16 @@
   </registry>
   <node concept="1TIwiD" id="6fYiNFad_9U">
     <property role="EcuMT" value="7205279169712116346" />
-    <property role="TrG5h" value="LionWebLanguageKey" />
+    <property role="TrG5h" value="LionWebLanguage" />
     <property role="R4oN_" value="Key of Language imported from LionWeb" />
     <property role="19KtqR" value="true" />
-    <property role="34LRSv" value="LionWeb Language Key" />
+    <property role="34LRSv" value="LionWeb Language" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="6jbF0BnT6Ct" role="1TKVEl">
+      <property role="IQ2nx" value="7263087982341810717" />
+      <property role="TrG5h" value="version" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+    </node>
     <node concept="PrWs8" id="6fYiNFad_a4" role="PzmwI">
       <ref role="PrY4T" node="6fYiNFad_a1" resolve="ILionWebKey" />
     </node>

--- a/solutions/io.lionweb.mps.build/models/io.lionweb.mps.build.mps
+++ b/solutions/io.lionweb.mps.build/models/io.lionweb.mps.build.mps
@@ -639,6 +639,11 @@
             <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
           </node>
         </node>
+        <node concept="1SiIV0" id="6jbF0BozSm_" role="3bR37C">
+          <node concept="3bR9La" id="6jbF0BozSmA" role="1SiIV1">
+            <ref role="3bR37D" node="6jI_U5e9kIC" resolve="io.lionweb.mps.m3.runtime" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="RuBGkv2iXR" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -3533,6 +3538,116 @@
           </node>
         </node>
       </node>
+      <node concept="1E1JtD" id="6LPkCA_epmF" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="io.lionweb.mps.converter.TestDeprecated" />
+        <property role="3LESm3" value="09360184-8598-44e7-9bf5-fb1ce45a480a" />
+        <node concept="398BVA" id="6LPkCA_epxl" role="3LF7KH">
+          <ref role="398BVh" node="5wsogBcGDKe" resolve="lionweb-mps.home" />
+          <node concept="2Ry0Ak" id="6LPkCA_epzy" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="6LPkCA_ep_1" role="2Ry0An">
+              <property role="2Ry0Am" value="io.lionweb.mps.converter.TestDeprecated" />
+              <node concept="2Ry0Ak" id="6LPkCA_epAw" role="2Ry0An">
+                <property role="2Ry0Am" value="io.lionweb.mps.converter.TestDeprecated.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="6LPkCA_epKf" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="6LPkCA_epKg" role="1HemKq">
+            <node concept="398BVA" id="6LPkCA_epK3" role="3LXTmr">
+              <ref role="398BVh" node="5wsogBcGDKe" resolve="lionweb-mps.home" />
+              <node concept="2Ry0Ak" id="6LPkCA_epK4" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="6LPkCA_epK5" role="2Ry0An">
+                  <property role="2Ry0Am" value="io.lionweb.mps.converter.TestDeprecated" />
+                  <node concept="2Ry0Ak" id="6LPkCA_epK6" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="6LPkCA_epKh" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="6LPkCA_epMp" role="3bR31x">
+          <node concept="3LXTmp" id="6LPkCA_epMq" role="3rtmxm">
+            <node concept="398BVA" id="6LPkCA_epMr" role="3LXTmr">
+              <ref role="398BVh" node="5wsogBcGDKe" resolve="lionweb-mps.home" />
+              <node concept="2Ry0Ak" id="6LPkCA_epMs" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="6LPkCA_epMt" role="2Ry0An">
+                  <property role="2Ry0Am" value="io.lionweb.mps.converter.TestDeprecated" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="6LPkCA_epMv" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="2NSuNu8q$2G" role="2G$12L">
+        <property role="TrG5h" value="io.lionweb.mps.converter.TestEnum" />
+        <property role="3LESm3" value="1ec6d5e7-6402-4c18-95d0-6e0906eb1ff1" />
+        <property role="BnDLt" value="true" />
+        <node concept="398BVA" id="2NSuNu8q$dC" role="3LF7KH">
+          <ref role="398BVh" node="5wsogBcGDKe" resolve="lionweb-mps.home" />
+          <node concept="2Ry0Ak" id="2NSuNu8q$gy" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="2NSuNu8q$i1" role="2Ry0An">
+              <property role="2Ry0Am" value="io.lionweb.mps.converter.TestEnum" />
+              <node concept="2Ry0Ak" id="2NSuNu8q$jw" role="2Ry0An">
+                <property role="2Ry0Am" value="io.lionweb.mps.converter.TestEnum.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="2NSuNu8q$tr" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2NSuNu8q$ts" role="1HemKq">
+            <node concept="398BVA" id="2NSuNu8q$tf" role="3LXTmr">
+              <ref role="398BVh" node="5wsogBcGDKe" resolve="lionweb-mps.home" />
+              <node concept="2Ry0Ak" id="2NSuNu8q$tg" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="2NSuNu8q$th" role="2Ry0An">
+                  <property role="2Ry0Am" value="io.lionweb.mps.converter.TestEnum" />
+                  <node concept="2Ry0Ak" id="2NSuNu8q$ti" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2NSuNu8q$tt" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="2NSuNu8q$wZ" role="3bR31x">
+          <node concept="3LXTmp" id="2NSuNu8q$x0" role="3rtmxm">
+            <node concept="398BVA" id="2NSuNu8q$x1" role="3LXTmr">
+              <ref role="398BVh" node="5wsogBcGDKe" resolve="lionweb-mps.home" />
+              <node concept="2Ry0Ak" id="2NSuNu8q$x2" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="2NSuNu8q$x3" role="2Ry0An">
+                  <property role="2Ry0Am" value="io.lionweb.mps.converter.TestEnum" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2NSuNu8q$x5" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="1E1JtA" id="3RxvfZghCzp" role="2G$12L">
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="io.lionweb.mps.converter.test.support" />
@@ -3888,6 +4003,11 @@
       <node concept="1SiIV0" id="nWBHrKVRkE" role="3bR37C">
         <node concept="3bR9La" id="nWBHrKVRkF" role="1SiIV1">
           <ref role="3bR37D" node="nWBHrKVQK1" resolve="io.lionweb.mps.converter.TestComputedProperty" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="2NSuNu8q$G5" role="3bR37C">
+        <node concept="3bR9La" id="2NSuNu8q$G6" role="1SiIV1">
+          <ref role="3bR37D" node="2NSuNu8q$2G" resolve="io.lionweb.mps.converter.TestEnum" />
         </node>
       </node>
     </node>

--- a/solutions/io.lionweb.mps.cmdline/models/io.lionweb.mps.cmdline.cmd.mps
+++ b/solutions/io.lionweb.mps.cmdline/models/io.lionweb.mps.cmdline.cmd.mps
@@ -990,67 +990,158 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="6jbF0BoE1e9" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoE1ea" role="3cpWs9">
+            <property role="TrG5h" value="metaAdapterByDeclarationHelper" />
+            <node concept="3uibUv" id="6jbF0BoE0Ux" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BoE1eb" role="33vP2m">
+              <node concept="HV5vD" id="6jbF0BoE1ec" role="2ShVmc">
+                <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6jbF0BoE4Dw" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoE4Dx" role="3cpWs9">
+            <property role="TrG5h" value="attributeFinder" />
+            <node concept="3uibUv" id="6jbF0BoE4mc" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BoE4Dy" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BoE4Dz" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+                <node concept="37vLTw" id="6jbF0BoE4D$" role="37wK5m">
+                  <ref role="3cqZAo" node="12kZjFJeNvA" resolve="repository" />
+                </node>
+                <node concept="37vLTw" id="6jbF0BoE4D_" role="37wK5m">
+                  <ref role="3cqZAo" node="12kZjFJeNv3" resolve="constants" />
+                </node>
+                <node concept="37vLTw" id="6jbF0BoE4DA" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BoE1ea" resolve="metaAdapterByDeclarationHelper" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6jbF0BoE9e1" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoE9e2" role="3cpWs9">
+            <property role="TrG5h" value="directMetaPointerPostprocessor" />
+            <node concept="3uibUv" id="6jbF0BoE8UL" role="1tU5fm">
+              <ref role="3uigEE" to="pe0e:6lVb1tfT0pq" resolve="DirectMetaPointerPostprocessor" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BoE9e3" role="33vP2m">
+              <node concept="HV5vD" id="6jbF0BoE9e4" role="2ShVmc">
+                <ref role="HV5vE" to="pe0e:6lVb1tfT0pq" resolve="DirectMetaPointerPostprocessor" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6jbF0BoEbHj" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoEbHk" role="3cpWs9">
+            <property role="TrG5h" value="sLanguageIdDeriver" />
+            <node concept="3uibUv" id="6jbF0BoEbqN" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:6VkSF6aHm0Q" resolve="SLanguageIdDeriver" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BoEbHl" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BoEbHm" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:6VkSF6aIt83" resolve="SLanguageIdDeriver" />
+                <node concept="37vLTw" id="6jbF0BoEbHn" role="37wK5m">
+                  <ref role="3cqZAo" node="12kZjFJeNv3" resolve="constants" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6jbF0BoEet2" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoEet3" role="3cpWs9">
+            <property role="TrG5h" value="sLanguageIdExtractor" />
+            <node concept="3uibUv" id="6jbF0BoEech" role="1tU5fm">
+              <ref role="3uigEE" to="faaz:6VkSF6aHm0Q" resolve="SLanguageIdExtractor" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BoEet4" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BoEet5" role="2ShVmc">
+                <ref role="37wK5l" to="faaz:6VkSF6aIt83" resolve="SLanguageIdExtractor" />
+                <node concept="37vLTw" id="6jbF0BoEet6" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BoEbHk" resolve="sLanguageIdDeriver" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6jbF0BoEfMN" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoEfMO" role="3cpWs9">
+            <property role="TrG5h" value="metaAdapterFactoryHelper" />
+            <node concept="3uibUv" id="6jbF0BoEfwt" role="1tU5fm">
+              <ref role="3uigEE" to="apzt:59Df55lb06j" resolve="MetaAdapterFactoryHelper" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BoEfMP" role="33vP2m">
+              <node concept="HV5vD" id="6jbF0BoEfMQ" role="2ShVmc">
+                <ref role="HV5vE" to="apzt:59Df55lb06j" resolve="MetaAdapterFactoryHelper" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6jbF0BoEizZ" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoEi$0" role="3cpWs9">
+            <property role="TrG5h" value="metaPointerConverter" />
+            <node concept="3uibUv" id="6jbF0BoEihr" role="1tU5fm">
+              <ref role="3uigEE" to="pe0e:6lVb1tfUY2A" resolve="MetaPointerConverter" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BoEi$1" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BoEi$2" role="2ShVmc">
+                <ref role="37wK5l" to="pe0e:6lVb1tfVtvX" resolve="MetaPointerConverter" />
+                <node concept="37vLTw" id="6jbF0BoEi$3" role="37wK5m">
+                  <ref role="3cqZAo" node="12kZjFJeNv9" resolve="jsonKeyMapper" />
+                </node>
+                <node concept="37vLTw" id="6jbF0BoEi$4" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BoEfMO" resolve="metaAdapterFactoryHelper" />
+                </node>
+                <node concept="37vLTw" id="6jbF0BoEi$5" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BoE9e2" resolve="directMetaPointerPostprocessor" />
+                </node>
+                <node concept="37vLTw" id="6jbF0BoEi$6" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BoEet3" resolve="sLanguageIdExtractor" />
+                </node>
+                <node concept="37vLTw" id="6jbF0BoEi$7" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BoE4Dx" resolve="attributeFinder" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6jbF0BoEljt" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoElju" role="3cpWs9">
+            <property role="TrG5h" value="metaPointerLookup" />
+            <node concept="3uibUv" id="6jbF0BoEl0r" role="1tU5fm">
+              <ref role="3uigEE" to="pe0e:9wS6VcuOAi" resolve="MetaPointerLookup" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BoEljv" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BoEljw" role="2ShVmc">
+                <ref role="37wK5l" to="pe0e:9wS6VcuPbR" resolve="MetaPointerLookup" />
+                <node concept="37vLTw" id="6jbF0BoEljx" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BoE4Dx" resolve="attributeFinder" />
+                </node>
+                <node concept="37vLTw" id="6jbF0BoEljy" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BoEi$0" resolve="metaPointerConverter" />
+                </node>
+                <node concept="37vLTw" id="6jbF0BoEljz" role="37wK5m">
+                  <ref role="3cqZAo" node="12kZjFJeNv9" resolve="jsonKeyMapper" />
+                </node>
+                <node concept="37vLTw" id="6jbF0BoElj$" role="37wK5m">
+                  <ref role="3cqZAo" node="12kZjFJeNv3" resolve="constants" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs6" id="12kZjFJeNve" role="3cqZAp">
           <node concept="2ShNRf" id="12kZjFJeNvf" role="3cqZAk">
             <node concept="1pGfFk" id="12kZjFJeNvg" role="2ShVmc">
               <ref role="37wK5l" to="pe0e:A9P4gGNs$J" resolve="CancellingMetaPointerLookup" />
-              <node concept="2ShNRf" id="12kZjFJeNvh" role="37wK5m">
-                <node concept="1pGfFk" id="12kZjFJeNvi" role="2ShVmc">
-                  <ref role="37wK5l" to="pe0e:9wS6VcuPbR" resolve="MetaPointerLookup" />
-                  <node concept="2ShNRf" id="12kZjFJeNvj" role="37wK5m">
-                    <node concept="1pGfFk" id="12kZjFJeNvk" role="2ShVmc">
-                      <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
-                      <node concept="37vLTw" id="12kZjFJeNvl" role="37wK5m">
-                        <ref role="3cqZAo" node="12kZjFJeNvA" resolve="repository" />
-                      </node>
-                      <node concept="37vLTw" id="12kZjFJeNvm" role="37wK5m">
-                        <ref role="3cqZAo" node="12kZjFJeNv3" resolve="constants" />
-                      </node>
-                      <node concept="2ShNRf" id="12kZjFJeNvn" role="37wK5m">
-                        <node concept="HV5vD" id="12kZjFJeNvo" role="2ShVmc">
-                          <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2ShNRf" id="12kZjFJeNvp" role="37wK5m">
-                    <node concept="1pGfFk" id="12kZjFJeNvq" role="2ShVmc">
-                      <ref role="37wK5l" to="pe0e:6lVb1tfVtvX" resolve="MetaPointerConverter" />
-                      <node concept="37vLTw" id="12kZjFJeNvr" role="37wK5m">
-                        <ref role="3cqZAo" node="12kZjFJeNv9" resolve="jsonKeyMapper" />
-                      </node>
-                      <node concept="2ShNRf" id="12kZjFJeNvs" role="37wK5m">
-                        <node concept="HV5vD" id="12kZjFJeNvt" role="2ShVmc">
-                          <ref role="HV5vE" to="apzt:59Df55lb06j" resolve="MetaAdapterFactoryHelper" />
-                        </node>
-                      </node>
-                      <node concept="2ShNRf" id="12kZjFJeNvu" role="37wK5m">
-                        <node concept="HV5vD" id="12kZjFJeNvv" role="2ShVmc">
-                          <ref role="HV5vE" to="pe0e:6lVb1tfT0pq" resolve="DirectMetaPointerPostprocessor" />
-                        </node>
-                      </node>
-                      <node concept="2ShNRf" id="12kZjFJeNvw" role="37wK5m">
-                        <node concept="1pGfFk" id="12kZjFJeNvx" role="2ShVmc">
-                          <ref role="37wK5l" to="faaz:6VkSF6aIt83" resolve="SLanguageIdExtractor" />
-                          <node concept="2ShNRf" id="4r3Tp$q9g2z" role="37wK5m">
-                            <node concept="1pGfFk" id="4r3Tp$q9hM8" role="2ShVmc">
-                              <ref role="37wK5l" to="y7p:6VkSF6aIt83" resolve="SLanguageIdDeriver" />
-                              <node concept="37vLTw" id="4r3Tp$q9iqy" role="37wK5m">
-                                <ref role="3cqZAo" node="12kZjFJeNv3" resolve="constants" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="37vLTw" id="12kZjFJeNvz" role="37wK5m">
-                    <ref role="3cqZAo" node="12kZjFJeNv9" resolve="jsonKeyMapper" />
-                  </node>
-                  <node concept="37vLTw" id="12kZjFJeNv$" role="37wK5m">
-                    <ref role="3cqZAo" node="12kZjFJeNv3" resolve="constants" />
-                  </node>
-                </node>
+              <node concept="37vLTw" id="6jbF0BoElj_" role="37wK5m">
+                <ref role="3cqZAo" node="6jbF0BoElju" resolve="metaPointerLookup" />
               </node>
             </node>
           </node>

--- a/solutions/io.lionweb.mps.cmdline/models/io.lionweb.mps.cmdline.mps
+++ b/solutions/io.lionweb.mps.cmdline/models/io.lionweb.mps.cmdline.mps
@@ -5,6 +5,7 @@
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
   </languages>
   <imports>
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
@@ -20,6 +21,8 @@
     <import index="c9jv" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:com.google.gson.stream(io.lionweb.lionweb.java/)" />
     <import index="wy2b" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:com.google.gson(io.lionweb.lionweb.java/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">

--- a/solutions/io.lionweb.mps.cmdline/readme.md
+++ b/solutions/io.lionweb.mps.cmdline/readme.md
@@ -178,7 +178,7 @@ pluginManagement {
 
 and some `gradle.properties` (adjust the versions accordingly):
 ```properties
-lionwebVersion=0.2.8
+lionwebVersion=0.2.10
 lionwebRelease=2023.1
 mpsVersionSuffix=2021.1
 mpsVersion=2021.1.4

--- a/solutions/io.lionweb.mps.converter.lang.runtime/models/io.lionweb.mps.converter.lang.runtime.mps
+++ b/solutions/io.lionweb.mps.converter.lang.runtime/models/io.lionweb.mps.converter.lang.runtime.mps
@@ -1440,8 +1440,8 @@
                 <node concept="37vLTw" id="4R9pospSlUF" role="37wK5m">
                   <ref role="3cqZAo" node="4R9pospSlUC" resolve="languageLookup" />
                 </node>
-                <node concept="37vLTw" id="4WflrVb01fV" role="37wK5m">
-                  <ref role="3cqZAo" node="4WflrVaT4Mg" resolve="metaAdapterByDeclarationHelper" />
+                <node concept="37vLTw" id="6jbF0Bo_2Sp" role="37wK5m">
+                  <ref role="3cqZAo" node="4R9pospS5TE" resolve="attributeFinder" />
                 </node>
               </node>
             </node>

--- a/solutions/io.lionweb.mps.converter.test.mpsextensions/models/io.lionweb.mps.converter.test.mpsextensions.languagedependsonfinder@tests.mps
+++ b/solutions/io.lionweb.mps.converter.test.mpsextensions/models/io.lionweb.mps.converter.test.mpsextensions.languagedependsonfinder@tests.mps
@@ -33,6 +33,9 @@
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -177,6 +180,12 @@
                         <ref role="2WH_rO" node="3M8YG$a_1p4" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="4hN16EIyY28" role="37wK5m">
+                      <node concept="2WthIp" id="4hN16EIyXUD" role="2Oq$k0" />
+                      <node concept="2XshWL" id="4hN16EIyY7A" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$RYI" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$RYJ" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$RYK" role="2OqNvi">
@@ -214,6 +223,12 @@
                         <ref role="2WH_rO" node="3M8YG$a_1p4" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="4hN16EIyYdJ" role="37wK5m">
+                      <node concept="2WthIp" id="4hN16EIyYbN" role="2Oq$k0" />
+                      <node concept="2XshWL" id="4hN16EIyYgx" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$WbE" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$WbF" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$WbG" role="2OqNvi">
@@ -246,6 +261,12 @@
                       <node concept="2WthIp" id="3M8YG$a$WGH" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$WGI" role="2OqNvi">
                         <ref role="2WH_rO" node="3M8YG$a_1p4" resolve="constants" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="4hN16EIyZea" role="37wK5m">
+                      <node concept="2WthIp" id="4hN16EIyZ6l" role="2Oq$k0" />
+                      <node concept="2XshWL" id="4hN16EIyZjG" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="3M8YG$a$WGJ" role="37wK5m">
@@ -298,6 +319,12 @@
                         <ref role="2WH_rO" node="3M8YG$a_1p4" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="4hN16EIyZsQ" role="37wK5m">
+                      <node concept="2WthIp" id="4hN16EIyZo1" role="2Oq$k0" />
+                      <node concept="2XshWL" id="4hN16EIyZvG" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$XgI" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$XgJ" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$XgK" role="2OqNvi">
@@ -346,6 +373,12 @@
                       <node concept="2WthIp" id="3M8YG$a_0Kk" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a_0Kl" role="2OqNvi">
                         <ref role="2WH_rO" node="3M8YG$a_1p4" resolve="constants" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="4hN16EIyZAG" role="37wK5m">
+                      <node concept="2WthIp" id="4hN16EIyZy4" role="2Oq$k0" />
+                      <node concept="2XshWL" id="4hN16EIyZIq" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="3M8YG$a_0Km" role="37wK5m">
@@ -612,6 +645,12 @@
                       <node concept="2WthIp" id="3M8YG$a$XVH" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$XVI" role="2OqNvi">
                         <ref role="2WH_rO" node="3M8YG$a_1p4" resolve="constants" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="4hN16EIyZYl" role="37wK5m">
+                      <node concept="2WthIp" id="4hN16EIyZVK" role="2Oq$k0" />
+                      <node concept="2XshWL" id="4hN16EIz01b" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="3M8YG$a$XVJ" role="37wK5m">
@@ -922,6 +961,12 @@
                         <ref role="2WH_rO" node="3M8YG$a_1p4" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="4hN16EIz0fr" role="37wK5m">
+                      <node concept="2WthIp" id="4hN16EIz07M" role="2Oq$k0" />
+                      <node concept="2XshWL" id="4hN16EIz0l3" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$Ysr" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$Yss" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$Yst" role="2OqNvi">
@@ -965,6 +1010,12 @@
                         <ref role="2WH_rO" node="3M8YG$a_1p4" resolve="constants" />
                       </node>
                     </node>
+                    <node concept="2OqwBi" id="4hN16EIz0rB" role="37wK5m">
+                      <node concept="2WthIp" id="4hN16EIz0px" role="2Oq$k0" />
+                      <node concept="2XshWL" id="4hN16EIz0uz" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
+                      </node>
+                    </node>
                     <node concept="2OqwBi" id="3M8YG$a$Z0K" role="37wK5m">
                       <node concept="2WthIp" id="3M8YG$a$Z0L" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$Z0M" role="2OqNvi">
@@ -1006,6 +1057,12 @@
                       <node concept="2WthIp" id="3M8YG$a$ZEl" role="2Oq$k0" />
                       <node concept="2XshWL" id="3M8YG$a$ZEm" role="2OqNvi">
                         <ref role="2WH_rO" node="3M8YG$a_1p4" resolve="constants" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="4hN16EIz0z5" role="37wK5m">
+                      <node concept="2WthIp" id="4hN16EIz0x1" role="2Oq$k0" />
+                      <node concept="2XshWL" id="4hN16EIz0EX" role="2OqNvi">
+                        <ref role="2WH_rO" node="5M8g5cT1YwP" resolve="annotationFinder" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="3M8YG$a$ZEn" role="37wK5m">
@@ -1066,6 +1123,39 @@
       <node concept="3uibUv" id="5M3rB6_S5ni" role="3clF45">
         <ref role="3uigEE" to="y7p:5JNiskhxHcX" resolve="ILionCoreConstants" />
       </node>
+    </node>
+    <node concept="2XrIbr" id="5M8g5cT1YwP" role="1qtyYc">
+      <property role="TrG5h" value="annotationFinder" />
+      <node concept="3uibUv" id="5M8g5cT1YwQ" role="3clF45">
+        <ref role="3uigEE" to="apzt:18UigYQMpCK" resolve="AnnotationFinder" />
+      </node>
+      <node concept="3clFbS" id="5M8g5cT1YwR" role="3clF47">
+        <node concept="3clFbF" id="5M8g5cT1YwS" role="3cqZAp">
+          <node concept="2ShNRf" id="5M8g5cT1YwT" role="3clFbG">
+            <node concept="1pGfFk" id="5M8g5cT1YwU" role="2ShVmc">
+              <ref role="37wK5l" to="apzt:5AGBwuFEKL7" resolve="AnnotationFinder" />
+              <node concept="2OqwBi" id="5M8g5cT1YwV" role="37wK5m">
+                <node concept="2WthIp" id="5M8g5cT1YwW" role="2Oq$k0" />
+                <node concept="2XshWL" id="5M8g5cT1YwX" role="2OqNvi">
+                  <ref role="2WH_rO" node="3M8YG$a_1oW" resolve="repository" />
+                </node>
+              </node>
+              <node concept="2ShNRf" id="5M8g5cT1YwY" role="37wK5m">
+                <node concept="HV5vD" id="5M8g5cT1YwZ" role="2ShVmc">
+                  <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5M8g5cT1Yx0" role="37wK5m">
+                <node concept="2WthIp" id="5M8g5cT1Yx1" role="2Oq$k0" />
+                <node concept="2XshWL" id="5M8g5cT1Yx2" role="2OqNvi">
+                  <ref role="2WH_rO" node="3M8YG$a_1p4" resolve="constants" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="5M8g5cT1Yx3" role="1B3o_S" />
     </node>
     <node concept="2XrIbr" id="3M8YG$a$QVU" role="1qtyYc">
       <property role="TrG5h" value="languages" />

--- a/solutions/io.lionweb.mps.converter.test.support/models/io.lionweb.mps.converter.test.support.mps
+++ b/solutions/io.lionweb.mps.converter.test.support/models/io.lionweb.mps.converter.test.support.mps
@@ -263,6 +263,31 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="3clFb_" id="6jbF0BogdcI" role="jymVt">
+      <property role="TrG5h" value="mapLanguageVersion" />
+      <node concept="3Tm1VV" id="6jbF0BogdcK" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0BogdcL" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0BogdcM" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="17QB3L" id="6jbF0BogdcQ" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0BogdcO" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BogdcP" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="6jbF0BogdcR" role="3clF47">
+        <node concept="3clFbF" id="6jbF0BogeHR" role="3cqZAp">
+          <node concept="37vLTw" id="6jbF0BogeHO" role="3clFbG">
+            <ref role="3cqZAo" node="6jbF0BogdcM" resolve="language" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BogdcS" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="4oHUzWXSZo6" role="jymVt">
       <property role="TrG5h" value="mapClassifier" />
       <node concept="3Tm1VV" id="4oHUzWXSZo7" role="1B3o_S" />
@@ -1366,6 +1391,29 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="4oHUzWXSlSX" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="6jbF0BogfIo" role="jymVt">
+      <property role="TrG5h" value="mapLanguageVersion" />
+      <node concept="3Tm1VV" id="6jbF0BogfIq" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0BogfIr" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0BogfIs" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="17QB3L" id="6jbF0BogfIw" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0BogfIu" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BogfIv" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="6jbF0BogfIx" role="3clF47">
+        <node concept="3clFbF" id="6jbF0Boghcv" role="3cqZAp">
+          <node concept="10Nm6u" id="6jbF0Boghcs" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BogfIy" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>

--- a/solutions/io.lionweb.mps.converter.test/models/io.lionweb.mps.converter.test.attributefinder@tests.mps
+++ b/solutions/io.lionweb.mps.converter.test/models/io.lionweb.mps.converter.test.attributefinder@tests.mps
@@ -5089,5 +5089,519 @@
       </node>
     </node>
   </node>
+  <node concept="1lH9Xt" id="6jbF0BnZ5ws">
+    <property role="TrG5h" value="findVersionFromLanguage_model" />
+    <node concept="2XrIbr" id="6jbF0BnZ5wt" role="1qtyYc">
+      <property role="TrG5h" value="create" />
+      <node concept="3uibUv" id="6jbF0BnZ5wu" role="3clF45">
+        <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
+      </node>
+      <node concept="3clFbS" id="6jbF0BnZ5wv" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BnZ5ww" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BnZ5wx" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6jbF0BnZ5wy" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0BnZ5wz" role="33vP2m">
+              <node concept="1jGwE1" id="6jbF0BnZ5w$" role="2Oq$k0" />
+              <node concept="liA8E" id="6jbF0BnZ5w_" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6jbF0BnZ5wA" role="3cqZAp">
+          <node concept="2ShNRf" id="6jbF0BnZ5wB" role="3clFbG">
+            <node concept="1pGfFk" id="6jbF0BnZ5wC" role="2ShVmc">
+              <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+              <node concept="37vLTw" id="6jbF0BnZ5wD" role="37wK5m">
+                <ref role="3cqZAo" node="6jbF0BnZ5wx" resolve="repository" />
+              </node>
+              <node concept="2ShNRf" id="6jbF0BnZ5wE" role="37wK5m">
+                <node concept="1pGfFk" id="6jbF0BnZ5wF" role="2ShVmc">
+                  <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                  <node concept="37vLTw" id="6jbF0BnZ5wG" role="37wK5m">
+                    <ref role="3cqZAo" node="6jbF0BnZ5wx" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2ShNRf" id="6jbF0BnZ5wH" role="37wK5m">
+                <node concept="HV5vD" id="6jbF0BnZ5wI" role="2ShVmc">
+                  <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6jbF0BnZ5wJ" role="1B3o_S" />
+    </node>
+    <node concept="1LZb2c" id="6jbF0BnZ5wK" role="1SL9yI">
+      <property role="TrG5h" value="existing" />
+      <node concept="3cqZAl" id="6jbF0BnZ5wL" role="3clF45" />
+      <node concept="3clFbS" id="6jbF0BnZ5wM" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BnZ5wN" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BnZ5wO" role="3cpWs9">
+            <property role="TrG5h" value="version" />
+            <node concept="17QB3L" id="6jbF0BnZ5wP" role="1tU5fm" />
+            <node concept="2OqwBi" id="6jbF0BnZ5wQ" role="33vP2m">
+              <node concept="2OqwBi" id="6jbF0BnZ5wR" role="2Oq$k0">
+                <node concept="2WthIp" id="6jbF0BnZ5wS" role="2Oq$k0" />
+                <node concept="2XshWL" id="6jbF0BnZ5wT" role="2OqNvi">
+                  <ref role="2WH_rO" node="6jbF0BnZ5wt" resolve="create" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6jbF0BnZ5wU" role="2OqNvi">
+                <ref role="37wK5l" to="y7p:6jbF0BnTYkP" resolve="findVersionFromLanguage" />
+                <node concept="2OqwBi" id="6jbF0BnZ5wV" role="37wK5m">
+                  <node concept="1Xw6AR" id="6jbF0BnZ5wW" role="2Oq$k0">
+                    <node concept="1dCxOl" id="6jbF0BnZc0F" role="1XwpL7">
+                      <property role="1XweGQ" value="r:2e1d95ed-4ed0-4ecd-bc84-f6c7c405fa7f" />
+                      <node concept="1j_P7g" id="6jbF0BnZc0G" role="1j$8Uc">
+                        <property role="1j_P7h" value="io.lionweb.mps.converter.TestLang3.structure" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2yCiCJ" id="6jbF0BnZ5wZ" role="2OqNvi">
+                    <node concept="2OqwBi" id="6jbF0BnZ5x0" role="Vysub">
+                      <node concept="1jGwE1" id="6jbF0BnZ5x1" role="2Oq$k0" />
+                      <node concept="liA8E" id="6jbF0BnZ5x2" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6jbF0BnZ5x3" role="3cqZAp">
+          <node concept="37vLTw" id="6jbF0BnZ5x4" role="3tpDZA">
+            <ref role="3cqZAo" node="6jbF0BnZ5wO" resolve="version" />
+          </node>
+          <node concept="Xl_RD" id="6jbF0BnZ5x5" role="3tpDZB">
+            <property role="Xl_RC" value="00 my! VERSION 😀" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6jbF0BnZ5x6" role="1SL9yI">
+      <property role="TrG5h" value="M3" />
+      <node concept="3cqZAl" id="6jbF0BnZ5x7" role="3clF45" />
+      <node concept="3clFbS" id="6jbF0BnZ5x8" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BnZ5x9" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BnZ5xa" role="3cpWs9">
+            <property role="TrG5h" value="version" />
+            <node concept="17QB3L" id="6jbF0BnZ5xb" role="1tU5fm" />
+            <node concept="2OqwBi" id="6jbF0BnZ5xc" role="33vP2m">
+              <node concept="2OqwBi" id="6jbF0BnZ5xd" role="2Oq$k0">
+                <node concept="2WthIp" id="6jbF0BnZ5xe" role="2Oq$k0" />
+                <node concept="2XshWL" id="6jbF0BnZ5xf" role="2OqNvi">
+                  <ref role="2WH_rO" node="6jbF0BnZ5wt" resolve="create" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6jbF0BnZ5xg" role="2OqNvi">
+                <ref role="37wK5l" to="y7p:6jbF0BnTYkP" resolve="findVersionFromLanguage" />
+                <node concept="2OqwBi" id="6jbF0BnZ5xh" role="37wK5m">
+                  <node concept="1Xw6AR" id="6jbF0BnZ5xi" role="2Oq$k0">
+                    <node concept="1dCxOl" id="6jbF0BnZ5xj" role="1XwpL7">
+                      <property role="1XweGQ" value="r:11596e6a-4231-47c9-b3df-0dcce1111a54" />
+                      <node concept="1j_P7g" id="6jbF0BnZ5xk" role="1j$8Uc">
+                        <property role="1j_P7h" value="io.lionweb.mps.m3.structure" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2yCiCJ" id="6jbF0BnZ5xl" role="2OqNvi">
+                    <node concept="2OqwBi" id="6jbF0BnZ5xm" role="Vysub">
+                      <node concept="1jGwE1" id="6jbF0BnZ5xn" role="2Oq$k0" />
+                      <node concept="liA8E" id="6jbF0BnZ5xo" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6jbF0BnZ5xp" role="3cqZAp">
+          <node concept="37vLTw" id="6jbF0BnZ5xq" role="3tpDZA">
+            <ref role="3cqZAo" node="6jbF0BnZ5xa" resolve="version" />
+          </node>
+          <node concept="Xl_RD" id="6jbF0BnZ5xr" role="3tpDZB">
+            <property role="Xl_RC" value="2023.1" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6jbF0BnZ5xs" role="1SL9yI">
+      <property role="TrG5h" value="builtins" />
+      <node concept="3cqZAl" id="6jbF0BnZ5xt" role="3clF45" />
+      <node concept="3clFbS" id="6jbF0BnZ5xu" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BnZ5xv" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BnZ5xw" role="3cpWs9">
+            <property role="TrG5h" value="version" />
+            <node concept="17QB3L" id="6jbF0BnZ5xx" role="1tU5fm" />
+            <node concept="2OqwBi" id="6jbF0BnZ5xy" role="33vP2m">
+              <node concept="2OqwBi" id="6jbF0BnZ5xz" role="2Oq$k0">
+                <node concept="2WthIp" id="6jbF0BnZ5x$" role="2Oq$k0" />
+                <node concept="2XshWL" id="6jbF0BnZ5x_" role="2OqNvi">
+                  <ref role="2WH_rO" node="6jbF0BnZ5wt" resolve="create" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6jbF0BnZ5xA" role="2OqNvi">
+                <ref role="37wK5l" to="y7p:6jbF0BnTYkP" resolve="findVersionFromLanguage" />
+                <node concept="2OqwBi" id="6jbF0BnZ5xB" role="37wK5m">
+                  <node concept="1Xw6AR" id="6jbF0BnZ5xC" role="2Oq$k0">
+                    <node concept="1dCxOl" id="6jbF0BnZ5xD" role="1XwpL7">
+                      <property role="1XweGQ" value="r:00000000-0000-4000-0000-011c89590288" />
+                      <node concept="1j_P7g" id="6jbF0BnZ5xE" role="1j$8Uc">
+                        <property role="1j_P7h" value="jetbrains.mps.lang.core.structure" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2yCiCJ" id="6jbF0BnZ5xF" role="2OqNvi">
+                    <node concept="2OqwBi" id="6jbF0BnZ5xG" role="Vysub">
+                      <node concept="1jGwE1" id="6jbF0BnZ5xH" role="2Oq$k0" />
+                      <node concept="liA8E" id="6jbF0BnZ5xI" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="6jbF0BnZ5xJ" role="3cqZAp">
+          <node concept="1PaTwC" id="6jbF0BnZ5xK" role="1aUNEU">
+            <node concept="3oM_SD" id="6jbF0BnZ5xL" role="1PaTwD">
+              <property role="3oM_SC" value="AttributeFinder" />
+            </node>
+            <node concept="3oM_SD" id="6jbF0BnZ5xM" role="1PaTwD">
+              <property role="3oM_SC" value="should" />
+            </node>
+            <node concept="3oM_SD" id="6jbF0BnZ5xN" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="6jbF0BnZ5xO" role="1PaTwD">
+              <property role="3oM_SC" value="translate" />
+            </node>
+            <node concept="3oM_SD" id="6jbF0BnZ5xP" role="1PaTwD">
+              <property role="3oM_SC" value="versions" />
+            </node>
+          </node>
+        </node>
+        <node concept="3ykFI1" id="6jbF0BnZ5xQ" role="3cqZAp">
+          <node concept="37vLTw" id="6jbF0BnZ5xR" role="3ykU8v">
+            <ref role="3cqZAo" node="6jbF0BnZ5xw" resolve="version" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6jbF0BnZ5xS" role="1SL9yI">
+      <property role="TrG5h" value="unknown" />
+      <node concept="3cqZAl" id="6jbF0BnZ5xT" role="3clF45" />
+      <node concept="3clFbS" id="6jbF0BnZ5xU" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BnZ5xV" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BnZ5xW" role="3cpWs9">
+            <property role="TrG5h" value="version" />
+            <node concept="17QB3L" id="6jbF0BnZ5xX" role="1tU5fm" />
+            <node concept="2OqwBi" id="6jbF0BnZ5xY" role="33vP2m">
+              <node concept="2OqwBi" id="6jbF0BnZ5xZ" role="2Oq$k0">
+                <node concept="2WthIp" id="6jbF0BnZ5y0" role="2Oq$k0" />
+                <node concept="2XshWL" id="6jbF0BnZ5y1" role="2OqNvi">
+                  <ref role="2WH_rO" node="6jbF0BnZ5wt" resolve="create" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6jbF0BnZ5y2" role="2OqNvi">
+                <ref role="37wK5l" to="y7p:6jbF0BnTYkP" resolve="findVersionFromLanguage" />
+                <node concept="2OqwBi" id="6jbF0BnZ5y3" role="37wK5m">
+                  <node concept="1Xw6AR" id="6jbF0BnZ5y4" role="2Oq$k0">
+                    <node concept="1dCxOl" id="6jbF0BnZ5y5" role="1XwpL7">
+                      <property role="1XweGQ" value="r:c9b5090c-7263-4642-b8f4-1265e3a15687" />
+                      <node concept="1j_P7g" id="6jbF0BnZ5y6" role="1j$8Uc">
+                        <property role="1j_P7h" value="library.structure" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2yCiCJ" id="6jbF0BnZ5y7" role="2OqNvi">
+                    <node concept="2OqwBi" id="6jbF0BnZ5y8" role="Vysub">
+                      <node concept="1jGwE1" id="6jbF0BnZ5y9" role="2Oq$k0" />
+                      <node concept="liA8E" id="6jbF0BnZ5ya" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3ykFI1" id="6jbF0BnZ5yb" role="3cqZAp">
+          <node concept="37vLTw" id="6jbF0BnZ5yc" role="3ykU8v">
+            <ref role="3cqZAo" node="6jbF0BnZ5xW" resolve="version" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6jbF0BnZ5yd" role="1SL9yI">
+      <property role="TrG5h" value="noStructure" />
+      <node concept="3cqZAl" id="6jbF0BnZ5ye" role="3clF45" />
+      <node concept="3clFbS" id="6jbF0BnZ5yf" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BnZ5yg" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BnZ5yh" role="3cpWs9">
+            <property role="TrG5h" value="version" />
+            <node concept="17QB3L" id="6jbF0BnZ5yi" role="1tU5fm" />
+            <node concept="2OqwBi" id="6jbF0BnZ5yj" role="33vP2m">
+              <node concept="2OqwBi" id="6jbF0BnZ5yk" role="2Oq$k0">
+                <node concept="2WthIp" id="6jbF0BnZ5yl" role="2Oq$k0" />
+                <node concept="2XshWL" id="6jbF0BnZ5ym" role="2OqNvi">
+                  <ref role="2WH_rO" node="6jbF0BnZ5wt" resolve="create" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6jbF0BnZ5yn" role="2OqNvi">
+                <ref role="37wK5l" to="y7p:6jbF0BnTYkP" resolve="findVersionFromLanguage" />
+                <node concept="2OqwBi" id="6jbF0BnZ5yo" role="37wK5m">
+                  <node concept="1Xw6AR" id="6jbF0BnZ5yp" role="2Oq$k0">
+                    <node concept="1dCxOl" id="6jbF0BnZ5yq" role="1XwpL7">
+                      <property role="1XweGQ" value="r:ca50f3ca-935e-45db-989c-015c3471057b" />
+                      <node concept="1j_P7g" id="6jbF0BnZ5yr" role="1j$8Uc">
+                        <property role="1j_P7h" value="MultiRefLang.behavior" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2yCiCJ" id="6jbF0BnZ5ys" role="2OqNvi">
+                    <node concept="2OqwBi" id="6jbF0BnZ5yt" role="Vysub">
+                      <node concept="1jGwE1" id="6jbF0BnZ5yu" role="2Oq$k0" />
+                      <node concept="liA8E" id="6jbF0BnZ5yv" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3ykFI1" id="6jbF0BnZ5yw" role="3cqZAp">
+          <node concept="37vLTw" id="6jbF0BnZ5yx" role="3ykU8v">
+            <ref role="3cqZAo" node="6jbF0BnZ5yh" resolve="version" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="6jbF0BnZ5yy">
+    <property role="TrG5h" value="findVersionFromLanguage_mps" />
+    <node concept="2XrIbr" id="6jbF0BnZ5yz" role="1qtyYc">
+      <property role="TrG5h" value="create" />
+      <node concept="3uibUv" id="6jbF0BnZ5y$" role="3clF45">
+        <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
+      </node>
+      <node concept="3clFbS" id="6jbF0BnZ5y_" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BnZ5yA" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BnZ5yB" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6jbF0BnZ5yC" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0BnZ5yD" role="33vP2m">
+              <node concept="1jGwE1" id="6jbF0BnZ5yE" role="2Oq$k0" />
+              <node concept="liA8E" id="6jbF0BnZ5yF" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6jbF0BnZ5yG" role="3cqZAp">
+          <node concept="2ShNRf" id="6jbF0BnZ5yH" role="3clFbG">
+            <node concept="1pGfFk" id="6jbF0BnZ5yI" role="2ShVmc">
+              <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+              <node concept="37vLTw" id="6jbF0BnZ5yJ" role="37wK5m">
+                <ref role="3cqZAo" node="6jbF0BnZ5yB" resolve="repository" />
+              </node>
+              <node concept="2ShNRf" id="6jbF0BnZ5yK" role="37wK5m">
+                <node concept="1pGfFk" id="6jbF0BnZ5yL" role="2ShVmc">
+                  <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                  <node concept="37vLTw" id="6jbF0BnZ5yM" role="37wK5m">
+                    <ref role="3cqZAo" node="6jbF0BnZ5yB" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2ShNRf" id="6jbF0BnZ5yN" role="37wK5m">
+                <node concept="HV5vD" id="6jbF0BnZ5yO" role="2ShVmc">
+                  <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6jbF0BnZ5yP" role="1B3o_S" />
+    </node>
+    <node concept="1LZb2c" id="6jbF0BnZ5yQ" role="1SL9yI">
+      <property role="TrG5h" value="existing" />
+      <node concept="3cqZAl" id="6jbF0BnZ5yR" role="3clF45" />
+      <node concept="3clFbS" id="6jbF0BnZ5yS" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BnZ5yT" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BnZ5yU" role="3cpWs9">
+            <property role="TrG5h" value="version" />
+            <node concept="17QB3L" id="6jbF0BnZ5yV" role="1tU5fm" />
+            <node concept="2OqwBi" id="6jbF0BnZ5yW" role="33vP2m">
+              <node concept="2OqwBi" id="6jbF0BnZ5yX" role="2Oq$k0">
+                <node concept="2WthIp" id="6jbF0BnZ5yY" role="2Oq$k0" />
+                <node concept="2XshWL" id="6jbF0BnZ5yZ" role="2OqNvi">
+                  <ref role="2WH_rO" node="6jbF0BnZ5yz" resolve="create" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6jbF0BnZ5z0" role="2OqNvi">
+                <ref role="37wK5l" to="y7p:6jbF0BnTYl$" resolve="findVersionFromLanguage" />
+                <node concept="pHN19" id="6jbF0BnZ5z1" role="37wK5m">
+                  <node concept="2V$Bhx" id="6jbF0BnZ6PB" role="2V$M_3">
+                    <property role="2V$B1T" value="099490a3-1e39-4ed1-bebc-8027665cecf9" />
+                    <property role="2V$B1Q" value="io.lionweb.mps.converter.TestLang3" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6jbF0BnZ5z3" role="3cqZAp">
+          <node concept="37vLTw" id="6jbF0BnZ5z4" role="3tpDZA">
+            <ref role="3cqZAo" node="6jbF0BnZ5yU" resolve="version" />
+          </node>
+          <node concept="Xl_RD" id="6jbF0BnZ5z5" role="3tpDZB">
+            <property role="Xl_RC" value="00 my! VERSION 😀" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6jbF0BnZ5z6" role="1SL9yI">
+      <property role="TrG5h" value="M3" />
+      <node concept="3cqZAl" id="6jbF0BnZ5z7" role="3clF45" />
+      <node concept="3clFbS" id="6jbF0BnZ5z8" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BnZ5z9" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BnZ5za" role="3cpWs9">
+            <property role="TrG5h" value="version" />
+            <node concept="17QB3L" id="6jbF0BnZ5zb" role="1tU5fm" />
+            <node concept="2OqwBi" id="6jbF0BnZ5zc" role="33vP2m">
+              <node concept="2OqwBi" id="6jbF0BnZ5zd" role="2Oq$k0">
+                <node concept="2WthIp" id="6jbF0BnZ5ze" role="2Oq$k0" />
+                <node concept="2XshWL" id="6jbF0BnZ5zf" role="2OqNvi">
+                  <ref role="2WH_rO" node="6jbF0BnZ5yz" resolve="create" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6jbF0BnZ5zg" role="2OqNvi">
+                <ref role="37wK5l" to="y7p:6jbF0BnTYl$" resolve="findVersionFromLanguage" />
+                <node concept="pHN19" id="6jbF0BnZ5zh" role="37wK5m">
+                  <node concept="2V$Bhx" id="6jbF0BnZ5zi" role="2V$M_3">
+                    <property role="2V$B1T" value="01cf0d82-8d29-4fc4-be96-28abaf4ad33d" />
+                    <property role="2V$B1Q" value="io.lionweb.mps.m3" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6jbF0BnZ5zj" role="3cqZAp">
+          <node concept="37vLTw" id="6jbF0BnZ5zk" role="3tpDZA">
+            <ref role="3cqZAo" node="6jbF0BnZ5za" resolve="version" />
+          </node>
+          <node concept="Xl_RD" id="6jbF0BnZ5zl" role="3tpDZB">
+            <property role="Xl_RC" value="2023.1" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6jbF0BnZ5zm" role="1SL9yI">
+      <property role="TrG5h" value="builtins" />
+      <node concept="3cqZAl" id="6jbF0BnZ5zn" role="3clF45" />
+      <node concept="3clFbS" id="6jbF0BnZ5zo" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BnZ5zp" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BnZ5zq" role="3cpWs9">
+            <property role="TrG5h" value="version" />
+            <node concept="17QB3L" id="6jbF0BnZ5zr" role="1tU5fm" />
+            <node concept="2OqwBi" id="6jbF0BnZ5zs" role="33vP2m">
+              <node concept="2OqwBi" id="6jbF0BnZ5zt" role="2Oq$k0">
+                <node concept="2WthIp" id="6jbF0BnZ5zu" role="2Oq$k0" />
+                <node concept="2XshWL" id="6jbF0BnZ5zv" role="2OqNvi">
+                  <ref role="2WH_rO" node="6jbF0BnZ5yz" resolve="create" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6jbF0BnZ5zw" role="2OqNvi">
+                <ref role="37wK5l" to="y7p:6jbF0BnTYl$" resolve="findVersionFromLanguage" />
+                <node concept="pHN19" id="6jbF0BnZ5zx" role="37wK5m">
+                  <node concept="2V$Bhx" id="6jbF0BnZ5zy" role="2V$M_3">
+                    <property role="2V$B1T" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
+                    <property role="2V$B1Q" value="jetbrains.mps.lang.core" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="6jbF0BnZ5zz" role="3cqZAp">
+          <node concept="1PaTwC" id="6jbF0BnZ5z$" role="1aUNEU">
+            <node concept="3oM_SD" id="6jbF0BnZ5z_" role="1PaTwD">
+              <property role="3oM_SC" value="AttributeFinder" />
+            </node>
+            <node concept="3oM_SD" id="6jbF0BnZ5zA" role="1PaTwD">
+              <property role="3oM_SC" value="should" />
+            </node>
+            <node concept="3oM_SD" id="6jbF0BnZ5zB" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="6jbF0BnZ5zC" role="1PaTwD">
+              <property role="3oM_SC" value="translate" />
+            </node>
+            <node concept="3oM_SD" id="6jbF0BnZ5zD" role="1PaTwD">
+              <property role="3oM_SC" value="versions" />
+            </node>
+          </node>
+        </node>
+        <node concept="3ykFI1" id="6jbF0BnZ5zE" role="3cqZAp">
+          <node concept="37vLTw" id="6jbF0BnZ5zF" role="3ykU8v">
+            <ref role="3cqZAo" node="6jbF0BnZ5zq" resolve="version" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6jbF0BnZ5zG" role="1SL9yI">
+      <property role="TrG5h" value="unknown" />
+      <node concept="3cqZAl" id="6jbF0BnZ5zH" role="3clF45" />
+      <node concept="3clFbS" id="6jbF0BnZ5zI" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BnZ5zJ" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BnZ5zK" role="3cpWs9">
+            <property role="TrG5h" value="version" />
+            <node concept="17QB3L" id="6jbF0BnZ5zL" role="1tU5fm" />
+            <node concept="2OqwBi" id="6jbF0BnZ5zM" role="33vP2m">
+              <node concept="2OqwBi" id="6jbF0BnZ5zN" role="2Oq$k0">
+                <node concept="2WthIp" id="6jbF0BnZ5zO" role="2Oq$k0" />
+                <node concept="2XshWL" id="6jbF0BnZ5zP" role="2OqNvi">
+                  <ref role="2WH_rO" node="6jbF0BnZ5yz" resolve="create" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6jbF0BnZ5zQ" role="2OqNvi">
+                <ref role="37wK5l" to="y7p:6jbF0BnTYl$" resolve="findVersionFromLanguage" />
+                <node concept="pHN19" id="6jbF0BnZ5zR" role="37wK5m">
+                  <node concept="2V$Bhx" id="6jbF0BnZ5zS" role="2V$M_3">
+                    <property role="2V$B1T" value="537f9cb0-0f25-3c76-8b86-308f45010100" />
+                    <property role="2V$B1Q" value="library" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3ykFI1" id="6jbF0BnZ5zT" role="3cqZAp">
+          <node concept="37vLTw" id="6jbF0BnZ5zU" role="3ykU8v">
+            <ref role="3cqZAo" node="6jbF0BnZ5zK" resolve="version" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/solutions/io.lionweb.mps.converter.test/models/io.lionweb.mps.converter.test.converter@tests.mps
+++ b/solutions/io.lionweb.mps.converter.test/models/io.lionweb.mps.converter.test.converter@tests.mps
@@ -24,6 +24,12 @@
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1215603922101" name="jetbrains.mps.lang.test.structure.NodeOperationsContainer" flags="ng" index="7CXmI">
+        <child id="1215604436604" name="nodeOperations" index="7EUXB" />
+      </concept>
+      <concept id="1215607067978" name="jetbrains.mps.lang.test.structure.CheckNodeForErrorMessagesOperation" flags="ng" index="7OXhh">
+        <property id="3743352646565420194" name="includeSelf" index="GvXf4" />
+      </concept>
       <concept id="1211979288880" name="jetbrains.mps.lang.test.structure.AssertMatch" flags="nn" index="JA50E">
         <child id="1211979305365" name="before" index="JA92f" />
         <child id="1211979322383" name="after" index="JAdkl" />
@@ -151,8 +157,14 @@
     </language>
     <language id="97ef2b8d-23e1-433e-8d23-48f916dd314d" name="io.lionweb.mps.converter.lang">
       <concept id="5066961138993480707" name="io.lionweb.mps.converter.lang.structure.ConvertLanguageToLionCore" flags="ng" index="qeN9c" />
+      <concept id="5028875375328515028" name="io.lionweb.mps.converter.lang.structure.APathConverter" flags="ng" index="VS7hm">
+        <property id="5028875375328515031" name="path" index="VS7hl" />
+      </concept>
       <concept id="1622443184644647655" name="io.lionweb.mps.converter.lang.structure.ILanguageIdentityContainer" flags="ng" index="3IuRAt">
         <child id="5066961138993587939" name="languages" index="qeD2G" />
+      </concept>
+      <concept id="1622443184644647418" name="io.lionweb.mps.converter.lang.structure.ExportMpsLanguageToJson" flags="ng" index="3IuRE0">
+        <property id="548682208089002477" name="scope" index="2G9pTy" />
       </concept>
     </language>
     <language id="4a963078-62c4-4f96-9b52-198a0c63da4b" name="io.lionweb.mps.testsupport">
@@ -332,7 +344,7 @@
     <node concept="1qefOq" id="48csSBOZRSQ" role="1SKRRt">
       <node concept="2RzRRF" id="2fx6VTTnYmk" role="1qenE9">
         <property role="TrG5h" value="io.lionweb.mps.m3" />
-        <property role="3HH78N" value="0" />
+        <property role="3HH78N" value="2023.1" />
         <property role="2RzON1" value="LionCore-M3" />
         <node concept="2RzPaY" id="7Cdxs9DYA_l" role="2RzR6B">
           <property role="2RzON1" value="IKeyed" />
@@ -3713,6 +3725,25 @@
           </node>
           <node concept="3xONca" id="1xqd6ptkwqd" role="JA92f">
             <ref role="3xOPvv" node="18UigYR952J" resolve="expected" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="6LPkCA_eaHl">
+    <property role="TrG5h" value="ExportMpsLanguageToJson" />
+    <node concept="1qefOq" id="6LPkCA_eaP1" role="1SKRRt">
+      <node concept="3IuRE0" id="6LPkCA_eaP5" role="1qenE9">
+        <property role="TrG5h" value="bla" />
+        <property role="VS7hl" value="myPath" />
+        <property role="2G9pTy" value="utjSYFIcjG/fineGrainedClosure" />
+        <node concept="2V$Bhx" id="6LPkCA_eaP7" role="qeD2G">
+          <property role="2V$B1T" value="08caad75-8246-4427-bb4d-8444b6c5c729" />
+          <property role="2V$B1Q" value="io.lionweb.mps.converter.TestLang" />
+        </node>
+        <node concept="7CXmI" id="6LPkCA_eaP9" role="lGtFl">
+          <node concept="7OXhh" id="6LPkCA_eaPb" role="7EUXB">
+            <property role="GvXf4" value="true" />
           </node>
         </node>
       </node>

--- a/solutions/io.lionweb.mps.converter.test/models/io.lionweb.mps.converter.test.languagecomparer@tests.mps
+++ b/solutions/io.lionweb.mps.converter.test/models/io.lionweb.mps.converter.test.languagecomparer@tests.mps
@@ -2825,7 +2825,7 @@
         <node concept="3vFxKo" id="4r3Tp$piBRm" role="3cqZAp">
           <node concept="2OqwBi" id="4r3Tp$piBRn" role="3vFALc">
             <node concept="liA8E" id="4r3Tp$piBRq" role="2OqNvi">
-              <ref role="37wK5l" to="y7p:4r3Tp$paYGy" resolve="equals" />
+              <ref role="37wK5l" to="y7p:4r3Tp$pb3gD" resolve="equals" />
               <node concept="10QFUN" id="4r3Tp$piBRr" role="37wK5m">
                 <node concept="10Nm6u" id="4r3Tp$piBRs" role="10QFUP" />
                 <node concept="3uibUv" id="4r3Tp$piBRt" role="10QFUM">
@@ -2856,7 +2856,7 @@
         <node concept="3vFxKo" id="4r3Tp$piBR$" role="3cqZAp">
           <node concept="2OqwBi" id="4r3Tp$piBR_" role="3vFALc">
             <node concept="liA8E" id="4r3Tp$piBRC" role="2OqNvi">
-              <ref role="37wK5l" to="y7p:4r3Tp$paYGy" resolve="equals" />
+              <ref role="37wK5l" to="y7p:4r3Tp$pb3gD" resolve="equals" />
               <node concept="10QFUN" id="4r3Tp$piBRD" role="37wK5m">
                 <node concept="10Nm6u" id="4r3Tp$piBRE" role="10QFUP" />
                 <node concept="3uibUv" id="4r3Tp$piBRF" role="10QFUM">
@@ -2884,7 +2884,7 @@
         <node concept="3vFxKo" id="4r3Tp$piBRK" role="3cqZAp">
           <node concept="2OqwBi" id="4r3Tp$piBRL" role="3vFALc">
             <node concept="liA8E" id="4r3Tp$piBRO" role="2OqNvi">
-              <ref role="37wK5l" to="y7p:4r3Tp$paYGy" resolve="equals" />
+              <ref role="37wK5l" to="y7p:4r3Tp$pb3gD" resolve="equals" />
               <node concept="1XH99k" id="4r3Tp$piEq2" role="37wK5m">
                 <ref role="1XH99l" to="tpce:3Ftr4R6BFyf" resolve="Cardinality" />
               </node>
@@ -2912,7 +2912,7 @@
         <node concept="3vwNmj" id="4r3Tp$piBRW" role="3cqZAp">
           <node concept="2OqwBi" id="4r3Tp$piBRX" role="3vwVQn">
             <node concept="liA8E" id="4r3Tp$piBS0" role="2OqNvi">
-              <ref role="37wK5l" to="y7p:4r3Tp$paYGy" resolve="equals" />
+              <ref role="37wK5l" to="y7p:4r3Tp$pb3gD" resolve="equals" />
               <node concept="1XH99k" id="4r3Tp$piF30" role="37wK5m">
                 <ref role="1XH99l" to="tpce:3Ftr4R6BFyf" resolve="Cardinality" />
               </node>
@@ -2937,7 +2937,7 @@
         <node concept="3vFxKo" id="4r3Tp$piBS6" role="3cqZAp">
           <node concept="2OqwBi" id="4r3Tp$piBS7" role="3vFALc">
             <node concept="liA8E" id="4r3Tp$piBSa" role="2OqNvi">
-              <ref role="37wK5l" to="y7p:4r3Tp$paYGy" resolve="equals" />
+              <ref role="37wK5l" to="y7p:4r3Tp$pb3gD" resolve="equals" />
               <node concept="1XH99k" id="4r3Tp$piFdL" role="37wK5m">
                 <ref role="1XH99l" to="tpce:3Ftr4R6BFyf" resolve="Cardinality" />
               </node>

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.declarationnode.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.declarationnode.mps
@@ -13,6 +13,7 @@
     <import index="e8bb" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter.ids(MPS.Core/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="y7p" ref="r:3303ef0b-a58e-4f50-b3cb-bd3d7aaf3653(io.lionweb.mps.m3.runtime)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -376,6 +377,40 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5M3rB6_USHF" role="jymVt" />
+    <node concept="3clFb_" id="6jbF0Bofg62" role="jymVt">
+      <property role="TrG5h" value="mapLanguageVersion" />
+      <node concept="3Tm1VV" id="6jbF0Bofg64" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0Bofg65" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0Bofg66" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="H_c77" id="6jbF0Bofg6o" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0Bofg68" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0Bofg69" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="6jbF0Bofg6p" role="3clF47">
+        <node concept="3clFbF" id="6jbF0BofiDu" role="3cqZAp">
+          <node concept="2OqwBi" id="6jbF0BofiDv" role="3clFbG">
+            <node concept="37vLTw" id="6jbF0BofiDw" role="2Oq$k0">
+              <ref role="3cqZAo" node="5M3rB6_ViGX" resolve="attributeFinder" />
+            </node>
+            <node concept="liA8E" id="6jbF0BofiDx" role="2OqNvi">
+              <ref role="37wK5l" to="y7p:6jbF0BnTYkP" resolve="findVersionFromLanguage" />
+              <node concept="37vLTw" id="6jbF0BofiDy" role="37wK5m">
+                <ref role="3cqZAo" node="6jbF0Bofg66" resolve="language" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0Bofg6q" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6jbF0BofjBw" role="jymVt" />
     <node concept="3clFb_" id="5M3rB6_USHG" role="jymVt">
       <property role="TrG5h" value="mapClassifier" />
       <node concept="3Tm1VV" id="5M3rB6_USHH" role="1B3o_S" />
@@ -883,6 +918,56 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="2tJIrI" id="6jbF0BofCAd" role="jymVt" />
+    <node concept="3clFb_" id="6jbF0BofAAC" role="jymVt">
+      <property role="TrG5h" value="mapLanguageVersion" />
+      <node concept="3Tm1VV" id="6jbF0BofAAE" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0BofAAF" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0BofAAG" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="H_c77" id="6jbF0BofAAY" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0BofAAI" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BofAAJ" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="6jbF0BofAAZ" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BofEq5" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BofEq6" role="3cpWs9">
+            <property role="TrG5h" value="slang" />
+            <node concept="3uibUv" id="6jbF0BofEq7" role="1tU5fm">
+              <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0BofEq8" role="33vP2m">
+              <node concept="2YIFZM" id="6jbF0BofEq9" role="2Oq$k0">
+                <ref role="37wK5l" to="y7p:39$JcGGnzni" resolve="getInstance" />
+                <ref role="1Pybhc" to="y7p:39$JcGGnjRO" resolve="MpsLanguageConverter" />
+              </node>
+              <node concept="liA8E" id="6jbF0BofEqa" role="2OqNvi">
+                <ref role="37wK5l" to="y7p:39$JcGGnAUM" resolve="toSLanguage" />
+                <node concept="37vLTw" id="6jbF0BofEqb" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BofAAG" resolve="language" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6jbF0BofEqc" role="3cqZAp">
+          <node concept="2YIFZM" id="6jbF0BofEqd" role="3clFbG">
+            <ref role="37wK5l" to="y7p:34Q84zMXVAC" resolve="getLanguageVersionString" />
+            <ref role="1Pybhc" to="y7p:6jTTMHD72IS" resolve="MpsLanguageUtil" />
+            <node concept="37vLTw" id="6jbF0BofEqe" role="37wK5m">
+              <ref role="3cqZAo" node="6jbF0BofEq6" resolve="slang" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BofAB0" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="5M3rB6AkE4g" role="jymVt" />
     <node concept="3clFb_" id="5M3rB6AkE4h" role="jymVt">
       <property role="TrG5h" value="mapClassifier" />
@@ -1351,6 +1436,56 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5M3rB6AmV$y" role="jymVt" />
+    <node concept="3clFb_" id="6jbF0BofoWt" role="jymVt">
+      <property role="TrG5h" value="mapLanguageVersion" />
+      <node concept="3Tm1VV" id="6jbF0BofoWv" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0BofoWw" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0BofoWx" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="H_c77" id="6jbF0BofoWN" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0BofoWz" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BofoW$" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="6jbF0BofoWO" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0Boft96" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0Boft97" role="3cpWs9">
+            <property role="TrG5h" value="slang" />
+            <node concept="3uibUv" id="6jbF0Bofsps" role="1tU5fm">
+              <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0Boft98" role="33vP2m">
+              <node concept="2YIFZM" id="6jbF0Boft99" role="2Oq$k0">
+                <ref role="37wK5l" to="y7p:39$JcGGnzni" resolve="getInstance" />
+                <ref role="1Pybhc" to="y7p:39$JcGGnjRO" resolve="MpsLanguageConverter" />
+              </node>
+              <node concept="liA8E" id="6jbF0Boft9a" role="2OqNvi">
+                <ref role="37wK5l" to="y7p:39$JcGGnAUM" resolve="toSLanguage" />
+                <node concept="37vLTw" id="6jbF0Boft9b" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BofoWx" resolve="language" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6jbF0Bofx$K" role="3cqZAp">
+          <node concept="2YIFZM" id="6jbF0BofypF" role="3clFbG">
+            <ref role="37wK5l" to="y7p:34Q84zMXVAC" resolve="getLanguageVersionString" />
+            <ref role="1Pybhc" to="y7p:6jTTMHD72IS" resolve="MpsLanguageUtil" />
+            <node concept="37vLTw" id="6jbF0Bofzw8" role="37wK5m">
+              <ref role="3cqZAo" node="6jbF0Boft97" resolve="slang" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BofoWP" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6jbF0Bof$pf" role="jymVt" />
     <node concept="3clFb_" id="5M3rB6AmV$z" role="jymVt">
       <property role="TrG5h" value="mapClassifier" />
       <node concept="3Tm1VV" id="5M3rB6AmV$$" role="1B3o_S" />

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.lioncore.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.lioncore.mps
@@ -262,6 +262,39 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5M3rB6A0R$j" role="jymVt" />
+    <node concept="3clFb_" id="6jbF0Bof7MC" role="jymVt">
+      <property role="TrG5h" value="mapLanguageVersion" />
+      <node concept="3Tm1VV" id="6jbF0Bof7ME" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0Bof7MF" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0Bof7MG" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="3Tqbb2" id="6jbF0Bof7MY" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjkngz" resolve="Language" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0Bof7MI" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0Bof7MJ" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="6jbF0Bof7MZ" role="3clF47">
+        <node concept="3clFbF" id="6jbF0Bof9QC" role="3cqZAp">
+          <node concept="2OqwBi" id="6jbF0BofaHH" role="3clFbG">
+            <node concept="37vLTw" id="6jbF0Bof9Q_" role="2Oq$k0">
+              <ref role="3cqZAo" node="6jbF0Bof7MG" resolve="language" />
+            </node>
+            <node concept="3TrcHB" id="6jbF0Bofb$K" role="2OqNvi">
+              <ref role="3TsBF5" to="h3y3:2chztJeDvZC" resolve="version" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0Bof7N0" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6jbF0BofchW" role="jymVt" />
     <node concept="3clFb_" id="5M3rB6A0R$k" role="jymVt">
       <property role="TrG5h" value="mapClassifier" />
       <node concept="3Tm1VV" id="5M3rB6A0R$l" role="1B3o_S" />

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.mps
@@ -250,6 +250,24 @@
         <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
     </node>
+    <node concept="3clFb_" id="6jbF0BodlwV" role="jymVt">
+      <property role="TrG5h" value="mapLanguageVersion" />
+      <node concept="3clFbS" id="6jbF0BodlwW" role="3clF47" />
+      <node concept="3Tm1VV" id="6jbF0BodlwX" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0BodlwY" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0BodlwZ" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="16syzq" id="6jbF0Bodlx0" role="1tU5fm">
+          <ref role="16sUi3" node="6VkSF6aHjJY" resolve="LANGUAGE" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0Bodlx1" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0Bodlx2" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+    </node>
     <node concept="3clFb_" id="6VkSF6aR3TD" role="jymVt">
       <property role="TrG5h" value="mapClassifier" />
       <node concept="3clFbS" id="6VkSF6aR3TG" role="3clF47" />
@@ -799,6 +817,115 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5M3rB6A9PBD" role="jymVt" />
+    <node concept="3clFb_" id="6jbF0BoekY5" role="jymVt">
+      <property role="TrG5h" value="processLanguageVersion" />
+      <node concept="37vLTG" id="6jbF0BoekY6" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="16syzq" id="6jbF0BoekYg" role="1tU5fm">
+          <ref role="16sUi3" node="5M3rB6_P07w" resolve="LANGUAGE" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0BoekY8" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6jbF0BoekY9" role="3clF46">
+        <property role="TrG5h" value="version" />
+        <node concept="17QB3L" id="6jbF0BoekYa" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0BoekYb" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="6jbF0BoekYc" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0BoekYd" role="3clF45" />
+      <node concept="2AHcQZ" id="6jbF0BoekYe" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="6jbF0BoekYh" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0Boepsk" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0Boepsl" role="3cpWs9">
+            <property role="TrG5h" value="staple" />
+            <node concept="3uibUv" id="6jbF0Boepsm" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageStaple" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0Boepsn" role="33vP2m">
+              <node concept="2OqwBi" id="6jbF0Boepso" role="2Oq$k0">
+                <node concept="37vLTw" id="6jbF0Boepsp" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5M3rB6_S5nf" resolve="constants" />
+                </node>
+                <node concept="liA8E" id="6jbF0Boepsq" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqwXhGH" resolve="listLcLanguages" />
+                </node>
+              </node>
+              <node concept="1z4cxt" id="6jbF0Boepsr" role="2OqNvi">
+                <node concept="1bVj0M" id="6jbF0Boepss" role="23t8la">
+                  <node concept="3clFbS" id="6jbF0Boepst" role="1bW5cS">
+                    <node concept="3clFbF" id="6jbF0Boepsu" role="3cqZAp">
+                      <node concept="17R0WA" id="6jbF0Boepsv" role="3clFbG">
+                        <node concept="37vLTw" id="6jbF0Boepsw" role="3uHU7w">
+                          <ref role="3cqZAo" node="6jbF0BoekY9" resolve="version" />
+                        </node>
+                        <node concept="2OqwBi" id="6jbF0BopDTm" role="3uHU7B">
+                          <node concept="37vLTw" id="6jbF0BopFO5" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6jbF0Boeps$" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="6jbF0BopDTp" role="2OqNvi">
+                            <ref role="37wK5l" to="y7p:6jbF0Boi_gF" resolve="getLcLanguageVersion" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="6jbF0Boeps$" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="6jbF0Boeps_" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6jbF0BoepsA" role="3cqZAp">
+          <node concept="3clFbS" id="6jbF0BoepsB" role="3clFbx">
+            <node concept="3cpWs8" id="6jbF0BoepsC" role="3cqZAp">
+              <node concept="3cpWsn" id="6jbF0BoepsD" role="3cpWs9">
+                <property role="TrG5h" value="result" />
+                <node concept="17QB3L" id="6jbF0BoepsE" role="1tU5fm" />
+                <node concept="2YIFZM" id="6jbF0BoeAfX" role="33vP2m">
+                  <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
+                  <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
+                  <node concept="2OqwBi" id="6jbF0BoepsF" role="37wK5m">
+                    <node concept="37vLTw" id="6jbF0BoepsG" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6jbF0Boepsl" resolve="staple" />
+                    </node>
+                    <node concept="liA8E" id="6jbF0BoepsH" role="2OqNvi">
+                      <ref role="37wK5l" to="y7p:7OJcYqwoA7z" resolve="getMpsVersion" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="6jbF0BoepsI" role="3cqZAp">
+              <node concept="37vLTw" id="6jbF0BoepsJ" role="3cqZAk">
+                <ref role="3cqZAo" node="6jbF0BoepsD" resolve="result" />
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="6jbF0BoepsK" role="3clFbw">
+            <node concept="10Nm6u" id="6jbF0BoepsL" role="3uHU7w" />
+            <node concept="37vLTw" id="6jbF0BoepsM" role="3uHU7B">
+              <ref role="3cqZAo" node="6jbF0Boepsl" resolve="staple" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6jbF0BoepsN" role="3cqZAp">
+          <node concept="10Nm6u" id="6jbF0BoepsO" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BoekYi" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6jbF0BoenzH" role="jymVt" />
     <node concept="3clFb_" id="5M3rB6A9Al2" role="jymVt">
       <property role="TrG5h" value="processClassifier" />
       <node concept="3Tmbuc" id="5M3rB6A9Al3" role="1B3o_S" />
@@ -1815,6 +1942,96 @@
       <node concept="3clFbS" id="5M3rB6A1xLb" role="3clF47" />
     </node>
     <node concept="2tJIrI" id="5M3rB6A1sDQ" role="jymVt" />
+    <node concept="3clFb_" id="6jbF0BodqUV" role="jymVt">
+      <property role="TrG5h" value="mapLanguageVersion" />
+      <node concept="3Tm1VV" id="6jbF0BodqUX" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0BodqUY" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0BodqUZ" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="16syzq" id="6jbF0BodqV3" role="1tU5fm">
+          <ref role="16sUi3" node="5M3rB6A1byP" resolve="LANGUAGE" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0BodqV1" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BodqV2" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="6jbF0BodqV4" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BodAhF" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BodAhG" role="3cpWs9">
+            <property role="TrG5h" value="version" />
+            <node concept="17QB3L" id="6jbF0BodAhH" role="1tU5fm" />
+            <node concept="2OqwBi" id="6jbF0BodAhI" role="33vP2m">
+              <node concept="37vLTw" id="6jbF0BodAhJ" role="2Oq$k0">
+                <ref role="3cqZAo" node="5M3rB6A1jCA" resolve="delegate" />
+              </node>
+              <node concept="liA8E" id="6jbF0BodAhK" role="2OqNvi">
+                <ref role="37wK5l" node="6jbF0BodlwV" resolve="mapLanguageVersion" />
+                <node concept="37vLTw" id="6jbF0BodAhL" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BodqUZ" resolve="language" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6jbF0BodAhM" role="3cqZAp">
+          <node concept="3clFbS" id="6jbF0BodAhN" role="3clFbx">
+            <node concept="3cpWs6" id="6jbF0BodAhO" role="3cqZAp">
+              <node concept="1rXfSq" id="6jbF0BodAhP" role="3cqZAk">
+                <ref role="37wK5l" node="6jbF0BodFQ3" resolve="processLanguageVersion" />
+                <node concept="37vLTw" id="6jbF0BodAhQ" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BodqUZ" resolve="language" />
+                </node>
+                <node concept="37vLTw" id="6jbF0BodAhR" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BodAhG" resolve="version" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="6jbF0BodAhS" role="3clFbw">
+            <node concept="10Nm6u" id="6jbF0BodAhT" role="3uHU7w" />
+            <node concept="37vLTw" id="6jbF0BodAhU" role="3uHU7B">
+              <ref role="3cqZAo" node="6jbF0BodAhG" resolve="version" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6jbF0BodAhV" role="3cqZAp">
+          <node concept="10Nm6u" id="6jbF0BodAhW" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BodqV5" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="6jbF0BodFQ3" role="jymVt">
+      <property role="TrG5h" value="processLanguageVersion" />
+      <property role="1EzhhJ" value="true" />
+      <node concept="37vLTG" id="6jbF0BodFQ4" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="16syzq" id="6jbF0BodFQ5" role="1tU5fm">
+          <ref role="16sUi3" node="5M3rB6A1byP" resolve="LANGUAGE" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0BodFQ6" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6jbF0BodFQ7" role="3clF46">
+        <property role="TrG5h" value="version" />
+        <node concept="17QB3L" id="6jbF0BodFQ8" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0BodFQ9" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="6jbF0BodFQa" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0BodFQb" role="3clF45" />
+      <node concept="2AHcQZ" id="6jbF0BodFQc" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="6jbF0BodFQd" role="3clF47" />
+    </node>
+    <node concept="2tJIrI" id="6jbF0BodOW0" role="jymVt" />
     <node concept="3clFb_" id="5M3rB6A1sDR" role="jymVt">
       <property role="TrG5h" value="mapClassifier" />
       <node concept="3Tm1VV" id="5M3rB6A1sDS" role="1B3o_S" />
@@ -3199,6 +3416,41 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="2tJIrI" id="6jbF0Boe89J" role="jymVt" />
+    <node concept="3clFb_" id="6jbF0Boea2w" role="jymVt">
+      <property role="TrG5h" value="processLanguageVersion" />
+      <node concept="37vLTG" id="6jbF0Boea2x" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="16syzq" id="6jbF0Boea2F" role="1tU5fm">
+          <ref role="16sUi3" node="5M3rB6Abj00" resolve="LANGUAGE" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0Boea2z" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6jbF0Boea2$" role="3clF46">
+        <property role="TrG5h" value="version" />
+        <node concept="17QB3L" id="6jbF0Boea2_" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0Boea2A" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="6jbF0Boea2B" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0Boea2C" role="3clF45" />
+      <node concept="2AHcQZ" id="6jbF0Boea2D" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="6jbF0Boea2G" role="3clF47">
+        <node concept="3clFbF" id="6jbF0Boea2J" role="3cqZAp">
+          <node concept="37vLTw" id="6jbF0BoegnQ" role="3clFbG">
+            <ref role="3cqZAo" node="6jbF0Boea2$" resolve="version" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0Boea2H" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="5M3rB6Abj0M" role="jymVt" />
     <node concept="3clFb_" id="5M3rB6Abj0N" role="jymVt">
       <property role="TrG5h" value="processClassifier" />
@@ -3851,6 +4103,24 @@
       </node>
       <node concept="3clFbS" id="5M3rB6AdDAR" role="3clF47" />
     </node>
+    <node concept="3clFb_" id="6jbF0BodZve" role="jymVt">
+      <property role="TrG5h" value="mapLanguageVersion" />
+      <node concept="3Tm1VV" id="6jbF0BodZvg" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0BodZvh" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0BodZvi" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="16syzq" id="6jbF0BodZvm" role="1tU5fm">
+          <ref role="16sUi3" node="5M3rB6AdDx1" resolve="LANGUAGE" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0BodZvk" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BodZvl" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3clFbS" id="6jbF0BodZvn" role="3clF47" />
+    </node>
     <node concept="3clFb_" id="5M3rB6AdDAS" role="jymVt">
       <property role="TrG5h" value="mapClassifier" />
       <property role="1EzhhJ" value="true" />
@@ -4378,6 +4648,109 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5M3rB6Aeu3A" role="jymVt" />
+    <node concept="3clFb_" id="6jbF0BoeFMx" role="jymVt">
+      <property role="TrG5h" value="mapLanguageVersion" />
+      <node concept="3Tm1VV" id="6jbF0BoeFMz" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0BoeFM$" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0BoeFM_" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="16syzq" id="6jbF0BoeFN4" role="1tU5fm">
+          <ref role="16sUi3" node="5M3rB6Ae38o" resolve="LANGUAGE" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0BoeFMB" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BoeFMC" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="6jbF0BoeFN5" role="3clF47">
+        <node concept="3clFbF" id="6jbF0BoeMjL" role="3cqZAp">
+          <node concept="2YIFZM" id="6jbF0BoeMjM" role="3clFbG">
+            <ref role="37wK5l" to="33ny:~Objects.requireNonNull(java.lang.Object,java.lang.String)" resolve="requireNonNull" />
+            <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+            <node concept="2OqwBi" id="6jbF0BoeMjN" role="37wK5m">
+              <node concept="2OqwBi" id="6jbF0BoeMjO" role="2Oq$k0">
+                <node concept="2OqwBi" id="6jbF0BoeMjP" role="2Oq$k0">
+                  <node concept="37vLTw" id="6jbF0BoeMjQ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5M3rB6AefuF" resolve="delegates" />
+                  </node>
+                  <node concept="3$u5V9" id="6jbF0BoeMjR" role="2OqNvi">
+                    <node concept="1bVj0M" id="6jbF0BoeMjS" role="23t8la">
+                      <node concept="3clFbS" id="6jbF0BoeMjT" role="1bW5cS">
+                        <node concept="3J1_TO" id="6jbF0BoeMjU" role="3cqZAp">
+                          <node concept="3clFbS" id="6jbF0BoeMjV" role="1zxBo7">
+                            <node concept="3cpWs6" id="6jbF0BoeMjW" role="3cqZAp">
+                              <node concept="2OqwBi" id="6jbF0BoeMjX" role="3cqZAk">
+                                <node concept="37vLTw" id="6jbF0BoeMjY" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="6jbF0BoeMkd" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="6jbF0BoeMjZ" role="2OqNvi">
+                                  <ref role="37wK5l" node="6jbF0BodlwV" resolve="mapLanguageVersion" />
+                                  <node concept="37vLTw" id="6jbF0BoeMk0" role="37wK5m">
+                                    <ref role="3cqZAo" node="6jbF0BoeFM_" resolve="language" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3uVAMA" id="6jbF0BoeMk1" role="1zxBo5">
+                            <node concept="XOnhg" id="6jbF0BoeMk2" role="1zc67B">
+                              <property role="TrG5h" value="e" />
+                              <node concept="nSUau" id="6jbF0BoeMk3" role="1tU5fm">
+                                <node concept="3uibUv" id="6jbF0BoeMk4" role="nSUat">
+                                  <ref role="3uigEE" to="apzt:3zvxfLhsQ3L" resolve="IdDeserializationException" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbS" id="6jbF0BoeMk5" role="1zc67A">
+                              <node concept="3SKdUt" id="6jbF0BoeMk6" role="3cqZAp">
+                                <node concept="1PaTwC" id="6jbF0BoeMk7" role="1aUNEU">
+                                  <node concept="3oM_SD" id="6jbF0BoeMk8" role="1PaTwD">
+                                    <property role="3oM_SC" value="fall-through," />
+                                  </node>
+                                  <node concept="3oM_SD" id="6jbF0BoeMk9" role="1PaTwD">
+                                    <property role="3oM_SC" value="try" />
+                                  </node>
+                                  <node concept="3oM_SD" id="6jbF0BoeMka" role="1PaTwD">
+                                    <property role="3oM_SC" value="next" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3cpWs6" id="6jbF0BoeMkb" role="3cqZAp">
+                                <node concept="10Nm6u" id="6jbF0BoeMkc" role="3cqZAk" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="6jbF0BoeMkd" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="6jbF0BoeMke" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1KnU$U" id="6jbF0BoeMkf" role="2OqNvi" />
+              </node>
+              <node concept="1uHKPH" id="6jbF0BoeMkg" role="2OqNvi" />
+            </node>
+            <node concept="3cpWs3" id="6jbF0BoeMkh" role="37wK5m">
+              <node concept="37vLTw" id="6jbF0BoeMki" role="3uHU7w">
+                <ref role="3cqZAo" node="6jbF0BoeFM_" resolve="language" />
+              </node>
+              <node concept="Xl_RD" id="6jbF0BoeMkj" role="3uHU7B">
+                <property role="Xl_RC" value="Cannot get version for language " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BoeFN6" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6jbF0BoePmL" role="jymVt" />
     <node concept="3clFb_" id="5M3rB6Ae5mL" role="jymVt">
       <property role="TrG5h" value="mapClassifier" />
       <node concept="3Tm1VV" id="5M3rB6Ae5mN" role="1B3o_S" />

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.slanguage.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.idmapper.slanguage.mps
@@ -1548,6 +1548,41 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="3clFb_" id="6jbF0BofHkz" role="jymVt">
+      <property role="TrG5h" value="mapLanguageVersion" />
+      <node concept="3Tm1VV" id="6jbF0BofHk_" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0BofHkA" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0BofHkB" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="3uibUv" id="6jbF0BofHkT" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0BofHkD" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BofHkE" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="6jbF0BofHkU" role="3clF47">
+        <node concept="3clFbF" id="6jbF0BofIWd" role="3cqZAp">
+          <node concept="2OqwBi" id="6jbF0BofIWe" role="3clFbG">
+            <node concept="37vLTw" id="6jbF0BofIWf" role="2Oq$k0">
+              <ref role="3cqZAo" node="5M3rB6_Y03D" resolve="attributeFinder" />
+            </node>
+            <node concept="liA8E" id="6jbF0BofIWg" role="2OqNvi">
+              <ref role="37wK5l" to="y7p:6jbF0BnTYl$" resolve="findVersionFromLanguage" />
+              <node concept="37vLTw" id="6jbF0BofIWh" role="37wK5m">
+                <ref role="3cqZAo" node="6jbF0BofHkB" resolve="language" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BofHkV" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="5M3rB6_YMjd" role="jymVt">
       <property role="TrG5h" value="mapClassifier" />
       <node concept="3Tm1VV" id="5M3rB6_YMjf" role="1B3o_S" />
@@ -2085,6 +2120,38 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5M3rB6A$kwG" role="jymVt" />
+    <node concept="3clFb_" id="6jbF0BofMpJ" role="jymVt">
+      <property role="TrG5h" value="mapLanguageVersion" />
+      <node concept="3Tm1VV" id="6jbF0BofMpL" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0BofMpM" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0BofMpN" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="3uibUv" id="6jbF0BofMq5" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0BofMpP" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BofMpQ" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="6jbF0BofMq6" role="3clF47">
+        <node concept="3clFbF" id="6jbF0BofEqc" role="3cqZAp">
+          <node concept="2YIFZM" id="6jbF0BofEqd" role="3clFbG">
+            <ref role="1Pybhc" to="y7p:6jTTMHD72IS" resolve="MpsLanguageUtil" />
+            <ref role="37wK5l" to="y7p:34Q84zMXVAC" resolve="getLanguageVersionString" />
+            <node concept="37vLTw" id="6jbF0BofEqe" role="37wK5m">
+              <ref role="3cqZAo" node="6jbF0BofMpN" resolve="language" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BofMq7" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6jbF0BofOMr" role="jymVt" />
     <node concept="3clFb_" id="5M3rB6AzA$p" role="jymVt">
       <property role="TrG5h" value="mapClassifier" />
       <node concept="3Tm1VV" id="5M3rB6AzA$r" role="1B3o_S" />
@@ -2661,6 +2728,38 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5M3rB6A_o99" role="jymVt" />
+    <node concept="3clFb_" id="6jbF0Bog63r" role="jymVt">
+      <property role="TrG5h" value="mapLanguageVersion" />
+      <node concept="3Tm1VV" id="6jbF0Bog63t" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0Bog63u" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0Bog63v" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="3uibUv" id="6jbF0Bog63L" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0Bog63x" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0Bog63y" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="6jbF0Bog63M" role="3clF47">
+        <node concept="3clFbF" id="6jbF0Bogbdr" role="3cqZAp">
+          <node concept="2YIFZM" id="6jbF0Bogbds" role="3clFbG">
+            <ref role="37wK5l" to="y7p:34Q84zMXVAC" resolve="getLanguageVersionString" />
+            <ref role="1Pybhc" to="y7p:6jTTMHD72IS" resolve="MpsLanguageUtil" />
+            <node concept="37vLTw" id="6jbF0Bogbdt" role="37wK5m">
+              <ref role="3cqZAo" node="6jbF0Bog63v" resolve="language" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0Bog63N" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6jbF0Bog8Mv" role="jymVt" />
     <node concept="3clFb_" id="5M3rB6A_o9a" role="jymVt">
       <property role="TrG5h" value="mapClassifier" />
       <node concept="3Tm1VV" id="5M3rB6A_o9b" role="1B3o_S" />

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.language2lioncore.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.language2lioncore.mps
@@ -1571,12 +1571,15 @@
               </node>
               <node concept="2pJxcG" id="2chztJeE$93" role="2pJxcM">
                 <ref role="2pJxcJ" to="h3y3:2chztJeDvZC" resolve="version" />
-                <node concept="WxPPo" id="6jTTMHD7tY7" role="28ntcv">
-                  <node concept="2YIFZM" id="34Q84zMXYsl" role="WxPPp">
-                    <ref role="37wK5l" to="y7p:34Q84zMXVAC" resolve="getLanguageVersionString" />
+                <node concept="WxPPo" id="6jbF0BnWL_4" role="28ntcv">
+                  <node concept="2YIFZM" id="6jbF0Bo9502" role="WxPPp">
                     <ref role="1Pybhc" to="y7p:6jTTMHD72IS" resolve="MpsLanguageUtil" />
-                    <node concept="37vLTw" id="34Q84zMXYsm" role="37wK5m">
+                    <ref role="37wK5l" to="y7p:6jbF0Bo0uK5" resolve="getLanguageVersionString" />
+                    <node concept="37vLTw" id="6jbF0Bo9503" role="37wK5m">
                       <ref role="3cqZAo" node="48csSBNReDf" resolve="mps" />
+                    </node>
+                    <node concept="37vLTw" id="6jbF0Bo9fFQ" role="37wK5m">
+                      <ref role="3cqZAo" node="5AGBwuDD_bQ" resolve="attributeFinder" />
                     </node>
                   </node>
                 </node>

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.lioncore2mps.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.m2.lioncore2mps.mps
@@ -4599,7 +4599,7 @@
               <ref role="37wK5l" to="mhbf:~SModel.addRootNode(org.jetbrains.mps.openapi.model.SNode)" resolve="addRootNode" />
               <node concept="2pJPEk" id="6fYiNFaeCQm" role="37wK5m">
                 <node concept="2pJPED" id="6fYiNFaeCQn" role="2pJPEn">
-                  <ref role="2pJxaS" to="234s:6fYiNFad_9U" resolve="LionWebLanguageKey" />
+                  <ref role="2pJxaS" to="234s:6fYiNFad_9U" resolve="LionWebLanguage" />
                   <node concept="2pJxcG" id="6fYiNFaeQ8$" role="2pJxcM">
                     <ref role="2pJxcJ" to="234s:6fYiNFad_a2" resolve="key" />
                     <node concept="WxPPo" id="6fYiNFaeSy5" role="28ntcv">
@@ -4609,6 +4609,19 @@
                         </node>
                         <node concept="3TrcHB" id="6fYiNFaf03w" role="2OqNvi">
                           <ref role="3TsBF5" to="h3y3:2ju2syjkkk9" resolve="key" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2pJxcG" id="6jbF0BnTgMz" role="2pJxcM">
+                    <ref role="2pJxcJ" to="234s:6jbF0BnT6Ct" resolve="version" />
+                    <node concept="WxPPo" id="6jbF0BnTj7H" role="28ntcv">
+                      <node concept="2OqwBi" id="6jbF0BnTl1h" role="WxPPp">
+                        <node concept="37vLTw" id="6jbF0BnTj7F" role="2Oq$k0">
+                          <ref role="3cqZAo" node="DUXtH0$iPr" resolve="lcLanguage" />
+                        </node>
+                        <node concept="3TrcHB" id="6jbF0BnTp51" role="2OqNvi">
+                          <ref role="3TsBF5" to="h3y3:2chztJeDvZC" resolve="version" />
                         </node>
                       </node>
                     </node>
@@ -27616,12 +27629,12 @@
         <ref role="3uigEE" to="apzt:4R9pospH1E7" resolve="ILanguageLookup" />
       </node>
     </node>
-    <node concept="312cEg" id="4WflrVaSVzq" role="jymVt">
-      <property role="TrG5h" value="metaAdapterByDeclarationHelper" />
+    <node concept="312cEg" id="6jbF0Bo$VbY" role="jymVt">
+      <property role="TrG5h" value="attributeFinder" />
       <property role="3TUv4t" value="true" />
-      <node concept="3Tm6S6" id="4WflrVaSVzr" role="1B3o_S" />
-      <node concept="3uibUv" id="4WflrVaSVzt" role="1tU5fm">
-        <ref role="3uigEE" to="y7p:18UigYOOPKz" resolve="IMetaAdapterByDeclarationHelper" />
+      <node concept="3Tm6S6" id="6jbF0Bo$VbZ" role="1B3o_S" />
+      <node concept="3uibUv" id="6jbF0Bo$Vc1" role="1tU5fm">
+        <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
       </node>
     </node>
     <node concept="2tJIrI" id="3ePT3MiTGk6" role="jymVt" />
@@ -27671,12 +27684,12 @@
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
-      <node concept="37vLTG" id="4WflrVaHS$T" role="3clF46">
-        <property role="TrG5h" value="metaAdapterByDeclarationHelper" />
-        <node concept="3uibUv" id="4WflrVaHUC9" role="1tU5fm">
-          <ref role="3uigEE" to="y7p:18UigYOOPKz" resolve="IMetaAdapterByDeclarationHelper" />
+      <node concept="37vLTG" id="6jbF0Bo$UUR" role="3clF46">
+        <property role="TrG5h" value="attributeFinder" />
+        <node concept="3uibUv" id="6jbF0Bo$UUT" role="1tU5fm">
+          <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
         </node>
-        <node concept="2AHcQZ" id="4WflrVaLtYD" role="2AJF6D">
+        <node concept="2AHcQZ" id="6jbF0Bo$V6k" role="2AJF6D">
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
@@ -27748,16 +27761,16 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="4WflrVaSVzu" role="3cqZAp">
-          <node concept="37vLTI" id="4WflrVaSVzw" role="3clFbG">
-            <node concept="2OqwBi" id="4WflrVaSW8R" role="37vLTJ">
-              <node concept="Xjq3P" id="4WflrVaSWvE" role="2Oq$k0" />
-              <node concept="2OwXpG" id="4WflrVaSW8U" role="2OqNvi">
-                <ref role="2Oxat5" node="4WflrVaSVzq" resolve="metaAdapterByDeclarationHelper" />
+        <node concept="3clFbF" id="6jbF0Bo$Vc2" role="3cqZAp">
+          <node concept="37vLTI" id="6jbF0Bo$Vc4" role="3clFbG">
+            <node concept="2OqwBi" id="6jbF0Bo$Wby" role="37vLTJ">
+              <node concept="Xjq3P" id="6jbF0Bo$WA3" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6jbF0Bo$Wb_" role="2OqNvi">
+                <ref role="2Oxat5" node="6jbF0Bo$VbY" resolve="attributeFinder" />
               </node>
             </node>
-            <node concept="37vLTw" id="4WflrVaSVz$" role="37vLTx">
-              <ref role="3cqZAo" node="4WflrVaHS$T" resolve="metaAdapterByDeclarationHelper" />
+            <node concept="37vLTw" id="6jbF0Bo$Vc8" role="37vLTx">
+              <ref role="3cqZAo" node="6jbF0Bo$UUR" resolve="attributeFinder" />
             </node>
           </node>
         </node>
@@ -27837,49 +27850,6 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="5M3rB6Biwf4" role="3cqZAp">
-          <node concept="3cpWsn" id="5M3rB6Biwf5" role="3cpWs9">
-            <property role="TrG5h" value="repository" />
-            <node concept="3uibUv" id="5M3rB6BivOy" role="1tU5fm">
-              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
-            </node>
-            <node concept="2OqwBi" id="5M3rB6Biwf6" role="33vP2m">
-              <node concept="2JrnkZ" id="5M3rB6Biwf7" role="2Oq$k0">
-                <node concept="2OqwBi" id="5M3rB6Biwf8" role="2JrQYb">
-                  <node concept="37vLTw" id="5M3rB6Biwf9" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3ePT3MiTASV" resolve="lcLanguage" />
-                  </node>
-                  <node concept="I4A8Y" id="5M3rB6Biwfa" role="2OqNvi" />
-                </node>
-              </node>
-              <node concept="liA8E" id="5M3rB6Biwfb" role="2OqNvi">
-                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="5AGBwuETfBC" role="3cqZAp">
-          <node concept="3cpWsn" id="5AGBwuETfBD" role="3cpWs9">
-            <property role="TrG5h" value="attributeFinder" />
-            <node concept="3uibUv" id="5AGBwuETfBE" role="1tU5fm">
-              <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
-            </node>
-            <node concept="2ShNRf" id="5AGBwuETg$G" role="33vP2m">
-              <node concept="1pGfFk" id="5AGBwuETiw0" role="2ShVmc">
-                <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
-                <node concept="37vLTw" id="5M3rB6Biwfc" role="37wK5m">
-                  <ref role="3cqZAo" node="5M3rB6Biwf5" resolve="repository" />
-                </node>
-                <node concept="37vLTw" id="5M3rB6BiwUg" role="37wK5m">
-                  <ref role="3cqZAo" node="3ePT3MiTG_$" resolve="constants" />
-                </node>
-                <node concept="37vLTw" id="4WflrVaT35w" role="37wK5m">
-                  <ref role="3cqZAo" node="4WflrVaSVzq" resolve="metaAdapterByDeclarationHelper" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3clFbJ" id="3ePT3MiTD4L" role="3cqZAp">
           <node concept="3clFbS" id="3ePT3MiTD4M" role="3clFbx">
             <node concept="3cpWs8" id="59Df55l8f3H" role="3cqZAp">
@@ -27926,7 +27896,7 @@
                       <ref role="3cqZAo" node="6VkSF6bW41k" resolve="mpsIdMapper" />
                     </node>
                     <node concept="37vLTw" id="5M3rB6B$2wq" role="37wK5m">
-                      <ref role="3cqZAo" node="5AGBwuETfBD" resolve="attributeFinder" />
+                      <ref role="3cqZAo" node="6jbF0Bo$VbY" resolve="attributeFinder" />
                     </node>
                   </node>
                 </node>
@@ -28075,7 +28045,7 @@
                         <ref role="3cqZAo" node="6VkSF6bW41k" resolve="mpsIdMapper" />
                       </node>
                       <node concept="37vLTw" id="5M3rB6Bz_qI" role="37wK5m">
-                        <ref role="3cqZAo" node="5AGBwuETfBD" resolve="attributeFinder" />
+                        <ref role="3cqZAo" node="6jbF0Bo$VbY" resolve="attributeFinder" />
                       </node>
                       <node concept="37vLTw" id="5M3rB6Bz_qJ" role="37wK5m">
                         <ref role="3cqZAo" node="3ePT3MiTD5d" resolve="language" />

--- a/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.util.mps
+++ b/solutions/io.lionweb.mps.converter/models/io.lionweb.mps.converter.util.mps
@@ -2140,10 +2140,6 @@
     <property role="TrG5h" value="IModifyingLanguageLookup" />
     <node concept="3clFb_" id="59Df55laZKQ" role="jymVt">
       <property role="TrG5h" value="createLanguage" />
-      <node concept="15s5l7" id="7OJcYqyLbtB" role="lGtFl">
-        <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;reference scopes (reference scopes)&quot;;FLAVOUR_MESSAGE=&quot;The reference  ILanguageCreator (classifier) is out of search scope&quot;;FLAVOUR_NODE_FEATURE=&quot;classifier&quot;;FLAVOUR_RULE_ID=&quot;[r:28bcf003-0004-46b6-9fe7-2093e7fb1368(jetbrains.mps.baseLanguage.javadoc.constraints)/6836281137582713718]&quot;;" />
-        <property role="huDt6" value="The reference  ILanguageCreator (classifier) is out of search scope" />
-      </node>
       <node concept="15s5l7" id="3M8YG$b6x9v" role="lGtFl">
         <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;reference scopes (reference scopes)&quot;;FLAVOUR_MESSAGE=&quot;The reference  ILanguageCreator (classifier) is out of search scope&quot;;FLAVOUR_NODE_FEATURE=&quot;classifier&quot;;FLAVOUR_RULE_ID=&quot;[r:28bcf003-0004-46b6-9fe7-2093e7fb1368(jetbrains.mps.baseLanguage.javadoc.constraints)/6836281137582713718]&quot;;" />
         <property role="huDt6" value="The reference  ILanguageCreator (classifier) is out of search scope" />

--- a/solutions/io.lionweb.mps.json.test.support/models/io.lionweb.mps.json.test.support.mps
+++ b/solutions/io.lionweb.mps.json.test.support/models/io.lionweb.mps.json.test.support.mps
@@ -26,6 +26,7 @@
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="apzt" ref="r:ea3bdd37-0680-4524-8252-d8093e3b6903(io.lionweb.mps.converter.util)" />
     <import index="m8w9" ref="r:6f1f08ee-098f-4244-ab7d-593d31c55c1e(io.lionweb.mps.json.sorted)" />
+    <import index="ni5j" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.regex(JDK/)" />
     <import index="e8bb" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter.ids(MPS.Core/)" implicit="true" />
   </imports>
   <registry>
@@ -80,6 +81,7 @@
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
       <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
       <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
@@ -96,6 +98,7 @@
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534555686" name="jetbrains.mps.baseLanguage.structure.CharType" flags="in" index="10Pfzv" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
@@ -120,6 +123,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -180,6 +184,7 @@
         <child id="8276990574895933173" name="catchBody" index="1zc67A" />
         <child id="8276990574895933172" name="throwable" index="1zc67B" />
       </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1184950988562" name="jetbrains.mps.baseLanguage.structure.ArrayCreator" flags="nn" index="3$_iS1">
         <child id="1184951007469" name="componentType" index="3$_nBY" />
         <child id="1184952969026" name="dimensionExpression" index="3$GQph" />
@@ -318,6 +323,7 @@
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1240247536947" name="jetbrains.mps.baseLanguage.collections.structure.TreeSetCreator" flags="nn" index="34wSKj" />
       <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
     </language>
@@ -880,6 +886,22 @@
   </node>
   <node concept="312cEu" id="5lijfVJWAoN">
     <property role="TrG5h" value="M1JsonComparer" />
+    <node concept="Wx3nA" id="6LPkCA_i8YH" role="jymVt">
+      <property role="TrG5h" value="ID_PATTERN" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="6LPkCA_i6a7" role="1B3o_S" />
+      <node concept="2YIFZM" id="6LPkCA_idRY" role="33vP2m">
+        <ref role="37wK5l" to="ni5j:~Pattern.compile(java.lang.String)" resolve="compile" />
+        <ref role="1Pybhc" to="ni5j:~Pattern" resolve="Pattern" />
+        <node concept="Xl_RD" id="6LPkCA_ieAG" role="37wK5m">
+          <property role="Xl_RC" value="[a-zA-Z0-9_-]+" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="6LPkCA_ib$h" role="1tU5fm">
+        <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA_i3MC" role="jymVt" />
     <node concept="312cEg" id="5lijfVJWAwv" role="jymVt">
       <property role="TrG5h" value="file" />
       <property role="3TUv4t" value="true" />
@@ -903,6 +925,25 @@
           <node concept="1LlUBW" id="5lijfVJWD3U" role="HW$YZ">
             <node concept="3Tqbb2" id="5lijfVJWD3V" role="1Lm7xW" />
             <node concept="17QB3L" id="5lijfVJWD3W" role="1Lm7xW" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="6LPkCA_k$6n" role="jymVt">
+      <property role="TrG5h" value="enumProperties" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="6LPkCA_k$6o" role="1B3o_S" />
+      <node concept="_YKpA" id="6LPkCA_k$6p" role="1tU5fm">
+        <node concept="1LlUBW" id="6LPkCA_k$6q" role="_ZDj9">
+          <node concept="3Tqbb2" id="6LPkCA_k$6r" role="1Lm7xW" />
+          <node concept="17QB3L" id="6LPkCA_lOGJ" role="1Lm7xW" />
+        </node>
+      </node>
+      <node concept="2ShNRf" id="6LPkCA_k$6t" role="33vP2m">
+        <node concept="Tc6Ow" id="6LPkCA_k$6u" role="2ShVmc">
+          <node concept="1LlUBW" id="6LPkCA_k$6v" role="HW$YZ">
+            <node concept="3Tqbb2" id="6LPkCA_k$6w" role="1Lm7xW" />
+            <node concept="17QB3L" id="6LPkCA_lRCZ" role="1Lm7xW" />
           </node>
         </node>
       </node>
@@ -986,6 +1027,39 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5lijfVJWFva" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA_kqpj" role="jymVt">
+      <property role="TrG5h" value="assertEnumLiteralId" />
+      <node concept="3clFbS" id="6LPkCA_kqpm" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA_myGC" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_mIJI" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_myGB" role="2Oq$k0">
+              <ref role="3cqZAo" node="6LPkCA_k$6n" resolve="enumProperties" />
+            </node>
+            <node concept="TSZUe" id="6LPkCA_mLh6" role="2OqNvi">
+              <node concept="1Ls8ON" id="6LPkCA_mNDf" role="25WWJ7">
+                <node concept="37vLTw" id="6LPkCA_mT5w" role="1Lso8e">
+                  <ref role="3cqZAo" node="6LPkCA_ksW$" resolve="node" />
+                </node>
+                <node concept="37vLTw" id="6LPkCA_mVzr" role="1Lso8e">
+                  <ref role="3cqZAo" node="6LPkCA_kvTa" resolve="propertyKey" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6LPkCA_knbO" role="1B3o_S" />
+      <node concept="3cqZAl" id="6LPkCA_kpC$" role="3clF45" />
+      <node concept="37vLTG" id="6LPkCA_ksW$" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="6LPkCA_ksWz" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6LPkCA_kvTa" role="3clF46">
+        <property role="TrG5h" value="propertyKey" />
+        <node concept="17QB3L" id="6LPkCA_mlz6" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA_mtkW" role="jymVt" />
     <node concept="3clFb_" id="5lijfVJWFSf" role="jymVt">
       <property role="TrG5h" value="assertEquals" />
       <node concept="37vLTG" id="5glO5qKYPfi" role="3clF46">
@@ -1083,6 +1157,170 @@
         <node concept="10P_77" id="5TNjoy257Rf" role="1tU5fm" />
       </node>
       <node concept="3clFbS" id="5TNjoy254Wc" role="3clF47">
+        <node concept="2Gpval" id="6LPkCA_iJ38" role="3cqZAp">
+          <node concept="2GrKxI" id="6LPkCA_iJ3a" role="2Gsz3X">
+            <property role="TrG5h" value="node" />
+          </node>
+          <node concept="37vLTw" id="6LPkCA_iP7c" role="2GsD0m">
+            <ref role="3cqZAo" node="5TNjoy254W6" resolve="nodes" />
+          </node>
+          <node concept="3clFbS" id="6LPkCA_iJ3e" role="2LFqv$">
+            <node concept="3clFbF" id="6LPkCA_iQUC" role="3cqZAp">
+              <node concept="1rXfSq" id="6LPkCA_iQUB" role="3clFbG">
+                <ref role="37wK5l" node="6LPkCA_fKSh" resolve="assertIds" />
+                <node concept="2GrUjf" id="6LPkCA_iS$x" role="37wK5m">
+                  <ref role="2Gs0qQ" node="6LPkCA_iJ3a" resolve="node" />
+                </node>
+              </node>
+            </node>
+            <node concept="2Gpval" id="6LPkCA_kPOr" role="3cqZAp">
+              <node concept="2GrKxI" id="6LPkCA_kPOy" role="2Gsz3X">
+                <property role="TrG5h" value="pair" />
+              </node>
+              <node concept="2OqwBi" id="6LPkCA_kX0U" role="2GsD0m">
+                <node concept="37vLTw" id="6LPkCA_kTBW" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6LPkCA_k$6n" resolve="enumProperties" />
+                </node>
+                <node concept="3zZkjj" id="6LPkCA_kZDd" role="2OqNvi">
+                  <node concept="1bVj0M" id="6LPkCA_kZDf" role="23t8la">
+                    <node concept="3clFbS" id="6LPkCA_kZDg" role="1bW5cS">
+                      <node concept="3clFbF" id="6LPkCA_l2wb" role="3cqZAp">
+                        <node concept="17R0WA" id="6LPkCA_lsh3" role="3clFbG">
+                          <node concept="2OqwBi" id="6LPkCA_lw9X" role="3uHU7w">
+                            <node concept="2GrUjf" id="6LPkCA_lumj" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="6LPkCA_iJ3a" resolve="node" />
+                            </node>
+                            <node concept="liA8E" id="6LPkCA_lz4s" role="2OqNvi">
+                              <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getID()" resolve="getID" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="6LPkCA_lmJa" role="3uHU7B">
+                            <node concept="2OqwBi" id="6LPkCA_ldX0" role="2Oq$k0">
+                              <node concept="2JrnkZ" id="6LPkCA_lhGW" role="2Oq$k0">
+                                <node concept="1LFfDK" id="6LPkCA_l99p" role="2JrQYb">
+                                  <node concept="3cmrfG" id="6LPkCA_lbOD" role="1LF_Uc">
+                                    <property role="3cmrfH" value="0" />
+                                  </node>
+                                  <node concept="37vLTw" id="6LPkCA_l2wa" role="1LFl5Q">
+                                    <ref role="3cqZAo" node="6LPkCA_kZDh" resolve="it" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="6LPkCA_lkDJ" role="2OqNvi">
+                                <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="6LPkCA_lp2o" role="2OqNvi">
+                              <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="6LPkCA_kZDh" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="6LPkCA_kZDi" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="6LPkCA_kPOK" role="2LFqv$">
+                <node concept="3cpWs8" id="6LPkCA_rgIv" role="3cqZAp">
+                  <node concept="3cpWsn" id="6LPkCA_rgIw" role="3cpWs9">
+                    <property role="TrG5h" value="localContext" />
+                    <node concept="17QB3L" id="6LPkCA_rfCd" role="1tU5fm" />
+                    <node concept="3cpWs3" id="6LPkCA_rw2G" role="33vP2m">
+                      <node concept="1LFfDK" id="6LPkCA_r__W" role="3uHU7w">
+                        <node concept="3cmrfG" id="6LPkCA_rCKY" role="1LF_Uc">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                        <node concept="2GrUjf" id="6LPkCA_rz9o" role="1LFl5Q">
+                          <ref role="2Gs0qQ" node="6LPkCA_kPOy" resolve="pair" />
+                        </node>
+                      </node>
+                      <node concept="3cpWs3" id="6LPkCA_rgIx" role="3uHU7B">
+                        <node concept="2OqwBi" id="6LPkCA_rgIy" role="3uHU7B">
+                          <node concept="2GrUjf" id="6LPkCA_rHFm" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="6LPkCA_iJ3a" resolve="node" />
+                          </node>
+                          <node concept="liA8E" id="6LPkCA_rgI$" role="2OqNvi">
+                            <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getID()" resolve="getID" />
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="6LPkCA_rgI_" role="3uHU7w">
+                          <property role="Xl_RC" value=" - property " />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="6LPkCA_m0eM" role="3cqZAp">
+                  <node concept="3cpWsn" id="6LPkCA_m0eN" role="3cpWs9">
+                    <property role="TrG5h" value="propertyValue" />
+                    <node concept="17QB3L" id="6LPkCA_m2fp" role="1tU5fm" />
+                    <node concept="2OqwBi" id="6LPkCA_m0eO" role="33vP2m">
+                      <node concept="2GrUjf" id="6LPkCA_m0eP" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="6LPkCA_iJ3a" resolve="node" />
+                      </node>
+                      <node concept="liA8E" id="6LPkCA_m0eQ" role="2OqNvi">
+                        <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getPropertyValue(java.lang.String)" resolve="getPropertyValue" />
+                        <node concept="1LFfDK" id="6LPkCA_m0eR" role="37wK5m">
+                          <node concept="3cmrfG" id="6LPkCA_m0eS" role="1LF_Uc">
+                            <property role="3cmrfH" value="1" />
+                          </node>
+                          <node concept="2GrUjf" id="6LPkCA_m0eT" role="1LFl5Q">
+                            <ref role="2Gs0qQ" node="6LPkCA_kPOy" resolve="pair" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="6LPkCA_m4hj" role="3cqZAp">
+                  <node concept="3clFbS" id="6LPkCA_m4hl" role="3clFbx">
+                    <node concept="3clFbF" id="6LPkCA_md_H" role="3cqZAp">
+                      <node concept="1rXfSq" id="6LPkCA_md_E" role="3clFbG">
+                        <ref role="37wK5l" node="6LPkCA_fPAh" resolve="assertId" />
+                        <node concept="37vLTw" id="6LPkCA_miwg" role="37wK5m">
+                          <ref role="3cqZAo" node="6LPkCA_m0eN" resolve="propertyValue" />
+                        </node>
+                        <node concept="37vLTw" id="6LPkCA_rMBm" role="37wK5m">
+                          <ref role="3cqZAo" node="6LPkCA_rgIw" resolve="localContext" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3y3z36" id="6LPkCA_m9VD" role="3clFbw">
+                    <node concept="10Nm6u" id="6LPkCA_mby9" role="3uHU7w" />
+                    <node concept="37vLTw" id="6LPkCA_m7ad" role="3uHU7B">
+                      <ref role="3cqZAo" node="6LPkCA_m0eN" resolve="propertyValue" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA_iX5s" role="3cqZAp" />
+        <node concept="2Gpval" id="6LPkCA_iYUT" role="3cqZAp">
+          <node concept="2GrKxI" id="6LPkCA_iYUV" role="2Gsz3X">
+            <property role="TrG5h" value="lang" />
+          </node>
+          <node concept="37vLTw" id="6LPkCA_j3hF" role="2GsD0m">
+            <ref role="3cqZAo" node="5TNjoy254W9" resolve="languages" />
+          </node>
+          <node concept="3clFbS" id="6LPkCA_iYUZ" role="2LFqv$">
+            <node concept="3clFbF" id="6LPkCA_j5hY" role="3cqZAp">
+              <node concept="1rXfSq" id="6LPkCA_j5hX" role="3clFbG">
+                <ref role="37wK5l" node="6LPkCA_jfuJ" resolve="assertId" />
+                <node concept="2GrUjf" id="6LPkCA_j7EL" role="37wK5m">
+                  <ref role="2Gs0qQ" node="6LPkCA_iYUV" resolve="lang" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA_iGr8" role="3cqZAp" />
         <node concept="3cpWs8" id="5TNjoy254Wd" role="3cqZAp">
           <node concept="3cpWsn" id="5TNjoy254We" role="3cpWs9">
             <property role="TrG5h" value="writer" />
@@ -1623,7 +1861,523 @@
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="5TNjoy2546Y" role="jymVt" />
+    <node concept="2tJIrI" id="6LPkCA_fH67" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA_fKSh" role="jymVt">
+      <property role="TrG5h" value="assertIds" />
+      <node concept="3clFbS" id="6LPkCA_fKSk" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA_fR7D" role="3cqZAp">
+          <node concept="1rXfSq" id="6LPkCA_fR7C" role="3clFbG">
+            <ref role="37wK5l" node="6LPkCA_fPAh" resolve="assertId" />
+            <node concept="2OqwBi" id="6LPkCA_fTrJ" role="37wK5m">
+              <node concept="37vLTw" id="6LPkCA_fSST" role="2Oq$k0">
+                <ref role="3cqZAo" node="6LPkCA_fLXl" resolve="node" />
+              </node>
+              <node concept="liA8E" id="6LPkCA_fUy9" role="2OqNvi">
+                <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getID()" resolve="getID" />
+              </node>
+            </node>
+            <node concept="Xl_RD" id="6LPkCA_qVaj" role="37wK5m">
+              <property role="Xl_RC" value="node" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6LPkCA_fZW2" role="3cqZAp">
+          <node concept="3clFbS" id="6LPkCA_fZW4" role="3clFbx">
+            <node concept="3clFbF" id="6LPkCA_g5u5" role="3cqZAp">
+              <node concept="1rXfSq" id="6LPkCA_g5u3" role="3clFbG">
+                <ref role="37wK5l" node="6LPkCA_fPAh" resolve="assertId" />
+                <node concept="2OqwBi" id="6LPkCA_g7LK" role="37wK5m">
+                  <node concept="37vLTw" id="6LPkCA_g7e9" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6LPkCA_fLXl" resolve="node" />
+                  </node>
+                  <node concept="liA8E" id="6LPkCA_g8DS" role="2OqNvi">
+                    <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getParentNodeID()" resolve="getParentNodeID" />
+                  </node>
+                </node>
+                <node concept="3cpWs3" id="6LPkCA_r1Mn" role="37wK5m">
+                  <node concept="2OqwBi" id="6LPkCA_r1Mo" role="3uHU7B">
+                    <node concept="37vLTw" id="6LPkCA_r1Mp" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6LPkCA_fLXl" resolve="node" />
+                    </node>
+                    <node concept="liA8E" id="6LPkCA_r1Mq" role="2OqNvi">
+                      <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getID()" resolve="getID" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="6LPkCA_r1Mr" role="3uHU7w">
+                    <property role="Xl_RC" value=" parent" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="6LPkCA_g4h0" role="3clFbw">
+            <node concept="10Nm6u" id="6LPkCA_g4L$" role="3uHU7w" />
+            <node concept="2OqwBi" id="6LPkCA_g1OG" role="3uHU7B">
+              <node concept="37vLTw" id="6LPkCA_g0C5" role="2Oq$k0">
+                <ref role="3cqZAo" node="6LPkCA_fLXl" resolve="node" />
+              </node>
+              <node concept="liA8E" id="6LPkCA_g3iu" role="2OqNvi">
+                <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getParentNodeID()" resolve="getParentNodeID" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA_gsTP" role="3cqZAp" />
+        <node concept="2Gpval" id="6LPkCA_gtKJ" role="3cqZAp">
+          <node concept="2GrKxI" id="6LPkCA_gtKL" role="2Gsz3X">
+            <property role="TrG5h" value="prop" />
+          </node>
+          <node concept="2OqwBi" id="6LPkCA_gyLd" role="2GsD0m">
+            <node concept="37vLTw" id="6LPkCA_gxwL" role="2Oq$k0">
+              <ref role="3cqZAo" node="6LPkCA_fLXl" resolve="node" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_g$ix" role="2OqNvi">
+              <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getProperties()" resolve="getProperties" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="6LPkCA_gtKP" role="2LFqv$">
+            <node concept="3cpWs8" id="6LPkCA_qHtY" role="3cqZAp">
+              <node concept="3cpWsn" id="6LPkCA_qHtZ" role="3cpWs9">
+                <property role="TrG5h" value="localContext" />
+                <node concept="17QB3L" id="6LPkCA_qHu0" role="1tU5fm" />
+                <node concept="3cpWs3" id="6LPkCA_qHu1" role="33vP2m">
+                  <node concept="2GrUjf" id="6LPkCA_qHu2" role="3uHU7w">
+                    <ref role="2Gs0qQ" node="6LPkCA_gtKL" resolve="prop" />
+                  </node>
+                  <node concept="3cpWs3" id="6LPkCA_qHu3" role="3uHU7B">
+                    <node concept="2OqwBi" id="6LPkCA_qHu4" role="3uHU7B">
+                      <node concept="37vLTw" id="6LPkCA_qHu5" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6LPkCA_fLXl" resolve="node" />
+                      </node>
+                      <node concept="liA8E" id="6LPkCA_qHu6" role="2OqNvi">
+                        <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getID()" resolve="getID" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="6LPkCA_qHu7" role="3uHU7w">
+                      <property role="Xl_RC" value=" - " />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="6LPkCA_g_aN" role="3cqZAp">
+              <node concept="1rXfSq" id="6LPkCA_g_aM" role="3clFbG">
+                <ref role="37wK5l" node="6LPkCA_h$gz" resolve="assertId" />
+                <node concept="2OqwBi" id="6LPkCA_gCcy" role="37wK5m">
+                  <node concept="2GrUjf" id="6LPkCA_gARK" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="6LPkCA_gtKL" resolve="prop" />
+                  </node>
+                  <node concept="liA8E" id="6LPkCA_gDWb" role="2OqNvi">
+                    <ref role="37wK5l" to="xfsv:~SerializedPropertyValue.getMetaPointer()" resolve="getMetaPointer" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="6LPkCA_qPzj" role="37wK5m">
+                  <ref role="3cqZAo" node="6LPkCA_qHtZ" resolve="localContext" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA_gETc" role="3cqZAp" />
+        <node concept="2Gpval" id="6LPkCA_gGto" role="3cqZAp">
+          <node concept="2GrKxI" id="6LPkCA_gGtq" role="2Gsz3X">
+            <property role="TrG5h" value="cont" />
+          </node>
+          <node concept="2OqwBi" id="6LPkCA_gKeK" role="2GsD0m">
+            <node concept="37vLTw" id="6LPkCA_gIRr" role="2Oq$k0">
+              <ref role="3cqZAo" node="6LPkCA_fLXl" resolve="node" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_gLcD" role="2OqNvi">
+              <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getContainments()" resolve="getContainments" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="6LPkCA_gGtu" role="2LFqv$">
+            <node concept="3cpWs8" id="6LPkCA_qvtR" role="3cqZAp">
+              <node concept="3cpWsn" id="6LPkCA_qvtS" role="3cpWs9">
+                <property role="TrG5h" value="localContext" />
+                <node concept="17QB3L" id="6LPkCA_qvtT" role="1tU5fm" />
+                <node concept="3cpWs3" id="6LPkCA_qvtU" role="33vP2m">
+                  <node concept="2GrUjf" id="6LPkCA_qvtV" role="3uHU7w">
+                    <ref role="2Gs0qQ" node="6LPkCA_gGtq" resolve="cont" />
+                  </node>
+                  <node concept="3cpWs3" id="6LPkCA_qvtW" role="3uHU7B">
+                    <node concept="2OqwBi" id="6LPkCA_qvtX" role="3uHU7B">
+                      <node concept="37vLTw" id="6LPkCA_qvtY" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6LPkCA_fLXl" resolve="node" />
+                      </node>
+                      <node concept="liA8E" id="6LPkCA_qvtZ" role="2OqNvi">
+                        <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getID()" resolve="getID" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="6LPkCA_qvu0" role="3uHU7w">
+                      <property role="Xl_RC" value=" - " />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="6LPkCA_gMxj" role="3cqZAp">
+              <node concept="1rXfSq" id="6LPkCA_gMxi" role="3clFbG">
+                <ref role="37wK5l" node="6LPkCA_h$gz" resolve="assertId" />
+                <node concept="2OqwBi" id="6LPkCA_gPfQ" role="37wK5m">
+                  <node concept="2GrUjf" id="6LPkCA_gOdE" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="6LPkCA_gGtq" resolve="cont" />
+                  </node>
+                  <node concept="liA8E" id="6LPkCA_gRcd" role="2OqNvi">
+                    <ref role="37wK5l" to="xfsv:~SerializedContainmentValue.getMetaPointer()" resolve="getMetaPointer" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="6LPkCA_qA1P" role="37wK5m">
+                  <ref role="3cqZAo" node="6LPkCA_qvtS" resolve="localContext" />
+                </node>
+              </node>
+            </node>
+            <node concept="2Gpval" id="6LPkCA_gT9x" role="3cqZAp">
+              <node concept="2GrKxI" id="6LPkCA_gT9z" role="2Gsz3X">
+                <property role="TrG5h" value="target" />
+              </node>
+              <node concept="2OqwBi" id="6LPkCA_gY2F" role="2GsD0m">
+                <node concept="2GrUjf" id="6LPkCA_gWC1" role="2Oq$k0">
+                  <ref role="2Gs0qQ" node="6LPkCA_gGtq" resolve="cont" />
+                </node>
+                <node concept="liA8E" id="6LPkCA_h003" role="2OqNvi">
+                  <ref role="37wK5l" to="xfsv:~SerializedContainmentValue.getValue()" resolve="getValue" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="6LPkCA_gT9B" role="2LFqv$">
+                <node concept="3clFbF" id="6LPkCA_h13o" role="3cqZAp">
+                  <node concept="1rXfSq" id="6LPkCA_h13n" role="3clFbG">
+                    <ref role="37wK5l" node="6LPkCA_fPAh" resolve="assertId" />
+                    <node concept="2GrUjf" id="6LPkCA_h2JA" role="37wK5m">
+                      <ref role="2Gs0qQ" node="6LPkCA_gT9z" resolve="target" />
+                    </node>
+                    <node concept="37vLTw" id="6LPkCA_qFiz" role="37wK5m">
+                      <ref role="3cqZAo" node="6LPkCA_qvtS" resolve="localContext" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA_h75b" role="3cqZAp" />
+        <node concept="2Gpval" id="6LPkCA_h563" role="3cqZAp">
+          <node concept="2GrKxI" id="6LPkCA_h564" role="2Gsz3X">
+            <property role="TrG5h" value="ref" />
+          </node>
+          <node concept="2OqwBi" id="6LPkCA_h565" role="2GsD0m">
+            <node concept="37vLTw" id="6LPkCA_h566" role="2Oq$k0">
+              <ref role="3cqZAo" node="6LPkCA_fLXl" resolve="node" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_h567" role="2OqNvi">
+              <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getReferences()" resolve="getReferences" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="6LPkCA_h568" role="2LFqv$">
+            <node concept="3cpWs8" id="6LPkCA_qk3p" role="3cqZAp">
+              <node concept="3cpWsn" id="6LPkCA_qk3q" role="3cpWs9">
+                <property role="TrG5h" value="localContext" />
+                <node concept="17QB3L" id="6LPkCA_qjra" role="1tU5fm" />
+                <node concept="3cpWs3" id="6LPkCA_qk3r" role="33vP2m">
+                  <node concept="2GrUjf" id="6LPkCA_qk3s" role="3uHU7w">
+                    <ref role="2Gs0qQ" node="6LPkCA_h564" resolve="ref" />
+                  </node>
+                  <node concept="3cpWs3" id="6LPkCA_qk3t" role="3uHU7B">
+                    <node concept="2OqwBi" id="6LPkCA_qk3u" role="3uHU7B">
+                      <node concept="37vLTw" id="6LPkCA_qk3v" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6LPkCA_fLXl" resolve="node" />
+                      </node>
+                      <node concept="liA8E" id="6LPkCA_qk3w" role="2OqNvi">
+                        <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getID()" resolve="getID" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="6LPkCA_qk3x" role="3uHU7w">
+                      <property role="Xl_RC" value=" - " />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="6LPkCA_h569" role="3cqZAp">
+              <node concept="1rXfSq" id="6LPkCA_h56a" role="3clFbG">
+                <ref role="37wK5l" node="6LPkCA_h$gz" resolve="assertId" />
+                <node concept="2OqwBi" id="6LPkCA_h56b" role="37wK5m">
+                  <node concept="2GrUjf" id="6LPkCA_h56c" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="6LPkCA_h564" resolve="ref" />
+                  </node>
+                  <node concept="liA8E" id="6LPkCA_h56d" role="2OqNvi">
+                    <ref role="37wK5l" to="xfsv:~SerializedReferenceValue.getMetaPointer()" resolve="getMetaPointer" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="6LPkCA_qk3y" role="37wK5m">
+                  <ref role="3cqZAo" node="6LPkCA_qk3q" resolve="localContext" />
+                </node>
+              </node>
+            </node>
+            <node concept="2Gpval" id="6LPkCA_h56e" role="3cqZAp">
+              <node concept="2GrKxI" id="6LPkCA_h56f" role="2Gsz3X">
+                <property role="TrG5h" value="entry" />
+              </node>
+              <node concept="2OqwBi" id="6LPkCA_h56g" role="2GsD0m">
+                <node concept="2GrUjf" id="6LPkCA_h56h" role="2Oq$k0">
+                  <ref role="2Gs0qQ" node="6LPkCA_h564" resolve="ref" />
+                </node>
+                <node concept="liA8E" id="6LPkCA_h56i" role="2OqNvi">
+                  <ref role="37wK5l" to="xfsv:~SerializedReferenceValue.getValue()" resolve="getValue" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="6LPkCA_h56j" role="2LFqv$">
+                <node concept="3clFbJ" id="6LPkCA_he6t" role="3cqZAp">
+                  <node concept="3clFbS" id="6LPkCA_he6v" role="3clFbx">
+                    <node concept="3clFbF" id="6LPkCA_h56k" role="3cqZAp">
+                      <node concept="1rXfSq" id="6LPkCA_h56l" role="3clFbG">
+                        <ref role="37wK5l" node="6LPkCA_fPAh" resolve="assertId" />
+                        <node concept="2OqwBi" id="6LPkCA_hqO0" role="37wK5m">
+                          <node concept="2GrUjf" id="6LPkCA_h56m" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="6LPkCA_h56f" resolve="entry" />
+                          </node>
+                          <node concept="liA8E" id="6LPkCA_htDW" role="2OqNvi">
+                            <ref role="37wK5l" to="xfsv:~SerializedReferenceValue$Entry.getReference()" resolve="getReference" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="6LPkCA_qr6X" role="37wK5m">
+                          <ref role="3cqZAo" node="6LPkCA_qk3q" resolve="localContext" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3y3z36" id="6LPkCA_hlg4" role="3clFbw">
+                    <node concept="10Nm6u" id="6LPkCA_hmqF" role="3uHU7w" />
+                    <node concept="2OqwBi" id="6LPkCA_hhhJ" role="3uHU7B">
+                      <node concept="2GrUjf" id="6LPkCA_hfWA" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="6LPkCA_h56f" resolve="entry" />
+                      </node>
+                      <node concept="liA8E" id="6LPkCA_hj8h" role="2OqNvi">
+                        <ref role="37wK5l" to="xfsv:~SerializedReferenceValue$Entry.getReference()" resolve="getReference" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA_h46A" role="3cqZAp" />
+        <node concept="2Gpval" id="6LPkCA_ghp_" role="3cqZAp">
+          <node concept="2GrKxI" id="6LPkCA_ghpB" role="2Gsz3X">
+            <property role="TrG5h" value="ann" />
+          </node>
+          <node concept="2OqwBi" id="6LPkCA_gkDE" role="2GsD0m">
+            <node concept="37vLTw" id="6LPkCA_gjuc" role="2Oq$k0">
+              <ref role="3cqZAo" node="6LPkCA_fLXl" resolve="node" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_glur" role="2OqNvi">
+              <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getAnnotations()" resolve="getAnnotations" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="6LPkCA_ghpF" role="2LFqv$">
+            <node concept="3clFbF" id="6LPkCA_gmix" role="3cqZAp">
+              <node concept="1rXfSq" id="6LPkCA_gmiw" role="3clFbG">
+                <ref role="37wK5l" node="6LPkCA_fPAh" resolve="assertId" />
+                <node concept="2GrUjf" id="6LPkCA_goaC" role="37wK5m">
+                  <ref role="2Gs0qQ" node="6LPkCA_ghpB" resolve="ann" />
+                </node>
+                <node concept="3cpWs3" id="6LPkCA_pJf7" role="37wK5m">
+                  <node concept="2OqwBi" id="6LPkCA_pELF" role="3uHU7B">
+                    <node concept="37vLTw" id="6LPkCA_pCPa" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6LPkCA_fLXl" resolve="node" />
+                    </node>
+                    <node concept="liA8E" id="6LPkCA_pGRG" role="2OqNvi">
+                      <ref role="37wK5l" to="xfsv:~SerializedClassifierInstance.getID()" resolve="getID" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="6LPkCA_pKYw" role="3uHU7w">
+                    <property role="Xl_RC" value=" annotations" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6LPkCA_fJFp" role="1B3o_S" />
+      <node concept="3cqZAl" id="6LPkCA_fKLG" role="3clF45" />
+      <node concept="37vLTG" id="6LPkCA_fLXl" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3uibUv" id="6LPkCA_fLXk" role="1tU5fm">
+          <ref role="3uigEE" to="xfsv:~SerializedClassifierInstance" resolve="SerializedClassifierInstance" />
+        </node>
+        <node concept="2AHcQZ" id="6LPkCA_fWzY" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA_hwPc" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA_h$gz" role="jymVt">
+      <property role="TrG5h" value="assertId" />
+      <node concept="3clFbS" id="6LPkCA_h$gA" role="3clF47">
+        <node concept="3cpWs8" id="6LPkCA_piIX" role="3cqZAp">
+          <node concept="3cpWsn" id="6LPkCA_piIY" role="3cpWs9">
+            <property role="TrG5h" value="localContext" />
+            <node concept="17QB3L" id="6LPkCA_pi8Z" role="1tU5fm" />
+            <node concept="3cpWs3" id="6LPkCA_piIZ" role="33vP2m">
+              <node concept="37vLTw" id="6LPkCA_piJ0" role="3uHU7w">
+                <ref role="3cqZAo" node="6LPkCA_h_Qq" resolve="metaPointer" />
+              </node>
+              <node concept="3cpWs3" id="6LPkCA_piJ1" role="3uHU7B">
+                <node concept="37vLTw" id="6LPkCA_pw15" role="3uHU7B">
+                  <ref role="3cqZAo" node="6LPkCA_oT$v" resolve="context" />
+                </node>
+                <node concept="Xl_RD" id="6LPkCA_piJ5" role="3uHU7w">
+                  <property role="Xl_RC" value=" - " />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_hIqf" role="3cqZAp">
+          <node concept="1rXfSq" id="6LPkCA_hIqe" role="3clFbG">
+            <ref role="37wK5l" node="6LPkCA_fPAh" resolve="assertId" />
+            <node concept="2OqwBi" id="6LPkCA_hLRN" role="37wK5m">
+              <node concept="37vLTw" id="6LPkCA_hKwK" role="2Oq$k0">
+                <ref role="3cqZAo" node="6LPkCA_h_Qq" resolve="metaPointer" />
+              </node>
+              <node concept="liA8E" id="6LPkCA_hOf_" role="2OqNvi">
+                <ref role="37wK5l" to="xfsv:~MetaPointer.getLanguage()" resolve="getLanguage" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="6LPkCA_piJ6" role="37wK5m">
+              <ref role="3cqZAo" node="6LPkCA_piIY" resolve="localContext" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_hTI$" role="3cqZAp">
+          <node concept="1rXfSq" id="6LPkCA_hTIy" role="3clFbG">
+            <ref role="37wK5l" node="6LPkCA_fPAh" resolve="assertId" />
+            <node concept="2OqwBi" id="6LPkCA_hXIc" role="37wK5m">
+              <node concept="37vLTw" id="6LPkCA_hW7Z" role="2Oq$k0">
+                <ref role="3cqZAo" node="6LPkCA_h_Qq" resolve="metaPointer" />
+              </node>
+              <node concept="liA8E" id="6LPkCA_hZyc" role="2OqNvi">
+                <ref role="37wK5l" to="xfsv:~MetaPointer.getKey()" resolve="getKey" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="6LPkCA_ppDG" role="37wK5m">
+              <ref role="3cqZAo" node="6LPkCA_piIY" resolve="localContext" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6LPkCA_hykp" role="1B3o_S" />
+      <node concept="3cqZAl" id="6LPkCA_h$8a" role="3clF45" />
+      <node concept="37vLTG" id="6LPkCA_h_Qq" role="3clF46">
+        <property role="TrG5h" value="metaPointer" />
+        <node concept="3uibUv" id="6LPkCA_h_Qp" role="1tU5fm">
+          <ref role="3uigEE" to="xfsv:~MetaPointer" resolve="MetaPointer" />
+        </node>
+        <node concept="2AHcQZ" id="6LPkCA_hEpK" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6LPkCA_oT$v" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <node concept="3uibUv" id="6LPkCA_oWJp" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA_ja3i" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA_jfuJ" role="jymVt">
+      <property role="TrG5h" value="assertId" />
+      <node concept="3clFbS" id="6LPkCA_jfuM" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA_jtZh" role="3cqZAp">
+          <node concept="1rXfSq" id="6LPkCA_jtZg" role="3clFbG">
+            <ref role="37wK5l" node="6LPkCA_fPAh" resolve="assertId" />
+            <node concept="2OqwBi" id="6LPkCA_jyjZ" role="37wK5m">
+              <node concept="37vLTw" id="6LPkCA_jwCH" role="2Oq$k0">
+                <ref role="3cqZAo" node="6LPkCA_jhC5" resolve="language" />
+              </node>
+              <node concept="liA8E" id="6LPkCA_j_gp" role="2OqNvi">
+                <ref role="37wK5l" to="xfsv:~UsedLanguage.getKey()" resolve="getKey" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="6LPkCA_oIFt" role="37wK5m">
+              <ref role="3cqZAo" node="6LPkCA_jhC5" resolve="language" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6LPkCA_jch_" role="1B3o_S" />
+      <node concept="3cqZAl" id="6LPkCA_jeJ0" role="3clF45" />
+      <node concept="37vLTG" id="6LPkCA_jhC5" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="3uibUv" id="6LPkCA_jhC4" role="1tU5fm">
+          <ref role="3uigEE" to="xfsv:~UsedLanguage" resolve="UsedLanguage" />
+        </node>
+        <node concept="2AHcQZ" id="6LPkCA_jqph" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA_kiAa" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA_fPAh" role="jymVt">
+      <property role="TrG5h" value="assertId" />
+      <node concept="3clFbS" id="6LPkCA_fPAk" role="3clF47">
+        <node concept="3vwNmj" id="6LPkCA_ilNk" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_jPJx" role="3vwVQn">
+            <node concept="2OqwBi" id="6LPkCA_iqaN" role="2Oq$k0">
+              <node concept="37vLTw" id="6LPkCA_ioh9" role="2Oq$k0">
+                <ref role="3cqZAo" node="6LPkCA_i8YH" resolve="ID_PATTERN" />
+              </node>
+              <node concept="liA8E" id="6LPkCA_it0P" role="2OqNvi">
+                <ref role="37wK5l" to="ni5j:~Pattern.matcher(java.lang.CharSequence)" resolve="matcher" />
+                <node concept="37vLTw" id="6LPkCA_ivc5" role="37wK5m">
+                  <ref role="3cqZAo" node="6LPkCA_fQmN" resolve="id" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="6LPkCA_jSwX" role="2OqNvi">
+              <ref role="37wK5l" to="ni5j:~Matcher.matches()" resolve="matches" />
+            </node>
+          </node>
+          <node concept="3_1$Yv" id="6LPkCA_ix1R" role="3_9lra">
+            <node concept="3cpWs3" id="6LPkCA_iCzt" role="3_1BAH">
+              <node concept="37vLTw" id="6LPkCA_iEFq" role="3uHU7w">
+                <ref role="3cqZAo" node="6LPkCA_fQmN" resolve="id" />
+              </node>
+              <node concept="3cpWs3" id="6LPkCA_o$CH" role="3uHU7B">
+                <node concept="3cpWs3" id="6LPkCA_oBrg" role="3uHU7B">
+                  <node concept="37vLTw" id="6LPkCA_oD$w" role="3uHU7w">
+                    <ref role="3cqZAo" node="6LPkCA_ooen" resolve="context" />
+                  </node>
+                  <node concept="Xl_RD" id="6LPkCA_o$CN" role="3uHU7B">
+                    <property role="Xl_RC" value="not a valid id at " />
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="6LPkCA_o$CP" role="3uHU7w">
+                  <property role="Xl_RC" value=": " />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6LPkCA_mnAI" role="1B3o_S" />
+      <node concept="3cqZAl" id="6LPkCA_fPvG" role="3clF45" />
+      <node concept="37vLTG" id="6LPkCA_fQmN" role="3clF46">
+        <property role="TrG5h" value="id" />
+        <node concept="17QB3L" id="6LPkCA_fQmM" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6LPkCA_fYgE" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6LPkCA_ooen" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <node concept="3uibUv" id="6LPkCA_oLBx" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+    </node>
     <node concept="3Tm1VV" id="5lijfVJWAoO" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="24j7TNH2adn">
@@ -2464,17 +3218,13 @@
               <node concept="Xl_RD" id="3FWZcLW4OeJ" role="37wK5m">
                 <property role="Xl_RC" value="io-lionweb-mps-specific" />
               </node>
-              <node concept="2YIFZM" id="3FWZcLW4O$v" role="37wK5m">
-                <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
-                <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
-                <node concept="2YIFZM" id="3FWZcLW4Okb" role="37wK5m">
-                  <ref role="1Pybhc" to="y7p:6jTTMHD72IS" resolve="MpsLanguageUtil" />
-                  <ref role="37wK5l" to="y7p:6jTTMHD72KX" resolve="getLanguageVersion" />
-                  <node concept="pHN19" id="3FWZcLW4Ou2" role="37wK5m">
-                    <node concept="2V$Bhx" id="3FWZcLW4OuU" role="2V$M_3">
-                      <property role="2V$B1T" value="e92f782f-6faf-41c2-bf76-2b1a350c0516" />
-                      <property role="2V$B1Q" value="io.lionweb.mps.specific" />
-                    </node>
+              <node concept="2YIFZM" id="6jbF0Bo26jJ" role="37wK5m">
+                <ref role="37wK5l" to="y7p:34Q84zMXVAC" resolve="getLanguageVersionString" />
+                <ref role="1Pybhc" to="y7p:6jTTMHD72IS" resolve="MpsLanguageUtil" />
+                <node concept="pHN19" id="6jbF0Bo26jK" role="37wK5m">
+                  <node concept="2V$Bhx" id="6jbF0Bo26jL" role="2V$M_3">
+                    <property role="2V$B1T" value="e92f782f-6faf-41c2-bf76-2b1a350c0516" />
+                    <property role="2V$B1Q" value="io.lionweb.mps.specific" />
                   </node>
                 </node>
               </node>
@@ -2516,15 +3266,14 @@
                   </node>
                 </node>
               </node>
-              <node concept="2YIFZM" id="3FWZcLVTYXq" role="37wK5m">
-                <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
-                <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
-                <node concept="2YIFZM" id="3FWZcLVTYF1" role="37wK5m">
-                  <ref role="1Pybhc" to="y7p:6jTTMHD72IS" resolve="MpsLanguageUtil" />
-                  <ref role="37wK5l" to="y7p:6jTTMHD72KX" resolve="getLanguageVersion" />
-                  <node concept="37vLTw" id="3FWZcLVUMb7" role="37wK5m">
-                    <ref role="3cqZAo" node="3FWZcLVUM1g" resolve="sLanguage" />
-                  </node>
+              <node concept="2YIFZM" id="6jbF0Bo2alx" role="37wK5m">
+                <ref role="1Pybhc" to="y7p:6jTTMHD72IS" resolve="MpsLanguageUtil" />
+                <ref role="37wK5l" to="y7p:6jbF0Bo0uK5" resolve="getLanguageVersionString" />
+                <node concept="37vLTw" id="6jbF0Bo2aly" role="37wK5m">
+                  <ref role="3cqZAo" node="3FWZcLVUM1g" resolve="sLanguage" />
+                </node>
+                <node concept="37vLTw" id="6jbF0Bo2arj" role="37wK5m">
+                  <ref role="3cqZAo" node="5AGBwuFaS4W" resolve="attributeFinder" />
                 </node>
               </node>
             </node>
@@ -2539,6 +3288,15 @@
         <property role="TrG5h" value="sLanguage" />
         <node concept="3uibUv" id="3FWZcLVUM1f" role="1tU5fm">
           <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5AGBwuFaS4W" role="3clF46">
+        <property role="TrG5h" value="attributeFinder" />
+        <node concept="3uibUv" id="5AGBwuFaSMf" role="1tU5fm">
+          <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
+        </node>
+        <node concept="2AHcQZ" id="1f4Qr8Vhi5l" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
     </node>

--- a/solutions/io.lionweb.mps.json.test/io.lionweb.mps.json.test.msd
+++ b/solutions/io.lionweb.mps.json.test/io.lionweb.mps.json.test.msd
@@ -34,6 +34,7 @@
     <dependency reexport="false">3ecd737b-418b-4a70-a991-f6b83f0e3247(io.lionweb.mps.converter.TestAbstract)</dependency>
     <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
     <dependency reexport="false">60791ea2-7a1d-4862-a1ef-f87878cc3b6e(io.lionweb.mps.converter.TestComputedProperty)</dependency>
+    <dependency reexport="false">1ec6d5e7-6402-4c18-95d0-6e0906eb1ff1(io.lionweb.mps.converter.TestEnum)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:76d927fd-3a5a-4e40-865b-7c2d329ca675:MultiRefLang" version="1" />
@@ -41,6 +42,7 @@
     <language slang="l:afd6d8a2-5e3b-49d1-ab82-c9cb7dc063bb:io.lionweb.mps.converter.TestAnnotation" version="0" />
     <language slang="l:60791ea2-7a1d-4862-a1ef-f87878cc3b6e:io.lionweb.mps.converter.TestComputedProperty" version="0" />
     <language slang="l:11541b24-a02a-4586-a931-92521b3f6166:io.lionweb.mps.converter.TestCustomDatatype" version="0" />
+    <language slang="l:1ec6d5e7-6402-4c18-95d0-6e0906eb1ff1:io.lionweb.mps.converter.TestEnum" version="0" />
     <language slang="l:08caad75-8246-4427-bb4d-8444b6c5c729:io.lionweb.mps.converter.TestLang" version="0" />
     <language slang="l:48d0f6eb-6186-4cec-83d1-7caedb05a494:io.lionweb.mps.converter.TestLang2" version="0" />
     <language slang="l:099490a3-1e39-4ed1-bebc-8027665cecf9:io.lionweb.mps.converter.TestLang3" version="0" />
@@ -72,6 +74,7 @@
     <module reference="4d96f781-5fa4-4d94-817a-c51f74fdf43f(io.lionweb.mps.converter)" version="0" />
     <module reference="3ecd737b-418b-4a70-a991-f6b83f0e3247(io.lionweb.mps.converter.TestAbstract)" version="0" />
     <module reference="60791ea2-7a1d-4862-a1ef-f87878cc3b6e(io.lionweb.mps.converter.TestComputedProperty)" version="0" />
+    <module reference="1ec6d5e7-6402-4c18-95d0-6e0906eb1ff1(io.lionweb.mps.converter.TestEnum)" version="0" />
     <module reference="08caad75-8246-4427-bb4d-8444b6c5c729(io.lionweb.mps.converter.TestLang)" version="0" />
     <module reference="48d0f6eb-6186-4cec-83d1-7caedb05a494(io.lionweb.mps.converter.TestLang2)" version="0" />
     <module reference="099490a3-1e39-4ed1-bebc-8027665cecf9(io.lionweb.mps.converter.TestLang3)" version="0" />

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2lioncore@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2lioncore@tests.mps
@@ -1486,7 +1486,7 @@
     <node concept="1qefOq" id="5sACIIs_h1$" role="1SKRRt">
       <node concept="2RzRRF" id="5sACIIs$PgG" role="1qenE9">
         <property role="TrG5h" value="LionCore_M3" />
-        <property role="3HH78N" value="1" />
+        <property role="3HH78N" value="2023.1" />
         <property role="2RzON1" value="LionCore-M3" />
         <node concept="3xLA65" id="5sACIIs_is2" role="lGtFl">
           <property role="TrG5h" value="lionCore" />
@@ -1748,7 +1748,7 @@
       <node concept="2RzRRF" id="4R9posqf3NK" role="1qenE9">
         <property role="2RzON1" value="My-TestLang3" />
         <property role="TrG5h" value="io.lionweb.mps.converter.TestLang3" />
-        <property role="3HH78N" value="0" />
+        <property role="3HH78N" value="00 my! VERSION 😀" />
         <node concept="3xLA65" id="4R9posqf3YV" role="lGtFl">
           <property role="TrG5h" value="TestLang3" />
         </node>

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2lionweb@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2lionweb@tests.mps
@@ -19,12 +19,13 @@
     <use id="3ecd737b-418b-4a70-a991-f6b83f0e3247" name="io.lionweb.mps.converter.TestAbstract" version="0" />
     <use id="60791ea2-7a1d-4862-a1ef-f87878cc3b6e" name="io.lionweb.mps.converter.TestComputedProperty" version="0" />
     <use id="97ef2b8d-23e1-433e-8d23-48f916dd314d" name="io.lionweb.mps.converter.lang" version="0" />
+    <use id="1ec6d5e7-6402-4c18-95d0-6e0906eb1ff1" name="io.lionweb.mps.converter.TestEnum" version="0" />
   </languages>
   <imports>
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="6peh" ref="r:677983a1-6578-432d-8175-68c906e0375c(io.lionweb.mps.json)" />
     <import index="h2gc" ref="r:c9b5090c-7263-4642-b8f4-1265e3a15687(library.structure)" />
-    <import index="xfsv" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.serialization.data(io.lionweb.lioncore.java/)" />
+    <import index="xfsv" ref="9d6d7230-3178-4b3f-a837-7c0180c86207/java:io.lionweb.lioncore.java.serialization.data(io.lionweb.lionweb.java/)" />
     <import index="apzt" ref="r:ea3bdd37-0680-4524-8252-d8093e3b6903(io.lionweb.mps.converter.util)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="y7p" ref="r:3303ef0b-a58e-4f50-b3cb-bd3d7aaf3653(io.lionweb.mps.m3.runtime)" />
@@ -40,6 +41,10 @@
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="i5cy" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.concurrent.atomic(JDK/)" />
     <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
+    <import index="qa91" ref="r:38742da4-ca90-4db1-b16c-4863d9d39613(io.lionweb.mps.converter.TestLang.structure)" />
+    <import index="43ba" ref="r:45d4cca0-b85a-4b49-8b0a-a764324dd84b(io.lionweb.mps.converter.TestEnum.structure)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="q6xk" ref="r:2e1d95ed-4ed0-4ecd-bc84-f6c7c405fa7f(io.lionweb.mps.converter.TestLang3.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
   </imports>
@@ -98,6 +103,9 @@
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -117,6 +125,10 @@
       </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
@@ -453,6 +465,38 @@
       <concept id="3546057254280163909" name="io.lionweb.mps.converter.TestAbstract.structure.ConcretePartition" flags="ng" index="33DH8d" />
       <concept id="3546057254280163911" name="io.lionweb.mps.converter.TestAbstract.structure.AbstractConcept" flags="ng" index="33DH8f" />
     </language>
+    <language id="1ec6d5e7-6402-4c18-95d0-6e0906eb1ff1" name="io.lionweb.mps.converter.TestEnum">
+      <concept id="3240475410332951281" name="io.lionweb.mps.converter.TestEnum.structure.EnumHostWithKeyOptional" flags="ng" index="2$GdB6">
+        <property id="3240475410332951718" name="noDefault" index="2$GdYh" />
+        <property id="3240475410332951712" name="defaultWithoutKey" index="2$GdYn" />
+        <property id="3240475410332951708" name="defaultWithKey" index="2$GdYF" />
+      </concept>
+      <concept id="3240475410332951734" name="io.lionweb.mps.converter.TestEnum.structure.EnumHostWithoutKeyOptional" flags="ng" index="2$GdY1">
+        <property id="3240475410332951735" name="defaultWithKey" index="2$GdY0" />
+        <property id="3240475410332951739" name="noDefault" index="2$GdYc" />
+        <property id="3240475410332951737" name="defaultWithoutKey" index="2$GdYe" />
+      </concept>
+      <concept id="3240475410332951742" name="io.lionweb.mps.converter.TestEnum.structure.EnumHostWithoutKeyRequired" flags="ng" index="2$GdY9">
+        <property id="3240475410332951743" name="defaultWithKey" index="2$GdY8" />
+        <property id="3240475410332951747" name="noDefault" index="2$GdZO" />
+        <property id="3240475410332951745" name="defaultWithoutKey" index="2$GdZQ" />
+      </concept>
+      <concept id="3240475410332951726" name="io.lionweb.mps.converter.TestEnum.structure.EnumHostWithKeyRequired" flags="ng" index="2$GdYp">
+        <property id="3240475410332951731" name="noDefault" index="2$GdY4" />
+        <property id="3240475410332951729" name="defaultWithoutKey" index="2$GdY6" />
+        <property id="3240475410332951727" name="defaultWithKey" index="2$GdYo" />
+      </concept>
+      <concept id="3240475410332993337" name="io.lionweb.mps.converter.TestEnum.structure.EnumHostWithKeyUnset" flags="ng" index="2$GjKe">
+        <property id="3240475410332993342" name="noDefault" index="2$GjK9" />
+        <property id="3240475410332993340" name="defaultWithoutKey" index="2$GjKb" />
+        <property id="3240475410332993338" name="defaultWithKey" index="2$GjKd" />
+      </concept>
+      <concept id="3240475410332993353" name="io.lionweb.mps.converter.TestEnum.structure.EnumHostWithoutKeyUnset" flags="ng" index="2$GjLY">
+        <property id="3240475410332993358" name="noDefault" index="2$GjLT" />
+        <property id="3240475410332993356" name="defaultWithoutKey" index="2$GjLV" />
+        <property id="3240475410332993354" name="defaultWithKey" index="2$GjLX" />
+      </concept>
+    </language>
     <language id="48d0f6eb-6186-4cec-83d1-7caedb05a494" name="io.lionweb.mps.converter.TestLang2">
       <concept id="5605122842158780280" name="io.lionweb.mps.converter.TestLang2.structure.Test2ConceptUnkeyed" flags="ng" index="1kx2G0">
         <property id="5605122842163857069" name="propKeyed" index="1kkUcG" />
@@ -550,6 +594,9 @@
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="4611582986551314327" name="jetbrains.mps.baseLanguage.collections.structure.OfTypeOperation" flags="nn" index="UnYns">
+        <child id="4611582986551314344" name="requestedType" index="UnYnz" />
+      </concept>
       <concept id="1240217271293" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashSetCreator" flags="nn" index="32HrFt" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
@@ -1298,7 +1345,7 @@
                         <property role="Xl_RC" value="My-TestLang3" />
                       </node>
                       <node concept="Xl_RD" id="3FWZcLVWa_m" role="37wK5m">
-                        <property role="Xl_RC" value="0" />
+                        <property role="Xl_RC" value="00 my! VERSION 😀" />
                       </node>
                     </node>
                   </node>
@@ -1770,6 +1817,56 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="6LPkCA_n53A" role="3cqZAp" />
+        <node concept="3clFbF" id="6LPkCA_n5mu" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_n5Dn" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_n5ms" role="2Oq$k0">
+              <ref role="3cqZAo" node="4R9pospjyHs" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_n63o" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_n6il" role="37wK5m">
+                <ref role="3xOPvv" node="4R9pospjydp" resolve="keyed" />
+              </node>
+              <node concept="2YIFZM" id="6LPkCA_n8pu" role="37wK5m">
+                <ref role="37wK5l" to="apzt:2fx6VTSziaY" resolve="toLionWeb" />
+                <ref role="1Pybhc" to="apzt:2fx6VTSzhNf" resolve="IdEncoder" />
+                <node concept="2OqwBi" id="6LPkCA_n9Hq" role="37wK5m">
+                  <node concept="1eOMI4" id="6LPkCA_naqI" role="2Oq$k0">
+                    <node concept="10QFUN" id="6LPkCA_naqH" role="1eOMHV">
+                      <node concept="355D3s" id="6LPkCA_naqG" role="10QFUP">
+                        <ref role="355D3t" to="q6xk:4R9pospjbQk" resolve="Test3ConceptKeyed" />
+                        <ref role="355D3u" to="q6xk:4R9pospAGqo" resolve="propUnkeyed" />
+                      </node>
+                      <node concept="3uibUv" id="6LPkCA_naJj" role="10QFUM">
+                        <ref role="3uigEE" to="pwx:~SPropertyAdapter" resolve="SPropertyAdapter" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="6LPkCA_nbn5" role="2OqNvi">
+                    <ref role="37wK5l" to="pwx:~SPropertyAdapter.getId()" resolve="getId" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_n7ue" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_n7uf" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_n7ug" role="2Oq$k0">
+              <ref role="3cqZAo" node="4R9pospjyHs" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_n7uh" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_n7ui" role="37wK5m">
+                <ref role="3xOPvv" node="4R9pospjydp" resolve="keyed" />
+              </node>
+              <node concept="Xl_RD" id="6LPkCA_n7uj" role="37wK5m">
+                <property role="Xl_RC" value="My-KeyedProp" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbH" id="4R9pospjyHN" role="3cqZAp" />
         <node concept="3clFbF" id="4R9pospjyHO" role="3cqZAp">
           <node concept="2OqwBi" id="4R9pospjyHP" role="3clFbG">
@@ -1793,7 +1890,7 @@
                         <property role="Xl_RC" value="My-TestLang3" />
                       </node>
                       <node concept="Xl_RD" id="3FWZcLVWI51" role="37wK5m">
-                        <property role="Xl_RC" value="0" />
+                        <property role="Xl_RC" value="00 my! VERSION 😀" />
                       </node>
                     </node>
                   </node>
@@ -1944,6 +2041,56 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="6LPkCA_s55t" role="3cqZAp" />
+        <node concept="3clFbF" id="6LPkCA_s4G4" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_s4G5" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_s4G6" role="2Oq$k0">
+              <ref role="3cqZAo" node="4R9pospjHPA" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_s4G7" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_s4G8" role="37wK5m">
+                <ref role="3xOPvv" node="4R9pospjydr" resolve="unkeyed" />
+              </node>
+              <node concept="2YIFZM" id="6LPkCA_s4G9" role="37wK5m">
+                <ref role="1Pybhc" to="apzt:2fx6VTSzhNf" resolve="IdEncoder" />
+                <ref role="37wK5l" to="apzt:2fx6VTSziaY" resolve="toLionWeb" />
+                <node concept="2OqwBi" id="6LPkCA_s4Ga" role="37wK5m">
+                  <node concept="1eOMI4" id="6LPkCA_s4Gb" role="2Oq$k0">
+                    <node concept="10QFUN" id="6LPkCA_s4Gc" role="1eOMHV">
+                      <node concept="355D3s" id="6LPkCA_s4Gd" role="10QFUP">
+                        <ref role="355D3t" to="q6xk:4R9pospjkXS" resolve="Test3ConceptUnkeyed" />
+                        <ref role="355D3u" to="q6xk:4R9pospAGqG" resolve="propUnkeyed" />
+                      </node>
+                      <node concept="3uibUv" id="6LPkCA_s4Ge" role="10QFUM">
+                        <ref role="3uigEE" to="pwx:~SPropertyAdapter" resolve="SPropertyAdapter" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="6LPkCA_s4Gf" role="2OqNvi">
+                    <ref role="37wK5l" to="pwx:~SPropertyAdapter.getId()" resolve="getId" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_s4Gg" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_s4Gh" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_s4Gi" role="2Oq$k0">
+              <ref role="3cqZAo" node="4R9pospjHPA" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_s4Gj" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_s4Gk" role="37wK5m">
+                <ref role="3xOPvv" node="4R9pospjydr" resolve="unkeyed" />
+              </node>
+              <node concept="Xl_RD" id="6LPkCA_s4Gl" role="37wK5m">
+                <property role="Xl_RC" value="My-KeyedProp" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbH" id="4R9pospjHPX" role="3cqZAp" />
         <node concept="3clFbF" id="4R9pospjHPY" role="3cqZAp">
           <node concept="2OqwBi" id="4R9pospjHPZ" role="3clFbG">
@@ -1967,7 +2114,7 @@
                         <property role="Xl_RC" value="My-TestLang3" />
                       </node>
                       <node concept="Xl_RD" id="3FWZcLVWIrW" role="37wK5m">
-                        <property role="Xl_RC" value="0" />
+                        <property role="Xl_RC" value="00 my! VERSION 😀" />
                       </node>
                     </node>
                   </node>
@@ -2361,6 +2508,20 @@
           </node>
         </node>
         <node concept="3clFbH" id="4R9pospmzGN" role="3cqZAp" />
+        <node concept="3cpWs8" id="6jbF0BobBqw" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BobBqx" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6jbF0BoaM7p" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0BobBqy" role="33vP2m">
+              <node concept="1jGwE1" id="6jbF0BobBqz" role="2Oq$k0" />
+              <node concept="liA8E" id="6jbF0BobBq$" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="4R9pospmzGO" role="3cqZAp">
           <node concept="3cpWsn" id="4R9pospmzGP" role="3cpWs9">
             <property role="TrG5h" value="converter" />
@@ -2370,11 +2531,8 @@
             <node concept="2ShNRf" id="4R9pospmzGR" role="33vP2m">
               <node concept="1pGfFk" id="4R9pospmzGS" role="2ShVmc">
                 <ref role="37wK5l" to="6peh:5lijfVJTSc9" resolve="M1ToJson" />
-                <node concept="2OqwBi" id="4R9pospmzGT" role="37wK5m">
-                  <node concept="1jGwE1" id="4R9pospmzGU" role="2Oq$k0" />
-                  <node concept="liA8E" id="4R9pospmzGV" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-                  </node>
+                <node concept="37vLTw" id="6jbF0BobBq_" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BobBqx" resolve="repository" />
                 </node>
                 <node concept="2ShNRf" id="4R9pospmzGW" role="37wK5m">
                   <node concept="2HTt$P" id="4R9pospmzGX" role="2ShVmc">
@@ -2488,12 +2646,89 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="4R9pospmzHD" role="3cqZAp" />
-        <node concept="3clFbF" id="3FWZcLVXMF6" role="3cqZAp">
-          <node concept="2OqwBi" id="3FWZcLVXMF7" role="3clFbG">
-            <node concept="37vLTw" id="3FWZcLVXMF8" role="2Oq$k0">
+        <node concept="3clFbH" id="6LPkCA_E8bp" role="3cqZAp" />
+        <node concept="3clFbF" id="6LPkCA_E8bq" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_E8br" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_E8bs" role="2Oq$k0">
               <ref role="3cqZAo" node="4R9pospmzHi" resolve="comparer" />
             </node>
+            <node concept="liA8E" id="6LPkCA_E8bt" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_E8bu" role="37wK5m">
+                <ref role="3xOPvv" node="4R9pospm_$F" resolve="keyed" />
+              </node>
+              <node concept="2YIFZM" id="6LPkCA_E8bv" role="37wK5m">
+                <ref role="1Pybhc" to="apzt:2fx6VTSzhNf" resolve="IdEncoder" />
+                <ref role="37wK5l" to="apzt:2fx6VTSziaY" resolve="toLionWeb" />
+                <node concept="2OqwBi" id="6LPkCA_E8bw" role="37wK5m">
+                  <node concept="1eOMI4" id="6LPkCA_E8bx" role="2Oq$k0">
+                    <node concept="10QFUN" id="6LPkCA_E8by" role="1eOMHV">
+                      <node concept="355D3s" id="6LPkCA_E8bz" role="10QFUP">
+                        <ref role="355D3t" to="zf9n:4R9pospjbQk" resolve="Test2ConceptKeyed" />
+                        <ref role="355D3u" to="zf9n:4R9pospAGqo" resolve="propUnkeyed" />
+                      </node>
+                      <node concept="3uibUv" id="6LPkCA_E8b$" role="10QFUM">
+                        <ref role="3uigEE" to="pwx:~SPropertyAdapter" resolve="SPropertyAdapter" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="6LPkCA_E8b_" role="2OqNvi">
+                    <ref role="37wK5l" to="pwx:~SPropertyAdapter.getId()" resolve="getId" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_E8bA" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_E8bB" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_E8bC" role="2Oq$k0">
+              <ref role="3cqZAo" node="4R9pospmzHi" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_E8bD" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_E8bE" role="37wK5m">
+                <ref role="3xOPvv" node="4R9pospm_$F" resolve="keyed" />
+              </node>
+              <node concept="Xl_RD" id="6LPkCA_E8bF" role="37wK5m">
+                <property role="Xl_RC" value="My-KeyedProp" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4R9pospmzHD" role="3cqZAp" />
+        <node concept="3cpWs8" id="6jbF0BobB4R" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BobB4S" role="3cpWs9">
+            <property role="TrG5h" value="attributeFinder" />
+            <node concept="3uibUv" id="6jbF0BobB4T" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BobB4U" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BobB4V" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+                <node concept="37vLTw" id="6jbF0BobB4W" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BobBqx" resolve="repository" />
+                </node>
+                <node concept="2ShNRf" id="6jbF0BobB4X" role="37wK5m">
+                  <node concept="1pGfFk" id="6jbF0BobB4Y" role="2ShVmc">
+                    <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                    <node concept="37vLTw" id="6jbF0BobB4Z" role="37wK5m">
+                      <ref role="3cqZAo" node="6jbF0BobBqx" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6jbF0BobB50" role="37wK5m">
+                  <node concept="HV5vD" id="6jbF0BobB51" role="2ShVmc">
+                    <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6jbF0BobB52" role="3cqZAp" />
+        <node concept="3clFbF" id="3FWZcLVXMF6" role="3cqZAp">
+          <node concept="2OqwBi" id="3FWZcLVXMF7" role="3clFbG">
             <node concept="liA8E" id="3FWZcLVXMF9" role="2OqNvi">
               <ref role="37wK5l" to="kte7:5TNjoy25t5T" resolve="assertSortedEquals" />
               <node concept="37vLTw" id="3FWZcLVXMFa" role="37wK5m">
@@ -2511,7 +2746,7 @@
                         <property role="Xl_RC" value="My-TestLang3" />
                       </node>
                       <node concept="Xl_RD" id="3FWZcLVXMFh" role="37wK5m">
-                        <property role="Xl_RC" value="0" />
+                        <property role="Xl_RC" value="00 my! VERSION 😀" />
                       </node>
                     </node>
                   </node>
@@ -2524,9 +2759,15 @@
                         <property role="2V$B1Q" value="io.lionweb.mps.converter.TestLang2" />
                       </node>
                     </node>
+                    <node concept="37vLTw" id="6jbF0BobC3V" role="37wK5m">
+                      <ref role="3cqZAo" node="6jbF0BobB4S" resolve="attributeFinder" />
+                    </node>
                   </node>
                 </node>
               </node>
+            </node>
+            <node concept="37vLTw" id="3FWZcLVXMF8" role="2Oq$k0">
+              <ref role="3cqZAo" node="4R9pospmzHi" resolve="comparer" />
             </node>
           </node>
         </node>
@@ -2545,6 +2786,20 @@
           </node>
         </node>
         <node concept="3clFbH" id="4R9pospmzHQ" role="3cqZAp" />
+        <node concept="3cpWs8" id="6jbF0BobErE" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BobErF" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6jbF0BobC_R" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0BobErG" role="33vP2m">
+              <node concept="1jGwE1" id="6jbF0BobErH" role="2Oq$k0" />
+              <node concept="liA8E" id="6jbF0BobErI" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="4R9pospmzHR" role="3cqZAp">
           <node concept="3cpWsn" id="4R9pospmzHS" role="3cpWs9">
             <property role="TrG5h" value="converter" />
@@ -2554,11 +2809,8 @@
             <node concept="2ShNRf" id="4R9pospmzHU" role="33vP2m">
               <node concept="1pGfFk" id="4R9pospmzHV" role="2ShVmc">
                 <ref role="37wK5l" to="6peh:5lijfVJTSc9" resolve="M1ToJson" />
-                <node concept="2OqwBi" id="4R9pospmzHW" role="37wK5m">
-                  <node concept="1jGwE1" id="4R9pospmzHX" role="2Oq$k0" />
-                  <node concept="liA8E" id="4R9pospmzHY" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-                  </node>
+                <node concept="37vLTw" id="6jbF0BobErJ" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BobErF" resolve="repository" />
                 </node>
                 <node concept="2ShNRf" id="4R9pospmzHZ" role="37wK5m">
                   <node concept="2HTt$P" id="4R9pospmzI0" role="2ShVmc">
@@ -2672,7 +2924,87 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="6LPkCA_Ea01" role="3cqZAp" />
+        <node concept="3clFbF" id="6LPkCA_Ea02" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_Ea03" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_Ea04" role="2Oq$k0">
+              <ref role="3cqZAo" node="4R9pospmzIl" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_Ea05" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_Ea06" role="37wK5m">
+                <ref role="3xOPvv" node="4R9pospmBfb" resolve="unkeyed" />
+              </node>
+              <node concept="2YIFZM" id="6LPkCA_Ea07" role="37wK5m">
+                <ref role="1Pybhc" to="apzt:2fx6VTSzhNf" resolve="IdEncoder" />
+                <ref role="37wK5l" to="apzt:2fx6VTSziaY" resolve="toLionWeb" />
+                <node concept="2OqwBi" id="6LPkCA_Ea08" role="37wK5m">
+                  <node concept="1eOMI4" id="6LPkCA_Ea09" role="2Oq$k0">
+                    <node concept="10QFUN" id="6LPkCA_Ea0a" role="1eOMHV">
+                      <node concept="355D3s" id="6LPkCA_Ea0b" role="10QFUP">
+                        <ref role="355D3t" to="zf9n:4R9pospjkXS" resolve="Test2ConceptUnkeyed" />
+                        <ref role="355D3u" to="zf9n:4R9pospAGqG" resolve="propUnkeyed" />
+                      </node>
+                      <node concept="3uibUv" id="6LPkCA_Ea0c" role="10QFUM">
+                        <ref role="3uigEE" to="pwx:~SPropertyAdapter" resolve="SPropertyAdapter" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="6LPkCA_Ea0d" role="2OqNvi">
+                    <ref role="37wK5l" to="pwx:~SPropertyAdapter.getId()" resolve="getId" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_Ea0e" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_Ea0f" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_Ea0g" role="2Oq$k0">
+              <ref role="3cqZAo" node="4R9pospmzIl" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_Ea0h" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_Ea0i" role="37wK5m">
+                <ref role="3xOPvv" node="4R9pospmBfb" resolve="unkeyed" />
+              </node>
+              <node concept="Xl_RD" id="6LPkCA_Ea0j" role="37wK5m">
+                <property role="Xl_RC" value="My-KeyedProp" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbH" id="4R9pospmzIG" role="3cqZAp" />
+        <node concept="3cpWs8" id="6jbF0BobE5W" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BobE5X" role="3cpWs9">
+            <property role="TrG5h" value="attributeFinder" />
+            <node concept="3uibUv" id="6jbF0BobE5Y" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BobE5Z" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BobE60" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+                <node concept="37vLTw" id="6jbF0BobE61" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BobErF" resolve="repository" />
+                </node>
+                <node concept="2ShNRf" id="6jbF0BobE62" role="37wK5m">
+                  <node concept="1pGfFk" id="6jbF0BobE63" role="2ShVmc">
+                    <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                    <node concept="37vLTw" id="6jbF0BobE64" role="37wK5m">
+                      <ref role="3cqZAo" node="6jbF0BobErF" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6jbF0BobE65" role="37wK5m">
+                  <node concept="HV5vD" id="6jbF0BobE66" role="2ShVmc">
+                    <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6jbF0BobE67" role="3cqZAp" />
         <node concept="3clFbF" id="4R9pospmzIH" role="3cqZAp">
           <node concept="2OqwBi" id="4R9pospmzII" role="3clFbG">
             <node concept="37vLTw" id="4R9pospmzIJ" role="2Oq$k0">
@@ -2695,7 +3027,7 @@
                         <property role="Xl_RC" value="My-TestLang3" />
                       </node>
                       <node concept="Xl_RD" id="3FWZcLVYi9W" role="37wK5m">
-                        <property role="Xl_RC" value="0" />
+                        <property role="Xl_RC" value="00 my! VERSION 😀" />
                       </node>
                     </node>
                   </node>
@@ -2707,6 +3039,9 @@
                         <property role="2V$B1T" value="48d0f6eb-6186-4cec-83d1-7caedb05a494" />
                         <property role="2V$B1Q" value="io.lionweb.mps.converter.TestLang2" />
                       </node>
+                    </node>
+                    <node concept="37vLTw" id="6jbF0BobGfr" role="37wK5m">
+                      <ref role="3cqZAo" node="6jbF0BobE5X" resolve="attributeFinder" />
                     </node>
                   </node>
                 </node>
@@ -3028,6 +3363,20 @@
           </node>
         </node>
         <node concept="3clFbH" id="4R9posq5S4U" role="3cqZAp" />
+        <node concept="3cpWs8" id="6jbF0Bob_pa" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0Bob_pb" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6jbF0Bob_3r" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0Bob_pc" role="33vP2m">
+              <node concept="1jGwE1" id="6jbF0Bob_pd" role="2Oq$k0" />
+              <node concept="liA8E" id="6jbF0Bob_pe" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="4R9posq5S4V" role="3cqZAp">
           <node concept="3cpWsn" id="4R9posq5S4W" role="3cpWs9">
             <property role="TrG5h" value="converter" />
@@ -3037,11 +3386,8 @@
             <node concept="2ShNRf" id="4R9posq5S4Y" role="33vP2m">
               <node concept="1pGfFk" id="4R9posq5S4Z" role="2ShVmc">
                 <ref role="37wK5l" to="6peh:5lijfVJTSc9" resolve="M1ToJson" />
-                <node concept="2OqwBi" id="4R9posq5S50" role="37wK5m">
-                  <node concept="1jGwE1" id="4R9posq5S51" role="2Oq$k0" />
-                  <node concept="liA8E" id="4R9posq5S52" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-                  </node>
+                <node concept="37vLTw" id="6jbF0Bob_pf" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Bob_pb" resolve="repository" />
                 </node>
                 <node concept="2ShNRf" id="4R9posq5S53" role="37wK5m">
                   <node concept="2HTt$P" id="4R9posq5S54" role="2ShVmc">
@@ -3124,6 +3470,36 @@
           </node>
         </node>
         <node concept="3clFbH" id="4R9posq5S5K" role="3cqZAp" />
+        <node concept="3cpWs8" id="6jbF0Bob_9c" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0Bob_9d" role="3cpWs9">
+            <property role="TrG5h" value="attributeFinder" />
+            <node concept="3uibUv" id="6jbF0Bob_9e" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0Bob_9f" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0Bob_9g" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+                <node concept="37vLTw" id="6jbF0Bob_9h" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Bob_pb" resolve="repository" />
+                </node>
+                <node concept="2ShNRf" id="6jbF0Bob_9i" role="37wK5m">
+                  <node concept="1pGfFk" id="6jbF0Bob_9j" role="2ShVmc">
+                    <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                    <node concept="37vLTw" id="6jbF0Bob_9k" role="37wK5m">
+                      <ref role="3cqZAo" node="6jbF0Bob_pb" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6jbF0Bob_9l" role="37wK5m">
+                  <node concept="HV5vD" id="6jbF0Bob_9m" role="2ShVmc">
+                    <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6jbF0Bob_9n" role="3cqZAp" />
         <node concept="3clFbF" id="4R9posq5S5L" role="3cqZAp">
           <node concept="2OqwBi" id="4R9posq5S5M" role="3clFbG">
             <node concept="37vLTw" id="4R9posq5S5N" role="2Oq$k0">
@@ -3147,6 +3523,9 @@
                         <property role="2V$B1T" value="11541b24-a02a-4586-a931-92521b3f6166" />
                         <property role="2V$B1Q" value="io.lionweb.mps.converter.TestCustomDatatype" />
                       </node>
+                    </node>
+                    <node concept="37vLTw" id="6jbF0Bob_Ax" role="37wK5m">
+                      <ref role="3cqZAo" node="6jbF0Bob_9d" resolve="attributeFinder" />
                     </node>
                   </node>
                 </node>
@@ -3872,6 +4251,20 @@
           </node>
         </node>
         <node concept="3clFbH" id="1xqd6ptaZvL" role="3cqZAp" />
+        <node concept="3cpWs8" id="6jbF0BobrLr" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BobrLs" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6jbF0BoblFa" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0BobrLt" role="33vP2m">
+              <node concept="1jGwE1" id="6jbF0BobrLu" role="2Oq$k0" />
+              <node concept="liA8E" id="6jbF0BobrLv" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="1xqd6ptaZvM" role="3cqZAp">
           <node concept="3cpWsn" id="1xqd6ptaZvN" role="3cpWs9">
             <property role="TrG5h" value="converter" />
@@ -3881,11 +4274,8 @@
             <node concept="2ShNRf" id="1xqd6ptaZvP" role="33vP2m">
               <node concept="1pGfFk" id="1xqd6ptaZvQ" role="2ShVmc">
                 <ref role="37wK5l" to="6peh:5lijfVJTSc9" resolve="M1ToJson" />
-                <node concept="2OqwBi" id="1xqd6ptaZvR" role="37wK5m">
-                  <node concept="1jGwE1" id="1xqd6ptaZvS" role="2Oq$k0" />
-                  <node concept="liA8E" id="1xqd6ptaZvT" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-                  </node>
+                <node concept="37vLTw" id="6jbF0BobrLw" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BobrLs" resolve="repository" />
                 </node>
                 <node concept="2ShNRf" id="1xqd6ptaZvU" role="37wK5m">
                   <node concept="2HTt$P" id="1xqd6ptaZvV" role="2ShVmc">
@@ -4240,6 +4630,36 @@
           </node>
         </node>
         <node concept="3clFbH" id="1xqd6ptaZxs" role="3cqZAp" />
+        <node concept="3cpWs8" id="6jbF0BobvNA" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BobvNB" role="3cpWs9">
+            <property role="TrG5h" value="attributeFinder" />
+            <node concept="3uibUv" id="6jbF0BobvA9" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BobvNC" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BobvND" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+                <node concept="37vLTw" id="6jbF0BobvNE" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BobrLs" resolve="repository" />
+                </node>
+                <node concept="2ShNRf" id="6jbF0BobvNF" role="37wK5m">
+                  <node concept="1pGfFk" id="6jbF0BobvNG" role="2ShVmc">
+                    <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                    <node concept="37vLTw" id="6jbF0BobvNH" role="37wK5m">
+                      <ref role="3cqZAo" node="6jbF0BobrLs" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6jbF0BobvNI" role="37wK5m">
+                  <node concept="HV5vD" id="6jbF0BobvNJ" role="2ShVmc">
+                    <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6jbF0Bobm7N" role="3cqZAp" />
         <node concept="3clFbF" id="1xqd6ptaZxt" role="3cqZAp">
           <node concept="2OqwBi" id="1xqd6ptaZxu" role="3clFbG">
             <node concept="37vLTw" id="1xqd6ptaZxv" role="2Oq$k0">
@@ -4279,6 +4699,9 @@
                         <property role="2V$B1Q" value="library" />
                       </node>
                     </node>
+                    <node concept="37vLTw" id="6jbF0Bobxby" role="37wK5m">
+                      <ref role="3cqZAo" node="6jbF0BobvNB" resolve="attributeFinder" />
+                    </node>
                   </node>
                   <node concept="2YIFZM" id="3FWZcLVUZgN" role="HW$Y0">
                     <ref role="37wK5l" to="kte7:3FWZcLVUM0z" resolve="toUsedLanguage" />
@@ -4288,6 +4711,9 @@
                         <property role="2V$B1T" value="afd6d8a2-5e3b-49d1-ab82-c9cb7dc063bb" />
                         <property role="2V$B1Q" value="io.lionweb.mps.converter.TestAnnotation" />
                       </node>
+                    </node>
+                    <node concept="37vLTw" id="6jbF0BobxTd" role="37wK5m">
+                      <ref role="3cqZAo" node="6jbF0BobvNB" resolve="attributeFinder" />
                     </node>
                   </node>
                 </node>
@@ -4516,6 +4942,20 @@
           </node>
         </node>
         <node concept="3clFbH" id="5TNjoy234z4" role="3cqZAp" />
+        <node concept="3cpWs8" id="6jbF0BobHM7" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BobHM8" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6jbF0BobHje" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0BobHM9" role="33vP2m">
+              <node concept="1jGwE1" id="6jbF0BobHMa" role="2Oq$k0" />
+              <node concept="liA8E" id="6jbF0BobHMb" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="5TNjoy1ZBCL" role="3cqZAp">
           <node concept="3cpWsn" id="5TNjoy1ZBCM" role="3cpWs9">
             <property role="TrG5h" value="converter" />
@@ -4525,11 +4965,8 @@
             <node concept="2ShNRf" id="5TNjoy1ZBCO" role="33vP2m">
               <node concept="1pGfFk" id="5TNjoy1ZBCP" role="2ShVmc">
                 <ref role="37wK5l" to="6peh:5lijfVJTSc9" resolve="M1ToJson" />
-                <node concept="2OqwBi" id="5TNjoy1ZBCQ" role="37wK5m">
-                  <node concept="1jGwE1" id="5TNjoy1ZBCR" role="2Oq$k0" />
-                  <node concept="liA8E" id="5TNjoy1ZBCS" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-                  </node>
+                <node concept="37vLTw" id="6jbF0BobHMc" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BobHM8" resolve="repository" />
                 </node>
                 <node concept="2ShNRf" id="5TNjoy1ZW$T" role="37wK5m">
                   <node concept="Tc6Ow" id="5TNjoy1ZX0s" role="2ShVmc">
@@ -4699,6 +5136,36 @@
           </node>
         </node>
         <node concept="3clFbH" id="5TNjoy1ZBFh" role="3cqZAp" />
+        <node concept="3cpWs8" id="6jbF0BobHzi" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BobHzj" role="3cpWs9">
+            <property role="TrG5h" value="attributeFinder" />
+            <node concept="3uibUv" id="6jbF0BobHzk" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BobHzl" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BobHzm" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+                <node concept="37vLTw" id="6jbF0BobHzn" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BobHM8" resolve="repository" />
+                </node>
+                <node concept="2ShNRf" id="6jbF0BobHzo" role="37wK5m">
+                  <node concept="1pGfFk" id="6jbF0BobHzp" role="2ShVmc">
+                    <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                    <node concept="37vLTw" id="6jbF0BobHzq" role="37wK5m">
+                      <ref role="3cqZAo" node="6jbF0BobHM8" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6jbF0BobHzr" role="37wK5m">
+                  <node concept="HV5vD" id="6jbF0BobHzs" role="2ShVmc">
+                    <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6jbF0BobHzt" role="3cqZAp" />
         <node concept="3clFbF" id="5TNjoy1ZBFi" role="3cqZAp">
           <node concept="2OqwBi" id="5TNjoy1ZBFj" role="3clFbG">
             <node concept="37vLTw" id="5TNjoy1ZBFk" role="2Oq$k0">
@@ -4726,6 +5193,9 @@
                         <property role="2V$B1T" value="a95063a5-27eb-4ae8-894e-ea20f8b3d6a2" />
                         <property role="2V$B1Q" value="io.lionweb.mps.converter.TestRefs" />
                       </node>
+                    </node>
+                    <node concept="37vLTw" id="6jbF0BobIiD" role="37wK5m">
+                      <ref role="3cqZAo" node="6jbF0BobHzj" resolve="attributeFinder" />
                     </node>
                   </node>
                 </node>
@@ -6893,6 +7363,20 @@
           </node>
         </node>
         <node concept="3clFbH" id="5JNiskiVWJL" role="3cqZAp" />
+        <node concept="3cpWs8" id="6jbF0Bob$6c" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0Bob$6d" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6jbF0BobzQ3" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0Bob$6e" role="33vP2m">
+              <node concept="1jGwE1" id="6jbF0Bob$6f" role="2Oq$k0" />
+              <node concept="liA8E" id="6jbF0Bob$6g" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="5JNiskiVWJM" role="3cqZAp">
           <node concept="3cpWsn" id="5JNiskiVWJN" role="3cpWs9">
             <property role="TrG5h" value="converter" />
@@ -6902,11 +7386,8 @@
             <node concept="2ShNRf" id="5JNiskiVWJP" role="33vP2m">
               <node concept="1pGfFk" id="5JNiskiVWJQ" role="2ShVmc">
                 <ref role="37wK5l" to="6peh:5lijfVJTSc9" resolve="M1ToJson" />
-                <node concept="2OqwBi" id="5JNiskiVWJR" role="37wK5m">
-                  <node concept="1jGwE1" id="5JNiskiVWJS" role="2Oq$k0" />
-                  <node concept="liA8E" id="5JNiskiVWJT" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-                  </node>
+                <node concept="37vLTw" id="6jbF0Bob$6h" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Bob$6d" resolve="repository" />
                 </node>
                 <node concept="2ShNRf" id="5JNiskiVWJU" role="37wK5m">
                   <node concept="2HTt$P" id="5JNiskiVWJV" role="2ShVmc">
@@ -7005,6 +7486,37 @@
           </node>
         </node>
         <node concept="3clFbH" id="5JNiskiVWM0" role="3cqZAp" />
+        <node concept="3cpWs8" id="6jbF0BobzWy" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BobzWz" role="3cpWs9">
+            <property role="TrG5h" value="attributeFinder" />
+            <node concept="3uibUv" id="6jbF0BobzW$" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BobzW_" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BobzWA" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+                <node concept="37vLTw" id="6jbF0BobzWB" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Bob$6d" resolve="repository" />
+                </node>
+                <node concept="2ShNRf" id="6jbF0BobzWC" role="37wK5m">
+                  <node concept="1pGfFk" id="6jbF0BobzWD" role="2ShVmc">
+                    <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                    <node concept="37vLTw" id="6jbF0BobzWE" role="37wK5m">
+                      <ref role="3cqZAo" node="6jbF0Bob$6d" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6jbF0BobzWF" role="37wK5m">
+                  <node concept="HV5vD" id="6jbF0BobzWG" role="2ShVmc">
+                    <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6jbF0BobzWH" role="3cqZAp" />
+        <node concept="3clFbH" id="6jbF0BobzVv" role="3cqZAp" />
         <node concept="3clFbF" id="5JNiskiVWM1" role="3cqZAp">
           <node concept="2OqwBi" id="5JNiskiVWM2" role="3clFbG">
             <node concept="37vLTw" id="5JNiskiVWM3" role="2Oq$k0">
@@ -7032,6 +7544,9 @@
                         <property role="2V$B1T" value="537f9cb0-0f25-3c76-8b86-308f45010100" />
                         <property role="2V$B1Q" value="library" />
                       </node>
+                    </node>
+                    <node concept="37vLTw" id="6jbF0Bob$NC" role="37wK5m">
+                      <ref role="3cqZAo" node="6jbF0BobzWz" resolve="attributeFinder" />
                     </node>
                   </node>
                   <node concept="2YIFZM" id="3FWZcLW4Vx7" role="HW$Y0">
@@ -7159,6 +7674,20 @@
           </node>
         </node>
         <node concept="3clFbH" id="3FWZcLW7bnb" role="3cqZAp" />
+        <node concept="3cpWs8" id="6jbF0BobLU8" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BobLU9" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6jbF0BobKBJ" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0BobLUa" role="33vP2m">
+              <node concept="1jGwE1" id="6jbF0BobLUb" role="2Oq$k0" />
+              <node concept="liA8E" id="6jbF0BobLUc" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="3FWZcLW7bnc" role="3cqZAp">
           <node concept="3cpWsn" id="3FWZcLW7bnd" role="3cpWs9">
             <property role="TrG5h" value="converter" />
@@ -7168,11 +7697,8 @@
             <node concept="2ShNRf" id="3FWZcLW7bnf" role="33vP2m">
               <node concept="1pGfFk" id="3FWZcLW7bng" role="2ShVmc">
                 <ref role="37wK5l" to="6peh:5lijfVJTSc9" resolve="M1ToJson" />
-                <node concept="2OqwBi" id="3FWZcLW7bnh" role="37wK5m">
-                  <node concept="1jGwE1" id="3FWZcLW7bni" role="2Oq$k0" />
-                  <node concept="liA8E" id="3FWZcLW7bnj" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-                  </node>
+                <node concept="37vLTw" id="6jbF0BobLUd" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BobLU9" resolve="repository" />
                 </node>
                 <node concept="2ShNRf" id="3FWZcLW7bnk" role="37wK5m">
                   <node concept="2HTt$P" id="3FWZcLW7bnl" role="2ShVmc">
@@ -7479,6 +8005,303 @@
           </node>
         </node>
         <node concept="3clFbH" id="3FWZcLW7boQ" role="3cqZAp" />
+        <node concept="3cpWs8" id="6LPkCA_EfA8" role="3cqZAp">
+          <node concept="3cpWsn" id="6LPkCA_EfA9" role="3cpWs9">
+            <property role="TrG5h" value="testConceptBaseEnumPropId" />
+            <node concept="17QB3L" id="6LPkCA_EfpG" role="1tU5fm" />
+            <node concept="2YIFZM" id="6LPkCA_EfAa" role="33vP2m">
+              <ref role="37wK5l" to="apzt:2fx6VTSziaY" resolve="toLionWeb" />
+              <ref role="1Pybhc" to="apzt:2fx6VTSzhNf" resolve="IdEncoder" />
+              <node concept="2OqwBi" id="6LPkCA_EfAb" role="37wK5m">
+                <node concept="1eOMI4" id="6LPkCA_EfAc" role="2Oq$k0">
+                  <node concept="10QFUN" id="6LPkCA_EfAd" role="1eOMHV">
+                    <node concept="355D3s" id="6LPkCA_EfAe" role="10QFUP">
+                      <ref role="355D3t" to="qa91:2fx6VTSS$mN" resolve="TestConceptBase" />
+                      <ref role="355D3u" to="qa91:2fx6VTSS$O0" resolve="enumProp" />
+                    </node>
+                    <node concept="3uibUv" id="6LPkCA_EfAf" role="10QFUM">
+                      <ref role="3uigEE" to="pwx:~SPropertyAdapter" resolve="SPropertyAdapter" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="6LPkCA_EfAg" role="2OqNvi">
+                  <ref role="37wK5l" to="pwx:~SPropertyAdapter.getId()" resolve="getId" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_EcgW" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_EcCD" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_EcgU" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FWZcLW7bnD" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_Ed3H" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_Edmn" role="37wK5m">
+                <ref role="3xOPvv" node="3FWZcLW7dIq" resolve="baseA" />
+              </node>
+              <node concept="37vLTw" id="6LPkCA_EfAh" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA_EfA9" resolve="testConceptBaseEnumPropId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_Ei54" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_Ei55" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_Ei56" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FWZcLW7bnD" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_Ei57" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_Ei58" role="37wK5m">
+                <ref role="3xOPvv" node="3FWZcLW7dIs" resolve="baseB" />
+              </node>
+              <node concept="37vLTw" id="6LPkCA_Ei59" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA_EfA9" resolve="testConceptBaseEnumPropId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_Eito" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_Eitp" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_Eitq" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FWZcLW7bnD" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_Eitr" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_Eits" role="37wK5m">
+                <ref role="3xOPvv" node="3FWZcLW7dIw" resolve="baseC" />
+              </node>
+              <node concept="37vLTw" id="6LPkCA_Eitt" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA_EfA9" resolve="testConceptBaseEnumPropId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_Eiw8" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_Eiw9" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_Eiwa" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FWZcLW7bnD" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_Eiwb" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_Eiwc" role="37wK5m">
+                <ref role="3xOPvv" node="3FWZcLW7dI$" resolve="baseD" />
+              </node>
+              <node concept="37vLTw" id="6LPkCA_Eiwd" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA_EfA9" resolve="testConceptBaseEnumPropId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_EiyY" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_EiyZ" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_Eiz0" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FWZcLW7bnD" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_Eiz1" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_Eiz2" role="37wK5m">
+                <ref role="3xOPvv" node="3FWZcLW7dIE" resolve="baseE" />
+              </node>
+              <node concept="37vLTw" id="6LPkCA_Eiz3" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA_EfA9" resolve="testConceptBaseEnumPropId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_Ei_U" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_Ei_V" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_Ei_W" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FWZcLW7bnD" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_Ei_X" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_Ei_Y" role="37wK5m">
+                <ref role="3xOPvv" node="3FWZcLW7dIK" resolve="baseF" />
+              </node>
+              <node concept="37vLTw" id="6LPkCA_Ei_Z" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA_EfA9" resolve="testConceptBaseEnumPropId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_EiCW" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_EiCX" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_EiCY" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FWZcLW7bnD" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_EiCZ" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_EiD0" role="37wK5m">
+                <ref role="3xOPvv" node="3FWZcLW7dIQ" resolve="baseG" />
+              </node>
+              <node concept="37vLTw" id="6LPkCA_EiD1" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA_EfA9" resolve="testConceptBaseEnumPropId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_EiG4" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_EiG5" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_EiG6" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FWZcLW7bnD" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_EiG7" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_EiG8" role="37wK5m">
+                <ref role="3xOPvv" node="3FWZcLW7dIy" resolve="extends1A" />
+              </node>
+              <node concept="37vLTw" id="6LPkCA_EiG9" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA_EfA9" resolve="testConceptBaseEnumPropId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_EnSS" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_EnST" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_EnSU" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FWZcLW7bnD" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_EnSV" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_EnSW" role="37wK5m">
+                <ref role="3xOPvv" node="3FWZcLW7dIA" resolve="extends1B" />
+              </node>
+              <node concept="37vLTw" id="6LPkCA_EnSX" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA_EfA9" resolve="testConceptBaseEnumPropId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_EnWc" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_EnWd" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_EnWe" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FWZcLW7bnD" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_EnWf" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_EnWg" role="37wK5m">
+                <ref role="3xOPvv" node="3FWZcLW7dIC" resolve="extends1C" />
+              </node>
+              <node concept="37vLTw" id="6LPkCA_EnWh" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA_EfA9" resolve="testConceptBaseEnumPropId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_EnZA" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_EnZB" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_EnZC" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FWZcLW7bnD" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_EnZD" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_EnZE" role="37wK5m">
+                <ref role="3xOPvv" node="3FWZcLW7dIG" resolve="extends1D" />
+              </node>
+              <node concept="37vLTw" id="6LPkCA_EnZF" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA_EfA9" resolve="testConceptBaseEnumPropId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_Eo36" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_Eo37" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_Eo38" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FWZcLW7bnD" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_Eo39" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_Eo3a" role="37wK5m">
+                <ref role="3xOPvv" node="3FWZcLW7dII" resolve="extends1E" />
+              </node>
+              <node concept="37vLTw" id="6LPkCA_Eo3b" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA_EfA9" resolve="testConceptBaseEnumPropId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_Eo6G" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_Eo6H" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_Eo6I" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FWZcLW7bnD" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_Eo6J" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_Eo6K" role="37wK5m">
+                <ref role="3xOPvv" node="3FWZcLW7dIM" resolve="extends1F" />
+              </node>
+              <node concept="37vLTw" id="6LPkCA_Eo6L" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA_EfA9" resolve="testConceptBaseEnumPropId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_Eoao" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_Eoap" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_Eoaq" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FWZcLW7bnD" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_Eoar" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_Eoas" role="37wK5m">
+                <ref role="3xOPvv" node="3FWZcLW7dIO" resolve="extends1G" />
+              </node>
+              <node concept="37vLTw" id="6LPkCA_Eoat" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA_EfA9" resolve="testConceptBaseEnumPropId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_Eoea" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_Eoeb" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_Eoec" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FWZcLW7bnD" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_Eoed" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+              <node concept="3xONca" id="6LPkCA_Eoee" role="37wK5m">
+                <ref role="3xOPvv" node="3FWZcLW7dIu" resolve="extends2" />
+              </node>
+              <node concept="37vLTw" id="6LPkCA_Eoef" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA_EfA9" resolve="testConceptBaseEnumPropId" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA_EbVI" role="3cqZAp" />
+        <node concept="3cpWs8" id="6jbF0BobLj2" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BobLj3" role="3cpWs9">
+            <property role="TrG5h" value="attributeFinder" />
+            <node concept="3uibUv" id="6jbF0BobLj4" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BobLj5" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BobLj6" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+                <node concept="37vLTw" id="6jbF0BobLj7" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BobLU9" resolve="repository" />
+                </node>
+                <node concept="2ShNRf" id="6jbF0BobLj8" role="37wK5m">
+                  <node concept="1pGfFk" id="6jbF0BobLj9" role="2ShVmc">
+                    <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                    <node concept="37vLTw" id="6jbF0BobLja" role="37wK5m">
+                      <ref role="3cqZAo" node="6jbF0BobLU9" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6jbF0BobLjb" role="37wK5m">
+                  <node concept="HV5vD" id="6jbF0BobLjc" role="2ShVmc">
+                    <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6jbF0BobLjd" role="3cqZAp" />
         <node concept="3clFbF" id="3FWZcLW7boR" role="3cqZAp">
           <node concept="2OqwBi" id="3FWZcLW7boS" role="3clFbG">
             <node concept="37vLTw" id="3FWZcLW7boT" role="2Oq$k0">
@@ -7502,6 +8325,9 @@
                         <property role="2V$B1T" value="08caad75-8246-4427-bb4d-8444b6c5c729" />
                         <property role="2V$B1Q" value="io.lionweb.mps.converter.TestLang" />
                       </node>
+                    </node>
+                    <node concept="37vLTw" id="6jbF0BobO5s" role="37wK5m">
+                      <ref role="3cqZAo" node="6jbF0BobLj3" resolve="attributeFinder" />
                     </node>
                   </node>
                 </node>
@@ -9917,6 +10743,996 @@
         <property role="pjpzt" value="39$JcGFainl/descendants" />
         <node concept="pgsVv" id="nWBHrKVdP1" role="pgtdD">
           <ref role="pgsW4" node="nWBHrKmor$" resolve="computedName" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="2NSuNu8iaXL">
+    <property role="TrG5h" value="enumLiterals_WithKey" />
+    <node concept="1qefOq" id="2NSuNu8icag" role="1SKRRt">
+      <node concept="2$GdB6" id="2NSuNu8icKv" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithKeyOptional_unset" />
+        <node concept="3xLA65" id="2NSuNu8icU1" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithKeyOptional_unset" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8icU3" role="1SKRRt">
+      <node concept="2$GdB6" id="2NSuNu8icU4" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithKeyOptional_setWithKey" />
+        <property role="2$GdYn" value="2NSuNu8iai9/literalWithKey" />
+        <property role="2$GdYh" value="2NSuNu8iabP/literalWithKey" />
+        <node concept="3xLA65" id="2NSuNu8icU5" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithKeyOptional_setWithKey" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8id0I" role="1SKRRt">
+      <node concept="2$GdB6" id="2NSuNu8id0J" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithKeyOptional_setWithoutKey" />
+        <property role="2$GdYh" value="2NSuNu8iabQ/literalWithoutKey" />
+        <property role="2$GdYF" value="2NSuNu8iai6/literalWithoutKey" />
+        <node concept="3xLA65" id="2NSuNu8id0K" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithKeyOptional_setWithoutKey" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8id9u" role="1SKRRt">
+      <node concept="2$GdYp" id="2NSuNu8idgd" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithKeyRequired_unset" />
+        <node concept="3xLA65" id="2NSuNu8idpJ" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithKeyRequired_unset" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8idpL" role="1SKRRt">
+      <node concept="2$GdYp" id="2NSuNu8idpM" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithKeyRequired_setWithKey" />
+        <property role="2$GdY6" value="2NSuNu8iai9/literalWithKey" />
+        <property role="2$GdY4" value="2NSuNu8iabP/literalWithKey" />
+        <node concept="3xLA65" id="2NSuNu8idpN" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithKeyRequired_setWithKey" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8idq3" role="1SKRRt">
+      <node concept="2$GdYp" id="2NSuNu8idq4" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithKeyRequired_setWithoutKey" />
+        <property role="2$GdYo" value="2NSuNu8iai6/literalWithoutKey" />
+        <property role="2$GdY4" value="2NSuNu8iabQ/literalWithoutKey" />
+        <node concept="3xLA65" id="2NSuNu8idq5" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithKeyRequired_setWithoutKey" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8ilTv" role="1SKRRt">
+      <node concept="2$GjKe" id="2NSuNu8ilZ_" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithKeyUnset_unset" />
+        <node concept="3xLA65" id="2NSuNu8im7L" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithKeyUnset_unset" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8im7N" role="1SKRRt">
+      <node concept="2$GjKe" id="2NSuNu8im7O" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithKeyUnset_setWithKey" />
+        <property role="2$GjKb" value="2NSuNu8iai9/literalWithKey" />
+        <property role="2$GjK9" value="2NSuNu8iabP/literalWithKey" />
+        <node concept="3xLA65" id="2NSuNu8im7P" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithKeyUnset_setWithKey" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8im8w" role="1SKRRt">
+      <node concept="2$GjKe" id="2NSuNu8im8x" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithKeyUnset_setWithoutKey" />
+        <property role="2$GjKd" value="2NSuNu8iai6/literalWithoutKey" />
+        <property role="2$GjK9" value="2NSuNu8iabQ/literalWithoutKey" />
+        <node concept="3xLA65" id="2NSuNu8im8y" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithKeyUnset_setWithoutKey" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8iaY0" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithKeyOptional_unset" />
+      <node concept="3cqZAl" id="2NSuNu8iaY1" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8iaY2" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8nRO0" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8nRNY" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8nRNZ" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8nRNX" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8nRNS" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8nShK" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8icU1" resolve="EnumHostWithKeyOptional_unset" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8nSrr" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithKeyOptional_unset.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8omQh" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithKeyOptional_setWithKey" />
+      <node concept="3cqZAl" id="2NSuNu8omQi" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8omQj" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8omQk" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8omQl" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8omQm" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8omQn" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8nRNS" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8omQo" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8icU5" resolve="EnumHostWithKeyOptional_setWithKey" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8omQp" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithKeyOptional_setWithKey.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8omUT" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithKeyOptional_setWithoutKey" />
+      <node concept="3cqZAl" id="2NSuNu8omUU" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8omUV" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8omUW" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8omUX" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8omUY" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8omUZ" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8nRNS" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8omV0" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8id0K" resolve="EnumHostWithKeyOptional_setWithoutKey" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8omV1" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithKeyOptional_setWithoutKey.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8on01" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithKeyRequired_unset" />
+      <node concept="3cqZAl" id="2NSuNu8on02" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8on03" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8on04" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8on05" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8on06" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8on07" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8nRNS" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8on08" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8idpJ" resolve="EnumHostWithKeyRequired_unset" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8on09" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithKeyRequired_unset.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8omZS" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithKeyRequired_setWithKey" />
+      <node concept="3cqZAl" id="2NSuNu8omZT" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8omZU" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8omZV" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8omZW" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8omZX" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8omZY" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8nRNS" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8omZZ" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8idpN" resolve="EnumHostWithKeyRequired_setWithKey" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8on00" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithKeyRequired_setWithKey.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8omZJ" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithKeyRequired_setWithoutKey" />
+      <node concept="3cqZAl" id="2NSuNu8omZK" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8omZL" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8omZM" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8omZN" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8omZO" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8omZP" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8nRNS" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8omZQ" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8idq5" resolve="EnumHostWithKeyRequired_setWithoutKey" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8omZR" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithKeyRequired_setWithoutKey.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8onz7" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithKeyUnset_unset" />
+      <node concept="3cqZAl" id="2NSuNu8onz8" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8onz9" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8onza" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8onzb" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8onzc" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8onzd" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8nRNS" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8onze" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8im7L" resolve="EnumHostWithKeyUnset_unset" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8onzf" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithKeyUnset_unset.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8onyY" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithKeyUnset_setWithKey" />
+      <node concept="3cqZAl" id="2NSuNu8onyZ" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8onz0" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8onz1" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8onz2" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8onz3" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8onz4" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8nRNS" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8onz5" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8im7P" resolve="EnumHostWithKeyUnset_setWithKey" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8onz6" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithKeyUnset_setWithKey.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8onyP" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithKeyUnset_setWithoutKey" />
+      <node concept="3cqZAl" id="2NSuNu8onyQ" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8onyR" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8onyS" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8onyT" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8onyU" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8onyV" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8nRNS" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8onyW" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8im8y" resolve="EnumHostWithKeyUnset_setWithoutKey" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8onyX" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithKeyUnset_setWithoutKey.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2XrIbr" id="2NSuNu8nRNS" role="1qtyYc">
+      <property role="TrG5h" value="assertEnum" />
+      <node concept="3Tm6S6" id="2NSuNu8nRNT" role="1B3o_S" />
+      <node concept="3cqZAl" id="2NSuNu8nRNU" role="3clF45" />
+      <node concept="37vLTG" id="2NSuNu8nRNG" role="3clF46">
+        <property role="TrG5h" value="host" />
+        <node concept="3Tqbb2" id="2NSuNu8nRNH" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="2NSuNu8nRNI" role="3clF46">
+        <property role="TrG5h" value="file" />
+        <node concept="17QB3L" id="2NSuNu8nRNJ" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="2NSuNu8nRMg" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8nRMh" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8nRMi" role="3clFbG">
+            <node concept="37vLTw" id="2NSuNu8nRNM" role="2Oq$k0">
+              <ref role="3cqZAo" node="2NSuNu8nRNG" resolve="host" />
+            </node>
+            <node concept="3YRAZt" id="2NSuNu8nRMk" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="2NSuNu8nRMl" role="3cqZAp" />
+        <node concept="3cpWs8" id="2NSuNu8nRMm" role="3cqZAp">
+          <node concept="3cpWsn" id="2NSuNu8nRMn" role="3cpWs9">
+            <property role="TrG5h" value="converter" />
+            <node concept="3uibUv" id="2NSuNu8nRMo" role="1tU5fm">
+              <ref role="3uigEE" to="6peh:6jI_U5eOO9F" resolve="M1ToJson" />
+            </node>
+            <node concept="2ShNRf" id="2NSuNu8nRMp" role="33vP2m">
+              <node concept="1pGfFk" id="2NSuNu8nRMq" role="2ShVmc">
+                <ref role="37wK5l" to="6peh:5lijfVJTSc9" resolve="M1ToJson" />
+                <node concept="2OqwBi" id="2NSuNu8nRMr" role="37wK5m">
+                  <node concept="1jGwE1" id="2NSuNu8nRMs" role="2Oq$k0" />
+                  <node concept="liA8E" id="2NSuNu8nRMt" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="2NSuNu8nRMu" role="37wK5m">
+                  <node concept="2HTt$P" id="2NSuNu8nRMv" role="2ShVmc">
+                    <node concept="3uibUv" id="2NSuNu8nRMw" role="2HTBi0">
+                      <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                    </node>
+                    <node concept="37vLTw" id="2NSuNu8nRNL" role="2HTEbv">
+                      <ref role="3cqZAo" node="2NSuNu8nRNG" resolve="host" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2NSuNu8nRMy" role="3cqZAp" />
+        <node concept="3cpWs8" id="2NSuNu8nRMz" role="3cqZAp">
+          <node concept="3KEzu6" id="2NSuNu8nRM$" role="3cpWs9">
+            <property role="TrG5h" value="nodes" />
+            <node concept="2OqwBi" id="2NSuNu8nRM_" role="33vP2m">
+              <node concept="2OqwBi" id="2NSuNu8nRMA" role="2Oq$k0">
+                <node concept="37vLTw" id="2NSuNu8nRMB" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2NSuNu8nRMn" resolve="converter" />
+                </node>
+                <node concept="liA8E" id="2NSuNu8nRMC" role="2OqNvi">
+                  <ref role="37wK5l" to="6peh:6jI_U5eOR8U" resolve="convert" />
+                  <node concept="Rm8GO" id="2NSuNu8nRMD" role="37wK5m">
+                    <ref role="1Px2BO" to="6peh:6jI_U5eOQFV" resolve="M1ToJson.Scope" />
+                    <ref role="Rm8GQ" to="6peh:6jI_U5eOQOm" resolve="closure" />
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="2NSuNu8nRME" role="2OqNvi" />
+            </node>
+            <node concept="PeGgZ" id="2NSuNu8nRMF" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="2NSuNu8nRMG" role="3cqZAp">
+          <node concept="3cmrfG" id="2NSuNu8nRMH" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+          <node concept="2OqwBi" id="2NSuNu8nRMI" role="3tpDZA">
+            <node concept="37vLTw" id="2NSuNu8nRMJ" role="2Oq$k0">
+              <ref role="3cqZAo" node="2NSuNu8nRM$" resolve="nodes" />
+            </node>
+            <node concept="34oBXx" id="2NSuNu8nRMK" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="2NSuNu8nRML" role="3cqZAp" />
+        <node concept="3cpWs8" id="2NSuNu8nRMM" role="3cqZAp">
+          <node concept="3cpWsn" id="2NSuNu8nRMN" role="3cpWs9">
+            <property role="TrG5h" value="comparer" />
+            <node concept="3uibUv" id="2NSuNu8nRMO" role="1tU5fm">
+              <ref role="3uigEE" to="kte7:5lijfVJWAoN" resolve="M1JsonComparer" />
+            </node>
+            <node concept="2ShNRf" id="2NSuNu8nRMP" role="33vP2m">
+              <node concept="1pGfFk" id="2NSuNu8nRMQ" role="2ShVmc">
+                <ref role="37wK5l" to="kte7:5lijfVJWApT" resolve="M1JsonComparer" />
+                <node concept="37vLTw" id="2NSuNu8nRNN" role="37wK5m">
+                  <ref role="3cqZAo" node="2NSuNu8nRNI" resolve="file" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2NSuNu8nRMS" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8nRMT" role="3clFbG">
+            <node concept="37vLTw" id="2NSuNu8nRMU" role="2Oq$k0">
+              <ref role="3cqZAo" node="2NSuNu8nRMN" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="2NSuNu8nRMV" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:5lijfVJWADj" resolve="replaceId" />
+              <node concept="37vLTw" id="2NSuNu8nRNK" role="37wK5m">
+                <ref role="3cqZAo" node="2NSuNu8nRNG" resolve="host" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8nRMX" role="37wK5m">
+                <property role="Xl_RC" value="{id-host}" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2NSuNu8nRMY" role="3cqZAp" />
+        <node concept="2Gpval" id="2NSuNu8nRMZ" role="3cqZAp">
+          <node concept="2GrKxI" id="2NSuNu8nRN0" role="2Gsz3X">
+            <property role="TrG5h" value="prop" />
+          </node>
+          <node concept="3clFbS" id="2NSuNu8nRN1" role="2LFqv$">
+            <node concept="3clFbF" id="2NSuNu8nRN2" role="3cqZAp">
+              <node concept="2OqwBi" id="2NSuNu8nRN3" role="3clFbG">
+                <node concept="37vLTw" id="2NSuNu8nRN4" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2NSuNu8nRMN" resolve="comparer" />
+                </node>
+                <node concept="liA8E" id="2NSuNu8nRN5" role="2OqNvi">
+                  <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+                  <node concept="37vLTw" id="2NSuNu8nRNP" role="37wK5m">
+                    <ref role="3cqZAo" node="2NSuNu8nRNG" resolve="host" />
+                  </node>
+                  <node concept="2YIFZM" id="2NSuNu8nRN7" role="37wK5m">
+                    <ref role="1Pybhc" to="apzt:2fx6VTSzhNf" resolve="IdEncoder" />
+                    <ref role="37wK5l" to="apzt:2fx6VTSziaY" resolve="toLionWeb" />
+                    <node concept="2OqwBi" id="2NSuNu8nRN8" role="37wK5m">
+                      <node concept="2GrUjf" id="2NSuNu8nRN9" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="2NSuNu8nRN0" resolve="prop" />
+                      </node>
+                      <node concept="liA8E" id="2NSuNu8nRNa" role="2OqNvi">
+                        <ref role="37wK5l" to="pwx:~SPropertyAdapter.getId()" resolve="getId" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="2NSuNu8nRNb" role="2GsD0m">
+            <node concept="2OqwBi" id="2NSuNu8nRNc" role="2Oq$k0">
+              <node concept="1eOMI4" id="2NSuNu8nRNd" role="2Oq$k0">
+                <node concept="10QFUN" id="2NSuNu8nRNe" role="1eOMHV">
+                  <node concept="2OqwBi" id="2NSuNu8nRNf" role="10QFUP">
+                    <node concept="2OqwBi" id="2NSuNu8nRNg" role="2Oq$k0">
+                      <node concept="37vLTw" id="2NSuNu8nRNO" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2NSuNu8nRNG" resolve="host" />
+                      </node>
+                      <node concept="2yIwOk" id="2NSuNu8nRNi" role="2OqNvi" />
+                    </node>
+                    <node concept="liA8E" id="2NSuNu8nRNj" role="2OqNvi">
+                      <ref role="37wK5l" to="c17a:~SAbstractConcept.getProperties()" resolve="getProperties" />
+                    </node>
+                  </node>
+                  <node concept="A3Dl8" id="2NSuNu8nRNk" role="10QFUM">
+                    <node concept="3uibUv" id="2NSuNu8nRNl" role="A3Ik2">
+                      <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3zZkjj" id="2NSuNu8nRNm" role="2OqNvi">
+                <node concept="1bVj0M" id="2NSuNu8nRNn" role="23t8la">
+                  <node concept="3clFbS" id="2NSuNu8nRNo" role="1bW5cS">
+                    <node concept="3clFbF" id="2NSuNu8nRNp" role="3cqZAp">
+                      <node concept="2ZW3vV" id="2NSuNu8nRNq" role="3clFbG">
+                        <node concept="3uibUv" id="2NSuNu8nRNr" role="2ZW6by">
+                          <ref role="3uigEE" to="c17a:~SEnumeration" resolve="SEnumeration" />
+                        </node>
+                        <node concept="2OqwBi" id="2NSuNu8nRNs" role="2ZW6bz">
+                          <node concept="37vLTw" id="2NSuNu8nRNt" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2NSuNu8nRNv" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="2NSuNu8nRNu" role="2OqNvi">
+                            <ref role="37wK5l" to="c17a:~SProperty.getType()" resolve="getType" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="2NSuNu8nRNv" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="2NSuNu8nRNw" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="UnYns" id="2NSuNu8nRNx" role="2OqNvi">
+              <node concept="3uibUv" id="2NSuNu8nRNy" role="UnYnz">
+                <ref role="3uigEE" to="pwx:~SPropertyAdapter" resolve="SPropertyAdapter" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2NSuNu8nRNz" role="3cqZAp" />
+        <node concept="3clFbF" id="2NSuNu8nRN$" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8nRN_" role="3clFbG">
+            <node concept="37vLTw" id="2NSuNu8nRNA" role="2Oq$k0">
+              <ref role="3cqZAo" node="2NSuNu8nRMN" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="2NSuNu8nRNB" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:5TNjoy25t5T" resolve="assertSortedEquals" />
+              <node concept="37vLTw" id="2NSuNu8nRNC" role="37wK5m">
+                <ref role="3cqZAo" node="2NSuNu8nRM$" resolve="nodes" />
+              </node>
+              <node concept="2OqwBi" id="2NSuNu8nRND" role="37wK5m">
+                <node concept="37vLTw" id="2NSuNu8nRNE" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2NSuNu8nRMn" resolve="converter" />
+                </node>
+                <node concept="liA8E" id="2NSuNu8nRNF" role="2OqNvi">
+                  <ref role="37wK5l" to="6peh:5glO5qKYIk9" resolve="getLanguages" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="2NSuNu8imzk">
+    <property role="TrG5h" value="enumLiterals_WithoutKey" />
+    <node concept="1LZb2c" id="2NSuNu8pwzn" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithoutKeyOptional_unset" />
+      <node concept="3cqZAl" id="2NSuNu8pwzo" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8pwzp" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8pwzq" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8pwzr" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8pwzs" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8pwzt" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8pw8y" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8pwzu" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8imzM" resolve="EnumHostWithoutKeyOptional_unset" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8pwzv" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithoutKeyOptional_unset.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8pwzw" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithoutKeyOptional_setWithKey" />
+      <node concept="3cqZAl" id="2NSuNu8pwzx" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8pwzy" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8pwzz" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8pwz$" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8pwz_" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8pwzA" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8pw8y" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8pwzB" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8imzP" resolve="EnumHostWithoutKeyOptional_setWithKey" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8pwzC" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithoutKeyOptional_setWithKey.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8pwzD" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithoutKeyOptional_setWithoutKey" />
+      <node concept="3cqZAl" id="2NSuNu8pwzE" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8pwzF" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8pwzG" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8pwzH" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8pwzI" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8pwzJ" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8pw8y" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8pwzK" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8imzS" resolve="EnumHostWithoutKeyOptional_setWithoutKey" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8pwzL" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithoutKeyOptional_setWithoutKey.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8pwzM" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithoutKeyRequired_unset" />
+      <node concept="3cqZAl" id="2NSuNu8pwzN" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8pwzO" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8pwzP" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8pwzQ" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8pwzR" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8pwzS" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8pw8y" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8pwzT" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8imzV" resolve="EnumHostWithoutKeyRequired_unset" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8pwzU" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithoutKeyRequired_unset.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8pwzV" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithoutKeyRequired_setWithKey" />
+      <node concept="3cqZAl" id="2NSuNu8pwzW" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8pwzX" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8pwzY" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8pwzZ" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8pw$0" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8pw$1" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8pw8y" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8pw$2" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8imzY" resolve="EnumHostWithoutKeyRequired_setWithKey" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8pw$3" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithoutKeyRequired_setWithKey.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8pw$4" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithoutKeyRequired_setWithoutKey" />
+      <node concept="3cqZAl" id="2NSuNu8pw$5" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8pw$6" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8pw$7" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8pw$8" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8pw$9" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8pw$a" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8pw8y" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8pw$b" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8im$1" resolve="EnumHostWithoutKeyRequired_setWithoutKey" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8pw$c" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithoutKeyRequired_setWithoutKey.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8pw$d" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithoutKeyUnset_unset" />
+      <node concept="3cqZAl" id="2NSuNu8pw$e" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8pw$f" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8pw$g" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8pw$h" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8pw$i" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8pw$j" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8pw8y" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8pw$k" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8ipOP" resolve="EnumHostWithoutKeyUnset_unset" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8pw$l" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithoutKeyUnset_unset.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8pw$m" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithoutKeyUnset_setWithKey" />
+      <node concept="3cqZAl" id="2NSuNu8pw$n" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8pw$o" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8pw$p" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8pw$q" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8pw$r" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8pw$s" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8pw8y" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8pw$t" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8ipOT" resolve="EnumHostWithoutKeyUnset_setWithKey" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8pw$u" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithoutKeyUnset_setWithKey.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2NSuNu8pw$v" role="1SL9yI">
+      <property role="TrG5h" value="EnumHostWithoutKeyUnset_setWithoutKey" />
+      <node concept="3cqZAl" id="2NSuNu8pw$w" role="3clF45" />
+      <node concept="3clFbS" id="2NSuNu8pw$x" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8pw$y" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8pw$z" role="3clFbG">
+            <node concept="2WthIp" id="2NSuNu8pw$$" role="2Oq$k0" />
+            <node concept="2XshWL" id="2NSuNu8pw$_" role="2OqNvi">
+              <ref role="2WH_rO" node="2NSuNu8pw8y" resolve="assertEnum" />
+              <node concept="3xONca" id="2NSuNu8pw$A" role="2XxRq1">
+                <ref role="3xOPvv" node="2NSuNu8ipUM" resolve="EnumHostWithoutKeyUnset_setWithoutKey" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8pw$B" role="2XxRq1">
+                <property role="Xl_RC" value="enumLiterals-EnumHostWithoutKeyUnset_setWithoutKey.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2XrIbr" id="2NSuNu8pw8y" role="1qtyYc">
+      <property role="TrG5h" value="assertEnum" />
+      <node concept="3Tm6S6" id="2NSuNu8pw8z" role="1B3o_S" />
+      <node concept="3cqZAl" id="2NSuNu8pw8$" role="3clF45" />
+      <node concept="37vLTG" id="2NSuNu8pw8_" role="3clF46">
+        <property role="TrG5h" value="host" />
+        <node concept="3Tqbb2" id="2NSuNu8pw8A" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="2NSuNu8pw8B" role="3clF46">
+        <property role="TrG5h" value="file" />
+        <node concept="17QB3L" id="2NSuNu8pw8C" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="2NSuNu8pw8D" role="3clF47">
+        <node concept="3clFbF" id="2NSuNu8pw8E" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8pw8F" role="3clFbG">
+            <node concept="37vLTw" id="2NSuNu8pw8G" role="2Oq$k0">
+              <ref role="3cqZAo" node="2NSuNu8pw8_" resolve="host" />
+            </node>
+            <node concept="3YRAZt" id="2NSuNu8pw8H" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="2NSuNu8pw8I" role="3cqZAp" />
+        <node concept="3cpWs8" id="2NSuNu8pw8J" role="3cqZAp">
+          <node concept="3cpWsn" id="2NSuNu8pw8K" role="3cpWs9">
+            <property role="TrG5h" value="converter" />
+            <node concept="3uibUv" id="2NSuNu8pw8L" role="1tU5fm">
+              <ref role="3uigEE" to="6peh:6jI_U5eOO9F" resolve="M1ToJson" />
+            </node>
+            <node concept="2ShNRf" id="2NSuNu8pw8M" role="33vP2m">
+              <node concept="1pGfFk" id="2NSuNu8pw8N" role="2ShVmc">
+                <ref role="37wK5l" to="6peh:5lijfVJTSc9" resolve="M1ToJson" />
+                <node concept="2OqwBi" id="2NSuNu8pw8O" role="37wK5m">
+                  <node concept="1jGwE1" id="2NSuNu8pw8P" role="2Oq$k0" />
+                  <node concept="liA8E" id="2NSuNu8pw8Q" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="2NSuNu8pw8R" role="37wK5m">
+                  <node concept="2HTt$P" id="2NSuNu8pw8S" role="2ShVmc">
+                    <node concept="3uibUv" id="2NSuNu8pw8T" role="2HTBi0">
+                      <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                    </node>
+                    <node concept="37vLTw" id="2NSuNu8pw8U" role="2HTEbv">
+                      <ref role="3cqZAo" node="2NSuNu8pw8_" resolve="host" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2NSuNu8pw8V" role="3cqZAp" />
+        <node concept="3cpWs8" id="2NSuNu8pw8W" role="3cqZAp">
+          <node concept="3KEzu6" id="2NSuNu8pw8X" role="3cpWs9">
+            <property role="TrG5h" value="nodes" />
+            <node concept="2OqwBi" id="2NSuNu8pw8Y" role="33vP2m">
+              <node concept="2OqwBi" id="2NSuNu8pw8Z" role="2Oq$k0">
+                <node concept="37vLTw" id="2NSuNu8pw90" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2NSuNu8pw8K" resolve="converter" />
+                </node>
+                <node concept="liA8E" id="2NSuNu8pw91" role="2OqNvi">
+                  <ref role="37wK5l" to="6peh:6jI_U5eOR8U" resolve="convert" />
+                  <node concept="Rm8GO" id="2NSuNu8pw92" role="37wK5m">
+                    <ref role="1Px2BO" to="6peh:6jI_U5eOQFV" resolve="M1ToJson.Scope" />
+                    <ref role="Rm8GQ" to="6peh:6jI_U5eOQOm" resolve="closure" />
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="2NSuNu8pw93" role="2OqNvi" />
+            </node>
+            <node concept="PeGgZ" id="2NSuNu8pw94" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="2NSuNu8pw95" role="3cqZAp">
+          <node concept="3cmrfG" id="2NSuNu8pw96" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+          <node concept="2OqwBi" id="2NSuNu8pw97" role="3tpDZA">
+            <node concept="37vLTw" id="2NSuNu8pw98" role="2Oq$k0">
+              <ref role="3cqZAo" node="2NSuNu8pw8X" resolve="nodes" />
+            </node>
+            <node concept="34oBXx" id="2NSuNu8pw99" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="2NSuNu8pw9a" role="3cqZAp" />
+        <node concept="3cpWs8" id="2NSuNu8pw9b" role="3cqZAp">
+          <node concept="3cpWsn" id="2NSuNu8pw9c" role="3cpWs9">
+            <property role="TrG5h" value="comparer" />
+            <node concept="3uibUv" id="2NSuNu8pw9d" role="1tU5fm">
+              <ref role="3uigEE" to="kte7:5lijfVJWAoN" resolve="M1JsonComparer" />
+            </node>
+            <node concept="2ShNRf" id="2NSuNu8pw9e" role="33vP2m">
+              <node concept="1pGfFk" id="2NSuNu8pw9f" role="2ShVmc">
+                <ref role="37wK5l" to="kte7:5lijfVJWApT" resolve="M1JsonComparer" />
+                <node concept="37vLTw" id="2NSuNu8pw9g" role="37wK5m">
+                  <ref role="3cqZAo" node="2NSuNu8pw8B" resolve="file" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2NSuNu8pw9h" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8pw9i" role="3clFbG">
+            <node concept="37vLTw" id="2NSuNu8pw9j" role="2Oq$k0">
+              <ref role="3cqZAo" node="2NSuNu8pw9c" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="2NSuNu8pw9k" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:5lijfVJWADj" resolve="replaceId" />
+              <node concept="37vLTw" id="2NSuNu8pw9l" role="37wK5m">
+                <ref role="3cqZAo" node="2NSuNu8pw8_" resolve="host" />
+              </node>
+              <node concept="Xl_RD" id="2NSuNu8pw9m" role="37wK5m">
+                <property role="Xl_RC" value="{id-host}" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2NSuNu8pw9n" role="3cqZAp" />
+        <node concept="2Gpval" id="2NSuNu8pw9o" role="3cqZAp">
+          <node concept="2GrKxI" id="2NSuNu8pw9p" role="2Gsz3X">
+            <property role="TrG5h" value="prop" />
+          </node>
+          <node concept="3clFbS" id="2NSuNu8pw9q" role="2LFqv$">
+            <node concept="3clFbF" id="2NSuNu8pw9r" role="3cqZAp">
+              <node concept="2OqwBi" id="2NSuNu8pw9s" role="3clFbG">
+                <node concept="37vLTw" id="2NSuNu8pw9t" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2NSuNu8pw9c" resolve="comparer" />
+                </node>
+                <node concept="liA8E" id="2NSuNu8pw9u" role="2OqNvi">
+                  <ref role="37wK5l" to="kte7:6LPkCA_kqpj" resolve="assertEnumLiteralId" />
+                  <node concept="37vLTw" id="2NSuNu8pw9v" role="37wK5m">
+                    <ref role="3cqZAo" node="2NSuNu8pw8_" resolve="host" />
+                  </node>
+                  <node concept="2YIFZM" id="2NSuNu8pw9w" role="37wK5m">
+                    <ref role="1Pybhc" to="apzt:2fx6VTSzhNf" resolve="IdEncoder" />
+                    <ref role="37wK5l" to="apzt:2fx6VTSziaY" resolve="toLionWeb" />
+                    <node concept="2OqwBi" id="2NSuNu8pw9x" role="37wK5m">
+                      <node concept="2GrUjf" id="2NSuNu8pw9y" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="2NSuNu8pw9p" resolve="prop" />
+                      </node>
+                      <node concept="liA8E" id="2NSuNu8pw9z" role="2OqNvi">
+                        <ref role="37wK5l" to="pwx:~SPropertyAdapter.getId()" resolve="getId" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="2NSuNu8pw9$" role="2GsD0m">
+            <node concept="2OqwBi" id="2NSuNu8pw9_" role="2Oq$k0">
+              <node concept="1eOMI4" id="2NSuNu8pw9A" role="2Oq$k0">
+                <node concept="10QFUN" id="2NSuNu8pw9B" role="1eOMHV">
+                  <node concept="2OqwBi" id="2NSuNu8pw9C" role="10QFUP">
+                    <node concept="2OqwBi" id="2NSuNu8pw9D" role="2Oq$k0">
+                      <node concept="37vLTw" id="2NSuNu8pw9E" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2NSuNu8pw8_" resolve="host" />
+                      </node>
+                      <node concept="2yIwOk" id="2NSuNu8pw9F" role="2OqNvi" />
+                    </node>
+                    <node concept="liA8E" id="2NSuNu8pw9G" role="2OqNvi">
+                      <ref role="37wK5l" to="c17a:~SAbstractConcept.getProperties()" resolve="getProperties" />
+                    </node>
+                  </node>
+                  <node concept="A3Dl8" id="2NSuNu8pw9H" role="10QFUM">
+                    <node concept="3uibUv" id="2NSuNu8pw9I" role="A3Ik2">
+                      <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3zZkjj" id="2NSuNu8pw9J" role="2OqNvi">
+                <node concept="1bVj0M" id="2NSuNu8pw9K" role="23t8la">
+                  <node concept="3clFbS" id="2NSuNu8pw9L" role="1bW5cS">
+                    <node concept="3clFbF" id="2NSuNu8pw9M" role="3cqZAp">
+                      <node concept="2ZW3vV" id="2NSuNu8pw9N" role="3clFbG">
+                        <node concept="3uibUv" id="2NSuNu8pw9O" role="2ZW6by">
+                          <ref role="3uigEE" to="c17a:~SEnumeration" resolve="SEnumeration" />
+                        </node>
+                        <node concept="2OqwBi" id="2NSuNu8pw9P" role="2ZW6bz">
+                          <node concept="37vLTw" id="2NSuNu8pw9Q" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2NSuNu8pw9S" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="2NSuNu8pw9R" role="2OqNvi">
+                            <ref role="37wK5l" to="c17a:~SProperty.getType()" resolve="getType" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="2NSuNu8pw9S" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="2NSuNu8pw9T" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="UnYns" id="2NSuNu8pw9U" role="2OqNvi">
+              <node concept="3uibUv" id="2NSuNu8pw9V" role="UnYnz">
+                <ref role="3uigEE" to="pwx:~SPropertyAdapter" resolve="SPropertyAdapter" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2NSuNu8pw9W" role="3cqZAp" />
+        <node concept="3clFbF" id="2NSuNu8pw9X" role="3cqZAp">
+          <node concept="2OqwBi" id="2NSuNu8pw9Y" role="3clFbG">
+            <node concept="37vLTw" id="2NSuNu8pw9Z" role="2Oq$k0">
+              <ref role="3cqZAo" node="2NSuNu8pw9c" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="2NSuNu8pwa0" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:5TNjoy25t5T" resolve="assertSortedEquals" />
+              <node concept="37vLTw" id="2NSuNu8pwa1" role="37wK5m">
+                <ref role="3cqZAo" node="2NSuNu8pw8X" resolve="nodes" />
+              </node>
+              <node concept="2OqwBi" id="2NSuNu8pwa2" role="37wK5m">
+                <node concept="37vLTw" id="2NSuNu8pwa3" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2NSuNu8pw8K" resolve="converter" />
+                </node>
+                <node concept="liA8E" id="2NSuNu8pwa4" role="2OqNvi">
+                  <ref role="37wK5l" to="6peh:5glO5qKYIk9" resolve="getLanguages" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8imzK" role="1SKRRt">
+      <node concept="2$GdY1" id="2NSuNu8imzL" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithoutKeyOptional_unset" />
+        <node concept="3xLA65" id="2NSuNu8imzM" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithoutKeyOptional_unset" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8imzN" role="1SKRRt">
+      <node concept="2$GdY1" id="2NSuNu8imzO" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithoutKeyOptional_setWithKey" />
+        <property role="2$GdYe" value="2NSuNu8iaij/literalWithKey" />
+        <property role="2$GdYc" value="2NSuNu8iaio/literalWithKey" />
+        <node concept="3xLA65" id="2NSuNu8imzP" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithoutKeyOptional_setWithKey" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8imzQ" role="1SKRRt">
+      <node concept="2$GdY1" id="2NSuNu8imzR" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithoutKeyOptional_setWithoutKey" />
+        <property role="2$GdY0" value="2NSuNu8iaig/literalWithoutKey" />
+        <property role="2$GdYc" value="2NSuNu8iaiq/literalWithoutKey" />
+        <node concept="3xLA65" id="2NSuNu8imzS" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithoutKeyOptional_setWithoutKey" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8imzT" role="1SKRRt">
+      <node concept="2$GdY9" id="2NSuNu8imzU" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithoutKeyRequired_unset" />
+        <node concept="3xLA65" id="2NSuNu8imzV" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithoutKeyRequired_unset" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8imzW" role="1SKRRt">
+      <node concept="2$GdY9" id="2NSuNu8imzX" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithoutKeyRequired_setWithKey" />
+        <property role="2$GdZQ" value="2NSuNu8iaij/literalWithKey" />
+        <property role="2$GdZO" value="2NSuNu8iaio/literalWithKey" />
+        <node concept="3xLA65" id="2NSuNu8imzY" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithoutKeyRequired_setWithKey" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8imzZ" role="1SKRRt">
+      <node concept="2$GdY9" id="2NSuNu8im$0" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithoutKeyRequired_setWithoutKey" />
+        <property role="2$GdY8" value="2NSuNu8iaig/literalWithoutKey" />
+        <property role="2$GdZO" value="2NSuNu8iaiq/literalWithoutKey" />
+        <node concept="3xLA65" id="2NSuNu8im$1" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithoutKeyRequired_setWithoutKey" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8ipqC" role="1SKRRt">
+      <node concept="2$GjLY" id="2NSuNu8ipws" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithoutKeyUnset_unset" />
+        <node concept="3xLA65" id="2NSuNu8ipOP" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithoutKeyUnset_unset" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8ipOR" role="1SKRRt">
+      <node concept="2$GjLY" id="2NSuNu8ipOS" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithoutKeyUnset_setWithKey" />
+        <property role="2$GjLV" value="2NSuNu8iaij/literalWithKey" />
+        <property role="2$GjLT" value="2NSuNu8iaio/literalWithKey" />
+        <node concept="3xLA65" id="2NSuNu8ipOT" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithoutKeyUnset_setWithKey" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2NSuNu8ipUK" role="1SKRRt">
+      <node concept="2$GjLY" id="2NSuNu8ipUL" role="1qenE9">
+        <property role="TrG5h" value="EnumHostWithoutKeyUnset_setWithoutKey" />
+        <property role="2$GjLX" value="2NSuNu8iaig/literalWithoutKey" />
+        <property role="2$GjLT" value="2NSuNu8iaiq/literalWithoutKey" />
+        <node concept="3xLA65" id="2NSuNu8ipUM" role="lGtFl">
+          <property role="TrG5h" value="EnumHostWithoutKeyUnset_setWithoutKey" />
         </node>
       </node>
     </node>

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2slanguage@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2slanguage@tests.mps
@@ -1046,6 +1046,172 @@
         </node>
       </node>
     </node>
+    <node concept="1LZb2c" id="6LPkCA$4vuE" role="1SL9yI">
+      <property role="TrG5h" value="MpsDeprecated" />
+      <node concept="3cqZAl" id="6LPkCA$4vuF" role="3clF45" />
+      <node concept="3clFbS" id="6LPkCA$4vuG" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA$4vuH" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA$4vuI" role="3clFbG">
+            <node concept="2WthIp" id="6LPkCA$4vuJ" role="2Oq$k0" />
+            <node concept="2XshWL" id="6LPkCA$4vuK" role="2OqNvi">
+              <ref role="2WH_rO" node="5M8g5cT6Owk" resolve="exportAnnotated" />
+              <node concept="pHN19" id="6LPkCA$4vuL" role="2XxRq1">
+                <node concept="2V$Bhx" id="6LPkCA$4vLP" role="2V$M_3">
+                  <property role="2V$B1T" value="09360184-8598-44e7-9bf5-fb1ce45a480a" />
+                  <property role="2V$B1Q" value="io.lionweb.mps.converter.TestDeprecated" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="6LPkCA$4vuN" role="2XxRq1">
+                <property role="Xl_RC" value="MpsDeprecated-metamodel.json" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6LPkCA$R_Iw" role="1SL9yI">
+      <property role="TrG5h" value="MpsDeprecatedSpecial" />
+      <node concept="3cqZAl" id="6LPkCA$R_Ix" role="3clF45" />
+      <node concept="3clFbS" id="6LPkCA$R_Iy" role="3clF47">
+        <node concept="3cpWs8" id="6LPkCA$RA8_" role="3cqZAp">
+          <node concept="3cpWsn" id="6LPkCA$RA8z" role="3cpWs9">
+            <property role="TrG5h" value="language" />
+            <node concept="3uibUv" id="6LPkCA$RA8$" role="1tU5fm">
+              <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+            </node>
+            <node concept="pHN19" id="6LPkCA$R_IB" role="33vP2m">
+              <node concept="2V$Bhx" id="6LPkCA$R_IC" role="2V$M_3">
+                <property role="2V$B1T" value="09360184-8598-44e7-9bf5-fb1ce45a480a" />
+                <property role="2V$B1Q" value="io.lionweb.mps.converter.TestDeprecated" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6LPkCA$RA7M" role="3cqZAp">
+          <node concept="3cpWsn" id="6LPkCA$RA7N" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6LPkCA$RA7O" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6LPkCA$RA7P" role="33vP2m">
+              <node concept="1jGwE1" id="6LPkCA$RA7Q" role="2Oq$k0" />
+              <node concept="liA8E" id="6LPkCA$RA7R" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6LPkCA$RA7S" role="3cqZAp">
+          <node concept="3cpWsn" id="6LPkCA$RA7T" role="3cpWs9">
+            <property role="TrG5h" value="converter" />
+            <node concept="3uibUv" id="6LPkCA$RA7U" role="1tU5fm">
+              <ref role="3uigEE" to="6peh:24j7TNH1_mG" resolve="M2ToJson" />
+            </node>
+            <node concept="2ShNRf" id="6LPkCA$RA7V" role="33vP2m">
+              <node concept="1pGfFk" id="6LPkCA$RA7W" role="2ShVmc">
+                <ref role="37wK5l" to="6peh:24j7TNH1A2A" resolve="M2ToJson" />
+                <node concept="37vLTw" id="6LPkCA$RA7X" role="37wK5m">
+                  <ref role="3cqZAo" node="6LPkCA$RA7N" resolve="repository" />
+                </node>
+                <node concept="2ShNRf" id="6LPkCA$RA7Y" role="37wK5m">
+                  <node concept="2HTt$P" id="6LPkCA$RA7Z" role="2ShVmc">
+                    <node concept="3uibUv" id="6LPkCA$RA80" role="2HTBi0">
+                      <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+                    </node>
+                    <node concept="37vLTw" id="6LPkCA$RA8B" role="2HTEbv">
+                      <ref role="3cqZAo" node="6LPkCA$RA8z" resolve="language" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA$RAym" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA$RAOm" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA$RAyk" role="2Oq$k0">
+              <ref role="3cqZAo" node="6LPkCA$RA7T" resolve="converter" />
+            </node>
+            <node concept="liA8E" id="6LPkCA$RBkM" role="2OqNvi">
+              <ref role="37wK5l" to="6peh:6LPkCA$Ryk5" resolve="setExportSpecialAnnotations" />
+              <node concept="3clFbT" id="6LPkCA$RByV" role="37wK5m">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6LPkCA$RA87" role="3cqZAp">
+          <node concept="3cpWsn" id="6LPkCA$RA88" role="3cpWs9">
+            <property role="TrG5h" value="languages" />
+            <node concept="A3Dl8" id="6LPkCA$RA89" role="1tU5fm">
+              <node concept="3uibUv" id="6LPkCA$RA8a" role="A3Ik2">
+                <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6LPkCA$RA8b" role="33vP2m">
+              <node concept="37vLTw" id="6LPkCA$RA8c" role="2Oq$k0">
+                <ref role="3cqZAo" node="6LPkCA$RA7T" resolve="converter" />
+              </node>
+              <node concept="liA8E" id="6LPkCA$RA8d" role="2OqNvi">
+                <ref role="37wK5l" to="6peh:24j7TNH1Bia" resolve="convert" />
+                <node concept="Rm8GO" id="6LPkCA$RA8e" role="37wK5m">
+                  <ref role="1Px2BO" to="6peh:24j7TNH1AVU" resolve="M2ToJson.Scope" />
+                  <ref role="Rm8GQ" to="6peh:24j7TNH1AVV" resolve="listed" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6LPkCA$RA8f" role="3cqZAp">
+          <node concept="3cmrfG" id="6LPkCA$RA8g" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+          <node concept="2OqwBi" id="6LPkCA$RA8h" role="3tpDZA">
+            <node concept="37vLTw" id="6LPkCA$RA8i" role="2Oq$k0">
+              <ref role="3cqZAo" node="6LPkCA$RA88" resolve="languages" />
+            </node>
+            <node concept="34oBXx" id="6LPkCA$RA8j" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6LPkCA$RA8k" role="3cqZAp">
+          <node concept="3cpWsn" id="6LPkCA$RA8l" role="3cpWs9">
+            <property role="TrG5h" value="comparer" />
+            <node concept="3uibUv" id="6LPkCA$RA8m" role="1tU5fm">
+              <ref role="3uigEE" to="kte7:24j7TNH2adn" resolve="M2JsonComparer" />
+            </node>
+            <node concept="2ShNRf" id="6LPkCA$RA8n" role="33vP2m">
+              <node concept="1pGfFk" id="6LPkCA$RA8o" role="2ShVmc">
+                <ref role="37wK5l" to="kte7:24j7TNH2adB" resolve="M2JsonComparer" />
+                <node concept="Xl_RD" id="6LPkCA$RC1i" role="37wK5m">
+                  <property role="Xl_RC" value="MpsDeprecated-metamodel-special.json" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA$RA8q" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA$RA8r" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA$RA8s" role="2Oq$k0">
+              <ref role="3cqZAo" node="6LPkCA$RA8l" resolve="comparer" />
+            </node>
+            <node concept="liA8E" id="6LPkCA$RA8t" role="2OqNvi">
+              <ref role="37wK5l" to="kte7:5TNjoy24N5P" resolve="assertSortedEquals" />
+              <node concept="37vLTw" id="6LPkCA$RA8u" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA$RA88" resolve="languages" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA$R_Iz" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA$RA8C" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA$RA8D" role="2Oq$k0">
+              <ref role="3cqZAo" node="6LPkCA$RA88" resolve="languages" />
+            </node>
+            <node concept="1uHKPH" id="6LPkCA$RA8E" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1lH9Xt" id="5sACIIszQ7U">
     <property role="TrG5h" value="importJson2SLanguage" />

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.metapointer@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.metapointer@tests.mps
@@ -575,6 +575,36 @@
         <ref role="3uigEE" to="pe0e:3Lj28wlz81B" resolve="IMetaPointerConverter" />
       </node>
       <node concept="3clFbS" id="KVKr66i7DD" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BoEwH2" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoEwH3" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6jbF0BoEwES" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0BoEwH4" role="33vP2m">
+              <node concept="1jGwE1" id="6jbF0BoEwH5" role="2Oq$k0" />
+              <node concept="liA8E" id="6jbF0BoEwH6" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6jbF0BoEwO6" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoEwO7" role="3cpWs9">
+            <property role="TrG5h" value="constants" />
+            <node concept="3uibUv" id="6jbF0BoEwMt" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:DUXtGZOlwJ" resolve="LionCoreConstants" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BoEwO8" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BoEwO9" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                <node concept="37vLTw" id="6jbF0BoEwOa" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BoEwH3" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="KVKr66i7EI" role="3cqZAp">
           <node concept="2ShNRf" id="KVKr66i7EG" role="3clFbG">
             <node concept="1pGfFk" id="KVKr66i7Qn" role="2ShVmc">
@@ -600,17 +630,25 @@
                   <node concept="2ShNRf" id="4r3Tp$pVmzN" role="37wK5m">
                     <node concept="1pGfFk" id="4r3Tp$pVmYi" role="2ShVmc">
                       <ref role="37wK5l" to="y7p:6VkSF6aIt83" resolve="SLanguageIdDeriver" />
-                      <node concept="2ShNRf" id="4r3Tp$pVamu" role="37wK5m">
-                        <node concept="1pGfFk" id="4r3Tp$pVamv" role="2ShVmc">
-                          <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
-                          <node concept="2OqwBi" id="4r3Tp$pVamw" role="37wK5m">
-                            <node concept="1jGwE1" id="4r3Tp$pVamx" role="2Oq$k0" />
-                            <node concept="liA8E" id="4r3Tp$pVamy" role="2OqNvi">
-                              <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-                            </node>
-                          </node>
-                        </node>
+                      <node concept="37vLTw" id="6jbF0BoEwOb" role="37wK5m">
+                        <ref role="3cqZAo" node="6jbF0BoEwO7" resolve="constants" />
                       </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2ShNRf" id="6jbF0BoExkq" role="37wK5m">
+                <node concept="1pGfFk" id="6jbF0BoExkr" role="2ShVmc">
+                  <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+                  <node concept="37vLTw" id="6jbF0BoExks" role="37wK5m">
+                    <ref role="3cqZAo" node="6jbF0BoEwH3" resolve="repository" />
+                  </node>
+                  <node concept="37vLTw" id="6jbF0BoExkt" role="37wK5m">
+                    <ref role="3cqZAo" node="6jbF0BoEwO7" resolve="constants" />
+                  </node>
+                  <node concept="2ShNRf" id="6jbF0BoExku" role="37wK5m">
+                    <node concept="HV5vD" id="6jbF0BoExkv" role="2ShVmc">
+                      <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
                     </node>
                   </node>
                 </node>
@@ -1286,6 +1324,36 @@
         <ref role="3uigEE" to="pe0e:3Lj28wlz81B" resolve="IMetaPointerConverter" />
       </node>
       <node concept="3clFbS" id="KVKr66sZ$X" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BoExAN" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoExAO" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6jbF0BoExyf" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0BoExAP" role="33vP2m">
+              <node concept="1jGwE1" id="6jbF0BoExAQ" role="2Oq$k0" />
+              <node concept="liA8E" id="6jbF0BoExAR" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6jbF0BoExI7" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoExI8" role="3cpWs9">
+            <property role="TrG5h" value="constants" />
+            <node concept="3uibUv" id="6jbF0BoExGu" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:DUXtGZOlwJ" resolve="LionCoreConstants" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BoExI9" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BoExIa" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                <node concept="37vLTw" id="6jbF0BoExIb" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BoExAO" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="KVKr66sZ$Y" role="3cqZAp">
           <node concept="2ShNRf" id="KVKr66sZ$Z" role="3clFbG">
             <node concept="1pGfFk" id="KVKr66sZ_0" role="2ShVmc">
@@ -1311,17 +1379,25 @@
                   <node concept="2ShNRf" id="4r3Tp$pVnpy" role="37wK5m">
                     <node concept="1pGfFk" id="4r3Tp$pVnpz" role="2ShVmc">
                       <ref role="37wK5l" to="y7p:6VkSF6aIt83" resolve="SLanguageIdDeriver" />
-                      <node concept="2ShNRf" id="4r3Tp$pVnp$" role="37wK5m">
-                        <node concept="1pGfFk" id="4r3Tp$pVnp_" role="2ShVmc">
-                          <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
-                          <node concept="2OqwBi" id="4r3Tp$pVnpA" role="37wK5m">
-                            <node concept="1jGwE1" id="4r3Tp$pVnpB" role="2Oq$k0" />
-                            <node concept="liA8E" id="4r3Tp$pVnpC" role="2OqNvi">
-                              <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-                            </node>
-                          </node>
-                        </node>
+                      <node concept="37vLTw" id="6jbF0BoExIc" role="37wK5m">
+                        <ref role="3cqZAo" node="6jbF0BoExI8" resolve="constants" />
                       </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2ShNRf" id="6jbF0BoExVx" role="37wK5m">
+                <node concept="1pGfFk" id="6jbF0BoExVy" role="2ShVmc">
+                  <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+                  <node concept="37vLTw" id="6jbF0BoExVz" role="37wK5m">
+                    <ref role="3cqZAo" node="6jbF0BoExAO" resolve="repository" />
+                  </node>
+                  <node concept="37vLTw" id="6jbF0BoExV$" role="37wK5m">
+                    <ref role="3cqZAo" node="6jbF0BoExI8" resolve="constants" />
+                  </node>
+                  <node concept="2ShNRf" id="6jbF0BoExV_" role="37wK5m">
+                    <node concept="HV5vD" id="6jbF0BoExVA" role="2ShVmc">
+                      <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
                     </node>
                   </node>
                 </node>
@@ -1549,7 +1625,7 @@
                     <property role="Xl_RC" value="My-TestLang3" />
                   </node>
                   <node concept="Xl_RD" id="68Be_yIKE0" role="37wK5m">
-                    <property role="Xl_RC" value="1" />
+                    <property role="Xl_RC" value="00 my! VERSION 😀" />
                   </node>
                   <node concept="10Nm6u" id="68Be_yIKFO" role="37wK5m" />
                 </node>
@@ -1583,7 +1659,7 @@
                     <property role="Xl_RC" value="My-TestLang3" />
                   </node>
                   <node concept="Xl_RD" id="68Be_yJBzE" role="37wK5m">
-                    <property role="Xl_RC" value="1" />
+                    <property role="Xl_RC" value="00 my! VERSION 😀" />
                   </node>
                   <node concept="Xl_RD" id="68Be_yJCY_" role="37wK5m">
                     <property role="Xl_RC" value="My-Test3ConceptBase" />
@@ -1953,6 +2029,36 @@
         <ref role="3uigEE" to="pe0e:5wsogBcpo49" resolve="IMetaPointerLookup" />
       </node>
       <node concept="3clFbS" id="68Be_yUR44" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BoEv$R" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoEv$S" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6jbF0BoEvyU" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0BoEv$T" role="33vP2m">
+              <node concept="1jGwE1" id="6jbF0BoEv$U" role="2Oq$k0" />
+              <node concept="liA8E" id="6jbF0BoEv$V" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6jbF0BoEvG5" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoEvG6" role="3cpWs9">
+            <property role="TrG5h" value="constants" />
+            <node concept="3uibUv" id="6jbF0BoEvEW" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:DUXtGZOlwJ" resolve="LionCoreConstants" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BoEvG7" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BoEvG8" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                <node concept="37vLTw" id="6jbF0BoEvG9" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BoEv$S" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="68Be_yURyl" role="3cqZAp">
           <node concept="2ShNRf" id="68Be_yURyh" role="3clFbG">
             <node concept="1pGfFk" id="68Be_yURQm" role="2ShVmc">
@@ -1981,17 +2087,25 @@
                       <node concept="2ShNRf" id="4r3Tp$pVpEC" role="37wK5m">
                         <node concept="1pGfFk" id="4r3Tp$pVpED" role="2ShVmc">
                           <ref role="37wK5l" to="y7p:6VkSF6aIt83" resolve="SLanguageIdDeriver" />
-                          <node concept="2ShNRf" id="4r3Tp$pVpEE" role="37wK5m">
-                            <node concept="1pGfFk" id="4r3Tp$pVpEF" role="2ShVmc">
-                              <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
-                              <node concept="2OqwBi" id="4r3Tp$pVpEG" role="37wK5m">
-                                <node concept="1jGwE1" id="4r3Tp$pVpEH" role="2Oq$k0" />
-                                <node concept="liA8E" id="4r3Tp$pVpEI" role="2OqNvi">
-                                  <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-                                </node>
-                              </node>
-                            </node>
+                          <node concept="37vLTw" id="6jbF0BoEvGa" role="37wK5m">
+                            <ref role="3cqZAo" node="6jbF0BoEvG6" resolve="constants" />
                           </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2ShNRf" id="6jbF0BoEvVk" role="37wK5m">
+                    <node concept="1pGfFk" id="6jbF0BoEvVl" role="2ShVmc">
+                      <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+                      <node concept="37vLTw" id="6jbF0BoEvVm" role="37wK5m">
+                        <ref role="3cqZAo" node="6jbF0BoEv$S" resolve="repository" />
+                      </node>
+                      <node concept="37vLTw" id="6jbF0BoEvVn" role="37wK5m">
+                        <ref role="3cqZAo" node="6jbF0BoEvG6" resolve="constants" />
+                      </node>
+                      <node concept="2ShNRf" id="6jbF0BoEvVo" role="37wK5m">
+                        <node concept="HV5vD" id="6jbF0BoEvVp" role="2ShVmc">
+                          <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
                         </node>
                       </node>
                     </node>
@@ -2173,6 +2287,36 @@
         <ref role="3uigEE" to="pe0e:5wsogBcpo49" resolve="IMetaPointerLookup" />
       </node>
       <node concept="3clFbS" id="68Be_yV0R7" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BoEwde" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoEwdf" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6jbF0BoEw9K" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0BoEwdg" role="33vP2m">
+              <node concept="1jGwE1" id="6jbF0BoEwdh" role="2Oq$k0" />
+              <node concept="liA8E" id="6jbF0BoEwdi" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6jbF0BoEwkG" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoEwkH" role="3cpWs9">
+            <property role="TrG5h" value="constants" />
+            <node concept="3uibUv" id="6jbF0BoEwiV" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:DUXtGZOlwJ" resolve="LionCoreConstants" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BoEwkI" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BoEwkJ" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                <node concept="37vLTw" id="6jbF0BoEwkK" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BoEwdf" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="68Be_yV0R8" role="3cqZAp">
           <node concept="2ShNRf" id="68Be_yV0R9" role="3clFbG">
             <node concept="1pGfFk" id="68Be_yV0Ra" role="2ShVmc">
@@ -2201,17 +2345,25 @@
                       <node concept="2ShNRf" id="4r3Tp$pVp6A" role="37wK5m">
                         <node concept="1pGfFk" id="4r3Tp$pVp6B" role="2ShVmc">
                           <ref role="37wK5l" to="y7p:6VkSF6aIt83" resolve="SLanguageIdDeriver" />
-                          <node concept="2ShNRf" id="4r3Tp$pV9lf" role="37wK5m">
-                            <node concept="1pGfFk" id="4r3Tp$pV9lg" role="2ShVmc">
-                              <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
-                              <node concept="2OqwBi" id="4r3Tp$pV9lh" role="37wK5m">
-                                <node concept="1jGwE1" id="4r3Tp$pV9li" role="2Oq$k0" />
-                                <node concept="liA8E" id="4r3Tp$pV9lj" role="2OqNvi">
-                                  <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-                                </node>
-                              </node>
-                            </node>
+                          <node concept="37vLTw" id="6jbF0BoEwkL" role="37wK5m">
+                            <ref role="3cqZAo" node="6jbF0BoEwkH" resolve="constants" />
                           </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2ShNRf" id="6jbF0BoEwrY" role="37wK5m">
+                    <node concept="1pGfFk" id="6jbF0BoEwrZ" role="2ShVmc">
+                      <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+                      <node concept="37vLTw" id="6jbF0BoEws0" role="37wK5m">
+                        <ref role="3cqZAo" node="6jbF0BoEwdf" resolve="repository" />
+                      </node>
+                      <node concept="37vLTw" id="6jbF0BoEws1" role="37wK5m">
+                        <ref role="3cqZAo" node="6jbF0BoEwkH" resolve="constants" />
+                      </node>
+                      <node concept="2ShNRf" id="6jbF0BoEws2" role="37wK5m">
+                        <node concept="HV5vD" id="6jbF0BoEws3" role="2ShVmc">
+                          <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
                         </node>
                       </node>
                     </node>
@@ -2463,6 +2615,36 @@
         <ref role="3uigEE" to="pe0e:5wsogBcpo49" resolve="IMetaPointerLookup" />
       </node>
       <node concept="3clFbS" id="68Be_yV3W$" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BoEpYj" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoEpYk" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6jbF0BoEpX5" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0BoEpYl" role="33vP2m">
+              <node concept="1jGwE1" id="6jbF0BoEpYm" role="2Oq$k0" />
+              <node concept="liA8E" id="6jbF0BoEpYn" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6jbF0BoEqj7" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoEqj8" role="3cpWs9">
+            <property role="TrG5h" value="constants" />
+            <node concept="3uibUv" id="6jbF0BoEqhh" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:DUXtGZOlwJ" resolve="LionCoreConstants" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BoEqj9" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BoEqja" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                <node concept="37vLTw" id="6jbF0BoEqjb" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BoEpYk" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="68Be_yV3W_" role="3cqZAp">
           <node concept="2ShNRf" id="68Be_yV3WA" role="3clFbG">
             <node concept="1pGfFk" id="68Be_yV3WB" role="2ShVmc">
@@ -2491,17 +2673,25 @@
                       <node concept="2ShNRf" id="4r3Tp$pVqd$" role="37wK5m">
                         <node concept="1pGfFk" id="4r3Tp$pVqd_" role="2ShVmc">
                           <ref role="37wK5l" to="y7p:6VkSF6aIt83" resolve="SLanguageIdDeriver" />
-                          <node concept="2ShNRf" id="4r3Tp$pVqdA" role="37wK5m">
-                            <node concept="1pGfFk" id="4r3Tp$pVqdB" role="2ShVmc">
-                              <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
-                              <node concept="2OqwBi" id="4r3Tp$pVqdC" role="37wK5m">
-                                <node concept="1jGwE1" id="4r3Tp$pVqdD" role="2Oq$k0" />
-                                <node concept="liA8E" id="4r3Tp$pVqdE" role="2OqNvi">
-                                  <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-                                </node>
-                              </node>
-                            </node>
+                          <node concept="37vLTw" id="6jbF0BoEqjc" role="37wK5m">
+                            <ref role="3cqZAo" node="6jbF0BoEqj8" resolve="constants" />
                           </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2ShNRf" id="6jbF0BoEpr6" role="37wK5m">
+                    <node concept="1pGfFk" id="6jbF0BoEpRM" role="2ShVmc">
+                      <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+                      <node concept="37vLTw" id="6jbF0BoEq5F" role="37wK5m">
+                        <ref role="3cqZAo" node="6jbF0BoEpYk" resolve="repository" />
+                      </node>
+                      <node concept="37vLTw" id="6jbF0BoEqv5" role="37wK5m">
+                        <ref role="3cqZAo" node="6jbF0BoEqj8" resolve="constants" />
+                      </node>
+                      <node concept="2ShNRf" id="6jbF0BoEqIy" role="37wK5m">
+                        <node concept="HV5vD" id="6jbF0BoEr6k" role="2ShVmc">
+                          <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
                         </node>
                       </node>
                     </node>
@@ -2683,6 +2873,36 @@
         <ref role="3uigEE" to="pe0e:5wsogBcpo49" resolve="IMetaPointerLookup" />
       </node>
       <node concept="3clFbS" id="68Be_yV53f" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BoEtf0" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoEtf1" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6jbF0BoEtcy" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0BoEtf2" role="33vP2m">
+              <node concept="1jGwE1" id="6jbF0BoEtf3" role="2Oq$k0" />
+              <node concept="liA8E" id="6jbF0BoEtf4" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6jbF0BoEtnB" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoEtnC" role="3cpWs9">
+            <property role="TrG5h" value="constants" />
+            <node concept="3uibUv" id="6jbF0BoEtmE" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:DUXtGZOlwJ" resolve="LionCoreConstants" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0BoEtnD" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0BoEtnE" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                <node concept="37vLTw" id="6jbF0BoEtnF" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BoEtf1" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="68Be_yV53g" role="3cqZAp">
           <node concept="2ShNRf" id="68Be_yV53h" role="3clFbG">
             <node concept="1pGfFk" id="68Be_yV53i" role="2ShVmc">
@@ -2711,17 +2931,25 @@
                       <node concept="2ShNRf" id="4r3Tp$pVpYR" role="37wK5m">
                         <node concept="1pGfFk" id="4r3Tp$pVpYS" role="2ShVmc">
                           <ref role="37wK5l" to="y7p:6VkSF6aIt83" resolve="SLanguageIdDeriver" />
-                          <node concept="2ShNRf" id="4r3Tp$pVpYT" role="37wK5m">
-                            <node concept="1pGfFk" id="4r3Tp$pVpYU" role="2ShVmc">
-                              <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
-                              <node concept="2OqwBi" id="4r3Tp$pVpYV" role="37wK5m">
-                                <node concept="1jGwE1" id="4r3Tp$pVpYW" role="2Oq$k0" />
-                                <node concept="liA8E" id="4r3Tp$pVpYX" role="2OqNvi">
-                                  <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
-                                </node>
-                              </node>
-                            </node>
+                          <node concept="37vLTw" id="6jbF0BoEtnG" role="37wK5m">
+                            <ref role="3cqZAo" node="6jbF0BoEtnC" resolve="constants" />
                           </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2ShNRf" id="6jbF0BoEtAS" role="37wK5m">
+                    <node concept="1pGfFk" id="6jbF0BoEtSj" role="2ShVmc">
+                      <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+                      <node concept="37vLTw" id="6jbF0BoEtZW" role="37wK5m">
+                        <ref role="3cqZAo" node="6jbF0BoEtf1" resolve="repository" />
+                      </node>
+                      <node concept="37vLTw" id="6jbF0BoEu6v" role="37wK5m">
+                        <ref role="3cqZAo" node="6jbF0BoEtnC" resolve="constants" />
+                      </node>
+                      <node concept="2ShNRf" id="6jbF0BoEuf5" role="37wK5m">
+                        <node concept="HV5vD" id="6jbF0BoEuDp" role="2ShVmc">
+                          <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
                         </node>
                       </node>
                     </node>
@@ -3058,6 +3286,42 @@
             <node concept="2OqwBi" id="2fx6VTSZ2s8" role="2Oq$k0">
               <node concept="2WthIp" id="2fx6VTSZ2s9" role="2Oq$k0" />
               <node concept="2XshWL" id="2fx6VTSZ2sa" role="2OqNvi">
+                <ref role="2WH_rO" node="68Be_yWeLM" resolve="create" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6jbF0Bodbml" role="1SL9yI">
+      <property role="TrG5h" value="Concept_keyed" />
+      <node concept="3cqZAl" id="6jbF0Bodbmm" role="3clF45" />
+      <node concept="3clFbS" id="6jbF0Bodbmn" role="3clF47">
+        <node concept="3vlDli" id="6jbF0Bodbmo" role="3cqZAp">
+          <node concept="2ShNRf" id="6jbF0Bodbmp" role="3tpDZB">
+            <node concept="1pGfFk" id="6jbF0Bodbmq" role="2ShVmc">
+              <ref role="37wK5l" to="xfsv:~MetaPointer.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String)" resolve="MetaPointer" />
+              <node concept="Xl_RD" id="6jbF0Bodbmr" role="37wK5m">
+                <property role="Xl_RC" value="099490a3-1e39-4ed1-bebc-8027665cecf9" />
+              </node>
+              <node concept="Xl_RD" id="6jbF0Bodbms" role="37wK5m">
+                <property role="Xl_RC" value="0" />
+              </node>
+              <node concept="Xl_RD" id="6jbF0Bodbmt" role="37wK5m">
+                <property role="Xl_RC" value="2585378165973204112" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="6jbF0Bodbmu" role="3tpDZA">
+            <node concept="liA8E" id="6jbF0Bodbmv" role="2OqNvi">
+              <ref role="37wK5l" to="lai5:5s4Z0e0f2S8" resolve="createConcept" />
+              <node concept="35c_gC" id="6jbF0Bodbmw" role="37wK5m">
+                <ref role="35c_gD" to="q6xk:2fx6VTSSzMg" resolve="TestConceptPlain" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6jbF0Bodbmx" role="2Oq$k0">
+              <node concept="2WthIp" id="6jbF0Bodbmy" role="2Oq$k0" />
+              <node concept="2XshWL" id="6jbF0Bodbmz" role="2OqNvi">
                 <ref role="2WH_rO" node="68Be_yWeLM" resolve="create" />
               </node>
             </node>
@@ -4158,6 +4422,30 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="6jbF0Bocmc3" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0Bocmc4" role="3cpWs9">
+            <property role="TrG5h" value="attributeFinder" />
+            <node concept="3uibUv" id="6jbF0Bocm62" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
+            </node>
+            <node concept="2ShNRf" id="6jbF0Bocmc5" role="33vP2m">
+              <node concept="1pGfFk" id="6jbF0Bocmc6" role="2ShVmc">
+                <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
+                <node concept="37vLTw" id="6jbF0Bocmc7" role="37wK5m">
+                  <ref role="3cqZAo" node="1ryFPTS7O57" resolve="repository" />
+                </node>
+                <node concept="37vLTw" id="6jbF0Bocmc8" role="37wK5m">
+                  <ref role="3cqZAo" node="1ryFPTS7O5d" resolve="constants" />
+                </node>
+                <node concept="2ShNRf" id="6jbF0Bocmc9" role="37wK5m">
+                  <node concept="HV5vD" id="6jbF0Bocmca" role="2ShVmc">
+                    <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="1ryFPTS7O5i" role="3cqZAp">
           <node concept="2ShNRf" id="1ryFPTS7O5j" role="3clFbG">
             <node concept="1pGfFk" id="1ryFPTS7O5k" role="2ShVmc">
@@ -4165,21 +4453,8 @@
               <node concept="2ShNRf" id="1ryFPTS7O5l" role="37wK5m">
                 <node concept="1pGfFk" id="1ryFPTS7PZm" role="2ShVmc">
                   <ref role="37wK5l" to="faaz:6fYiNFaC6ei" resolve="SLanguageBase64GuaranteedMapper" />
-                  <node concept="2ShNRf" id="1ryFPTS7Q6o" role="37wK5m">
-                    <node concept="1pGfFk" id="1ryFPTS7Qtw" role="2ShVmc">
-                      <ref role="37wK5l" to="y7p:5AGBwuFEKL7" resolve="LionWebAttributeFinder" />
-                      <node concept="37vLTw" id="1ryFPTS7Qyy" role="37wK5m">
-                        <ref role="3cqZAo" node="1ryFPTS7O57" resolve="repository" />
-                      </node>
-                      <node concept="37vLTw" id="1ryFPTS7QIp" role="37wK5m">
-                        <ref role="3cqZAo" node="1ryFPTS7O5d" resolve="constants" />
-                      </node>
-                      <node concept="2ShNRf" id="4WflrVaUDca" role="37wK5m">
-                        <node concept="HV5vD" id="4WflrVaUDcb" role="2ShVmc">
-                          <ref role="HV5vE" to="y7p:18UigYOOPLq" resolve="MetaAdapterByDeclarationHelper" />
-                        </node>
-                      </node>
-                    </node>
+                  <node concept="37vLTw" id="6jbF0Bocmcb" role="37wK5m">
+                    <ref role="3cqZAo" node="6jbF0Bocmc4" resolve="attributeFinder" />
                   </node>
                   <node concept="2ShNRf" id="4r3Tp$pVd$h" role="37wK5m">
                     <node concept="1pGfFk" id="4r3Tp$pVdYF" role="2ShVmc">
@@ -4245,6 +4520,46 @@
             <node concept="2OqwBi" id="1ryFPTS7O5A" role="2Oq$k0">
               <node concept="2WthIp" id="1ryFPTS7O5B" role="2Oq$k0" />
               <node concept="2XshWL" id="1ryFPTS7O5C" role="2OqNvi">
+                <ref role="2WH_rO" node="1ryFPTS7O53" resolve="create" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6jbF0BohIhw" role="1SL9yI">
+      <property role="TrG5h" value="Concept_keyed" />
+      <node concept="3cqZAl" id="6jbF0BohIhx" role="3clF45" />
+      <node concept="3clFbS" id="6jbF0BohIhy" role="3clF47">
+        <node concept="3vlDli" id="6jbF0BohIhz" role="3cqZAp">
+          <node concept="2ShNRf" id="6jbF0BohIh$" role="3tpDZB">
+            <node concept="1pGfFk" id="6jbF0BohIh_" role="2ShVmc">
+              <ref role="37wK5l" to="xfsv:~MetaPointer.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String)" resolve="MetaPointer" />
+              <node concept="Xl_RD" id="6jbF0BohKLZ" role="37wK5m">
+                <property role="Xl_RC" value="My-TestLang3" />
+              </node>
+              <node concept="Xl_RD" id="6jbF0BohIhC" role="37wK5m">
+                <property role="Xl_RC" value="00 my! VERSION 😀" />
+              </node>
+              <node concept="2YIFZM" id="6jbF0BohIhD" role="37wK5m">
+                <ref role="37wK5l" to="apzt:2fx6VTSziaY" resolve="toLionWeb" />
+                <ref role="1Pybhc" to="apzt:2fx6VTSzhNf" resolve="IdEncoder" />
+                <node concept="Xl_RD" id="6jbF0BohIhE" role="37wK5m">
+                  <property role="Xl_RC" value="099490a3-1e39-4ed1-bebc-8027665cecf9/2585378165973204112" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="6jbF0BohIhF" role="3tpDZA">
+            <node concept="liA8E" id="6jbF0BohIhG" role="2OqNvi">
+              <ref role="37wK5l" to="lai5:5s4Z0e0f2S8" resolve="createConcept" />
+              <node concept="35c_gC" id="6jbF0BohIhH" role="37wK5m">
+                <ref role="35c_gD" to="q6xk:2fx6VTSSzMg" resolve="TestConceptPlain" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6jbF0BohIhI" role="2Oq$k0">
+              <node concept="2WthIp" id="6jbF0BohIhJ" role="2Oq$k0" />
+              <node concept="2XshWL" id="6jbF0BohIhK" role="2OqNvi">
                 <ref role="2WH_rO" node="1ryFPTS7O53" resolve="create" />
               </node>
             </node>

--- a/solutions/io.lionweb.mps.json.test/resources/MpsDeprecated-metamodel-special.json
+++ b/solutions/io.lionweb.mps.json.test/resources/MpsDeprecated-metamodel-special.json
@@ -1,0 +1,949 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-M3",
+      "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "io-lionweb-mps-specific",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "7815243479487993447",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "Deprecated"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-build"
+          },
+          "value": "deprConcept build"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-comment"
+          },
+          "value": "deprConcept comment"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDY"
+    },
+    {
+      "id": "7815243479487993451",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "Deprecated"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-build"
+          },
+          "value": "deprProp build"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-comment"
+          },
+          "value": "deprProp comment"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ0OQ"
+    },
+    {
+      "id": "7815243479487993456",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "Deprecated"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-build"
+          },
+          "value": "deprIface build"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-comment"
+          },
+          "value": "deprIface comment"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NTU"
+    },
+    {
+      "id": "7815243479487993464",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "Deprecated"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-build"
+          },
+          "value": "deprAnnotation build"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-comment"
+          },
+          "value": "deprAnnotation comment"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NjE"
+    },
+    {
+      "id": "7815243479487993467",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "Deprecated"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-build"
+          },
+          "value": "deprChild build"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-comment"
+          },
+          "value": "deprChild comment"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ1Mw"
+    },
+    {
+      "id": "7815243479487993469",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "Deprecated"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-build"
+          },
+          "value": "deprRef build"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-comment"
+          },
+          "value": "deprRef comment"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ1OA"
+    },
+    {
+      "id": "7815243479487993473",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "Deprecated"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-build"
+          },
+          "value": "deprEnum build"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-comment"
+          },
+          "value": "deprEnum comment"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzE"
+    },
+    {
+      "id": "7815243479487993485",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "Deprecated"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-build"
+          },
+          "value": "deprDatatype build"
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-comment"
+          },
+          "value": "deprDatatype comment"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0ODQ"
+    },
+    {
+      "id": "7815243479507587642",
+      "classifier": {
+        "language": "io-lionweb-mps-specific",
+        "version": "0",
+        "key": "Deprecated"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-build"
+          },
+          "value": null
+        },
+        {
+          "property": {
+            "language": "io-lionweb-mps-specific",
+            "version": "0",
+            "key": "Deprecated-comment"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk1MDc1ODcyODk"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBh",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Language"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBh"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-version"
+          },
+          "value": "0"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "io.lionweb.mps.converter.TestDeprecated"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-entities"
+          },
+          "children": [
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDY",
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NTU",
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NjE",
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzE",
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0ODQ",
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk1MDc1ODcyODk"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-dependsOn"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": null
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDY",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDY"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DeprConcept"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ0OQ",
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ1Mw",
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ1OA"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [
+        "7815243479487993447"
+      ],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBh"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ0OQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ0OQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "deprProp"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        "7815243479487993451"
+      ],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDY"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ1Mw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ1Mw"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "deprChild"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "DeprIface",
+              "reference": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NTU"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        "7815243479487993467"
+      ],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDY"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ1OA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ1OA"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "deprRef"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "DeprAnnotation",
+              "reference": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NjE"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        "7815243479487993469"
+      ],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDY"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NTU",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NTU"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DeprIface"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [
+        "7815243479487993456"
+      ],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBh"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NjE",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NjE"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DeprAnnotation"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [
+        "7815243479487993464"
+      ],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBh"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzE",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Enumeration"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzE"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DeprEnum"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Enumeration-literals"
+          },
+          "children": [
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzEvNzgxNTI0MzQ3OTQ4Nzk5MzQ3Mg",
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzEvNzgxNTI0MzQ3OTQ4Nzk5MzQ3NQ"
+          ]
+        }
+      ],
+      "references": [],
+      "annotations": [
+        "7815243479487993473"
+      ],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBh"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzEvNzgxNTI0MzQ3OTQ4Nzk5MzQ3Mg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzEvNzgxNTI0MzQ3OTQ4Nzk5MzQ3Mg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "A"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzE"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzEvNzgxNTI0MzQ3OTQ4Nzk5MzQ3NQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzEvNzgxNTI0MzQ3OTQ4Nzk5MzQ3NQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "B"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzE"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0ODQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "PrimitiveType"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0ODQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DeprDatatype"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [
+        "7815243479487993485"
+      ],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBh"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk1MDc1ODcyODk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk1MDc1ODcyODk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DeprNoComment"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [
+        "7815243479507587642"
+      ],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBh"
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/MpsDeprecated-metamodel.json
+++ b/solutions/io.lionweb.mps.json.test/resources/MpsDeprecated-metamodel.json
@@ -1,0 +1,657 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-M3",
+      "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBh",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Language"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBh"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-version"
+          },
+          "value": "0"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "io.lionweb.mps.converter.TestDeprecated"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-entities"
+          },
+          "children": [
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDY",
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NTU",
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NjE",
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzE",
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0ODQ",
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk1MDc1ODcyODk"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-dependsOn"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": null
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDY",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDY"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DeprConcept"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ0OQ",
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ1Mw",
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ1OA"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBh"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ0OQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ0OQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "deprProp"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDY"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ1Mw",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ1Mw"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "deprChild"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "DeprIface",
+              "reference": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NTU"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDY"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ1OA",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDYvNzgxNTI0MzQ3OTQ4Nzk5MzQ1OA"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "deprRef"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "DeprAnnotation",
+              "reference": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NjE"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NDY"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NTU",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Interface"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NTU"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DeprIface"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Interface-extends"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBh"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NjE",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NjE"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DeprAnnotation"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBh"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzE",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Enumeration"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzE"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DeprEnum"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Enumeration-literals"
+          },
+          "children": [
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzEvNzgxNTI0MzQ3OTQ4Nzk5MzQ3Mg",
+            "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzEvNzgxNTI0MzQ3OTQ4Nzk5MzQ3NQ"
+          ]
+        }
+      ],
+      "references": [],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBh"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzEvNzgxNTI0MzQ3OTQ4Nzk5MzQ3Mg",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzEvNzgxNTI0MzQ3OTQ4Nzk5MzQ3Mg"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "A"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzE"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzEvNzgxNTI0MzQ3OTQ4Nzk5MzQ3NQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "EnumerationLiteral"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzEvNzgxNTI0MzQ3OTQ4Nzk5MzQ3NQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "B"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0NzE"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0ODQ",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "PrimitiveType"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk0ODc5OTM0ODQ"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DeprDatatype"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBh"
+    },
+    {
+      "id": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk1MDc1ODcyODk",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBhLzc4MTUyNDM0Nzk1MDc1ODcyODk"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "DeprNoComment"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Node",
+              "reference": "LionCore-builtins-Node"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "MDkzNjAxODQtODU5OC00NGU3LTliZjUtZmIxY2U0NWE0ODBh"
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/MpsSpecific-metamodel-annotated.json
+++ b/solutions/io.lionweb.mps.json.test/resources/MpsSpecific-metamodel-annotated.json
@@ -192,6 +192,182 @@
       "parent": "ConceptDescription"
     },
     {
+      "id": "Deprecated",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Deprecated"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "Deprecated"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "Deprecated-build",
+            "Deprecated-comment"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "IKeyed",
+              "reference": "-id-IKeyed"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "io-lionweb-mps-specific"
+    },
+    {
+      "id": "Deprecated-build",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Deprecated-build"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "build"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Deprecated"
+    },
+    {
+      "id": "Deprecated-comment",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Deprecated-comment"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "comment"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Deprecated"
+    },
+    {
       "id": "ShortDescription",
       "classifier": {
         "language": "LionCore-M3",
@@ -494,6 +670,7 @@
           },
           "children": [
             "ConceptDescription",
+            "Deprecated",
             "ShortDescription",
             "VirtualPackage"
           ]

--- a/solutions/io.lionweb.mps.json.test/resources/MpsSpecific-metamodel.json
+++ b/solutions/io.lionweb.mps.json.test/resources/MpsSpecific-metamodel.json
@@ -188,6 +188,182 @@
       "parent": "ConceptDescription"
     },
     {
+      "id": "Deprecated",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Annotation"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Deprecated"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "Deprecated"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "Deprecated-build",
+            "Deprecated-comment"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-annotates"
+          },
+          "targets": [
+            {
+              "resolveInfo": "IKeyed",
+              "reference": "-id-IKeyed"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Annotation-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "io-lionweb-mps-specific"
+    },
+    {
+      "id": "Deprecated-build",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Deprecated-build"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "build"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Deprecated"
+    },
+    {
+      "id": "Deprecated-comment",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "Deprecated-comment"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "comment"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "Deprecated"
+    },
+    {
       "id": "ShortDescription",
       "classifier": {
         "language": "LionCore-M3",
@@ -426,6 +602,7 @@
           },
           "children": [
             "ConceptDescription",
+            "Deprecated",
             "ShortDescription",
             "VirtualPackage"
           ]

--- a/solutions/io.lionweb.mps.json.test/resources/Test3Properties.emptyValue.json
+++ b/solutions/io.lionweb.mps.json.test/resources/Test3Properties.emptyValue.json
@@ -3,7 +3,7 @@
   "languages": [
     {
       "key": "My-TestLang3",
-      "version": "0"
+      "version": "00 my! VERSION 😀"
     }
   ],
   "nodes": [
@@ -11,14 +11,14 @@
       "id": "{id-Test3Properties}",
       "classifier": {
         "language": "My-TestLang3",
-        "version": "0",
+        "version": "00 my! VERSION 😀",
         "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTY"
       },
       "properties": [
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc1Nw"
           },
           "value": ""
@@ -26,7 +26,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc1OQ"
           },
           "value": ""
@@ -34,7 +34,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc2NA"
           },
           "value": ""
@@ -42,7 +42,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc3MQ"
           },
           "value": ""
@@ -50,7 +50,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc3Mw"
           },
           "value": ""
@@ -58,7 +58,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc3NQ"
           },
           "value": ""
@@ -66,7 +66,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc4Ng"
           },
           "value": "false"
@@ -74,7 +74,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc4OA"
           },
           "value": "false"
@@ -82,7 +82,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc5MA"
           },
           "value": "false"
@@ -90,7 +90,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTgwNg"
           },
           "value": "0"
@@ -98,7 +98,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTgwOA"
           },
           "value": "0"
@@ -106,7 +106,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTgxMA"
           },
           "value": "0"

--- a/solutions/io.lionweb.mps.json.test/resources/Test3Properties.someValue.json
+++ b/solutions/io.lionweb.mps.json.test/resources/Test3Properties.someValue.json
@@ -3,7 +3,7 @@
   "languages": [
     {
       "key": "My-TestLang3",
-      "version": "0"
+      "version": "00 my! VERSION 😀"
     }
   ],
   "nodes": [
@@ -11,14 +11,14 @@
       "id": "{id-Test3Properties}",
       "classifier": {
         "language": "My-TestLang3",
-        "version": "0",
+        "version": "00 my! VERSION 😀",
         "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTY"
       },
       "properties": [
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc1Nw"
           },
           "value": "a"
@@ -26,7 +26,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc1OQ"
           },
           "value": "a"
@@ -34,7 +34,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc2NA"
           },
           "value": "a"
@@ -42,7 +42,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc3MQ"
           },
           "value": "[]"
@@ -50,7 +50,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc3Mw"
           },
           "value": "[]"
@@ -58,7 +58,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc3NQ"
           },
           "value": "[]"
@@ -66,7 +66,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc4Ng"
           },
           "value": "true"
@@ -74,7 +74,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc4OA"
           },
           "value": "true"
@@ -82,7 +82,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc5MA"
           },
           "value": "true"
@@ -90,7 +90,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTgwNg"
           },
           "value": "1"
@@ -98,7 +98,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTgwOA"
           },
           "value": "1"
@@ -106,7 +106,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTgxMA"
           },
           "value": "1"

--- a/solutions/io.lionweb.mps.json.test/resources/Test3Properties.unset.json
+++ b/solutions/io.lionweb.mps.json.test/resources/Test3Properties.unset.json
@@ -3,7 +3,7 @@
   "languages": [
     {
       "key": "My-TestLang3",
-      "version": "0"
+      "version": "00 my! VERSION 😀"
     }
   ],
   "nodes": [
@@ -11,14 +11,14 @@
       "id": "{id-Test3Properties}",
       "classifier": {
         "language": "My-TestLang3",
-        "version": "0",
+        "version": "00 my! VERSION 😀",
         "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTY"
       },
       "properties": [
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc2NA"
           },
           "value": null
@@ -26,7 +26,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc3MQ"
           },
           "value": null
@@ -34,7 +34,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc4Ng"
           },
           "value": "false"
@@ -42,7 +42,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc4OA"
           },
           "value": "false"
@@ -50,7 +50,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTc5MA"
           },
           "value": "false"
@@ -58,7 +58,7 @@
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzcyNzI5MTcxNjczMTc4NDU3NTYvNzI3MjkxNzE2NzMxNzg0NTgwNg"
           },
           "value": null

--- a/solutions/io.lionweb.mps.json.test/resources/TestLang-instance.json
+++ b/solutions/io.lionweb.mps.json.test/resources/TestLang-instance.json
@@ -45,7 +45,7 @@
             "version": "0",
             "key": "MDhjYWFkNzUtODI0Ni00NDI3LWJiNGQtODQ0NGI2YzVjNzI5LzI1ODUzNzgxNjU5NzMyMDY0NTEvMjU4NTM3ODE2NTk3MzIwODMyMA"
           },
-          "value": "2fx6VTSSzTB/TestLiteral1"
+          "value": "MDhjYWFkNzUtODI0Ni00NDI3LWJiNGQtODQ0NGI2YzVjNzI5LzI1ODUzNzgxNjU5NzMyMDQ1ODIvMjU4NTM3ODE2NTk3MzIwNDU4Mw"
         },
         {
           "property": {
@@ -134,7 +134,7 @@
             "version": "0",
             "key": "MDhjYWFkNzUtODI0Ni00NDI3LWJiNGQtODQ0NGI2YzVjNzI5LzI1ODUzNzgxNjU5NzMyMDY0NTEvMjU4NTM3ODE2NTk3MzIwODMyMA"
           },
-          "value": "2fx6VTSSzUf/TestLiteral2"
+          "value": "MDhjYWFkNzUtODI0Ni00NDI3LWJiNGQtODQ0NGI2YzVjNzI5LzI1ODUzNzgxNjU5NzMyMDQ1ODIvMjU4NTM3ODE2NTk3MzIwNDYyMw"
         },
         {
           "property": {
@@ -245,7 +245,7 @@
             "version": "0",
             "key": "MDhjYWFkNzUtODI0Ni00NDI3LWJiNGQtODQ0NGI2YzVjNzI5LzI1ODUzNzgxNjU5NzMyMDY0NTEvMjU4NTM3ODE2NTk3MzIwODMyMA"
           },
-          "value": "2fx6VTSSzTB/TestLiteral1"
+          "value": "MDhjYWFkNzUtODI0Ni00NDI3LWJiNGQtODQ0NGI2YzVjNzI5LzI1ODUzNzgxNjU5NzMyMDQ1ODIvMjU4NTM3ODE2NTk3MzIwNDU4Mw"
         },
         {
           "property": {
@@ -358,7 +358,7 @@
             "version": "0",
             "key": "MDhjYWFkNzUtODI0Ni00NDI3LWJiNGQtODQ0NGI2YzVjNzI5LzI1ODUzNzgxNjU5NzMyMDY0NTEvMjU4NTM3ODE2NTk3MzIwODMyMA"
           },
-          "value": "2fx6VTSSzUf/TestLiteral2"
+          "value": "MDhjYWFkNzUtODI0Ni00NDI3LWJiNGQtODQ0NGI2YzVjNzI5LzI1ODUzNzgxNjU5NzMyMDQ1ODIvMjU4NTM3ODE2NTk3MzIwNDYyMw"
         },
         {
           "property": {
@@ -483,7 +483,7 @@
             "version": "0",
             "key": "MDhjYWFkNzUtODI0Ni00NDI3LWJiNGQtODQ0NGI2YzVjNzI5LzI1ODUzNzgxNjU5NzMyMDY0NTEvMjU4NTM3ODE2NTk3MzIwODMyMA"
           },
-          "value": "2fx6VTSSzTB/TestLiteral1"
+          "value": "MDhjYWFkNzUtODI0Ni00NDI3LWJiNGQtODQ0NGI2YzVjNzI5LzI1ODUzNzgxNjU5NzMyMDQ1ODIvMjU4NTM3ODE2NTk3MzIwNDU4Mw"
         },
         {
           "property": {
@@ -580,7 +580,7 @@
             "version": "0",
             "key": "MDhjYWFkNzUtODI0Ni00NDI3LWJiNGQtODQ0NGI2YzVjNzI5LzI1ODUzNzgxNjU5NzMyMDY0NTEvMjU4NTM3ODE2NTk3MzIwODMyMA"
           },
-          "value": "2fx6VTSSzUf/TestLiteral2"
+          "value": "MDhjYWFkNzUtODI0Ni00NDI3LWJiNGQtODQ0NGI2YzVjNzI5LzI1ODUzNzgxNjU5NzMyMDQ1ODIvMjU4NTM3ODE2NTk3MzIwNDYyMw"
         },
         {
           "property": {

--- a/solutions/io.lionweb.mps.json.test/resources/TestLang3-metamodel.json
+++ b/solutions/io.lionweb.mps.json.test/resources/TestLang3-metamodel.json
@@ -3572,7 +3572,7 @@
             "version": "2023.1",
             "key": "Language-version"
           },
-          "value": "0"
+          "value": "00 my! VERSION 😀"
         },
         {
           "property": {

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyOptional_setWithKey.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyOptional_setWithKey.json
@@ -1,0 +1,61 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTEyODE"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithKeyOptional_setWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTEyODEvMzI0MDQ3NTQxMDMzMjk1MTcwOA"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTEyODEvMzI0MDQ3NTQxMDMzMjk1MTcxMg"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTEyODEvMzI0MDQ3NTQxMDMzMjk1MTcxOA"
+          },
+          "value": "key-literalWithKey"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyOptional_setWithoutKey.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyOptional_setWithoutKey.json
@@ -1,0 +1,61 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTEyODE"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithKeyOptional_setWithoutKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTEyODEvMzI0MDQ3NTQxMDMzMjk1MTcwOA"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2ODMvMzI0MDQ3NTQxMDMzMjk1MTY4Ng"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTEyODEvMzI0MDQ3NTQxMDMzMjk1MTcxMg"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2ODgvMzI0MDQ3NTQxMDMzMjk1MTY5MQ"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTEyODEvMzI0MDQ3NTQxMDMzMjk1MTcxOA"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTEyODQvMzI0MDQ3NTQxMDMzMjk1MTI4Ng"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyOptional_unset.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyOptional_unset.json
@@ -1,0 +1,53 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTEyODE"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithKeyOptional_unset"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTEyODEvMzI0MDQ3NTQxMDMzMjk1MTcwOA"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTEyODEvMzI0MDQ3NTQxMDMzMjk1MTcxMg"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2ODgvMzI0MDQ3NTQxMDMzMjk1MTY5MQ"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyRequired_setWithKey.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyRequired_setWithKey.json
@@ -1,0 +1,61 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MjY"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithKeyRequired_setWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MjYvMzI0MDQ3NTQxMDMzMjk1MTcyNw"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MjYvMzI0MDQ3NTQxMDMzMjk1MTcyOQ"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MjYvMzI0MDQ3NTQxMDMzMjk1MTczMQ"
+          },
+          "value": "key-literalWithKey"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyRequired_setWithoutKey.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyRequired_setWithoutKey.json
@@ -1,0 +1,61 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MjY"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithKeyRequired_setWithoutKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MjYvMzI0MDQ3NTQxMDMzMjk1MTcyNw"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2ODMvMzI0MDQ3NTQxMDMzMjk1MTY4Ng"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MjYvMzI0MDQ3NTQxMDMzMjk1MTcyOQ"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2ODgvMzI0MDQ3NTQxMDMzMjk1MTY5MQ"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MjYvMzI0MDQ3NTQxMDMzMjk1MTczMQ"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTEyODQvMzI0MDQ3NTQxMDMzMjk1MTI4Ng"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyRequired_unset.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyRequired_unset.json
@@ -1,0 +1,61 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MjY"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithKeyRequired_unset"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MjYvMzI0MDQ3NTQxMDMzMjk1MTcyNw"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MjYvMzI0MDQ3NTQxMDMzMjk1MTcyOQ"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2ODgvMzI0MDQ3NTQxMDMzMjk1MTY5MQ"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MjYvMzI0MDQ3NTQxMDMzMjk1MTczMQ"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyUnset_setWithKey.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyUnset_setWithKey.json
@@ -1,0 +1,61 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzMzc"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithKeyUnset_setWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzMzcvMzI0MDQ3NTQxMDMzMjk5MzM0MA"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzMzcvMzI0MDQ3NTQxMDMzMjk5MzM0Mg"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzMzcvMzI0MDQ3NTQxMDMzMjk5MzMzOA"
+          },
+          "value": "key-literalWithKey"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyUnset_setWithoutKey.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyUnset_setWithoutKey.json
@@ -1,0 +1,61 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzMzc"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithKeyUnset_setWithoutKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzMzcvMzI0MDQ3NTQxMDMzMjk5MzM0MA"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2ODgvMzI0MDQ3NTQxMDMzMjk1MTY5MQ"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzMzcvMzI0MDQ3NTQxMDMzMjk5MzM0Mg"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTEyODQvMzI0MDQ3NTQxMDMzMjk1MTI4Ng"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzMzcvMzI0MDQ3NTQxMDMzMjk5MzMzOA"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2ODMvMzI0MDQ3NTQxMDMzMjk1MTY4Ng"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyUnset_unset.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithKeyUnset_unset.json
@@ -1,0 +1,53 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzMzc"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithKeyUnset_unset"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzMzcvMzI0MDQ3NTQxMDMzMjk5MzM0MA"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2ODgvMzI0MDQ3NTQxMDMzMjk1MTY5MQ"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzMzcvMzI0MDQ3NTQxMDMzMjk5MzMzOA"
+          },
+          "value": "key-literalWithKey"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyOptional_setWithKey.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyOptional_setWithKey.json
@@ -1,0 +1,61 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MzQ"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithoutKeyOptional_setWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MzQvMzI0MDQ3NTQxMDMzMjk1MTczNQ"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MzQvMzI0MDQ3NTQxMDMzMjk1MTczNw"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MzQvMzI0MDQ3NTQxMDMzMjk1MTczOQ"
+          },
+          "value": "key-literalWithKey"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyOptional_setWithoutKey.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyOptional_setWithoutKey.json
@@ -1,0 +1,61 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MzQ"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithoutKeyOptional_setWithoutKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MzQvMzI0MDQ3NTQxMDMzMjk1MTczNQ"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2OTMvMzI0MDQ3NTQxMDMzMjk1MTY5Ng"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MzQvMzI0MDQ3NTQxMDMzMjk1MTczNw"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2OTgvMzI0MDQ3NTQxMDMzMjk1MTcwMQ"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MzQvMzI0MDQ3NTQxMDMzMjk1MTczOQ"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MDMvMzI0MDQ3NTQxMDMzMjk1MTcwNg"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyOptional_unset.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyOptional_unset.json
@@ -1,0 +1,53 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MzQ"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithoutKeyOptional_unset"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MzQvMzI0MDQ3NTQxMDMzMjk1MTczNQ"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MzQvMzI0MDQ3NTQxMDMzMjk1MTczNw"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2OTgvMzI0MDQ3NTQxMDMzMjk1MTcwMQ"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyRequired_setWithKey.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyRequired_setWithKey.json
@@ -1,0 +1,61 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3NDI"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithoutKeyRequired_setWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3NDIvMzI0MDQ3NTQxMDMzMjk1MTc0Mw"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3NDIvMzI0MDQ3NTQxMDMzMjk1MTc0NQ"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3NDIvMzI0MDQ3NTQxMDMzMjk1MTc0Nw"
+          },
+          "value": "key-literalWithKey"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyRequired_setWithoutKey.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyRequired_setWithoutKey.json
@@ -1,0 +1,61 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3NDI"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithoutKeyRequired_setWithoutKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3NDIvMzI0MDQ3NTQxMDMzMjk1MTc0Mw"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2OTMvMzI0MDQ3NTQxMDMzMjk1MTY5Ng"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3NDIvMzI0MDQ3NTQxMDMzMjk1MTc0NQ"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2OTgvMzI0MDQ3NTQxMDMzMjk1MTcwMQ"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3NDIvMzI0MDQ3NTQxMDMzMjk1MTc0Nw"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MDMvMzI0MDQ3NTQxMDMzMjk1MTcwNg"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyRequired_unset.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyRequired_unset.json
@@ -1,0 +1,61 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3NDI"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithoutKeyRequired_unset"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3NDIvMzI0MDQ3NTQxMDMzMjk1MTc0Mw"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3NDIvMzI0MDQ3NTQxMDMzMjk1MTc0NQ"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2OTgvMzI0MDQ3NTQxMDMzMjk1MTcwMQ"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3NDIvMzI0MDQ3NTQxMDMzMjk1MTc0Nw"
+          },
+          "value": null
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyUnset_setWithKey.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyUnset_setWithKey.json
@@ -1,0 +1,61 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzNTM"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithoutKeyUnset_setWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzNTMvMzI0MDQ3NTQxMDMzMjk5MzM1NA"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzNTMvMzI0MDQ3NTQxMDMzMjk5MzM1Ng"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzNTMvMzI0MDQ3NTQxMDMzMjk5MzM1OA"
+          },
+          "value": "key-literalWithKey"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyUnset_setWithoutKey.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyUnset_setWithoutKey.json
@@ -1,0 +1,61 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzNTM"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithoutKeyUnset_setWithoutKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzNTMvMzI0MDQ3NTQxMDMzMjk5MzM1NA"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2OTMvMzI0MDQ3NTQxMDMzMjk1MTY5Ng"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzNTMvMzI0MDQ3NTQxMDMzMjk5MzM1Ng"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2OTgvMzI0MDQ3NTQxMDMzMjk1MTcwMQ"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzNTMvMzI0MDQ3NTQxMDMzMjk5MzM1OA"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE3MDMvMzI0MDQ3NTQxMDMzMjk1MTcwNg"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyUnset_unset.json
+++ b/solutions/io.lionweb.mps.json.test/resources/enumLiterals-EnumHostWithoutKeyUnset_unset.json
@@ -1,0 +1,53 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    },
+    {
+      "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+      "version": "0"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "{id-host}",
+      "classifier": {
+        "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+        "version": "0",
+        "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzNTM"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "EnumHostWithoutKeyUnset_unset"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzNTMvMzI0MDQ3NTQxMDMzMjk5MzM1NA"
+          },
+          "value": "key-literalWithKey"
+        },
+        {
+          "property": {
+            "language": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYx",
+            "version": "0",
+            "key": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5OTMzNTMvMzI0MDQ3NTQxMDMzMjk5MzM1Ng"
+          },
+          "value": "MWVjNmQ1ZTctNjQwMi00YzE4LTk1ZDAtNmUwOTA2ZWIxZmYxLzMyNDA0NzU0MTAzMzI5NTE2OTgvMzI0MDQ3NTQxMDMzMjk1MTcwMQ"
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": [],
+      "parent": null
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/resources/lioncore.json
+++ b/solutions/io.lionweb.mps.json.test/resources/lioncore.json
@@ -1747,7 +1747,7 @@
             "version": "2023.1",
             "key": "Language-version"
           },
-          "value": "1"
+          "value": "2023.1"
         },
         {
           "property": {

--- a/solutions/io.lionweb.mps.json.test/resources/test2-keyed.json
+++ b/solutions/io.lionweb.mps.json.test/resources/test2-keyed.json
@@ -3,7 +3,7 @@
   "languages": [
     {
       "key": "My-TestLang3",
-      "version": "0"
+      "version": "00 my! VERSION 😀"
     },
     {
       "key": "NDhkMGY2ZWItNjE4Ni00Y2VjLTgzZDEtN2NhZWRiMDVhNDk0",
@@ -25,7 +25,7 @@
             "version": "0",
             "key": "My-KeyedProp"
           },
-          "value": "4R9pospAHRH/keyed"
+          "value": "My-EnumLiteralKeyed"
         },
         {
           "property": {
@@ -33,7 +33,7 @@
             "version": "0",
             "key": "NDhkMGY2ZWItNjE4Ni00Y2VjLTgzZDEtN2NhZWRiMDVhNDk0LzU2MDUxMjI4NDIxNTg3NDI5MzIvNTYwNTEyMjg0MjE2Mzg1NzA0OA"
           },
-          "value": "4R9pospAHRA/keyed"
+          "value": "My-EnumLiteralUnkeyed"
         }
       ],
       "containments": [
@@ -93,7 +93,7 @@
       "id": "{id-Plain}",
       "classifier": {
         "language": "My-TestLang3",
-        "version": "0",
+        "version": "00 my! VERSION 😀",
         "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzI1ODUzNzgxNjU5NzMyMDQxMTI"
       },
       "properties": [],
@@ -106,7 +106,7 @@
       "id": "{id-NoExtends}",
       "classifier": {
         "language": "My-TestLang3",
-        "version": "0",
+        "version": "00 my! VERSION 😀",
         "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzI1ODUzNzgxNjU5NzMyMDQ5MDM"
       },
       "properties": [],

--- a/solutions/io.lionweb.mps.json.test/resources/test2-unkeyed.json
+++ b/solutions/io.lionweb.mps.json.test/resources/test2-unkeyed.json
@@ -3,7 +3,7 @@
   "languages": [
     {
       "key": "My-TestLang3",
-      "version": "0"
+      "version": "00 my! VERSION 😀"
     },
     {
       "key": "NDhkMGY2ZWItNjE4Ni00Y2VjLTgzZDEtN2NhZWRiMDVhNDk0",
@@ -25,7 +25,7 @@
             "version": "0",
             "key": "My-UnkeyedProp"
           },
-          "value": "4R9pospAHRG/unkeyed"
+          "value": "NDhkMGY2ZWItNjE4Ni00Y2VjLTgzZDEtN2NhZWRiMDVhNDk0LzU2MDUxMjI4NDIxNjM4NjMwMTkvNTYwNTEyMjg0MjE2Mzg2MzAyMA"
         },
         {
           "property": {
@@ -33,7 +33,7 @@
             "version": "0",
             "key": "NDhkMGY2ZWItNjE4Ni00Y2VjLTgzZDEtN2NhZWRiMDVhNDk0LzU2MDUxMjI4NDIxNTg3ODAyODAvNTYwNTEyMjg0MjE2Mzg1NzA2OA"
           },
-          "value": "4R9pospAHR_/unkeyed"
+          "value": "NDhkMGY2ZWItNjE4Ni00Y2VjLTgzZDEtN2NhZWRiMDVhNDk0LzU2MDUxMjI4NDIxNjM4NjMwMTIvNTYwNTEyMjg0MjE2Mzg2MzAxMw"
         }
       ],
       "containments": [
@@ -93,7 +93,7 @@
       "id": "{id-Plain}",
       "classifier": {
         "language": "My-TestLang3",
-        "version": "0",
+        "version": "00 my! VERSION 😀",
         "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzI1ODUzNzgxNjU5NzMyMDQxMTI"
       },
       "properties": [],
@@ -106,7 +106,7 @@
       "id": "{id-NoExtends}",
       "classifier": {
         "language": "My-TestLang3",
-        "version": "0",
+        "version": "00 my! VERSION 😀",
         "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzI1ODUzNzgxNjU5NzMyMDQ5MDM"
       },
       "properties": [],

--- a/solutions/io.lionweb.mps.json.test/resources/test3-keyed.json
+++ b/solutions/io.lionweb.mps.json.test/resources/test3-keyed.json
@@ -3,7 +3,7 @@
   "languages": [
     {
       "key": "My-TestLang3",
-      "version": "0"
+      "version": "00 my! VERSION 😀"
     }
   ],
   "nodes": [
@@ -11,32 +11,32 @@
       "id": "{id-keyed}",
       "classifier": {
         "language": "My-TestLang3",
-        "version": "0",
+        "version": "00 my! VERSION 😀",
         "key": "My-Test3ConceptKeyed"
       },
       "properties": [
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzU2MDUxMjI4NDIxNTg3NDI5MzIvNTYwNTEyMjg0MjE2Mzg1NzA0OA"
           },
-          "value": "4R9pospAHRA/keyed"
+          "value": "My-EnumLiteralUnkeyed"
         },
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "My-KeyedProp"
           },
-          "value": "4R9pospAHRH/keyed"
+          "value": "My-EnumLiteralKeyed"
         }
       ],
       "containments": [
         {
           "containment": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzU2MDUxMjI4NDIxNTg3NDI5MzIvNTYwNTEyMjg0MjE1ODc0MjkzMw"
           },
           "children": [
@@ -46,7 +46,7 @@
         {
           "containment": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "My-KeyedChild"
           },
           "children": [
@@ -58,7 +58,7 @@
         {
           "reference": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzU2MDUxMjI4NDIxNTg3NDI5MzIvNTYwNTEyMjg0MjE2Mzg1NzA1NQ"
           },
           "targets": [
@@ -71,7 +71,7 @@
         {
           "reference": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "My-KeyedRef"
           },
           "targets": [
@@ -89,7 +89,7 @@
       "id": "{id-Plain}",
       "classifier": {
         "language": "My-TestLang3",
-        "version": "0",
+        "version": "00 my! VERSION 😀",
         "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzI1ODUzNzgxNjU5NzMyMDQxMTI"
       },
       "properties": [],
@@ -102,7 +102,7 @@
       "id": "{id-NoExtends}",
       "classifier": {
         "language": "My-TestLang3",
-        "version": "0",
+        "version": "00 my! VERSION 😀",
         "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzI1ODUzNzgxNjU5NzMyMDQ5MDM"
       },
       "properties": [],

--- a/solutions/io.lionweb.mps.json.test/resources/test3-unkeyed.json
+++ b/solutions/io.lionweb.mps.json.test/resources/test3-unkeyed.json
@@ -3,7 +3,7 @@
   "languages": [
     {
       "key": "My-TestLang3",
-      "version": "0"
+      "version": "00 my! VERSION 😀"
     }
   ],
   "nodes": [
@@ -11,32 +11,32 @@
       "id": "{id-unkeyed}",
       "classifier": {
         "language": "My-TestLang3",
-        "version": "0",
+        "version": "00 my! VERSION 😀",
         "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzU2MDUxMjI4NDIxNTg3ODAyODA"
       },
       "properties": [
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzU2MDUxMjI4NDIxNTg3ODAyODAvNTYwNTEyMjg0MjE2Mzg1NzA2OA"
           },
-          "value": "4R9pospAHR_/unkeyed"
+          "value": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzU2MDUxMjI4NDIxNjM4NjMwMTIvNTYwNTEyMjg0MjE2Mzg2MzAxMw"
         },
         {
           "property": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "My-UnkeyedProp"
           },
-          "value": "4R9pospAHRG/unkeyed"
+          "value": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzU2MDUxMjI4NDIxNjM4NjMwMTkvNTYwNTEyMjg0MjE2Mzg2MzAyMA"
         }
       ],
       "containments": [
         {
           "containment": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzU2MDUxMjI4NDIxNTg3ODAyODAvNTYwNTEyMjg0MjE1ODc4MDI4MQ"
           },
           "children": [
@@ -46,7 +46,7 @@
         {
           "containment": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "My-UnkeyedChild"
           },
           "children": [
@@ -58,7 +58,7 @@
         {
           "reference": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzU2MDUxMjI4NDIxNTg3ODAyODAvNTYwNTEyMjg0MjE2Mzg1NzA3NA"
           },
           "targets": [
@@ -71,7 +71,7 @@
         {
           "reference": {
             "language": "My-TestLang3",
-            "version": "0",
+            "version": "00 my! VERSION 😀",
             "key": "My-UnkeyedRef"
           },
           "targets": [
@@ -89,7 +89,7 @@
       "id": "{id-Plain}",
       "classifier": {
         "language": "My-TestLang3",
-        "version": "0",
+        "version": "00 my! VERSION 😀",
         "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzI1ODUzNzgxNjU5NzMyMDQxMTI"
       },
       "properties": [],
@@ -102,7 +102,7 @@
       "id": "{id-NoExtends}",
       "classifier": {
         "language": "My-TestLang3",
-        "version": "0",
+        "version": "00 my! VERSION 😀",
         "key": "MDk5NDkwYTMtMWUzOS00ZWQxLWJlYmMtODAyNzY2NWNlY2Y5LzI1ODUzNzgxNjU5NzMyMDQ5MDM"
       },
       "properties": [],

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.idmapper.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.idmapper.mps
@@ -288,6 +288,39 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5M3rB6A0Hkg" role="jymVt" />
+    <node concept="3clFb_" id="6jbF0BoeZEa" role="jymVt">
+      <property role="TrG5h" value="mapLanguageVersion" />
+      <node concept="3Tm1VV" id="6jbF0BoeZEc" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0BoeZEd" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0BoeZEe" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="3uibUv" id="6jbF0BoeZEw" role="1tU5fm">
+          <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0BoeZEg" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BoeZEh" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="6jbF0BoeZEx" role="3clF47">
+        <node concept="3clFbF" id="6jbF0BoeZE$" role="3cqZAp">
+          <node concept="2OqwBi" id="6jbF0Bof3P6" role="3clFbG">
+            <node concept="37vLTw" id="6jbF0Bof3pA" role="2Oq$k0">
+              <ref role="3cqZAo" node="6jbF0BoeZEe" resolve="language" />
+            </node>
+            <node concept="liA8E" id="6jbF0Bof5hW" role="2OqNvi">
+              <ref role="37wK5l" to="imb3:~Language.getVersion()" resolve="getVersion" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BoeZEy" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6jbF0Bof2kD" role="jymVt" />
     <node concept="3clFb_" id="5M3rB6A0Hkh" role="jymVt">
       <property role="TrG5h" value="mapClassifier" />
       <node concept="3Tm1VV" id="5M3rB6A0Hki" role="1B3o_S" />

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.lionweb2mps.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.lionweb2mps.mps
@@ -25,6 +25,7 @@
     <import index="y7p" ref="r:3303ef0b-a58e-4f50-b3cb-bd3d7aaf3653(io.lionweb.mps.m3.runtime)" />
     <import index="faaz" ref="r:63045ba4-9612-4b7c-87f4-19d1f2840fe2(io.lionweb.mps.converter.m2.idmapper.slanguage)" />
     <import index="en45" ref="r:22b51c3d-d5d6-4746-9401-f324f9429ada(io.lionweb.mps.converter.m2)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
     <import index="teza" ref="r:84248d29-a48a-459b-8ba9-05c71de1fb63(io.lionweb.mps.converter.m2.idmapper)" implicit="true" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" implicit="true" />
   </imports>
@@ -1004,22 +1005,102 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbF" id="2fx6VTSvLnO" role="3cqZAp">
-              <node concept="2OqwBi" id="2fx6VTSvO6p" role="3clFbG">
-                <node concept="37vLTw" id="2fx6VTSvLnM" role="2Oq$k0">
-                  <ref role="3cqZAo" node="2fx6VTSt4cX" resolve="result" />
+            <node concept="3cpWs8" id="6LPkCA_FCQJ" role="3cqZAp">
+              <node concept="3cpWsn" id="6LPkCA_FCQK" role="3cpWs9">
+                <property role="TrG5h" value="value" />
+                <node concept="17QB3L" id="6LPkCA_FEQX" role="1tU5fm" />
+                <node concept="2OqwBi" id="6LPkCA_FCQL" role="33vP2m">
+                  <node concept="2GrUjf" id="6LPkCA_FCQM" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="2fx6VTSt4di" resolve="jsonProp" />
+                  </node>
+                  <node concept="liA8E" id="6LPkCA_FCQN" role="2OqNvi">
+                    <ref role="37wK5l" to="xfsv:~SerializedPropertyValue.getValue()" resolve="getValue" />
+                  </node>
                 </node>
-                <node concept="liA8E" id="2fx6VTSvRyi" role="2OqNvi">
-                  <ref role="37wK5l" to="mhbf:~SNode.setProperty(org.jetbrains.mps.openapi.language.SProperty,java.lang.String)" resolve="setProperty" />
-                  <node concept="37vLTw" id="2fx6VTSvTo1" role="37wK5m">
+              </node>
+            </node>
+            <node concept="3clFbJ" id="6LPkCA_FsLB" role="3cqZAp">
+              <node concept="3clFbS" id="6LPkCA_FsLD" role="3clFbx">
+                <node concept="3cpWs8" id="6LPkCA_GNOR" role="3cqZAp">
+                  <node concept="3cpWsn" id="6LPkCA_GNOS" role="3cpWs9">
+                    <property role="TrG5h" value="enumLiteral" />
+                    <node concept="3uibUv" id="6LPkCA_GLUy" role="1tU5fm">
+                      <ref role="3uigEE" to="c17a:~SEnumerationLiteral" resolve="SEnumerationLiteral" />
+                    </node>
+                    <node concept="2OqwBi" id="6LPkCA_GNOT" role="33vP2m">
+                      <node concept="37vLTw" id="6LPkCA_GNOU" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2fx6VTSt3pr" resolve="metaPointerLookup" />
+                      </node>
+                      <node concept="liA8E" id="6LPkCA_GNOV" role="2OqNvi">
+                        <ref role="37wK5l" node="4R9posqHJPI" resolve="lookupEnumLiteral" />
+                        <node concept="10QFUN" id="6LPkCA_GNOW" role="37wK5m">
+                          <node concept="2OqwBi" id="6LPkCA_GNOX" role="10QFUP">
+                            <node concept="37vLTw" id="6LPkCA_GNOY" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2fx6VTSvHeW" resolve="mpsProp" />
+                            </node>
+                            <node concept="liA8E" id="6LPkCA_GNOZ" role="2OqNvi">
+                              <ref role="37wK5l" to="c17a:~SProperty.getType()" resolve="getType" />
+                            </node>
+                          </node>
+                          <node concept="3uibUv" id="6LPkCA_GNP0" role="10QFUM">
+                            <ref role="3uigEE" to="c17a:~SEnumeration" resolve="SEnumeration" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="6LPkCA_GNP1" role="37wK5m">
+                          <ref role="3cqZAo" node="2fx6VTSt4dH" resolve="json" />
+                        </node>
+                        <node concept="37vLTw" id="6LPkCA_GNP2" role="37wK5m">
+                          <ref role="3cqZAo" node="6LPkCA_FCQK" resolve="value" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="6LPkCA_GXdi" role="3cqZAp">
+                  <node concept="2YIFZM" id="6LPkCA_GZeS" role="3clFbG">
+                    <ref role="37wK5l" to="mhbf:~SNodeAccessUtil.setPropertyValue(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.language.SProperty,java.lang.Object)" resolve="setPropertyValue" />
+                    <ref role="1Pybhc" to="mhbf:~SNodeAccessUtil" resolve="SNodeAccessUtil" />
+                    <node concept="37vLTw" id="6LPkCA_H1r_" role="37wK5m">
+                      <ref role="3cqZAo" node="2fx6VTSt4cX" resolve="result" />
+                    </node>
+                    <node concept="37vLTw" id="6LPkCA_H5nI" role="37wK5m">
+                      <ref role="3cqZAo" node="2fx6VTSvHeW" resolve="mpsProp" />
+                    </node>
+                    <node concept="37vLTw" id="6LPkCA_H933" role="37wK5m">
+                      <ref role="3cqZAo" node="6LPkCA_GNOS" resolve="enumLiteral" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2ZW3vV" id="6LPkCA_F$Ul" role="3clFbw">
+                <node concept="3uibUv" id="6LPkCA_FAG5" role="2ZW6by">
+                  <ref role="3uigEE" to="c17a:~SEnumeration" resolve="SEnumeration" />
+                </node>
+                <node concept="2OqwBi" id="6LPkCA_Fwp7" role="2ZW6bz">
+                  <node concept="37vLTw" id="6LPkCA_FuDR" role="2Oq$k0">
                     <ref role="3cqZAo" node="2fx6VTSvHeW" resolve="mpsProp" />
                   </node>
-                  <node concept="2OqwBi" id="A9P4gGP5qA" role="37wK5m">
-                    <node concept="2GrUjf" id="A9P4gGP5qB" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="2fx6VTSt4di" resolve="jsonProp" />
-                    </node>
-                    <node concept="liA8E" id="A9P4gGP5qC" role="2OqNvi">
-                      <ref role="37wK5l" to="xfsv:~SerializedPropertyValue.getValue()" resolve="getValue" />
+                  <node concept="liA8E" id="6LPkCA_Fysg" role="2OqNvi">
+                    <ref role="37wK5l" to="c17a:~SProperty.getType()" resolve="getType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="9aQIb" id="6LPkCA_HcWL" role="9aQIa">
+                <node concept="3clFbS" id="6LPkCA_HcWM" role="9aQI4">
+                  <node concept="3clFbF" id="2fx6VTSvLnO" role="3cqZAp">
+                    <node concept="2OqwBi" id="2fx6VTSvO6p" role="3clFbG">
+                      <node concept="37vLTw" id="2fx6VTSvLnM" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2fx6VTSt4cX" resolve="result" />
+                      </node>
+                      <node concept="liA8E" id="2fx6VTSvRyi" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SNode.setProperty(org.jetbrains.mps.openapi.language.SProperty,java.lang.String)" resolve="setProperty" />
+                        <node concept="37vLTw" id="2fx6VTSvTo1" role="37wK5m">
+                          <ref role="3cqZAo" node="2fx6VTSvHeW" resolve="mpsProp" />
+                        </node>
+                        <node concept="37vLTw" id="6LPkCA_FCQO" role="37wK5m">
+                          <ref role="3cqZAo" node="6LPkCA_FCQK" resolve="value" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -7068,6 +7149,14 @@
         <ref role="3uigEE" to="faaz:6VkSF6aHm0Q" resolve="SLanguageIdExtractor" />
       </node>
     </node>
+    <node concept="312cEg" id="6jbF0BoAaGq" role="jymVt">
+      <property role="TrG5h" value="attributeFinder" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="6jbF0BoAaGr" role="1B3o_S" />
+      <node concept="3uibUv" id="6jbF0BoAaGt" role="1tU5fm">
+        <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="6lVb1tfVmJh" role="jymVt" />
     <node concept="3clFbW" id="6lVb1tfVtvX" role="jymVt">
       <node concept="3cqZAl" id="6lVb1tfVtvY" role="3clF45" />
@@ -7140,6 +7229,19 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbF" id="6jbF0BoAaGu" role="3cqZAp">
+          <node concept="37vLTI" id="6jbF0BoAaGw" role="3clFbG">
+            <node concept="2OqwBi" id="6jbF0BoAev2" role="37vLTJ">
+              <node concept="Xjq3P" id="6jbF0BoAeHD" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6jbF0BoAev5" role="2OqNvi">
+                <ref role="2Oxat5" node="6jbF0BoAaGq" resolve="attributeFinder" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="6jbF0BoAaG$" role="37vLTx">
+              <ref role="3cqZAo" node="6jbF0Bo0uNq" resolve="attributeFinder" />
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="37vLTG" id="6lVb1tfVtww" role="3clF46">
         <property role="TrG5h" value="idMapper" />
@@ -7174,6 +7276,15 @@
           <ref role="3uigEE" to="faaz:6VkSF6aHm0Q" resolve="SLanguageIdExtractor" />
         </node>
         <node concept="2AHcQZ" id="3M8YG$dgCjp" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6jbF0Bo0uNq" role="3clF46">
+        <property role="TrG5h" value="attributeFinder" />
+        <node concept="3uibUv" id="6jbF0Bo0uOp" role="1tU5fm">
+          <ref role="3uigEE" to="y7p:pPZz6cPvUw" resolve="LionWebAttributeFinder" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0Bo0zUM" role="2AJF6D">
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
@@ -7236,28 +7347,84 @@
             </node>
           </node>
         </node>
-        <node concept="3SKdUt" id="6lVb1tfV3cy" role="3cqZAp">
-          <node concept="1PaTwC" id="6lVb1tfV3cz" role="1aUNEU">
-            <node concept="3oM_SD" id="6lVb1tfV3c$" role="1PaTwD">
-              <property role="3oM_SC" value="TODO:" />
-            </node>
-            <node concept="3oM_SD" id="6lVb1tfV3c_" role="1PaTwD">
-              <property role="3oM_SC" value="Check" />
-            </node>
-            <node concept="3oM_SD" id="6lVb1tfV3cA" role="1PaTwD">
-              <property role="3oM_SC" value="if" />
-            </node>
-            <node concept="3oM_SD" id="6lVb1tfV3cB" role="1PaTwD">
-              <property role="3oM_SC" value="language" />
-            </node>
-            <node concept="3oM_SD" id="6lVb1tfV3cC" role="1PaTwD">
-              <property role="3oM_SC" value="versions" />
-            </node>
-            <node concept="3oM_SD" id="6lVb1tfV3cD" role="1PaTwD">
-              <property role="3oM_SC" value="match" />
+        <node concept="3clFbH" id="6jbF0Bo_Oer" role="3cqZAp" />
+        <node concept="3cpWs8" id="6jbF0BoAhBe" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoAhBf" role="3cpWs9">
+            <property role="TrG5h" value="mpsVersion" />
+            <node concept="17QB3L" id="6jbF0BoAgHq" role="1tU5fm" />
+            <node concept="2YIFZM" id="6jbF0BoAhBg" role="33vP2m">
+              <ref role="1Pybhc" to="y7p:6jTTMHD72IS" resolve="MpsLanguageUtil" />
+              <ref role="37wK5l" to="y7p:6jbF0Bo0uK5" resolve="getLanguageVersionString" />
+              <node concept="37vLTw" id="6jbF0BoAhBh" role="37wK5m">
+                <ref role="3cqZAo" node="6lVb1tfV9Yb" resolve="result" />
+              </node>
+              <node concept="37vLTw" id="6jbF0BoAhBi" role="37wK5m">
+                <ref role="3cqZAo" node="6jbF0BoAaGq" resolve="attributeFinder" />
+              </node>
             </node>
           </node>
         </node>
+        <node concept="3clFbJ" id="6jbF0BoApL7" role="3cqZAp">
+          <node concept="3clFbS" id="6jbF0BoApL9" role="3clFbx">
+            <node concept="3clFbF" id="6jbF0BoADX3" role="3cqZAp">
+              <node concept="1rXfSq" id="6jbF0BoADX4" role="3clFbG">
+                <ref role="37wK5l" node="6jbF0BoADX1" resolve="logWarning" />
+                <node concept="3cpWs3" id="6jbF0BoC29h" role="37wK5m">
+                  <node concept="3cpWs3" id="6jbF0BoBWBe" role="3uHU7B">
+                    <node concept="3cpWs3" id="6jbF0BoBuGq" role="3uHU7B">
+                      <node concept="3cpWs3" id="6jbF0BoBlIC" role="3uHU7B">
+                        <node concept="3cpWs3" id="6jbF0BoB8vp" role="3uHU7B">
+                          <node concept="3cpWs3" id="6jbF0BoB182" role="3uHU7B">
+                            <node concept="Xl_RD" id="6jbF0BoAUd_" role="3uHU7B">
+                              <property role="Xl_RC" value="language " />
+                            </node>
+                            <node concept="37vLTw" id="6jbF0BoB4Yv" role="3uHU7w">
+                              <ref role="3cqZAo" node="6lVb1tfV9Yb" resolve="result" />
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="6jbF0BoB8wl" role="3uHU7w">
+                            <property role="Xl_RC" value=": metaPointer version '" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="6jbF0BoBrqq" role="3uHU7w">
+                          <node concept="37vLTw" id="6jbF0BoBnEW" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6lVb1tfV3aH" resolve="metaPointer" />
+                          </node>
+                          <node concept="liA8E" id="6jbF0BoBsZm" role="2OqNvi">
+                            <ref role="37wK5l" to="xfsv:~MetaPointer.getVersion()" resolve="getVersion" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Xl_RD" id="6jbF0BoBy$a" role="3uHU7w">
+                        <property role="Xl_RC" value="' does not match language version '" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="6jbF0BoBY8X" role="3uHU7w">
+                      <ref role="3cqZAo" node="6jbF0BoAhBf" resolve="mpsVersion" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="6jbF0BoC93M" role="3uHU7w">
+                    <property role="Xl_RC" value="'." />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="17QLQc" id="6jbF0BoAwhM" role="3clFbw">
+            <node concept="2OqwBi" id="6jbF0BoA$xJ" role="3uHU7w">
+              <node concept="37vLTw" id="6jbF0BoAz36" role="2Oq$k0">
+                <ref role="3cqZAo" node="6lVb1tfV3aH" resolve="metaPointer" />
+              </node>
+              <node concept="liA8E" id="6jbF0BoACmA" role="2OqNvi">
+                <ref role="37wK5l" to="xfsv:~MetaPointer.getVersion()" resolve="getVersion" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="6jbF0BoAt_m" role="3uHU7B">
+              <ref role="3cqZAo" node="6jbF0BoAhBf" resolve="mpsVersion" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6jbF0BoCjIE" role="3cqZAp" />
         <node concept="3cpWs6" id="6lVb1tfV3c8" role="3cqZAp">
           <node concept="37vLTw" id="6lVb1tfV3c9" role="3cqZAk">
             <ref role="3cqZAo" node="6lVb1tfV9Yb" resolve="result" />
@@ -7269,6 +7436,32 @@
       </node>
       <node concept="3uibUv" id="68Be_yHJd1" role="Sfmx6">
         <ref role="3uigEE" to="apzt:3zvxfLhsQ3L" resolve="IdDeserializationException" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6jbF0BoALm1" role="jymVt" />
+    <node concept="3clFb_" id="6jbF0BoADX1" role="jymVt">
+      <property role="TrG5h" value="logWarning" />
+      <node concept="3clFbS" id="6jbF0BoADX2" role="3clF47">
+        <node concept="3clFbF" id="6jbF0BoCprU" role="3cqZAp">
+          <node concept="2OqwBi" id="6jbF0BoCprR" role="3clFbG">
+            <node concept="10M0yZ" id="6jbF0BoCprS" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+            </node>
+            <node concept="liA8E" id="6jbF0BoCprT" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="37vLTw" id="6jbF0BoCtiu" role="37wK5m">
+                <ref role="3cqZAo" node="6jbF0BoANpb" resolve="message" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="6jbF0BoADWZ" role="3clF45" />
+      <node concept="3Tmbuc" id="6jbF0BoAHWs" role="1B3o_S" />
+      <node concept="37vLTG" id="6jbF0BoANpb" role="3clF46">
+        <property role="TrG5h" value="message" />
+        <node concept="17QB3L" id="6jbF0BoANpa" role="1tU5fm" />
       </node>
     </node>
     <node concept="2tJIrI" id="6lVb1tfVeLA" role="jymVt" />
@@ -13009,28 +13202,6 @@
                       <ref role="3cqZAo" node="KVKr66xNEB" resolve="metaPointer" />
                     </node>
                   </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3SKdUt" id="KVKr66AgLK" role="3cqZAp">
-              <node concept="1PaTwC" id="KVKr66AgLL" role="1aUNEU">
-                <node concept="3oM_SD" id="KVKr66AgLM" role="1PaTwD">
-                  <property role="3oM_SC" value="TODO:" />
-                </node>
-                <node concept="3oM_SD" id="KVKr66AgLN" role="1PaTwD">
-                  <property role="3oM_SC" value="Check" />
-                </node>
-                <node concept="3oM_SD" id="KVKr66AgLO" role="1PaTwD">
-                  <property role="3oM_SC" value="if" />
-                </node>
-                <node concept="3oM_SD" id="KVKr66AgLP" role="1PaTwD">
-                  <property role="3oM_SC" value="language" />
-                </node>
-                <node concept="3oM_SD" id="KVKr66AgLQ" role="1PaTwD">
-                  <property role="3oM_SC" value="versions" />
-                </node>
-                <node concept="3oM_SD" id="KVKr66AgLR" role="1PaTwD">
-                  <property role="3oM_SC" value="match" />
                 </node>
               </node>
             </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.mps2lionweb.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.instance.mps2lionweb.mps
@@ -340,6 +340,14 @@
   <node concept="312cEu" id="48csSBNvYv0">
     <property role="TrG5h" value="AMps2LionWebConverter" />
     <property role="1sVAO0" value="true" />
+    <node concept="312cEg" id="6LPkCA_xLIE" role="jymVt">
+      <property role="TrG5h" value="mapper" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="6LPkCA_x__U" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA_xGcb" role="1tU5fm">
+        <ref role="3uigEE" to="faaz:5M3rB6B2O$B" resolve="ASLanguageGuaranteedMapper" />
+      </node>
+    </node>
     <node concept="312cEg" id="5AGBwuFn11a" role="jymVt">
       <property role="TrG5h" value="attributeFinder" />
       <property role="3TUv4t" value="true" />
@@ -566,6 +574,19 @@
       <node concept="3cqZAl" id="48csSBNwcsu" role="3clF45" />
       <node concept="3Tm1VV" id="48csSBNwcsv" role="1B3o_S" />
       <node concept="3clFbS" id="48csSBNwcsw" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA_xSlL" role="3cqZAp">
+          <node concept="37vLTI" id="6LPkCA_xTKE" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA_xTXy" role="37vLTx">
+              <ref role="3cqZAo" node="6LPkCA_xRnI" resolve="mapper" />
+            </node>
+            <node concept="2OqwBi" id="6LPkCA_xSyS" role="37vLTJ">
+              <node concept="Xjq3P" id="6LPkCA_xSlJ" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6LPkCA_xSEL" role="2OqNvi">
+                <ref role="2Oxat5" node="6LPkCA_xLIE" resolve="mapper" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="5AGBwuFn11e" role="3cqZAp">
           <node concept="37vLTI" id="5AGBwuFn11g" role="3clFbG">
             <node concept="2OqwBi" id="5AGBwuFn4e9" role="37vLTJ">
@@ -656,6 +677,15 @@
               <ref role="3cqZAo" node="48csSBNwcti" resolve="inputNodes" />
             </node>
           </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6LPkCA_xRnI" role="3clF46">
+        <property role="TrG5h" value="mapper" />
+        <node concept="3uibUv" id="6LPkCA_xRnK" role="1tU5fm">
+          <ref role="3uigEE" to="faaz:5M3rB6B2O$B" resolve="ASLanguageGuaranteedMapper" />
+        </node>
+        <node concept="2AHcQZ" id="6LPkCA_xRZs" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
       <node concept="37vLTG" id="5AGBwuFn0Ua" role="3clF46">
@@ -2163,6 +2193,36 @@
             </node>
             <node concept="3clFbJ" id="7KBsn2yvGJ" role="3cqZAp">
               <node concept="3clFbS" id="7KBsn2yvGL" role="3clFbx">
+                <node concept="3clFbJ" id="6LPkCA_x61V" role="3cqZAp">
+                  <node concept="3clFbS" id="6LPkCA_x61X" role="3clFbx">
+                    <node concept="3cpWs6" id="6LPkCA_xncs" role="3cqZAp">
+                      <node concept="2OqwBi" id="6LPkCA_y6J$" role="3cqZAk">
+                        <node concept="37vLTw" id="6LPkCA_y1H4" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6LPkCA_xLIE" resolve="mapper" />
+                        </node>
+                        <node concept="liA8E" id="6LPkCA_ycRf" role="2OqNvi">
+                          <ref role="37wK5l" to="teza:5M3rB6Ae5wB" resolve="mapEnumLiteral" />
+                          <node concept="10QFUN" id="6LPkCA_ytde" role="37wK5m">
+                            <node concept="37vLTw" id="6LPkCA_ytdd" role="10QFUP">
+                              <ref role="3cqZAo" node="5IkW5anFfoc" resolve="value" />
+                            </node>
+                            <node concept="3uibUv" id="6LPkCA_ytdc" role="10QFUM">
+                              <ref role="3uigEE" to="c17a:~SEnumerationLiteral" resolve="SEnumerationLiteral" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2ZW3vV" id="6LPkCA_xdB4" role="3clFbw">
+                    <node concept="3uibUv" id="6LPkCA_xipn" role="2ZW6by">
+                      <ref role="3uigEE" to="c17a:~SEnumerationLiteral" resolve="SEnumerationLiteral" />
+                    </node>
+                    <node concept="37vLTw" id="6LPkCA_x8Xo" role="2ZW6bz">
+                      <ref role="3cqZAo" node="5IkW5anFfoc" resolve="value" />
+                    </node>
+                  </node>
+                </node>
                 <node concept="3cpWs6" id="7KBsn2yw1g" role="3cqZAp">
                   <node concept="2OqwBi" id="nWBHrKsRzg" role="3cqZAk">
                     <node concept="37vLTw" id="nWBHrKsNUn" role="2Oq$k0">
@@ -2196,8 +2256,23 @@
               <node concept="10Nm6u" id="5IkW5anFfom" role="3cqZAk" />
             </node>
           </node>
-          <node concept="37vLTw" id="nWBHrKrtV2" role="3clFbw">
-            <ref role="3cqZAo" node="nWBHrKpCEh" resolve="exportComputedProperties" />
+          <node concept="22lmx$" id="6LPkCA_w$vL" role="3clFbw">
+            <node concept="2ZW3vV" id="6LPkCA_wSjV" role="3uHU7w">
+              <node concept="3uibUv" id="6LPkCA_wWIC" role="2ZW6by">
+                <ref role="3uigEE" to="c17a:~SEnumeration" resolve="SEnumeration" />
+              </node>
+              <node concept="2OqwBi" id="6LPkCA_wIln" role="2ZW6bz">
+                <node concept="37vLTw" id="6LPkCA_wCFG" role="2Oq$k0">
+                  <ref role="3cqZAo" node="nWBHrKpN94" resolve="mpsProp" />
+                </node>
+                <node concept="liA8E" id="6LPkCA_wNag" role="2OqNvi">
+                  <ref role="37wK5l" to="c17a:~SProperty.getType()" resolve="getType" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="nWBHrKrtV2" role="3uHU7B">
+              <ref role="3cqZAo" node="nWBHrKpCEh" resolve="exportComputedProperties" />
+            </node>
           </node>
         </node>
         <node concept="3cpWs6" id="nWBHrKpN8X" role="3cqZAp">
@@ -3889,6 +3964,9 @@
       <node concept="3clFbS" id="6VkSF6aDU2U" role="3clF47">
         <node concept="XkiVB" id="6VkSF6aDU2W" role="3cqZAp">
           <ref role="37wK5l" node="48csSBNwcss" resolve="AMps2LionWebConverter" />
+          <node concept="37vLTw" id="6LPkCA_yCQT" role="37wK5m">
+            <ref role="3cqZAo" node="6LPkCA_yCum" resolve="mapper" />
+          </node>
           <node concept="37vLTw" id="5AGBwuFv2vA" role="37wK5m">
             <ref role="3cqZAo" node="5AGBwuFv2p0" resolve="attributeFinder" />
           </node>
@@ -3910,6 +3988,15 @@
           <node concept="37vLTw" id="6VkSF6aDU31" role="37wK5m">
             <ref role="3cqZAo" node="6VkSF6aDU2X" resolve="inputNodes" />
           </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6LPkCA_yCum" role="3clF46">
+        <property role="TrG5h" value="mapper" />
+        <node concept="3uibUv" id="6LPkCA_yCun" role="1tU5fm">
+          <ref role="3uigEE" to="faaz:5M3rB6B2O$B" resolve="ASLanguageGuaranteedMapper" />
+        </node>
+        <node concept="2AHcQZ" id="6LPkCA_yCuo" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
       <node concept="37vLTG" id="5AGBwuFv2p0" role="3clF46">
@@ -4137,6 +4224,9 @@
       <node concept="3clFbS" id="6VkSF6aDU_6" role="3clF47">
         <node concept="XkiVB" id="6VkSF6aDU_7" role="3cqZAp">
           <ref role="37wK5l" node="48csSBNwcss" resolve="AMps2LionWebConverter" />
+          <node concept="37vLTw" id="6LPkCA_yA9a" role="37wK5m">
+            <ref role="3cqZAo" node="6LPkCA_y_VR" resolve="mapper" />
+          </node>
           <node concept="37vLTw" id="5AGBwuFv2k6" role="37wK5m">
             <ref role="3cqZAo" node="5AGBwuFv2aM" resolve="attributeFinder" />
           </node>
@@ -4158,6 +4248,15 @@
           <node concept="37vLTw" id="6VkSF6aDU_8" role="37wK5m">
             <ref role="3cqZAo" node="6VkSF6aDU_9" resolve="inputNodes" />
           </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6LPkCA_y_VR" role="3clF46">
+        <property role="TrG5h" value="mapper" />
+        <node concept="3uibUv" id="6LPkCA_y_VS" role="1tU5fm">
+          <ref role="3uigEE" to="faaz:5M3rB6B2O$B" resolve="ASLanguageGuaranteedMapper" />
+        </node>
+        <node concept="2AHcQZ" id="6LPkCA_y_VT" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
       <node concept="37vLTG" id="5AGBwuFv2aM" role="3clF46">
@@ -4373,6 +4472,9 @@
       <node concept="3clFbS" id="6VkSF6aF16c" role="3clF47">
         <node concept="XkiVB" id="6VkSF6aF16d" role="3cqZAp">
           <ref role="37wK5l" node="48csSBNwcss" resolve="AMps2LionWebConverter" />
+          <node concept="37vLTw" id="6LPkCA_yzG_" role="37wK5m">
+            <ref role="3cqZAo" node="6LPkCA_yzqx" resolve="mapper" />
+          </node>
           <node concept="37vLTw" id="5AGBwuFv20b" role="37wK5m">
             <ref role="3cqZAo" node="5AGBwuFv1PC" resolve="attributeFinder" />
           </node>
@@ -4394,6 +4496,15 @@
           <node concept="37vLTw" id="6VkSF6aF16e" role="37wK5m">
             <ref role="3cqZAo" node="6VkSF6aF16f" resolve="inputNodes" />
           </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6LPkCA_yzqx" role="3clF46">
+        <property role="TrG5h" value="mapper" />
+        <node concept="3uibUv" id="6LPkCA_yzqy" role="1tU5fm">
+          <ref role="3uigEE" to="faaz:5M3rB6B2O$B" resolve="ASLanguageGuaranteedMapper" />
+        </node>
+        <node concept="2AHcQZ" id="6LPkCA_yzqz" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
       <node concept="37vLTG" id="5AGBwuFv1PC" role="3clF46">
@@ -5466,240 +5577,37 @@
         </node>
       </node>
       <node concept="3clFbS" id="5s4Z0e0go9j" role="3clF47">
-        <node concept="3clFbJ" id="6Z_tmAedT2m" role="3cqZAp">
-          <node concept="3clFbS" id="6Z_tmAedT2o" role="3clFbx">
-            <node concept="3clFbJ" id="6Z_tmAeeK0Y" role="3cqZAp">
-              <node concept="3clFbS" id="6Z_tmAeeK10" role="3clFbx">
-                <node concept="3cpWs6" id="6Z_tmAef2FX" role="3cqZAp">
-                  <node concept="2OqwBi" id="7OJcYqzcLz1" role="3cqZAk">
-                    <node concept="2OqwBi" id="7OJcYqzcDzr" role="2Oq$k0">
-                      <node concept="2OqwBi" id="7OJcYqzcBaG" role="2Oq$k0">
-                        <node concept="37vLTw" id="7OJcYqzcA9T" role="2Oq$k0">
-                          <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
-                        </node>
-                        <node concept="liA8E" id="7OJcYqzcCij" role="2OqNvi">
-                          <ref role="37wK5l" to="y7p:7OJcYqx1HDk" resolve="listMpsInternalClassifiers" />
-                        </node>
-                      </node>
-                      <node concept="1z4cxt" id="7OJcYqzcELc" role="2OqNvi">
-                        <node concept="1bVj0M" id="7OJcYqzcELe" role="23t8la">
-                          <node concept="3clFbS" id="7OJcYqzcELf" role="1bW5cS">
-                            <node concept="3clFbF" id="4r3Tp$pdkV2" role="3cqZAp">
-                              <node concept="15s5l7" id="4r3Tp$peLg9" role="lGtFl">
-                                <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Warning: equals() between objects of inconvertible types&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6293790355739144894]&quot;;" />
-                                <property role="huDt6" value="Warning: equals() between objects of inconvertible types" />
-                              </node>
-                              <node concept="2OqwBi" id="4r3Tp$pdm00" role="3clFbG">
-                                <node concept="37vLTw" id="4r3Tp$pdkV0" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="4r3Tp$pcYul" resolve="sComparer" />
-                                </node>
-                                <node concept="liA8E" id="4r3Tp$pdmTf" role="2OqNvi">
-                                  <ref role="37wK5l" to="y7p:4r3Tp$paZgH" resolve="equals" />
-                                  <node concept="10QFUN" id="4r3Tp$pdsw2" role="37wK5m">
-                                    <node concept="2OqwBi" id="4r3Tp$pdsvZ" role="10QFUP">
-                                      <node concept="37vLTw" id="4r3Tp$pdsw0" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="7OJcYqzcELg" resolve="it" />
-                                      </node>
-                                      <node concept="liA8E" id="4r3Tp$pdsw1" role="2OqNvi">
-                                        <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
-                                      </node>
-                                    </node>
-                                    <node concept="3uibUv" id="4r3Tp$pdsvW" role="10QFUM">
-                                      <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-                                    </node>
-                                  </node>
-                                  <node concept="10QFUN" id="4r3Tp$pd$ka" role="37wK5m">
-                                    <node concept="37vLTw" id="4r3Tp$pd$k9" role="10QFUP">
-                                      <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
-                                    </node>
-                                    <node concept="3uibUv" id="4r3Tp$pd$k6" role="10QFUM">
-                                      <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="Rh6nW" id="7OJcYqzcELg" role="1bW2Oz">
-                            <property role="TrG5h" value="it" />
-                            <node concept="2jxLKc" id="7OJcYqzcELh" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="7OJcYqzcMCD" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:7OJcYq_s$7A" resolve="getLcLanguageKey" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2ZW3vV" id="6Z_tmAeeLUa" role="3clFbw">
-                <node concept="3uibUv" id="6Z_tmAeeMrh" role="2ZW6by">
-                  <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
-                </node>
-                <node concept="37vLTw" id="6Z_tmAeeL1L" role="2ZW6bz">
-                  <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
-                </node>
+        <node concept="3cpWs8" id="6jbF0BoifmR" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoifmS" role="3cpWs9">
+            <property role="TrG5h" value="staple" />
+            <node concept="3uibUv" id="6jbF0Boif7L" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:7OJcYqvKf0O" resolve="IKeyedStaple" />
+            </node>
+            <node concept="1rXfSq" id="6jbF0BoifmT" role="33vP2m">
+              <ref role="37wK5l" node="6jbF0BohVaT" resolve="extractStaple" />
+              <node concept="37vLTw" id="6jbF0BoifmU" role="37wK5m">
+                <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
               </node>
             </node>
-            <node concept="3clFbJ" id="6Z_tmAef3eD" role="3cqZAp">
-              <node concept="3clFbS" id="6Z_tmAef3eF" role="3clFbx">
-                <node concept="3cpWs6" id="6Z_tmAef6wu" role="3cqZAp">
-                  <node concept="2OqwBi" id="7OJcYqzcVFO" role="3cqZAk">
-                    <node concept="2OqwBi" id="7OJcYqzcVFP" role="2Oq$k0">
-                      <node concept="2OqwBi" id="7OJcYqzcVFQ" role="2Oq$k0">
-                        <node concept="37vLTw" id="7OJcYqzcVFR" role="2Oq$k0">
-                          <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
-                        </node>
-                        <node concept="liA8E" id="7OJcYqzcVFS" role="2OqNvi">
-                          <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
-                        </node>
-                      </node>
-                      <node concept="1z4cxt" id="7OJcYqzcVFT" role="2OqNvi">
-                        <node concept="1bVj0M" id="7OJcYqzcVFU" role="23t8la">
-                          <node concept="3clFbS" id="7OJcYqzcVFV" role="1bW5cS">
-                            <node concept="3clFbF" id="4r3Tp$pdvvw" role="3cqZAp">
-                              <node concept="15s5l7" id="4r3Tp$peMwD" role="lGtFl">
-                                <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Warning: equals() between objects of inconvertible types&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6293790355739144894]&quot;;" />
-                                <property role="huDt6" value="Warning: equals() between objects of inconvertible types" />
-                              </node>
-                              <node concept="2OqwBi" id="4r3Tp$pdvvy" role="3clFbG">
-                                <node concept="37vLTw" id="4r3Tp$pdvvz" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="4r3Tp$pcYul" resolve="sComparer" />
-                                </node>
-                                <node concept="liA8E" id="4r3Tp$pdvv$" role="2OqNvi">
-                                  <ref role="37wK5l" to="y7p:4r3Tp$pb180" resolve="equals" />
-                                  <node concept="10QFUN" id="4r3Tp$pdvv_" role="37wK5m">
-                                    <node concept="2OqwBi" id="4r3Tp$pdvvA" role="10QFUP">
-                                      <node concept="37vLTw" id="4r3Tp$pdvvB" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="7OJcYqzcVG2" resolve="it" />
-                                      </node>
-                                      <node concept="liA8E" id="4r3Tp$pdvvC" role="2OqNvi">
-                                        <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
-                                      </node>
-                                    </node>
-                                    <node concept="3uibUv" id="4r3Tp$pdvvD" role="10QFUM">
-                                      <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-                                    </node>
-                                  </node>
-                                  <node concept="10QFUN" id="4r3Tp$pdCTi" role="37wK5m">
-                                    <node concept="37vLTw" id="4r3Tp$pdCTh" role="10QFUP">
-                                      <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
-                                    </node>
-                                    <node concept="3uibUv" id="4r3Tp$pdCTe" role="10QFUM">
-                                      <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="Rh6nW" id="7OJcYqzcVG2" role="1bW2Oz">
-                            <property role="TrG5h" value="it" />
-                            <node concept="2jxLKc" id="7OJcYqzcVG3" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="7OJcYqzcVG4" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:7OJcYq_s$7A" resolve="getLcLanguageKey" />
-                    </node>
-                  </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6jbF0Boiicf" role="3cqZAp">
+          <node concept="3clFbS" id="6jbF0Boiich" role="3clFbx">
+            <node concept="3cpWs6" id="6jbF0BoissQ" role="3cqZAp">
+              <node concept="2OqwBi" id="6jbF0BoissS" role="3cqZAk">
+                <node concept="37vLTw" id="6jbF0BoissT" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6jbF0BoifmS" resolve="staple" />
                 </node>
-              </node>
-              <node concept="2ZW3vV" id="6Z_tmAef4TX" role="3clFbw">
-                <node concept="3uibUv" id="6Z_tmAef5tu" role="2ZW6by">
-                  <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
-                </node>
-                <node concept="37vLTw" id="6Z_tmAef4ib" role="2ZW6bz">
-                  <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="6Z_tmAegzvh" role="3cqZAp">
-              <node concept="3clFbS" id="6Z_tmAegzvj" role="3clFbx">
-                <node concept="3cpWs6" id="6Z_tmAegArS" role="3cqZAp">
-                  <node concept="2OqwBi" id="7OJcYqzcXSs" role="3cqZAk">
-                    <node concept="2OqwBi" id="7OJcYqzcXSt" role="2Oq$k0">
-                      <node concept="2OqwBi" id="7OJcYqzcXSu" role="2Oq$k0">
-                        <node concept="37vLTw" id="7OJcYqzcXSv" role="2Oq$k0">
-                          <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
-                        </node>
-                        <node concept="liA8E" id="7OJcYqzcXSw" role="2OqNvi">
-                          <ref role="37wK5l" to="y7p:7OJcYqx2zDi" resolve="listMpsInternalFeatures" />
-                        </node>
-                      </node>
-                      <node concept="1z4cxt" id="7OJcYqzcXSx" role="2OqNvi">
-                        <node concept="1bVj0M" id="7OJcYqzcXSy" role="23t8la">
-                          <node concept="3clFbS" id="7OJcYqzcXSz" role="1bW5cS">
-                            <node concept="3clFbF" id="7OJcYqzcXS$" role="3cqZAp">
-                              <node concept="15s5l7" id="4r3Tp$peNOG" role="lGtFl">
-                                <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Warning: equals() between objects of inconvertible types&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6293790355739144894]&quot;;" />
-                                <property role="huDt6" value="Warning: equals() between objects of inconvertible types" />
-                              </node>
-                              <node concept="2OqwBi" id="4r3Tp$pdKD2" role="3clFbG">
-                                <node concept="37vLTw" id="4r3Tp$pdKD3" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="4r3Tp$pcYul" resolve="sComparer" />
-                                </node>
-                                <node concept="liA8E" id="4r3Tp$pdKD4" role="2OqNvi">
-                                  <ref role="37wK5l" to="y7p:4r3Tp$paZj3" resolve="equals" />
-                                  <node concept="10QFUN" id="4r3Tp$pdKD5" role="37wK5m">
-                                    <node concept="2OqwBi" id="4r3Tp$pdKD6" role="10QFUP">
-                                      <node concept="37vLTw" id="4r3Tp$pdKD7" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="7OJcYqzcXSE" resolve="it" />
-                                      </node>
-                                      <node concept="liA8E" id="4r3Tp$pdKD8" role="2OqNvi">
-                                        <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
-                                      </node>
-                                    </node>
-                                    <node concept="3uibUv" id="4r3Tp$pdKD9" role="10QFUM">
-                                      <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
-                                    </node>
-                                  </node>
-                                  <node concept="10QFUN" id="4r3Tp$pdKDa" role="37wK5m">
-                                    <node concept="37vLTw" id="4r3Tp$pdKDb" role="10QFUP">
-                                      <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
-                                    </node>
-                                    <node concept="3uibUv" id="4r3Tp$pdKDc" role="10QFUM">
-                                      <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="Rh6nW" id="7OJcYqzcXSE" role="1bW2Oz">
-                            <property role="TrG5h" value="it" />
-                            <node concept="2jxLKc" id="7OJcYqzcXSF" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="7OJcYqzcXSG" role="2OqNvi">
-                      <ref role="37wK5l" to="y7p:7OJcYq_s$7A" resolve="getLcLanguageKey" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2ZW3vV" id="6Z_tmAeg_09" role="3clFbw">
-                <node concept="3uibUv" id="6Z_tmAeg__T" role="2ZW6by">
-                  <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
-                </node>
-                <node concept="37vLTw" id="6Z_tmAeg$4s" role="2ZW6bz">
-                  <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
+                <node concept="liA8E" id="6jbF0BoissU" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYq_s$7A" resolve="getLcLanguageKey" />
                 </node>
               </node>
             </node>
           </node>
-          <node concept="2OqwBi" id="6Z_tmAedUeC" role="3clFbw">
-            <node concept="37vLTw" id="6Z_tmAedTxC" role="2Oq$k0">
-              <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
-            </node>
-            <node concept="liA8E" id="6Z_tmAedVgQ" role="2OqNvi">
-              <ref role="37wK5l" to="y7p:5JNiskiswUo" resolve="isMpsInternalElement" />
-              <node concept="37vLTw" id="6Z_tmAedVKy" role="37wK5m">
-                <ref role="3cqZAo" node="5s4Z0e0go9r" resolve="element" />
-              </node>
+          <node concept="3y3z36" id="6jbF0Boimmk" role="3clFbw">
+            <node concept="10Nm6u" id="6jbF0Boinxe" role="3uHU7w" />
+            <node concept="37vLTw" id="6jbF0Boij5a" role="3uHU7B">
+              <ref role="3cqZAo" node="6jbF0BoifmS" resolve="staple" />
             </node>
           </node>
         </node>
@@ -5730,6 +5638,254 @@
         <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
       </node>
     </node>
+    <node concept="2tJIrI" id="6jbF0BohRJT" role="jymVt" />
+    <node concept="3clFb_" id="6jbF0BohVaT" role="jymVt">
+      <property role="TrG5h" value="extractStaple" />
+      <node concept="3clFbS" id="6jbF0BohVaW" role="3clF47">
+        <node concept="3clFbJ" id="6Z_tmAedT2m" role="3cqZAp">
+          <node concept="3clFbS" id="6Z_tmAedT2o" role="3clFbx">
+            <node concept="3clFbJ" id="6Z_tmAeeK0Y" role="3cqZAp">
+              <node concept="3clFbS" id="6Z_tmAeeK10" role="3clFbx">
+                <node concept="3cpWs6" id="6Z_tmAef2FX" role="3cqZAp">
+                  <node concept="2OqwBi" id="7OJcYqzcDzr" role="3cqZAk">
+                    <node concept="2OqwBi" id="7OJcYqzcBaG" role="2Oq$k0">
+                      <node concept="37vLTw" id="7OJcYqzcA9T" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYqzcCij" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:7OJcYqx1HDk" resolve="listMpsInternalClassifiers" />
+                      </node>
+                    </node>
+                    <node concept="1z4cxt" id="7OJcYqzcELc" role="2OqNvi">
+                      <node concept="1bVj0M" id="7OJcYqzcELe" role="23t8la">
+                        <node concept="3clFbS" id="7OJcYqzcELf" role="1bW5cS">
+                          <node concept="3clFbF" id="4r3Tp$pdkV2" role="3cqZAp">
+                            <node concept="15s5l7" id="4r3Tp$peLg9" role="lGtFl">
+                              <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Warning: equals() between objects of inconvertible types&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6293790355739144894]&quot;;" />
+                              <property role="huDt6" value="Warning: equals() between objects of inconvertible types" />
+                            </node>
+                            <node concept="2OqwBi" id="4r3Tp$pdm00" role="3clFbG">
+                              <node concept="37vLTw" id="4r3Tp$pdkV0" role="2Oq$k0">
+                                <ref role="3cqZAo" node="4r3Tp$pcYul" resolve="sComparer" />
+                              </node>
+                              <node concept="liA8E" id="4r3Tp$pdmTf" role="2OqNvi">
+                                <ref role="37wK5l" to="y7p:4r3Tp$paZgH" resolve="equals" />
+                                <node concept="10QFUN" id="4r3Tp$pdsw2" role="37wK5m">
+                                  <node concept="2OqwBi" id="4r3Tp$pdsvZ" role="10QFUP">
+                                    <node concept="37vLTw" id="4r3Tp$pdsw0" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="7OJcYqzcELg" resolve="it" />
+                                    </node>
+                                    <node concept="liA8E" id="4r3Tp$pdsw1" role="2OqNvi">
+                                      <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
+                                    </node>
+                                  </node>
+                                  <node concept="3uibUv" id="4r3Tp$pdsvW" role="10QFUM">
+                                    <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                                  </node>
+                                </node>
+                                <node concept="10QFUN" id="4r3Tp$pd$ka" role="37wK5m">
+                                  <node concept="37vLTw" id="4r3Tp$pd$k9" role="10QFUP">
+                                    <ref role="3cqZAo" node="6jbF0BohWb3" resolve="element" />
+                                  </node>
+                                  <node concept="3uibUv" id="4r3Tp$pd$k6" role="10QFUM">
+                                    <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="7OJcYqzcELg" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="7OJcYqzcELh" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2ZW3vV" id="6Z_tmAeeLUa" role="3clFbw">
+                <node concept="3uibUv" id="6Z_tmAeeMrh" role="2ZW6by">
+                  <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                </node>
+                <node concept="37vLTw" id="6Z_tmAeeL1L" role="2ZW6bz">
+                  <ref role="3cqZAo" node="6jbF0BohWb3" resolve="element" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="6Z_tmAef3eD" role="3cqZAp">
+              <node concept="3clFbS" id="6Z_tmAef3eF" role="3clFbx">
+                <node concept="3cpWs6" id="6Z_tmAef6wu" role="3cqZAp">
+                  <node concept="2OqwBi" id="7OJcYqzcVFP" role="3cqZAk">
+                    <node concept="2OqwBi" id="7OJcYqzcVFQ" role="2Oq$k0">
+                      <node concept="37vLTw" id="7OJcYqzcVFR" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYqzcVFS" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:7OJcYqx0tbv" resolve="listLcPrimitiveTypes" />
+                      </node>
+                    </node>
+                    <node concept="1z4cxt" id="7OJcYqzcVFT" role="2OqNvi">
+                      <node concept="1bVj0M" id="7OJcYqzcVFU" role="23t8la">
+                        <node concept="3clFbS" id="7OJcYqzcVFV" role="1bW5cS">
+                          <node concept="3clFbF" id="4r3Tp$pdvvw" role="3cqZAp">
+                            <node concept="15s5l7" id="4r3Tp$peMwD" role="lGtFl">
+                              <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Warning: equals() between objects of inconvertible types&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6293790355739144894]&quot;;" />
+                              <property role="huDt6" value="Warning: equals() between objects of inconvertible types" />
+                            </node>
+                            <node concept="2OqwBi" id="4r3Tp$pdvvy" role="3clFbG">
+                              <node concept="37vLTw" id="4r3Tp$pdvvz" role="2Oq$k0">
+                                <ref role="3cqZAo" node="4r3Tp$pcYul" resolve="sComparer" />
+                              </node>
+                              <node concept="liA8E" id="4r3Tp$pdvv$" role="2OqNvi">
+                                <ref role="37wK5l" to="y7p:4r3Tp$pb180" resolve="equals" />
+                                <node concept="10QFUN" id="4r3Tp$pdvv_" role="37wK5m">
+                                  <node concept="2OqwBi" id="4r3Tp$pdvvA" role="10QFUP">
+                                    <node concept="37vLTw" id="4r3Tp$pdvvB" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="7OJcYqzcVG2" resolve="it" />
+                                    </node>
+                                    <node concept="liA8E" id="4r3Tp$pdvvC" role="2OqNvi">
+                                      <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
+                                    </node>
+                                  </node>
+                                  <node concept="3uibUv" id="4r3Tp$pdvvD" role="10QFUM">
+                                    <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+                                  </node>
+                                </node>
+                                <node concept="10QFUN" id="4r3Tp$pdCTi" role="37wK5m">
+                                  <node concept="37vLTw" id="4r3Tp$pdCTh" role="10QFUP">
+                                    <ref role="3cqZAo" node="6jbF0BohWb3" resolve="element" />
+                                  </node>
+                                  <node concept="3uibUv" id="4r3Tp$pdCTe" role="10QFUM">
+                                    <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="7OJcYqzcVG2" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="7OJcYqzcVG3" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2ZW3vV" id="6Z_tmAef4TX" role="3clFbw">
+                <node concept="3uibUv" id="6Z_tmAef5tu" role="2ZW6by">
+                  <ref role="3uigEE" to="c17a:~SDataType" resolve="SDataType" />
+                </node>
+                <node concept="37vLTw" id="6Z_tmAef4ib" role="2ZW6bz">
+                  <ref role="3cqZAo" node="6jbF0BohWb3" resolve="element" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="6Z_tmAegzvh" role="3cqZAp">
+              <node concept="3clFbS" id="6Z_tmAegzvj" role="3clFbx">
+                <node concept="3cpWs6" id="6Z_tmAegArS" role="3cqZAp">
+                  <node concept="2OqwBi" id="7OJcYqzcXSt" role="3cqZAk">
+                    <node concept="2OqwBi" id="7OJcYqzcXSu" role="2Oq$k0">
+                      <node concept="37vLTw" id="7OJcYqzcXSv" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+                      </node>
+                      <node concept="liA8E" id="7OJcYqzcXSw" role="2OqNvi">
+                        <ref role="37wK5l" to="y7p:7OJcYqx2zDi" resolve="listMpsInternalFeatures" />
+                      </node>
+                    </node>
+                    <node concept="1z4cxt" id="7OJcYqzcXSx" role="2OqNvi">
+                      <node concept="1bVj0M" id="7OJcYqzcXSy" role="23t8la">
+                        <node concept="3clFbS" id="7OJcYqzcXSz" role="1bW5cS">
+                          <node concept="3clFbF" id="7OJcYqzcXS$" role="3cqZAp">
+                            <node concept="15s5l7" id="4r3Tp$peNOG" role="lGtFl">
+                              <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Warning: equals() between objects of inconvertible types&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/6293790355739144894]&quot;;" />
+                              <property role="huDt6" value="Warning: equals() between objects of inconvertible types" />
+                            </node>
+                            <node concept="2OqwBi" id="4r3Tp$pdKD2" role="3clFbG">
+                              <node concept="37vLTw" id="4r3Tp$pdKD3" role="2Oq$k0">
+                                <ref role="3cqZAo" node="4r3Tp$pcYul" resolve="sComparer" />
+                              </node>
+                              <node concept="liA8E" id="4r3Tp$pdKD4" role="2OqNvi">
+                                <ref role="37wK5l" to="y7p:4r3Tp$paZj3" resolve="equals" />
+                                <node concept="10QFUN" id="4r3Tp$pdKD5" role="37wK5m">
+                                  <node concept="2OqwBi" id="4r3Tp$pdKD6" role="10QFUP">
+                                    <node concept="37vLTw" id="4r3Tp$pdKD7" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="7OJcYqzcXSE" resolve="it" />
+                                    </node>
+                                    <node concept="liA8E" id="4r3Tp$pdKD8" role="2OqNvi">
+                                      <ref role="37wK5l" to="y7p:7OJcYqvKizN" resolve="getSlang" />
+                                    </node>
+                                  </node>
+                                  <node concept="3uibUv" id="4r3Tp$pdKD9" role="10QFUM">
+                                    <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
+                                  </node>
+                                </node>
+                                <node concept="10QFUN" id="4r3Tp$pdKDa" role="37wK5m">
+                                  <node concept="37vLTw" id="4r3Tp$pdKDb" role="10QFUP">
+                                    <ref role="3cqZAo" node="6jbF0BohWb3" resolve="element" />
+                                  </node>
+                                  <node concept="3uibUv" id="4r3Tp$pdKDc" role="10QFUM">
+                                    <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="7OJcYqzcXSE" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="7OJcYqzcXSF" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2ZW3vV" id="6Z_tmAeg_09" role="3clFbw">
+                <node concept="3uibUv" id="6Z_tmAeg__T" role="2ZW6by">
+                  <ref role="3uigEE" to="c17a:~SConceptFeature" resolve="SConceptFeature" />
+                </node>
+                <node concept="37vLTw" id="6Z_tmAeg$4s" role="2ZW6bz">
+                  <ref role="3cqZAo" node="6jbF0BohWb3" resolve="element" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="6Z_tmAedUeC" role="3clFbw">
+            <node concept="37vLTw" id="6Z_tmAedTxC" role="2Oq$k0">
+              <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+            </node>
+            <node concept="liA8E" id="6Z_tmAedVgQ" role="2OqNvi">
+              <ref role="37wK5l" to="y7p:5JNiskiswUo" resolve="isMpsInternalElement" />
+              <node concept="37vLTw" id="6Z_tmAedVKy" role="37wK5m">
+                <ref role="3cqZAo" node="6jbF0BohWb3" resolve="element" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6jbF0Boi9HZ" role="3cqZAp" />
+        <node concept="3cpWs6" id="6jbF0BoibrU" role="3cqZAp">
+          <node concept="10Nm6u" id="6jbF0BoibtK" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6jbF0BohTPR" role="1B3o_S" />
+      <node concept="3uibUv" id="6jbF0BohV43" role="3clF45">
+        <ref role="3uigEE" to="y7p:7OJcYqvKf0O" resolve="IKeyedStaple" />
+      </node>
+      <node concept="37vLTG" id="6jbF0BohWb3" role="3clF46">
+        <property role="TrG5h" value="element" />
+        <node concept="3uibUv" id="6jbF0BohWb2" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SElement" resolve="SElement" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0BohXjg" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BohXvH" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="5s4Z0e0gp$G" role="jymVt" />
     <node concept="3clFb_" id="5s4Z0e0gpy9" role="jymVt">
       <property role="TrG5h" value="extractLanguageVersion" />
@@ -5745,127 +5901,56 @@
         </node>
       </node>
       <node concept="3clFbS" id="5s4Z0e0gpye" role="3clF47">
-        <node concept="3cpWs8" id="1ryFPTS4LVW" role="3cqZAp">
-          <node concept="3cpWsn" id="1ryFPTS4LVX" role="3cpWs9">
-            <property role="TrG5h" value="languageKey" />
-            <node concept="17QB3L" id="1ryFPTS4LMe" role="1tU5fm" />
-            <node concept="1rXfSq" id="1ryFPTS4LVY" role="33vP2m">
-              <ref role="37wK5l" node="5s4Z0e0go9v" resolve="extractLanguageKey" />
-              <node concept="37vLTw" id="1ryFPTS4LVZ" role="37wK5m">
+        <node concept="3cpWs8" id="6jbF0BoiufL" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BoiufM" role="3cpWs9">
+            <property role="TrG5h" value="staple" />
+            <node concept="3uibUv" id="6jbF0BoiufN" role="1tU5fm">
+              <ref role="3uigEE" to="y7p:7OJcYqvKf0O" resolve="IKeyedStaple" />
+            </node>
+            <node concept="1rXfSq" id="6jbF0BoiufO" role="33vP2m">
+              <ref role="37wK5l" node="6jbF0BohVaT" resolve="extractStaple" />
+              <node concept="37vLTw" id="6jbF0BoiufP" role="37wK5m">
                 <ref role="3cqZAo" node="5s4Z0e0gpyc" resolve="element" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="1ryFPTS4Olu" role="3cqZAp" />
-        <node concept="3SKdUt" id="1ryFPTS6KMg" role="3cqZAp">
-          <node concept="1PaTwC" id="1ryFPTS6KMh" role="1aUNEU">
-            <node concept="3oM_SD" id="1ryFPTS6Lix" role="1PaTwD">
-              <property role="3oM_SC" value="TODO" />
-            </node>
-            <node concept="3oM_SD" id="1ryFPTS6Liz" role="1PaTwD">
-              <property role="3oM_SC" value="maybe" />
-            </node>
-            <node concept="3oM_SD" id="1ryFPTS6LiA" role="1PaTwD">
-              <property role="3oM_SC" value="move" />
-            </node>
-            <node concept="3oM_SD" id="1ryFPTS6LiE" role="1PaTwD">
-              <property role="3oM_SC" value="this" />
-            </node>
-            <node concept="3oM_SD" id="1ryFPTS6LiJ" role="1PaTwD">
-              <property role="3oM_SC" value="logic" />
-            </node>
-            <node concept="3oM_SD" id="1ryFPTS6LiP" role="1PaTwD">
-              <property role="3oM_SC" value="to" />
-            </node>
-            <node concept="3oM_SD" id="1ryFPTS6LiW" role="1PaTwD">
-              <property role="3oM_SC" value="idMapper?" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="7OJcYqzdfSj" role="3cqZAp">
-          <node concept="3cpWsn" id="7OJcYqzdfSk" role="3cpWs9">
-            <property role="TrG5h" value="staple" />
-            <node concept="3uibUv" id="7OJcYqzdfDj" role="1tU5fm">
-              <ref role="3uigEE" to="y7p:7OJcYqvMQ8$" resolve="LanguageStaple" />
-            </node>
-            <node concept="2OqwBi" id="7OJcYqzdfSl" role="33vP2m">
-              <node concept="2OqwBi" id="7OJcYqzdfSm" role="2Oq$k0">
-                <node concept="37vLTw" id="7OJcYqzdfSn" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3Lj28wlDSZ5" resolve="constants" />
+        <node concept="3clFbJ" id="6jbF0BoiufQ" role="3cqZAp">
+          <node concept="3clFbS" id="6jbF0BoiufR" role="3clFbx">
+            <node concept="3cpWs6" id="6jbF0BoiufS" role="3cqZAp">
+              <node concept="2OqwBi" id="6jbF0BoiufT" role="3cqZAk">
+                <node concept="37vLTw" id="6jbF0BoiufU" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6jbF0BoiufM" resolve="staple" />
                 </node>
-                <node concept="liA8E" id="7OJcYqzdfSo" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:7OJcYqwXhGH" resolve="listLcLanguages" />
-                </node>
-              </node>
-              <node concept="1z4cxt" id="7OJcYqzdfSp" role="2OqNvi">
-                <node concept="1bVj0M" id="7OJcYqzdfSq" role="23t8la">
-                  <node concept="3clFbS" id="7OJcYqzdfSr" role="1bW5cS">
-                    <node concept="3clFbF" id="7OJcYqzdfSs" role="3cqZAp">
-                      <node concept="17R0WA" id="7OJcYqzdfSt" role="3clFbG">
-                        <node concept="37vLTw" id="7OJcYqzdfSu" role="3uHU7w">
-                          <ref role="3cqZAo" node="1ryFPTS4LVX" resolve="languageKey" />
-                        </node>
-                        <node concept="2OqwBi" id="7OJcYqzdfSv" role="3uHU7B">
-                          <node concept="37vLTw" id="7OJcYqzdfSw" role="2Oq$k0">
-                            <ref role="3cqZAo" node="7OJcYqzdfSy" resolve="it" />
-                          </node>
-                          <node concept="liA8E" id="7OJcYqzdfSx" role="2OqNvi">
-                            <ref role="37wK5l" to="y7p:7OJcYqvKqdu" resolve="getLcKey" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="Rh6nW" id="7OJcYqzdfSy" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="7OJcYqzdfSz" role="1tU5fm" />
-                  </node>
+                <node concept="liA8E" id="6jbF0BoiufV" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:6jbF0Boix1I" resolve="getLcLanguageVersion" />
                 </node>
               </node>
             </node>
           </node>
-        </node>
-        <node concept="3clFbJ" id="1ryFPTS6_bF" role="3cqZAp">
-          <node concept="3clFbS" id="1ryFPTS6_bH" role="3clFbx">
-            <node concept="3cpWs6" id="1ryFPTS6C2w" role="3cqZAp">
-              <node concept="2OqwBi" id="7OJcYqzdszs" role="3cqZAk">
-                <node concept="37vLTw" id="7OJcYqzdrs2" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7OJcYqzdfSk" resolve="staple" />
-                </node>
-                <node concept="liA8E" id="7OJcYqzdu03" role="2OqNvi">
-                  <ref role="37wK5l" to="y7p:7OJcYqvN0Qp" resolve="getLcVersion" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3y3z36" id="7OJcYqzdpdx" role="3clFbw">
-            <node concept="10Nm6u" id="7OJcYqzdqzV" role="3uHU7w" />
-            <node concept="37vLTw" id="7OJcYqzdo7q" role="3uHU7B">
-              <ref role="3cqZAo" node="7OJcYqzdfSk" resolve="staple" />
+          <node concept="3y3z36" id="6jbF0BoiufW" role="3clFbw">
+            <node concept="10Nm6u" id="6jbF0BoiufX" role="3uHU7w" />
+            <node concept="37vLTw" id="6jbF0BoiufY" role="3uHU7B">
+              <ref role="3cqZAo" node="6jbF0BoiufM" resolve="staple" />
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="1ryFPTS4P1m" role="3cqZAp" />
-        <node concept="3cpWs6" id="5s4Z0e0gpyf" role="3cqZAp">
-          <node concept="15s5l7" id="1f4Qr8WLKeM" role="lGtFl">
-            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Warning: getLanguageVersion():int is deprecated&quot;;FLAVOUR_RULE_ID=&quot;[r:cec599e3-51d2-48a7-af31-989e3cbd593c(jetbrains.mps.lang.core.typesystem)/1225207423729]&quot;;" />
-            <property role="huDt6" value="Warning: getLanguageVersion():int is deprecated" />
-          </node>
-          <node concept="2YIFZM" id="5s4Z0e0gqe3" role="3cqZAk">
-            <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
-            <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
-            <node concept="2YIFZM" id="5JNiskiLBP5" role="37wK5m">
-              <ref role="37wK5l" to="y7p:6jTTMHD72KX" resolve="getLanguageVersion" />
-              <ref role="1Pybhc" to="y7p:6jTTMHD72IS" resolve="MpsLanguageUtil" />
-              <node concept="2YIFZM" id="1f4Qr8VgVn1" role="37wK5m">
-                <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+        <node concept="3clFbH" id="6jbF0Bosc9D" role="3cqZAp" />
+        <node concept="3cpWs6" id="6jbF0BoiufZ" role="3cqZAp">
+          <node concept="2OqwBi" id="6jbF0Boiug0" role="3cqZAk">
+            <node concept="37vLTw" id="6jbF0Boiug1" role="2Oq$k0">
+              <ref role="3cqZAo" node="5s4Z0e0f92p" resolve="idMapper" />
+            </node>
+            <node concept="liA8E" id="6jbF0Boiug2" role="2OqNvi">
+              <ref role="37wK5l" to="teza:6jbF0BoeFMx" resolve="mapLanguageVersion" />
+              <node concept="2YIFZM" id="6jbF0Boiug3" role="37wK5m">
                 <ref role="37wK5l" to="33ny:~Objects.requireNonNull(java.lang.Object)" resolve="requireNonNull" />
-                <node concept="2OqwBi" id="1f4Qr8VgVn2" role="37wK5m">
-                  <node concept="37vLTw" id="1f4Qr8VgVn3" role="2Oq$k0">
+                <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+                <node concept="2OqwBi" id="6jbF0Boiug4" role="37wK5m">
+                  <node concept="37vLTw" id="6jbF0Boiug5" role="2Oq$k0">
                     <ref role="3cqZAo" node="5s4Z0e0gpyc" resolve="element" />
                   </node>
-                  <node concept="liA8E" id="1f4Qr8VgVn4" role="2OqNvi">
+                  <node concept="liA8E" id="6jbF0Boiug6" role="2OqNvi">
                     <ref role="37wK5l" to="c17a:~SElement.getLanguage()" resolve="getLanguage" />
                   </node>
                 </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.language.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.language.mps
@@ -868,6 +868,12 @@
       <node concept="10P_77" id="5M8g5cT4LHd" role="1tU5fm" />
       <node concept="3clFbT" id="5M8g5cT4Trm" role="33vP2m" />
     </node>
+    <node concept="312cEg" id="6LPkCA$bOM5" role="jymVt">
+      <property role="TrG5h" value="exportSpecialAnnotations" />
+      <node concept="3Tm6S6" id="6LPkCA$bFZI" role="1B3o_S" />
+      <node concept="10P_77" id="6LPkCA$bOfx" role="1tU5fm" />
+      <node concept="3clFbT" id="6LPkCA$bX5O" role="33vP2m" />
+    </node>
     <node concept="2tJIrI" id="5M8g5cT4z7z" role="jymVt" />
     <node concept="3clFbW" id="48csSBNRe$T" role="jymVt">
       <node concept="3cqZAl" id="48csSBNRe$U" role="3clF45" />
@@ -2017,21 +2023,23 @@
             </node>
             <node concept="liA8E" id="2chztJeIYtE" role="2OqNvi">
               <ref role="37wK5l" to="imb3:~Language.setVersion(java.lang.String)" resolve="setVersion" />
-              <node concept="2YIFZM" id="2chztJeJ8dp" role="37wK5m">
-                <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
-                <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
-                <node concept="2YIFZM" id="5JNiskiLBP6" role="37wK5m">
-                  <ref role="37wK5l" to="y7p:6jTTMHD72KX" resolve="getLanguageVersion" />
-                  <ref role="1Pybhc" to="y7p:6jTTMHD72IS" resolve="MpsLanguageUtil" />
-                  <node concept="37vLTw" id="6jTTMHD81ew" role="37wK5m">
+              <node concept="2YIFZM" id="6jbF0Bo0HQI" role="37wK5m">
+                <ref role="1Pybhc" to="y7p:6jTTMHD72IS" resolve="MpsLanguageUtil" />
+                <ref role="37wK5l" to="y7p:6jbF0Bo0uK5" resolve="getLanguageVersionString" />
+                <node concept="2YIFZM" id="6jbF0Bo0HQJ" role="37wK5m">
+                  <ref role="37wK5l" to="33ny:~Objects.requireNonNull(java.lang.Object)" resolve="requireNonNull" />
+                  <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+                  <node concept="37vLTw" id="6jbF0Bo1eMG" role="37wK5m">
                     <ref role="3cqZAo" node="48csSBNReDf" resolve="mps" />
                   </node>
+                </node>
+                <node concept="37vLTw" id="6jbF0Bo0HQN" role="37wK5m">
+                  <ref role="3cqZAo" node="5AGBwuFaSOK" resolve="attributeFinder" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="48csSBPPFpP" role="3cqZAp" />
       </node>
       <node concept="3uibUv" id="48csSBPG5Gf" role="3clF45">
         <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
@@ -2050,6 +2058,7 @@
         <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
       </node>
     </node>
+    <node concept="2tJIrI" id="6jbF0Bo1XQH" role="jymVt" />
     <node concept="3clFb_" id="48csSBNReDh" role="jymVt">
       <property role="TrG5h" value="linkLanguage" />
       <node concept="3clFbS" id="48csSBNReDi" role="3clF47">
@@ -2387,6 +2396,20 @@
               <ref role="3cqZAo" node="48csSBNReFP" resolve="mps" />
             </node>
             <node concept="37vLTw" id="34Q84zNNhoK" role="37wK5m">
+              <ref role="3cqZAo" node="48csSBNReEt" resolve="result" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA$JfD3" role="3cqZAp">
+          <node concept="1rXfSq" id="6LPkCA$JfD1" role="3clFbG">
+            <ref role="37wK5l" node="6LPkCA$aC7q" resolve="addSpecialAnnotations" />
+            <node concept="1rXfSq" id="6LPkCA$LRKh" role="37wK5m">
+              <ref role="37wK5l" node="3IM5Sl$nlU8" resolve="retrieveSNode" />
+              <node concept="37vLTw" id="6LPkCA$LYRQ" role="37wK5m">
+                <ref role="3cqZAo" node="48csSBNReFP" resolve="mps" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="6LPkCA$J$wo" role="37wK5m">
               <ref role="3cqZAo" node="48csSBNReEt" resolve="result" />
             </node>
           </node>
@@ -4552,6 +4575,21 @@
           </node>
         </node>
         <node concept="3clFbH" id="48csSBPRku8" role="3cqZAp" />
+        <node concept="3clFbF" id="6LPkCA$MirA" role="3cqZAp">
+          <node concept="1rXfSq" id="6LPkCA$Mir$" role="3clFbG">
+            <ref role="37wK5l" node="6LPkCA$aC7q" resolve="addSpecialAnnotations" />
+            <node concept="1rXfSq" id="6LPkCA$P0v3" role="37wK5m">
+              <ref role="37wK5l" node="3IM5Sl$nlU8" resolve="retrieveSNode" />
+              <node concept="37vLTw" id="6LPkCA$PaBX" role="37wK5m">
+                <ref role="3cqZAo" node="48csSBNReLs" resolve="mps" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="6LPkCA$MsST" role="37wK5m">
+              <ref role="3cqZAo" node="5sACIIsA0Ad" resolve="json" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA$M8h3" role="3cqZAp" />
         <node concept="3clFbF" id="48csSBPS9ki" role="3cqZAp">
           <node concept="37vLTw" id="48csSBPS9kg" role="3clFbG">
             <ref role="3cqZAo" node="5sACIIsA0Ad" resolve="json" />
@@ -5024,6 +5062,21 @@
           </node>
         </node>
         <node concept="3clFbH" id="48csSBPScge" role="3cqZAp" />
+        <node concept="3clFbF" id="6LPkCA$PkrR" role="3cqZAp">
+          <node concept="1rXfSq" id="6LPkCA$PkrS" role="3clFbG">
+            <ref role="37wK5l" node="6LPkCA$aC7q" resolve="addSpecialAnnotations" />
+            <node concept="1rXfSq" id="6LPkCA$PkrT" role="37wK5m">
+              <ref role="37wK5l" node="3IM5Sl$nlU8" resolve="retrieveSNode" />
+              <node concept="37vLTw" id="6LPkCA$PkrU" role="37wK5m">
+                <ref role="3cqZAo" node="48csSBNReNN" resolve="mps" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="6LPkCA$PkrV" role="37wK5m">
+              <ref role="3cqZAo" node="5sACIIsPjNh" resolve="json" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA$PkrW" role="3cqZAp" />
         <node concept="3clFbF" id="48csSBPSNA1" role="3cqZAp">
           <node concept="37vLTw" id="48csSBPSN_Z" role="3clFbG">
             <ref role="3cqZAo" node="5sACIIsPjNh" resolve="json" />
@@ -5147,6 +5200,21 @@
           </node>
         </node>
         <node concept="3clFbH" id="5AGBwuFisWd" role="3cqZAp" />
+        <node concept="3clFbF" id="6LPkCA$Pvmq" role="3cqZAp">
+          <node concept="1rXfSq" id="6LPkCA$Pvmr" role="3clFbG">
+            <ref role="37wK5l" node="6LPkCA$aC7q" resolve="addSpecialAnnotations" />
+            <node concept="1rXfSq" id="6LPkCA$Pvms" role="37wK5m">
+              <ref role="37wK5l" node="3IM5Sl$nlU8" resolve="retrieveSNode" />
+              <node concept="37vLTw" id="6LPkCA$Pvmt" role="37wK5m">
+                <ref role="3cqZAo" node="5AGBwuFhCuj" resolve="mps" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="6LPkCA$Pvmu" role="37wK5m">
+              <ref role="3cqZAo" node="5AGBwuFisVC" resolve="json" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA$Pvmv" role="3cqZAp" />
         <node concept="3clFbF" id="5AGBwuFisWe" role="3cqZAp">
           <node concept="37vLTw" id="5AGBwuFisWf" role="3clFbG">
             <ref role="3cqZAo" node="5AGBwuFisVC" resolve="json" />
@@ -5268,6 +5336,21 @@
           </node>
         </node>
         <node concept="3clFbH" id="48csSBPSWg9" role="3cqZAp" />
+        <node concept="3clFbF" id="6LPkCA$PEGn" role="3cqZAp">
+          <node concept="1rXfSq" id="6LPkCA$PEGo" role="3clFbG">
+            <ref role="37wK5l" node="6LPkCA$aC7q" resolve="addSpecialAnnotations" />
+            <node concept="1rXfSq" id="6LPkCA$PEGp" role="37wK5m">
+              <ref role="37wK5l" node="3IM5Sl$nlU8" resolve="retrieveSNode" />
+              <node concept="37vLTw" id="6LPkCA$PEGq" role="37wK5m">
+                <ref role="3cqZAo" node="48csSBNReOn" resolve="mps" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="6LPkCA$PEGr" role="37wK5m">
+              <ref role="3cqZAo" node="5sACIIsA0_A" resolve="json" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA$PEGs" role="3cqZAp" />
         <node concept="3clFbF" id="48csSBPTb7Z" role="3cqZAp">
           <node concept="37vLTw" id="48csSBPTb7X" role="3clFbG">
             <ref role="3cqZAo" node="5sACIIsA0_A" resolve="json" />
@@ -5371,7 +5454,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="48csSBPTNjn" role="3cqZAp" />
-        <node concept="3clFbH" id="48csSBNReOG" role="3cqZAp" />
         <node concept="2Gpval" id="48csSBNReOH" role="3cqZAp">
           <node concept="2GrKxI" id="48csSBNReOI" role="2Gsz3X">
             <property role="TrG5h" value="lit" />
@@ -5430,6 +5512,21 @@
           </node>
         </node>
         <node concept="3clFbH" id="48csSBNReP5" role="3cqZAp" />
+        <node concept="3clFbF" id="6LPkCA$PWSw" role="3cqZAp">
+          <node concept="1rXfSq" id="6LPkCA$PWSx" role="3clFbG">
+            <ref role="37wK5l" node="6LPkCA$aC7q" resolve="addSpecialAnnotations" />
+            <node concept="1rXfSq" id="6LPkCA$PWSy" role="37wK5m">
+              <ref role="37wK5l" node="3IM5Sl$nlU8" resolve="retrieveSNode" />
+              <node concept="37vLTw" id="6LPkCA$PWSz" role="37wK5m">
+                <ref role="3cqZAo" node="48csSBNRePa" resolve="mps" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="6LPkCA$PWS$" role="37wK5m">
+              <ref role="3cqZAo" node="5sACIIsA0CX" resolve="json" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA$PWS_" role="3cqZAp" />
         <node concept="3clFbF" id="48csSBPV9kE" role="3cqZAp">
           <node concept="37vLTw" id="48csSBNReP7" role="3clFbG">
             <ref role="3cqZAo" node="5sACIIsA0CX" resolve="json" />
@@ -5646,6 +5743,22 @@
                 </node>
               </node>
             </node>
+            <node concept="3clFbH" id="6LPkCA$QOUR" role="3cqZAp" />
+            <node concept="3clFbF" id="6LPkCA$QE5Z" role="3cqZAp">
+              <node concept="1rXfSq" id="6LPkCA$QE60" role="3clFbG">
+                <ref role="37wK5l" node="6LPkCA$aC7q" resolve="addSpecialAnnotations" />
+                <node concept="1rXfSq" id="6LPkCA$QE61" role="37wK5m">
+                  <ref role="37wK5l" node="3IM5Sl$nlU8" resolve="retrieveSNode" />
+                  <node concept="37vLTw" id="6LPkCA$QE62" role="37wK5m">
+                    <ref role="3cqZAo" node="48csSBOhmGJ" resolve="primitiveType" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="6LPkCA$QE63" role="37wK5m">
+                  <ref role="3cqZAo" node="5sACIIsA0Cw" resolve="json" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="6LPkCA$QE64" role="3cqZAp" />
             <node concept="3cpWs6" id="48csSBOhmGv" role="3cqZAp">
               <node concept="37vLTw" id="48csSBPVSZp" role="3cqZAk">
                 <ref role="3cqZAo" node="5sACIIsA0Cw" resolve="json" />
@@ -5763,6 +5876,9 @@
         <node concept="3uibUv" id="4Yo3buYDGAo" role="1tU5fm">
           <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
         </node>
+        <node concept="2AHcQZ" id="6LPkCA$IMi0" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
       </node>
       <node concept="3clFbS" id="4Yo3buYDGAf" role="3clF47">
         <node concept="3cpWs6" id="4Yo3buYDGAg" role="3cqZAp">
@@ -5797,6 +5913,9 @@
         <property role="TrG5h" value="link" />
         <node concept="3uibUv" id="utjSYFcdeK" role="1tU5fm">
           <ref role="3uigEE" to="c17a:~SAbstractLink" resolve="SAbstractLink" />
+        </node>
+        <node concept="2AHcQZ" id="6LPkCA$I_Zl" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
       <node concept="3clFbS" id="utjSYFcdeB" role="3clF47">
@@ -5844,7 +5963,7 @@
               <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
             </node>
             <node concept="1rXfSq" id="3IM5Sl$ozjR" role="33vP2m">
-              <ref role="37wK5l" node="3IM5Sl$nlU8" resolve="retrieveConcept" />
+              <ref role="37wK5l" node="3IM5Sl$nlU8" resolve="retrieveSNode" />
               <node concept="37vLTw" id="3IM5Sl$oDyH" role="37wK5m">
                 <ref role="3cqZAo" node="34Q84zNrNyD" resolve="mps" />
               </node>
@@ -5873,7 +5992,7 @@
               <node concept="17QB3L" id="34Q84zN$hxl" role="3rvSg0" />
             </node>
             <node concept="1rXfSq" id="3IM5Sl$mTVn" role="33vP2m">
-              <ref role="37wK5l" node="3IM5Sl$mTVh" resolve="gatherDescriptionProperties" />
+              <ref role="37wK5l" node="3IM5Sl$mTVh" resolve="gatherAnnotationProperties" />
               <node concept="37vLTw" id="3IM5Sl$mTVm" role="37wK5m">
                 <ref role="3cqZAo" node="3IM5Sl$orpF" resolve="concept" />
               </node>
@@ -5911,21 +6030,321 @@
         <node concept="3uibUv" id="34Q84zNrNyC" role="1tU5fm">
           <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
         </node>
+        <node concept="2AHcQZ" id="6LPkCA$I532" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
       </node>
       <node concept="37vLTG" id="34Q84zNrTDO" role="3clF46">
         <property role="TrG5h" value="lw" />
         <node concept="3uibUv" id="34Q84zNrZku" role="1tU5fm">
           <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
         </node>
+        <node concept="2AHcQZ" id="6LPkCA$IiAG" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA$aTju" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA$aC7q" role="jymVt">
+      <property role="TrG5h" value="addSpecialAnnotations" />
+      <node concept="3clFbS" id="6LPkCA$aC7r" role="3clF47">
+        <node concept="3clFbJ" id="6LPkCA$aC7s" role="3cqZAp">
+          <node concept="3clFbS" id="6LPkCA$aC7t" role="3clFbx">
+            <node concept="3cpWs6" id="6LPkCA$aC7u" role="3cqZAp" />
+          </node>
+          <node concept="22lmx$" id="6LPkCA$LnjH" role="3clFbw">
+            <node concept="3clFbC" id="6LPkCA$LBlb" role="3uHU7w">
+              <node concept="10Nm6u" id="6LPkCA$LHsS" role="3uHU7w" />
+              <node concept="37vLTw" id="6LPkCA$Lx5m" role="3uHU7B">
+                <ref role="3cqZAo" node="6LPkCA$aC81" resolve="mps" />
+              </node>
+            </node>
+            <node concept="3fqX7Q" id="6LPkCA$aC7v" role="3uHU7B">
+              <node concept="37vLTw" id="6LPkCA$aC7w" role="3fr31v">
+                <ref role="3cqZAo" node="6LPkCA$bOM5" resolve="exportSpecialAnnotations" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA$aC7G" role="3cqZAp" />
+        <node concept="3cpWs8" id="6LPkCA$dE6d" role="3cqZAp">
+          <node concept="3cpWsn" id="6LPkCA$dE6e" role="3cpWs9">
+            <property role="TrG5h" value="specialAnnotations" />
+            <node concept="2OqwBi" id="6LPkCA$dE6h" role="33vP2m">
+              <node concept="37vLTw" id="6LPkCA$dE6i" role="2Oq$k0">
+                <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+              </node>
+              <node concept="liA8E" id="6LPkCA$dE6j" role="2OqNvi">
+                <ref role="37wK5l" to="y7p:6LPkCA$5BOW" resolve="listMpsM2Annotations" />
+              </node>
+            </node>
+            <node concept="_YKpA" id="6LPkCA$ksPp" role="1tU5fm">
+              <node concept="3uibUv" id="6LPkCA$ksPs" role="_ZDj9">
+                <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA$Hzsf" role="3cqZAp" />
+        <node concept="2Gpval" id="6LPkCA$h1wL" role="3cqZAp">
+          <node concept="2GrKxI" id="6LPkCA$h1wN" role="2Gsz3X">
+            <property role="TrG5h" value="mpsInstance" />
+          </node>
+          <node concept="3clFbS" id="6LPkCA$h1wR" role="2LFqv$">
+            <node concept="3cpWs8" id="6LPkCA$m3NA" role="3cqZAp">
+              <node concept="3cpWsn" id="6LPkCA$m3NB" role="3cpWs9">
+                <property role="TrG5h" value="staple" />
+                <node concept="3uibUv" id="6LPkCA$m0Qo" role="1tU5fm">
+                  <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
+                </node>
+                <node concept="2OqwBi" id="6LPkCA$m3NC" role="33vP2m">
+                  <node concept="37vLTw" id="6LPkCA$m3ND" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6LPkCA$dE6e" resolve="specialAnnotations" />
+                  </node>
+                  <node concept="1z4cxt" id="6LPkCA$m3NE" role="2OqNvi">
+                    <node concept="1bVj0M" id="6LPkCA$m3NF" role="23t8la">
+                      <node concept="3clFbS" id="6LPkCA$m3NG" role="1bW5cS">
+                        <node concept="3clFbF" id="6LPkCA$m3NH" role="3cqZAp">
+                          <node concept="17R0WA" id="6LPkCA$m3NI" role="3clFbG">
+                            <node concept="2OqwBi" id="6LPkCA$m3NJ" role="3uHU7w">
+                              <node concept="2GrUjf" id="6LPkCA$m3NK" role="2Oq$k0">
+                                <ref role="2Gs0qQ" node="6LPkCA$h1wN" resolve="mpsInstance" />
+                              </node>
+                              <node concept="liA8E" id="6LPkCA$m3NL" role="2OqNvi">
+                                <ref role="37wK5l" to="mhbf:~SNode.getConcept()" resolve="getConcept" />
+                              </node>
+                            </node>
+                            <node concept="2OqwBi" id="6LPkCA$m3NM" role="3uHU7B">
+                              <node concept="37vLTw" id="6LPkCA$m3NN" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6LPkCA$m3NP" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="6LPkCA$m3NO" role="2OqNvi">
+                                <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="6LPkCA$m3NP" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="6LPkCA$m3NQ" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="6LPkCA$hQz0" role="3cqZAp">
+              <node concept="3y3z36" id="6LPkCA$n55H" role="3clFbw">
+                <node concept="10Nm6u" id="6LPkCA$nbxx" role="3uHU7w" />
+                <node concept="37vLTw" id="6LPkCA$mXKK" role="3uHU7B">
+                  <ref role="3cqZAo" node="6LPkCA$m3NB" resolve="staple" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="6LPkCA$hQz2" role="3clFbx">
+                <node concept="3cpWs8" id="6LPkCA$$l9Z" role="3cqZAp">
+                  <node concept="3cpWsn" id="6LPkCA$$la0" role="3cpWs9">
+                    <property role="TrG5h" value="lwInstance" />
+                    <node concept="3uibUv" id="6LPkCA$$hZx" role="1tU5fm">
+                      <ref role="3uigEE" to="tzx8:~DynamicAnnotationInstance" resolve="DynamicAnnotationInstance" />
+                    </node>
+                    <node concept="2ShNRf" id="6LPkCA$$la1" role="33vP2m">
+                      <node concept="1pGfFk" id="6LPkCA$$la2" role="2ShVmc">
+                        <ref role="37wK5l" to="tzx8:~DynamicAnnotationInstance.&lt;init&gt;(java.lang.String,io.lionweb.lioncore.java.language.Annotation,io.lionweb.lioncore.java.model.ClassifierInstance)" resolve="DynamicAnnotationInstance" />
+                        <node concept="2OqwBi" id="6LPkCA$$la3" role="37wK5m">
+                          <node concept="2OqwBi" id="6LPkCA$$la4" role="2Oq$k0">
+                            <node concept="2GrUjf" id="6LPkCA$$la5" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="6LPkCA$h1wN" resolve="mpsInstance" />
+                            </node>
+                            <node concept="liA8E" id="6LPkCA$$la6" role="2OqNvi">
+                              <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="6LPkCA$$la7" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="6LPkCA$$la8" role="37wK5m">
+                          <node concept="2OqwBi" id="6LPkCA$$la9" role="2Oq$k0">
+                            <node concept="37vLTw" id="6LPkCA$$laa" role="2Oq$k0">
+                              <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
+                            </node>
+                            <node concept="liA8E" id="6LPkCA$$lab" role="2OqNvi">
+                              <ref role="37wK5l" to="6peh:6LPkCA$oiX_" resolve="getDeprecated" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="6LPkCA$$lac" role="2OqNvi">
+                            <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
+                          </node>
+                        </node>
+                        <node concept="10QFUN" id="6LPkCA$ZOw6" role="37wK5m">
+                          <node concept="37vLTw" id="6LPkCA$ZOw5" role="10QFUP">
+                            <ref role="3cqZAo" node="6LPkCA$aC83" resolve="lw" />
+                          </node>
+                          <node concept="3uibUv" id="6LPkCA$ZOw0" role="10QFUM">
+                            <ref role="3uigEE" to="1ppu:~ClassifierInstance" resolve="ClassifierInstance" />
+                            <node concept="3qTvmN" id="6LPkCA$ZOw1" role="11_B2D" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="6LPkCA$$GI9" role="3cqZAp">
+                  <node concept="2OqwBi" id="6LPkCA$$N9x" role="3clFbG">
+                    <node concept="37vLTw" id="6LPkCA$$GI6" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6LPkCA$aC83" resolve="lw" />
+                    </node>
+                    <node concept="liA8E" id="6LPkCA$$VDz" role="2OqNvi">
+                      <ref role="37wK5l" to="tzx8:~AbstractClassifierInstance.addAnnotation(io.lionweb.lioncore.java.model.AnnotationInstance)" resolve="addAnnotation" />
+                      <node concept="37vLTw" id="6LPkCA$_3wB" role="37wK5m">
+                        <ref role="3cqZAo" node="6LPkCA$$la0" resolve="lwInstance" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbH" id="6LPkCA$EUZI" role="3cqZAp" />
+                <node concept="3cpWs8" id="6LPkCA$aC7H" role="3cqZAp">
+                  <node concept="3cpWsn" id="6LPkCA$aC7I" role="3cpWs9">
+                    <property role="TrG5h" value="propValues" />
+                    <node concept="3rvAFt" id="6LPkCA$aC7J" role="1tU5fm">
+                      <node concept="3uibUv" id="6LPkCA$aC7K" role="3rvQeY">
+                        <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+                      </node>
+                      <node concept="17QB3L" id="6LPkCA$aC7L" role="3rvSg0" />
+                    </node>
+                    <node concept="1rXfSq" id="6LPkCA$aC7M" role="33vP2m">
+                      <ref role="37wK5l" node="3IM5Sl$mTVh" resolve="gatherAnnotationProperties" />
+                      <node concept="2GrUjf" id="6LPkCA$Fze$" role="37wK5m">
+                        <ref role="2Gs0qQ" node="6LPkCA$h1wN" resolve="mpsInstance" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2Gpval" id="6LPkCA$Epy1" role="3cqZAp">
+                  <node concept="2GrKxI" id="6LPkCA$Epy2" role="2Gsz3X">
+                    <property role="TrG5h" value="mapping" />
+                  </node>
+                  <node concept="37vLTw" id="6LPkCA$Epy3" role="2GsD0m">
+                    <ref role="3cqZAo" node="6LPkCA$aC7I" resolve="propValues" />
+                  </node>
+                  <node concept="3clFbS" id="6LPkCA$Epy4" role="2LFqv$">
+                    <node concept="3clFbF" id="6LPkCA$Epy5" role="3cqZAp">
+                      <node concept="2OqwBi" id="6LPkCA$Epy6" role="3clFbG">
+                        <node concept="37vLTw" id="6LPkCA$Epy7" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6LPkCA$$la0" resolve="lwInstance" />
+                        </node>
+                        <node concept="liA8E" id="6LPkCA$Epy8" role="2OqNvi">
+                          <ref role="37wK5l" to="tzx8:~DynamicClassifierInstance.setPropertyValue(io.lionweb.lioncore.java.language.Property,java.lang.Object)" resolve="setPropertyValue" />
+                          <node concept="1y4W85" id="6LPkCA$Epy9" role="37wK5m">
+                            <node concept="2OqwBi" id="6LPkCA$Epya" role="1y58nS">
+                              <node concept="2GrUjf" id="6LPkCA$Epyb" role="2Oq$k0">
+                                <ref role="2Gs0qQ" node="6LPkCA$Epy2" resolve="mapping" />
+                              </node>
+                              <node concept="3AY5_j" id="6LPkCA$Epyc" role="2OqNvi" />
+                            </node>
+                            <node concept="2OqwBi" id="6LPkCA$Epyd" role="1y566C">
+                              <node concept="2OqwBi" id="6LPkCA$Epye" role="2Oq$k0">
+                                <node concept="2OqwBi" id="6LPkCA$Epyf" role="2Oq$k0">
+                                  <node concept="37vLTw" id="6LPkCA$Epyg" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="48csSBNRezH" resolve="jsonConstants" />
+                                  </node>
+                                  <node concept="liA8E" id="6LPkCA$Epyh" role="2OqNvi">
+                                    <ref role="37wK5l" to="6peh:7OJcYqzAV4V" resolve="listMpsM2AnnotationProperties" />
+                                  </node>
+                                </node>
+                                <node concept="3$u5V9" id="6LPkCA$Epyi" role="2OqNvi">
+                                  <node concept="1bVj0M" id="6LPkCA$Epyj" role="23t8la">
+                                    <node concept="3clFbS" id="6LPkCA$Epyk" role="1bW5cS">
+                                      <node concept="3clFbF" id="6LPkCA$Epyl" role="3cqZAp">
+                                        <node concept="2OqwBi" id="6LPkCA$Epym" role="3clFbG">
+                                          <node concept="37vLTw" id="6LPkCA$Epyn" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="6LPkCA$Epyp" resolve="it" />
+                                          </node>
+                                          <node concept="liA8E" id="6LPkCA$Epyo" role="2OqNvi">
+                                            <ref role="37wK5l" to="6peh:7OJcYqxR0RG" resolve="getJson" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="Rh6nW" id="6LPkCA$Epyp" role="1bW2Oz">
+                                      <property role="TrG5h" value="it" />
+                                      <node concept="2jxLKc" id="6LPkCA$Epyq" role="1tU5fm" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="ANE8D" id="6LPkCA$Epyr" role="2OqNvi" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="6LPkCA$Epys" role="37wK5m">
+                            <node concept="2GrUjf" id="6LPkCA$Epyt" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="6LPkCA$Epy2" resolve="mapping" />
+                            </node>
+                            <node concept="3AV6Ez" id="6LPkCA$Epyu" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="6LPkCA$fzUA" role="2GsD0m">
+            <node concept="37vLTw" id="6LPkCA$fuGl" role="2Oq$k0">
+              <ref role="3cqZAo" node="6LPkCA$aC81" resolve="mps" />
+            </node>
+            <node concept="liA8E" id="6LPkCA$fF1n" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.getChildren(org.jetbrains.mps.openapi.language.SContainmentLink)" resolve="getChildren" />
+              <node concept="2OqwBi" id="6LPkCA$gfak" role="37wK5m">
+                <node concept="2OqwBi" id="6LPkCA$g0bg" role="2Oq$k0">
+                  <node concept="37vLTw" id="6LPkCA$fUp7" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5AGBwuFajTm" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="6LPkCA$g7X5" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:7OJcYqwQm2a" resolve="getAnnotationContainment" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="6LPkCA$gm1j" role="2OqNvi">
+                  <ref role="37wK5l" to="y7p:7OJcYqvKqcZ" resolve="getSlang" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6LPkCA$aC7Z" role="1B3o_S" />
+      <node concept="3cqZAl" id="6LPkCA$aC80" role="3clF45" />
+      <node concept="37vLTG" id="6LPkCA$aC81" role="3clF46">
+        <property role="TrG5h" value="mps" />
+        <node concept="3uibUv" id="6LPkCA$aC82" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+        <node concept="2AHcQZ" id="6LPkCA$HFxR" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6LPkCA$aC83" role="3clF46">
+        <property role="TrG5h" value="lw" />
+        <node concept="3uibUv" id="6LPkCA$aC84" role="1tU5fm">
+          <ref role="3uigEE" to="tzx8:~AbstractClassifierInstance" resolve="AbstractClassifierInstance" />
+        </node>
+        <node concept="2AHcQZ" id="6LPkCA$HRR9" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="3IM5Sl$pxZe" role="jymVt" />
     <node concept="3clFb_" id="3IM5Sl$nlU8" role="jymVt">
-      <property role="TrG5h" value="retrieveConcept" />
+      <property role="TrG5h" value="retrieveSNode" />
       <node concept="37vLTG" id="3IM5Sl$o8_3" role="3clF46">
         <property role="TrG5h" value="mps" />
         <node concept="3uibUv" id="3IM5Sl$o8_4" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+          <ref role="3uigEE" to="c17a:~SElement" resolve="SElement" />
+        </node>
+        <node concept="2AHcQZ" id="6LPkCA$GTco" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
       <node concept="3clFbS" id="3IM5Sl$nlUb" role="3clF47">
@@ -5940,7 +6359,7 @@
                 <ref role="3cqZAo" node="3IM5Sl$o8_3" resolve="mps" />
               </node>
               <node concept="liA8E" id="34Q84zNM0CH" role="2OqNvi">
-                <ref role="37wK5l" to="c17a:~SAbstractConcept.getSourceNode()" resolve="getSourceNode" />
+                <ref role="37wK5l" to="c17a:~SElement.getSourceNode()" resolve="getSourceNode" />
               </node>
             </node>
           </node>
@@ -5960,7 +6379,7 @@
         </node>
         <node concept="3cpWs8" id="34Q84zNsmZf" role="3cqZAp">
           <node concept="3cpWsn" id="34Q84zNsmZg" role="3cpWs9">
-            <property role="TrG5h" value="concept" />
+            <property role="TrG5h" value="node" />
             <node concept="3uibUv" id="34Q84zNsmYn" role="1tU5fm">
               <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
             </node>
@@ -5979,7 +6398,7 @@
         </node>
         <node concept="3cpWs6" id="3IM5Sl$nRrV" role="3cqZAp">
           <node concept="37vLTw" id="3IM5Sl$o2q$" role="3cqZAk">
-            <ref role="3cqZAo" node="34Q84zNsmZg" resolve="concept" />
+            <ref role="3cqZAo" node="34Q84zNsmZg" resolve="node" />
           </node>
         </node>
       </node>
@@ -5987,10 +6406,13 @@
       <node concept="3uibUv" id="3IM5Sl$nlfI" role="3clF45">
         <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
       </node>
+      <node concept="2AHcQZ" id="6LPkCA$GFa_" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
     </node>
     <node concept="2tJIrI" id="3IM5Sl$n7Mz" role="jymVt" />
     <node concept="3clFb_" id="3IM5Sl$mTVh" role="jymVt">
-      <property role="TrG5h" value="gatherDescriptionProperties" />
+      <property role="TrG5h" value="gatherAnnotationProperties" />
       <node concept="3Tm6S6" id="3IM5Sl$mTVi" role="1B3o_S" />
       <node concept="3rvAFt" id="3IM5Sl$mTVj" role="3clF45">
         <node concept="3uibUv" id="3IM5Sl$mTVk" role="3rvQeY">
@@ -6002,6 +6424,9 @@
         <property role="TrG5h" value="concept" />
         <node concept="3uibUv" id="3IM5Sl$mTV9" role="1tU5fm">
           <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+        <node concept="2AHcQZ" id="6LPkCA$H6h2" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
       <node concept="3clFbS" id="3IM5Sl$mTUj" role="3clF47">
@@ -6157,6 +6582,9 @@
         <property role="TrG5h" value="lw" />
         <node concept="3uibUv" id="3IM5Sl$oJOc" role="1tU5fm">
           <ref role="3uigEE" to="imb3:~Classifier" resolve="Classifier" />
+        </node>
+        <node concept="2AHcQZ" id="6LPkCA$Hmzd" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
       <node concept="37vLTG" id="3IM5Sl$oJOd" role="3clF46">
@@ -6396,6 +6824,46 @@
       <node concept="37vLTG" id="5M8g5cT4UjO" role="3clF46">
         <property role="TrG5h" value="exportDescriptionAnnotations" />
         <node concept="10P_77" id="5M8g5cT4UjP" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA$Rnc0" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA$RbCJ" role="jymVt">
+      <property role="TrG5h" value="isExportSpecialAnnotations" />
+      <node concept="10P_77" id="6LPkCA$RbCK" role="3clF45" />
+      <node concept="3Tm1VV" id="6LPkCA$RbCL" role="1B3o_S" />
+      <node concept="3clFbS" id="6LPkCA$RbCM" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA$RbCN" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA$RbCG" role="3clFbG">
+            <node concept="Xjq3P" id="6LPkCA$RbCH" role="2Oq$k0" />
+            <node concept="2OwXpG" id="6LPkCA$RbCI" role="2OqNvi">
+              <ref role="2Oxat5" node="6LPkCA$bOM5" resolve="exportSpecialAnnotations" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="6LPkCA$RbCO" role="jymVt">
+      <property role="TrG5h" value="setExportSpecialAnnotations" />
+      <node concept="3cqZAl" id="6LPkCA$RbCP" role="3clF45" />
+      <node concept="3Tm1VV" id="6LPkCA$RbCQ" role="1B3o_S" />
+      <node concept="3clFbS" id="6LPkCA$RbCR" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA$RbCS" role="3cqZAp">
+          <node concept="37vLTI" id="6LPkCA$RbCT" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA$RbCU" role="37vLTx">
+              <ref role="3cqZAo" node="6LPkCA$RbCV" resolve="exportSpecialAnnotations" />
+            </node>
+            <node concept="2OqwBi" id="6LPkCA$RbCD" role="37vLTJ">
+              <node concept="Xjq3P" id="6LPkCA$RbCE" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6LPkCA$RbCF" role="2OqNvi">
+                <ref role="2Oxat5" node="6LPkCA$bOM5" resolve="exportSpecialAnnotations" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6LPkCA$RbCV" role="3clF46">
+        <property role="TrG5h" value="exportSpecialAnnotations" />
+        <node concept="10P_77" id="6LPkCA$RbCW" role="1tU5fm" />
       </node>
     </node>
   </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
@@ -78,12 +78,17 @@
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
-      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P">
+        <reference id="1182955020723" name="classConcept" index="1HBi2w" />
+      </concept>
       <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
+      </concept>
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
@@ -228,6 +233,9 @@
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
       <concept id="1178893518978" name="jetbrains.mps.baseLanguage.structure.ThisConstructorInvocation" flags="nn" index="1VxSAg" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -3202,6 +3210,9 @@
                   <node concept="2ShNRf" id="6jI_U5eP5Iw" role="37vLTx">
                     <node concept="1pGfFk" id="34Q84zNk2WC" role="2ShVmc">
                       <ref role="37wK5l" to="lai5:6VkSF6aDU2Q" resolve="ListedMps2LionWebConverter" />
+                      <node concept="37vLTw" id="6LPkCA_yH57" role="37wK5m">
+                        <ref role="3cqZAo" node="5TNjoy1Aj0U" resolve="mapper" />
+                      </node>
                       <node concept="37vLTw" id="6jI_U5eP5Iy" role="37wK5m">
                         <ref role="3cqZAo" node="5TNjoy1Aj0R" resolve="attributeFinder" />
                       </node>
@@ -3244,6 +3255,9 @@
                   <node concept="2ShNRf" id="6jI_U5eP5IC" role="37vLTx">
                     <node concept="1pGfFk" id="34Q84zNk3t_" role="2ShVmc">
                       <ref role="37wK5l" to="lai5:6VkSF6aDU_3" resolve="DescendantMps2LionWebConverter" />
+                      <node concept="37vLTw" id="6LPkCA_yIoM" role="37wK5m">
+                        <ref role="3cqZAo" node="5TNjoy1Aj0U" resolve="mapper" />
+                      </node>
                       <node concept="37vLTw" id="6jI_U5eP5IE" role="37wK5m">
                         <ref role="3cqZAo" node="5TNjoy1Aj0R" resolve="attributeFinder" />
                       </node>
@@ -3287,6 +3301,9 @@
                   <node concept="2ShNRf" id="zA8J4H_YdL" role="33vP2m">
                     <node concept="1pGfFk" id="34Q84zNk4hp" role="2ShVmc">
                       <ref role="37wK5l" to="lai5:6VkSF6aF169" resolve="ClosureMps2LionWebConverter" />
+                      <node concept="37vLTw" id="6LPkCA_yJkr" role="37wK5m">
+                        <ref role="3cqZAo" node="5TNjoy1Aj0U" resolve="mapper" />
+                      </node>
                       <node concept="37vLTw" id="zA8J4H_YdN" role="37wK5m">
                         <ref role="3cqZAo" node="5TNjoy1Aj0R" resolve="attributeFinder" />
                       </node>
@@ -3698,6 +3715,25 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="6LPkCA$Ry0j" role="jymVt" />
+    <node concept="312cEg" id="6LPkCA$Rxqo" role="jymVt">
+      <property role="TrG5h" value="exportSpecialAnnotations" />
+      <node concept="3Tm6S6" id="6LPkCA$Rxqp" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA$Rxqq" role="1tU5fm">
+        <ref role="3uigEE" to="wyt6:~Boolean" resolve="Boolean" />
+      </node>
+      <node concept="10Nm6u" id="6LPkCA$Rxqr" role="33vP2m" />
+      <node concept="2AHcQZ" id="6LPkCA$Rxqs" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="z59LJ" id="6LPkCA$Rxqt" role="lGtFl">
+        <node concept="TZ5HA" id="6LPkCA$Rxqu" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$Rxqv" role="1dT_Ay">
+            <property role="1dT_AB" value="If true, export concept, feature, enum annotations like &lt;i&gt;Deprecated&lt;/i&gt;." />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="5TNjoy1AP3l" role="jymVt" />
     <node concept="3clFbW" id="24j7TNH1A2A" role="jymVt">
       <node concept="37vLTG" id="5TNjoy1AdX$" role="3clF46">
@@ -3922,6 +3958,29 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbJ" id="6LPkCA$RzJ9" role="3cqZAp">
+          <node concept="3clFbS" id="6LPkCA$RzJa" role="3clFbx">
+            <node concept="3clFbF" id="6LPkCA$RzJb" role="3cqZAp">
+              <node concept="2OqwBi" id="6LPkCA$RzJc" role="3clFbG">
+                <node concept="37vLTw" id="6LPkCA$RzJd" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5TNjoy1A$wU" resolve="converter" />
+                </node>
+                <node concept="liA8E" id="6LPkCA$RzJe" role="2OqNvi">
+                  <ref role="37wK5l" to="5els:6LPkCA$RbCO" resolve="setExportSpecialAnnotations" />
+                  <node concept="37vLTw" id="6LPkCA$RzJf" role="37wK5m">
+                    <ref role="3cqZAo" node="6LPkCA$Rxqo" resolve="exportSpecialAnnotations" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="6LPkCA$RzJg" role="3clFbw">
+            <node concept="10Nm6u" id="6LPkCA$RzJh" role="3uHU7w" />
+            <node concept="37vLTw" id="6LPkCA$RzJi" role="3uHU7B">
+              <ref role="3cqZAo" node="6LPkCA$Rxqo" resolve="exportSpecialAnnotations" />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbH" id="24j7TNH1ObR" role="3cqZAp" />
         <node concept="3clFbF" id="24j7TNH1Opg" role="3cqZAp">
           <node concept="15s5l7" id="5TNjoy1CFhH" role="lGtFl">
@@ -4021,6 +4080,30 @@
       <node concept="37vLTG" id="5M8g5cT5Ngt" role="3clF46">
         <property role="TrG5h" value="exportDescriptionAnnotations" />
         <node concept="10P_77" id="5M8g5cT5NQj" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="6LPkCA$Ryk5" role="jymVt">
+      <property role="TrG5h" value="setExportSpecialAnnotations" />
+      <node concept="3cqZAl" id="6LPkCA$Ryk6" role="3clF45" />
+      <node concept="3Tm1VV" id="6LPkCA$Ryk7" role="1B3o_S" />
+      <node concept="3clFbS" id="6LPkCA$Ryk8" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA$Ryk9" role="3cqZAp">
+          <node concept="37vLTI" id="6LPkCA$Ryka" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA$Rykb" role="37vLTx">
+              <ref role="3cqZAo" node="6LPkCA$Rykc" resolve="exportSpecialAnnotations" />
+            </node>
+            <node concept="2OqwBi" id="6LPkCA$Ryk2" role="37vLTJ">
+              <node concept="Xjq3P" id="6LPkCA$Ryk3" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6LPkCA$Ryk4" role="2OqNvi">
+                <ref role="2Oxat5" node="6LPkCA$Rxqo" resolve="exportSpecialAnnotations" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6LPkCA$Rykc" role="3clF46">
+        <property role="TrG5h" value="exportSpecialAnnotations" />
+        <node concept="10P_77" id="6LPkCA$Rz2w" role="1tU5fm" />
       </node>
     </node>
   </node>
@@ -4896,19 +4979,55 @@
               <ref role="3uigEE" to="pe0e:3Lj28wlz81B" resolve="IMetaPointerConverter" />
             </node>
             <node concept="2ShNRf" id="1xqd6ptu0S7" role="33vP2m">
-              <node concept="1pGfFk" id="1xqd6ptu0S8" role="2ShVmc">
-                <ref role="37wK5l" to="pe0e:6lVb1tfVtvX" resolve="MetaPointerConverter" />
-                <node concept="37vLTw" id="1xqd6ptu0S9" role="37wK5m">
-                  <ref role="3cqZAo" node="1xqd6ptu0RI" resolve="jsonKeyMapper" />
-                </node>
-                <node concept="37vLTw" id="1xqd6ptu0Sa" role="37wK5m">
-                  <ref role="3cqZAo" node="1xqd6ptu0RV" resolve="metaAdapterFactoryHelper" />
-                </node>
-                <node concept="37vLTw" id="1xqd6ptu0Sb" role="37wK5m">
-                  <ref role="3cqZAo" node="1xqd6ptu0S0" resolve="metaPointerPostprocessor" />
-                </node>
-                <node concept="37vLTw" id="3M8YG$dhmx6" role="37wK5m">
-                  <ref role="3cqZAo" node="3M8YG$dhl3_" resolve="sLanguageIdExtractor" />
+              <node concept="YeOm9" id="6jbF0BoEQi0" role="2ShVmc">
+                <node concept="1Y3b0j" id="6jbF0BoEQi3" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <ref role="37wK5l" to="pe0e:6lVb1tfVtvX" resolve="MetaPointerConverter" />
+                  <ref role="1Y3XeK" to="pe0e:6lVb1tfUY2A" resolve="MetaPointerConverter" />
+                  <node concept="3Tm1VV" id="6jbF0BoEQi4" role="1B3o_S" />
+                  <node concept="37vLTw" id="1xqd6ptu0S9" role="37wK5m">
+                    <ref role="3cqZAo" node="1xqd6ptu0RI" resolve="jsonKeyMapper" />
+                  </node>
+                  <node concept="37vLTw" id="1xqd6ptu0Sa" role="37wK5m">
+                    <ref role="3cqZAo" node="1xqd6ptu0RV" resolve="metaAdapterFactoryHelper" />
+                  </node>
+                  <node concept="37vLTw" id="1xqd6ptu0Sb" role="37wK5m">
+                    <ref role="3cqZAo" node="1xqd6ptu0S0" resolve="metaPointerPostprocessor" />
+                  </node>
+                  <node concept="37vLTw" id="3M8YG$dhmx6" role="37wK5m">
+                    <ref role="3cqZAo" node="3M8YG$dhl3_" resolve="sLanguageIdExtractor" />
+                  </node>
+                  <node concept="37vLTw" id="6jbF0BoDOgV" role="37wK5m">
+                    <ref role="3cqZAo" node="1xqd6ptu0RO" resolve="attributeFinder" />
+                  </node>
+                  <node concept="2tJIrI" id="6jbF0BoEQsH" role="jymVt" />
+                  <node concept="3clFb_" id="6jbF0BoEQBh" role="jymVt">
+                    <property role="TrG5h" value="logWarning" />
+                    <node concept="3cqZAl" id="6jbF0BoEQBo" role="3clF45" />
+                    <node concept="3Tmbuc" id="6jbF0BoEQBp" role="1B3o_S" />
+                    <node concept="37vLTG" id="6jbF0BoEQBq" role="3clF46">
+                      <property role="TrG5h" value="message" />
+                      <node concept="17QB3L" id="6jbF0BoEQBr" role="1tU5fm" />
+                    </node>
+                    <node concept="3clFbS" id="6jbF0BoEQBt" role="3clF47">
+                      <node concept="3clFbF" id="6jbF0BoEXaa" role="3cqZAp">
+                        <node concept="2OqwBi" id="6jbF0BoEXyE" role="3clFbG">
+                          <node concept="Xjq3P" id="6jbF0BoEXlL" role="2Oq$k0">
+                            <ref role="1HBi2w" node="5TNjoy1_$_I" resolve="AJsonToX" />
+                          </node>
+                          <node concept="liA8E" id="6jbF0BoEXQN" role="2OqNvi">
+                            <ref role="37wK5l" node="6jbF0BoERKz" resolve="logWarning" />
+                            <node concept="37vLTw" id="6jbF0BoEY2t" role="37wK5m">
+                              <ref role="3cqZAo" node="6jbF0BoEQBq" resolve="message" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="6jbF0BoEQBu" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -4945,6 +5064,32 @@
               <ref role="37wK5l" to="pe0e:A9P4gGNs$J" resolve="CancellingMetaPointerLookup" />
               <node concept="37vLTw" id="1xqd6ptu0Sq" role="37wK5m">
                 <ref role="3cqZAo" node="1xqd6ptu0Sd" resolve="metaPointerLookup" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6jbF0BoERxu" role="jymVt" />
+    <node concept="3clFb_" id="6jbF0BoERKz" role="jymVt">
+      <property role="TrG5h" value="logWarning" />
+      <node concept="3cqZAl" id="6jbF0BoERK$" role="3clF45" />
+      <node concept="3Tmbuc" id="6jbF0BoERK_" role="1B3o_S" />
+      <node concept="37vLTG" id="6jbF0BoERKA" role="3clF46">
+        <property role="TrG5h" value="message" />
+        <node concept="17QB3L" id="6jbF0BoERKB" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="6jbF0BoERKC" role="3clF47">
+        <node concept="3clFbF" id="6jbF0BoCprU" role="3cqZAp">
+          <node concept="2OqwBi" id="6jbF0BoCprR" role="3clFbG">
+            <node concept="10M0yZ" id="6jbF0BoCprS" role="2Oq$k0">
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+            </node>
+            <node concept="liA8E" id="6jbF0BoCprT" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="37vLTw" id="6jbF0BoCtiu" role="37wK5m">
+                <ref role="3cqZAo" node="6jbF0BoERKA" resolve="message" />
               </node>
             </node>
           </node>
@@ -5481,6 +5626,72 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqyb6NF" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA$oiX_" role="jymVt">
+      <property role="TrG5h" value="getDeprecated" />
+      <node concept="3clFbS" id="6LPkCA$oiXC" role="3clF47" />
+      <node concept="3Tm1VV" id="6LPkCA$oiXD" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA$oiSo" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
+        <node concept="3uibUv" id="6LPkCA$ovAN" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+        </node>
+        <node concept="3uibUv" id="6LPkCA$ovFP" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="6LPkCA$s0Lo" role="lGtFl">
+        <node concept="VUp57" id="6LPkCA$s0QT" role="3nqlJM">
+          <node concept="VXe0Z" id="6LPkCA$s0TD" role="VUp5m">
+            <ref role="VXe0S" to="y7p:6LPkCA$4Crf" resolve="getDeprecated" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA$ByIb" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA$BwHO" role="jymVt">
+      <property role="TrG5h" value="getDeprecated_comment" />
+      <node concept="3clFbS" id="6LPkCA$BwHP" role="3clF47" />
+      <node concept="3Tm1VV" id="6LPkCA$BwHQ" role="1B3o_S" />
+      <node concept="P$JXv" id="6LPkCA$BwHR" role="lGtFl">
+        <node concept="VUp57" id="6LPkCA$BwHS" role="3nqlJM">
+          <node concept="VXe0Z" id="6LPkCA$BwHT" role="VUp5m">
+            <ref role="VXe0S" to="y7p:6LPkCA$_zmH" resolve="getDeprecated_comment" />
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="6LPkCA$BwHU" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
+        <node concept="3uibUv" id="6LPkCA$BwHV" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="6LPkCA$BwHW" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA$B_Gi" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA$Bz_s" role="jymVt">
+      <property role="TrG5h" value="getDeprecated_build" />
+      <node concept="3clFbS" id="6LPkCA$Bz_t" role="3clF47" />
+      <node concept="3Tm1VV" id="6LPkCA$Bz_u" role="1B3o_S" />
+      <node concept="P$JXv" id="6LPkCA$Bz_v" role="lGtFl">
+        <node concept="VUp57" id="6LPkCA$Bz_w" role="3nqlJM">
+          <node concept="VXe0Z" id="6LPkCA$Bz_x" role="VUp5m">
+            <ref role="VXe0S" to="y7p:6LPkCA$_AgU" resolve="getDeprecated_build" />
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="6LPkCA$Bz_y" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
+        <node concept="3uibUv" id="6LPkCA$Bz_z" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="6LPkCA$Bz_$" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA$oiNe" role="jymVt" />
     <node concept="3clFb_" id="5JNiskiswUo" role="jymVt">
       <property role="TrG5h" value="isMpsInternalConcept" />
       <node concept="3clFbS" id="5JNiskiswUp" role="3clF47" />
@@ -5680,6 +5891,28 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7weWCFlvJ3J" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA_438v" role="jymVt">
+      <property role="TrG5h" value="getIKeyedInterface" />
+      <node concept="3clFbS" id="6LPkCA_438y" role="3clF47" />
+      <node concept="3Tm1VV" id="6LPkCA_438z" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA_40WV" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
+        <node concept="3uibUv" id="6LPkCA_42PV" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Interface" resolve="Interface" />
+        </node>
+        <node concept="3uibUv" id="6LPkCA_42Wg" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvXZ8V" resolve="InterfaceStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="6LPkCA_dNpC" role="lGtFl">
+        <node concept="VUp57" id="6LPkCA_dN$z" role="3nqlJM">
+          <node concept="VXe0Z" id="6LPkCA_dNBI" role="VUp5m">
+            <ref role="VXe0S" to="y7p:6LPkCA_2RQ$" resolve="getIKeyed" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA_40QS" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqybgVi" role="jymVt">
       <property role="TrG5h" value="getAnnotationConcept" />
       <node concept="3clFbS" id="7OJcYqybgVj" role="3clF47" />
@@ -5691,6 +5924,13 @@
         </node>
         <node concept="3uibUv" id="7OJcYqybgVn" role="11_B2D">
           <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="6LPkCA_dNIf" role="lGtFl">
+        <node concept="VUp57" id="6LPkCA_dNLv" role="3nqlJM">
+          <node concept="VXe0Z" id="6LPkCA_dNLw" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwQm21" resolve="getAnnotation" />
+          </node>
         </node>
       </node>
     </node>
@@ -5708,6 +5948,13 @@
           <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
         </node>
       </node>
+      <node concept="P$JXv" id="6LPkCA_dNUY" role="lGtFl">
+        <node concept="VUp57" id="6LPkCA_dNYe" role="3nqlJM">
+          <node concept="VXe0Z" id="6LPkCA_dNYf" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwQy$m" resolve="getClassifier" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqybjM5" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqybmuB" role="jymVt">
@@ -5723,6 +5970,13 @@
           <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
         </node>
       </node>
+      <node concept="P$JXv" id="6LPkCA_dO7H" role="lGtFl">
+        <node concept="VUp57" id="6LPkCA_dOaX" role="3nqlJM">
+          <node concept="VXe0Z" id="6LPkCA_dOaY" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwQy$v" resolve="getConcept" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="7OJcYqybmpz" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqybpgf" role="jymVt">
@@ -5736,6 +5990,13 @@
         </node>
         <node concept="3uibUv" id="7OJcYqybpgk" role="11_B2D">
           <ref role="3uigEE" to="y7p:7OJcYqvKWo$" resolve="ConceptStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="6LPkCA_dOks" role="lGtFl">
+        <node concept="VUp57" id="6LPkCA_dOnG" role="3nqlJM">
+          <node concept="VXe0Z" id="6LPkCA_dOnH" role="VUp5m">
+            <ref role="VXe0S" to="y7p:7OJcYqwQy$C" resolve="getInterface" />
+          </node>
         </node>
       </node>
     </node>
@@ -5811,6 +6072,20 @@
       <node concept="3Tm6S6" id="7OJcYqydvJV" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYq_4dIx" role="1tU5fm">
         <ref role="3uigEE" node="7OJcYq_2Ogv" resolve="JsonAnnotationPropertyStaple" />
+      </node>
+    </node>
+    <node concept="312cEg" id="6LPkCA_4LVF" role="jymVt">
+      <property role="TrG5h" value="IKEYED" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="6LPkCA_4Axz" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA_4H0G" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
+        <node concept="3uibUv" id="6LPkCA_4KKT" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Interface" resolve="Interface" />
+        </node>
+        <node concept="3uibUv" id="6LPkCA_4Lp3" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvXZ8V" resolve="InterfaceStaple" />
+        </node>
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqydNSU" role="jymVt">
@@ -5939,6 +6214,48 @@
         </node>
       </node>
     </node>
+    <node concept="312cEg" id="6LPkCA$oXGi" role="jymVt">
+      <property role="TrG5h" value="DEPRECATED" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="6LPkCA$oXGj" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA$oXGk" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
+        <node concept="3uibUv" id="6LPkCA$oXGl" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+        </node>
+        <node concept="3uibUv" id="6LPkCA$oXGm" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="6LPkCA$Cfbk" role="jymVt">
+      <property role="TrG5h" value="DEPRECATED_COMMENT" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="6LPkCA$Cfbl" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA$Cfbm" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
+        <node concept="3uibUv" id="6LPkCA$Cfbn" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="6LPkCA$Cfbo" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="6LPkCA$CnAu" role="jymVt">
+      <property role="TrG5h" value="DEPRECATED_BUILD" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="6LPkCA$CnAv" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA$CnAw" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqxTPY1" resolve="JsonStaple" />
+        <node concept="3uibUv" id="6LPkCA$CnAx" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="6LPkCA$CnAy" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="7OJcYqywJzl" role="jymVt" />
     <node concept="3clFbW" id="5JNiskj4SJa" role="jymVt">
       <node concept="37vLTG" id="5JNiskj4SJb" role="3clF46">
@@ -5960,6 +6277,43 @@
           </node>
           <node concept="37vLTw" id="7OJcYqxWuKn" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_581G" role="3cqZAp">
+          <node concept="37vLTI" id="6LPkCA_5gY8" role="3clFbG">
+            <node concept="2ShNRf" id="6LPkCA_5l5D" role="37vLTx">
+              <node concept="1pGfFk" id="6LPkCA_5ppe" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
+                <node concept="3uibUv" id="6LPkCA_5xh7" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~Interface" resolve="Interface" />
+                </node>
+                <node concept="3uibUv" id="6LPkCA_5Bt$" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqvXZ8V" resolve="InterfaceStaple" />
+                </node>
+                <node concept="2OqwBi" id="6LPkCA_5HvJ" role="37wK5m">
+                  <node concept="37vLTw" id="6LPkCA_5Fzz" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7weWCFlwAZa" resolve="m3" />
+                  </node>
+                  <node concept="liA8E" id="6LPkCA_5Rf4" role="2OqNvi">
+                    <ref role="37wK5l" node="6LPkCA_5LT0" resolve="getIKeyed" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="6LPkCA_5Yao" role="37wK5m">
+                  <node concept="37vLTw" id="6LPkCA_5Wtj" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="6LPkCA_62Ea" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:6LPkCA_2RQ$" resolve="getIKeyed" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6LPkCA_59G$" role="37vLTJ">
+              <node concept="Xjq3P" id="6LPkCA_581E" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6LPkCA_5d7c" role="2OqNvi">
+                <ref role="2Oxat5" node="6LPkCA_4LVF" resolve="IKEYED" />
+              </node>
+            </node>
           </node>
         </node>
         <node concept="3clFbF" id="7OJcYqydNT6" role="3cqZAp">
@@ -6678,6 +7032,251 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="6LPkCA$p5PP" role="3cqZAp" />
+        <node concept="3cpWs8" id="6LPkCA$pK0Y" role="3cqZAp">
+          <node concept="3cpWsn" id="6LPkCA$pK0Z" role="3cpWs9">
+            <property role="TrG5h" value="deprecated" />
+            <node concept="3uibUv" id="6LPkCA$pI6Y" role="1tU5fm">
+              <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+            </node>
+            <node concept="2ShNRf" id="6LPkCA$pK10" role="33vP2m">
+              <node concept="1pGfFk" id="6LPkCA$pK11" role="2ShVmc">
+                <ref role="37wK5l" to="imb3:~Annotation.&lt;init&gt;(io.lionweb.lioncore.java.language.Language,java.lang.String,java.lang.String,java.lang.String)" resolve="Annotation" />
+                <node concept="37vLTw" id="6LPkCA$pK12" role="37wK5m">
+                  <ref role="3cqZAo" node="7OJcYqypXxl" resolve="specificLanguage" />
+                </node>
+                <node concept="Xl_RD" id="6LPkCA$pK13" role="37wK5m">
+                  <property role="Xl_RC" value="Deprecated" />
+                </node>
+                <node concept="Xl_RD" id="6LPkCA$pK14" role="37wK5m">
+                  <property role="Xl_RC" value="Deprecated" />
+                </node>
+                <node concept="Xl_RD" id="6LPkCA$pK15" role="37wK5m">
+                  <property role="Xl_RC" value="Deprecated" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA$pPIL" role="3cqZAp" />
+        <node concept="3cpWs8" id="6LPkCA$qVQG" role="3cqZAp">
+          <node concept="3cpWsn" id="6LPkCA$qVQH" role="3cpWs9">
+            <property role="TrG5h" value="deprecatedComment" />
+            <node concept="3uibUv" id="6LPkCA$qTNN" role="1tU5fm">
+              <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+            </node>
+            <node concept="2YIFZM" id="6LPkCA$qVQI" role="33vP2m">
+              <ref role="1Pybhc" to="imb3:~Property" resolve="Property" />
+              <ref role="37wK5l" to="imb3:~Property.createOptional(java.lang.String,io.lionweb.lioncore.java.language.DataType,java.lang.String)" resolve="createOptional" />
+              <node concept="Xl_RD" id="6LPkCA$qVQJ" role="37wK5m">
+                <property role="Xl_RC" value="comment" />
+              </node>
+              <node concept="2OqwBi" id="6LPkCA$qVQK" role="37wK5m">
+                <node concept="1rXfSq" id="6LPkCA$qVQL" role="2Oq$k0">
+                  <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getString" />
+                </node>
+                <node concept="liA8E" id="6LPkCA$qVQM" role="2OqNvi">
+                  <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="6LPkCA$qVQN" role="37wK5m">
+                <property role="Xl_RC" value="comment" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA$pUU2" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA$qG2M" role="3clFbG">
+            <node concept="2OqwBi" id="6LPkCA$qrL2" role="2Oq$k0">
+              <node concept="37vLTw" id="6LPkCA$qVQO" role="2Oq$k0">
+                <ref role="3cqZAo" node="6LPkCA$qVQH" resolve="deprecatedComment" />
+              </node>
+              <node concept="liA8E" id="6LPkCA$qvL8" role="2OqNvi">
+                <ref role="37wK5l" to="imb3:~Feature.setKey(java.lang.String)" resolve="setKey" />
+                <node concept="Xl_RD" id="6LPkCA$qyV7" role="37wK5m">
+                  <property role="Xl_RC" value="Deprecated-comment" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="6LPkCA$qIaa" role="2OqNvi">
+              <ref role="37wK5l" to="tzx8:~M3Node.setParent(io.lionweb.lioncore.java.model.Node)" resolve="setParent" />
+              <node concept="37vLTw" id="6LPkCA$qLIM" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA$pK0Z" resolve="deprecated" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA$p9a_" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA$qPE5" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA$pK16" role="2Oq$k0">
+              <ref role="3cqZAo" node="6LPkCA$pK0Z" resolve="deprecated" />
+            </node>
+            <node concept="liA8E" id="6LPkCA$qSKA" role="2OqNvi">
+              <ref role="37wK5l" to="imb3:~Classifier.addFeature(io.lionweb.lioncore.java.language.Feature)" resolve="addFeature" />
+              <node concept="37vLTw" id="6LPkCA$r4mr" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA$qVQH" resolve="deprecatedComment" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA$D4JA" role="3cqZAp">
+          <node concept="37vLTI" id="6LPkCA$D4JB" role="3clFbG">
+            <node concept="2OqwBi" id="6LPkCA$D4JC" role="37vLTJ">
+              <node concept="Xjq3P" id="6LPkCA$D4JD" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6LPkCA$D4JE" role="2OqNvi">
+                <ref role="2Oxat5" node="6LPkCA$Cfbk" resolve="DEPRECATED_COMMENT" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="6LPkCA$D4JF" role="37vLTx">
+              <node concept="1pGfFk" id="6LPkCA$D4JG" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
+                <node concept="37vLTw" id="6LPkCA$D4JH" role="37wK5m">
+                  <ref role="3cqZAo" node="6LPkCA$qVQH" resolve="deprecatedComment" />
+                </node>
+                <node concept="2OqwBi" id="6LPkCA$D4JI" role="37wK5m">
+                  <node concept="37vLTw" id="6LPkCA$D4JJ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="6LPkCA$D4JK" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:6LPkCA$_zmH" resolve="getDeprecated_comment" />
+                  </node>
+                </node>
+                <node concept="3uibUv" id="6LPkCA$D4JL" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+                </node>
+                <node concept="3uibUv" id="6LPkCA$D4JM" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA$r8fT" role="3cqZAp" />
+        <node concept="3cpWs8" id="6LPkCA$r8fK" role="3cqZAp">
+          <node concept="3cpWsn" id="6LPkCA$r8fL" role="3cpWs9">
+            <property role="TrG5h" value="deprecatedBuild" />
+            <node concept="3uibUv" id="6LPkCA$r8fM" role="1tU5fm">
+              <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+            </node>
+            <node concept="2YIFZM" id="6LPkCA$r8fN" role="33vP2m">
+              <ref role="1Pybhc" to="imb3:~Property" resolve="Property" />
+              <ref role="37wK5l" to="imb3:~Property.createOptional(java.lang.String,io.lionweb.lioncore.java.language.DataType,java.lang.String)" resolve="createOptional" />
+              <node concept="Xl_RD" id="6LPkCA$r8fO" role="37wK5m">
+                <property role="Xl_RC" value="build" />
+              </node>
+              <node concept="2OqwBi" id="6LPkCA$r8fP" role="37wK5m">
+                <node concept="1rXfSq" id="6LPkCA$r8fQ" role="2Oq$k0">
+                  <ref role="37wK5l" node="7OJcYqxT_$X" resolve="getString" />
+                </node>
+                <node concept="liA8E" id="6LPkCA$r8fR" role="2OqNvi">
+                  <ref role="37wK5l" node="7OJcYqxR0RG" resolve="getJson" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="6LPkCA$r8fS" role="37wK5m">
+                <property role="Xl_RC" value="build" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA$r8fC" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA$r8fD" role="3clFbG">
+            <node concept="2OqwBi" id="6LPkCA$r8fE" role="2Oq$k0">
+              <node concept="37vLTw" id="6LPkCA$r8fF" role="2Oq$k0">
+                <ref role="3cqZAo" node="6LPkCA$r8fL" resolve="deprecatedBuild" />
+              </node>
+              <node concept="liA8E" id="6LPkCA$r8fG" role="2OqNvi">
+                <ref role="37wK5l" to="imb3:~Feature.setKey(java.lang.String)" resolve="setKey" />
+                <node concept="Xl_RD" id="6LPkCA$r8fH" role="37wK5m">
+                  <property role="Xl_RC" value="Deprecated-build" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="6LPkCA$r8fI" role="2OqNvi">
+              <ref role="37wK5l" to="tzx8:~M3Node.setParent(io.lionweb.lioncore.java.model.Node)" resolve="setParent" />
+              <node concept="37vLTw" id="6LPkCA$r8fJ" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA$pK0Z" resolve="deprecated" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA$r8fz" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA$r8f$" role="3clFbG">
+            <node concept="37vLTw" id="6LPkCA$r8f_" role="2Oq$k0">
+              <ref role="3cqZAo" node="6LPkCA$pK0Z" resolve="deprecated" />
+            </node>
+            <node concept="liA8E" id="6LPkCA$r8fA" role="2OqNvi">
+              <ref role="37wK5l" to="imb3:~Classifier.addFeature(io.lionweb.lioncore.java.language.Feature)" resolve="addFeature" />
+              <node concept="37vLTw" id="6LPkCA$r8fB" role="37wK5m">
+                <ref role="3cqZAo" node="6LPkCA$r8fL" resolve="deprecatedBuild" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA$DjrM" role="3cqZAp">
+          <node concept="37vLTI" id="6LPkCA$DjrN" role="3clFbG">
+            <node concept="2OqwBi" id="6LPkCA$DjrO" role="37vLTJ">
+              <node concept="Xjq3P" id="6LPkCA$DjrP" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6LPkCA$DjrQ" role="2OqNvi">
+                <ref role="2Oxat5" node="6LPkCA$CnAu" resolve="DEPRECATED_BUILD" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="6LPkCA$DjrR" role="37vLTx">
+              <node concept="1pGfFk" id="6LPkCA$DjrS" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
+                <node concept="37vLTw" id="6LPkCA$DjrT" role="37wK5m">
+                  <ref role="3cqZAo" node="6LPkCA$r8fL" resolve="deprecatedBuild" />
+                </node>
+                <node concept="2OqwBi" id="6LPkCA$DjrU" role="37wK5m">
+                  <node concept="37vLTw" id="6LPkCA$DjrV" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="6LPkCA$DjrW" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:6LPkCA$_AgU" resolve="getDeprecated_build" />
+                  </node>
+                </node>
+                <node concept="3uibUv" id="6LPkCA$DjrX" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+                </node>
+                <node concept="3uibUv" id="6LPkCA$DjrY" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA$rtAQ" role="3cqZAp" />
+        <node concept="3clFbF" id="6LPkCA$rx4b" role="3cqZAp">
+          <node concept="37vLTI" id="6LPkCA$rCPS" role="3clFbG">
+            <node concept="2ShNRf" id="6LPkCA$rGs9" role="37vLTx">
+              <node concept="1pGfFk" id="6LPkCA$rGrX" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqxTQa5" resolve="JsonStaple" />
+                <node concept="3uibUv" id="6LPkCA$rGrY" role="1pMfVU">
+                  <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+                </node>
+                <node concept="3uibUv" id="6LPkCA$rGrZ" role="1pMfVU">
+                  <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
+                </node>
+                <node concept="37vLTw" id="6LPkCA$rJZ7" role="37wK5m">
+                  <ref role="3cqZAo" node="6LPkCA$pK0Z" resolve="deprecated" />
+                </node>
+                <node concept="2OqwBi" id="6LPkCA$rS3P" role="37wK5m">
+                  <node concept="37vLTw" id="6LPkCA$rQuj" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7OJcYqxWqYT" resolve="constants" />
+                  </node>
+                  <node concept="liA8E" id="6LPkCA$rVKO" role="2OqNvi">
+                    <ref role="37wK5l" to="y7p:6LPkCA$4Crf" resolve="getDeprecated" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6LPkCA$ryC9" role="37vLTJ">
+              <node concept="Xjq3P" id="6LPkCA$rx49" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6LPkCA$rA5v" role="2OqNvi">
+                <ref role="2Oxat5" node="6LPkCA$oXGi" resolve="DEPRECATED" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="37vLTG" id="7weWCFlwAZa" role="3clF46">
         <property role="TrG5h" value="m3" />
@@ -6803,6 +7402,78 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYqyl4JI" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA$oJIY" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA$oAYd" role="jymVt">
+      <property role="TrG5h" value="getDeprecated" />
+      <node concept="3Tm1VV" id="6LPkCA$oAYf" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA$oAYg" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
+        <node concept="3uibUv" id="6LPkCA$oAYh" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Annotation" resolve="Annotation" />
+        </node>
+        <node concept="3uibUv" id="6LPkCA$oAYi" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6LPkCA$oAYk" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA$oAYn" role="3cqZAp">
+          <node concept="37vLTw" id="6LPkCA$BIhr" role="3clFbG">
+            <ref role="3cqZAo" node="6LPkCA$oXGi" resolve="DEPRECATED" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6LPkCA$oAYl" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA$C4bV" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA$BNXB" role="jymVt">
+      <property role="TrG5h" value="getDeprecated_comment" />
+      <node concept="3Tm1VV" id="6LPkCA$BNXD" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA$BNXH" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
+        <node concept="3uibUv" id="6LPkCA$BNXI" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="6LPkCA$BNXJ" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6LPkCA$BNXL" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA$BNXO" role="3cqZAp">
+          <node concept="37vLTw" id="6LPkCA$CvxX" role="3clFbG">
+            <ref role="3cqZAo" node="6LPkCA$Cfbk" resolve="DEPRECATED_COMMENT" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6LPkCA$BNXM" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA$C9zP" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA$BNXP" role="jymVt">
+      <property role="TrG5h" value="getDeprecated_build" />
+      <node concept="3Tm1VV" id="6LPkCA$BNXR" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA$BNXV" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
+        <node concept="3uibUv" id="6LPkCA$BNXW" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Property" resolve="Property" />
+        </node>
+        <node concept="3uibUv" id="6LPkCA$BNXX" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvRt75" resolve="PropertyStaple" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6LPkCA$BNXZ" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA$BNY2" role="3cqZAp">
+          <node concept="37vLTw" id="6LPkCA$C_1t" role="3clFbG">
+            <ref role="3cqZAo" node="6LPkCA$CnAu" resolve="DEPRECATED_BUILD" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6LPkCA$BNY0" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -7052,6 +7723,12 @@
               <node concept="1rXfSq" id="7OJcYqzJ07G" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqyisuh" resolve="getConceptDescriptionAnnotation_ConceptShortDescription" />
               </node>
+              <node concept="1rXfSq" id="6LPkCA$CIiP" role="HW$Y0">
+                <ref role="37wK5l" node="6LPkCA$BNXB" resolve="getDeprecated_comment" />
+              </node>
+              <node concept="1rXfSq" id="6LPkCA$CS6b" role="HW$Y0">
+                <ref role="37wK5l" node="6LPkCA$BNXP" resolve="getDeprecated_build" />
+              </node>
               <node concept="3uibUv" id="7OJcYqzJ5xC" role="HW$YZ">
                 <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
                 <node concept="3uibUv" id="7OJcYqzJ5xD" role="11_B2D">
@@ -7072,6 +7749,30 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7weWCFlwstm" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA_4fvP" role="jymVt">
+      <property role="TrG5h" value="getIKeyedInterface" />
+      <node concept="3Tm1VV" id="6LPkCA_4fvR" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA_4fvS" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
+        <node concept="3uibUv" id="6LPkCA_4fvT" role="11_B2D">
+          <ref role="3uigEE" to="imb3:~Interface" resolve="Interface" />
+        </node>
+        <node concept="3uibUv" id="6LPkCA_4fvU" role="11_B2D">
+          <ref role="3uigEE" to="y7p:7OJcYqvXZ8V" resolve="InterfaceStaple" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6LPkCA_4fvW" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA_4fvZ" role="3cqZAp">
+          <node concept="37vLTw" id="6LPkCA_4TRX" role="3clFbG">
+            <ref role="3cqZAo" node="6LPkCA_4LVF" resolve="IKEYED" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6LPkCA_4fvX" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA_4qrS" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqyiZMB" role="jymVt">
       <property role="TrG5h" value="getAnnotationConcept" />
       <node concept="3Tm1VV" id="7OJcYqyiZMD" role="1B3o_S" />
@@ -7207,6 +7908,12 @@
               </node>
               <node concept="1rXfSq" id="7OJcYqzJZXA" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqxTGtE" resolve="getINamed" />
+              </node>
+              <node concept="1rXfSq" id="6LPkCA_50ah" role="HW$Y0">
+                <ref role="37wK5l" node="6LPkCA_4fvP" resolve="getIKeyedInterface" />
+              </node>
+              <node concept="1rXfSq" id="6LPkCA$s86V" role="HW$Y0">
+                <ref role="37wK5l" node="6LPkCA$oAYd" resolve="getDeprecated" />
               </node>
               <node concept="3uibUv" id="7OJcYqzK6CI" role="HW$YZ">
                 <ref role="3uigEE" node="7OJcYqxQZIZ" resolve="IJsonStaple" />
@@ -7383,10 +8090,44 @@
     <node concept="3uibUv" id="7weWCFlyxmW" role="EKbjA">
       <ref role="3uigEE" node="7weWCFlywjb" resolve="ILionCoreAdapter" />
     </node>
+    <node concept="3clFb_" id="6LPkCA_66Q_" role="jymVt">
+      <property role="TrG5h" value="getIKeyed" />
+      <node concept="3Tm1VV" id="6LPkCA_66QB" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA_66QC" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Interface" resolve="Interface" />
+      </node>
+      <node concept="3clFbS" id="6LPkCA_66QE" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA_67ey" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_67Cn" role="3clFbG">
+            <node concept="2YIFZM" id="6LPkCA_67gh" role="2Oq$k0">
+              <ref role="37wK5l" to="cz4z:~LionCore.getInstance()" resolve="getInstance" />
+              <ref role="1Pybhc" to="cz4z:~LionCore" resolve="LionCore" />
+            </node>
+            <node concept="liA8E" id="6LPkCA_681e" role="2OqNvi">
+              <ref role="37wK5l" to="imb3:~Language.getInterfaceByName(java.lang.String)" resolve="getInterfaceByName" />
+              <node concept="Xl_RD" id="6LPkCA_68rJ" role="37wK5m">
+                <property role="Xl_RC" value="IKeyed" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6LPkCA_66QF" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
   </node>
   <node concept="3HP615" id="7weWCFlywjb">
     <property role="3GE5qa" value="lionCoreAdapter" />
     <property role="TrG5h" value="ILionCoreAdapter" />
+    <node concept="3clFb_" id="6LPkCA_5LT0" role="jymVt">
+      <property role="TrG5h" value="getIKeyed" />
+      <node concept="3clFbS" id="6LPkCA_5LT3" role="3clF47" />
+      <node concept="3Tm1VV" id="6LPkCA_5LT4" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA_5LSO" role="3clF45">
+        <ref role="3uigEE" to="imb3:~Interface" resolve="Interface" />
+      </node>
+    </node>
     <node concept="3Tm1VV" id="7weWCFlywjc" role="1B3o_S" />
     <node concept="3uibUv" id="7weWCFlywjL" role="3HQHJm">
       <ref role="3uigEE" node="7weWCFlyclH" resolve="ILionCoreAdapter_2023_1" />

--- a/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
+++ b/solutions/io.lionweb.mps.m3.runtime/models/io.lionweb.mps.m3.runtime.mps
@@ -438,12 +438,44 @@
         <ref role="3uigEE" node="7OJcYqwnwCi" resolve="AnnotationPropertyStaple" />
       </node>
     </node>
+    <node concept="312cEg" id="6LPkCA$4PdD" role="jymVt">
+      <property role="TrG5h" value="DEPRECATED" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="6LPkCA$4Mjb" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA$4Otp" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
+      </node>
+    </node>
+    <node concept="312cEg" id="6LPkCA$_MBG" role="jymVt">
+      <property role="TrG5h" value="DEPRECATED_COMMENT" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="6LPkCA$_MBH" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA$_MBI" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
+      </node>
+    </node>
+    <node concept="312cEg" id="6LPkCA$_ODm" role="jymVt">
+      <property role="TrG5h" value="DEPRECATED_BUILD" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="6LPkCA$_ODn" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA$_ODo" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
+      </node>
+    </node>
     <node concept="312cEg" id="7OJcYqwuwts" role="jymVt">
       <property role="TrG5h" value="STRUCTURE_LANGUAGE" />
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="7OJcYqwuwtq" role="1B3o_S" />
       <node concept="3uibUv" id="7OJcYqwuwtr" role="1tU5fm">
         <ref role="3uigEE" node="7OJcYqvMQ8$" resolve="LanguageStaple" />
+      </node>
+    </node>
+    <node concept="312cEg" id="6LPkCA_30CM" role="jymVt">
+      <property role="TrG5h" value="IKEYED" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="6LPkCA_30CN" role="1B3o_S" />
+      <node concept="3uibUv" id="6LPkCA_30CO" role="1tU5fm">
+        <ref role="3uigEE" node="7OJcYqvXZ8V" resolve="InterfaceStaple" />
       </node>
     </node>
     <node concept="312cEg" id="7OJcYqwuG9p" role="jymVt">
@@ -584,6 +616,20 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="6jbF0Boq2y1" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0Boq2y2" role="3cpWs9">
+            <property role="TrG5h" value="mpsSpecificVersion" />
+            <node concept="17QB3L" id="6jbF0Boq1_e" role="1tU5fm" />
+            <node concept="2OqwBi" id="6jbF0Boq2y3" role="33vP2m">
+              <node concept="37vLTw" id="6jbF0Boq2y4" role="2Oq$k0">
+                <ref role="3cqZAo" node="7OJcYqw9N$5" resolve="attributeLc" />
+              </node>
+              <node concept="3TrcHB" id="6jbF0Boq2y5" role="2OqNvi">
+                <ref role="3TsBF5" to="h3y3:2chztJeDvZC" resolve="version" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="7OJcYqwWzAz" role="3cqZAp">
           <node concept="37vLTI" id="7OJcYqwWzA$" role="3clFbG">
             <node concept="2OqwBi" id="7OJcYqwWzA_" role="37vLTJ">
@@ -604,13 +650,8 @@
                     <property role="2V$B1Q" value="io.lionweb.mps.specific" />
                   </node>
                 </node>
-                <node concept="2OqwBi" id="7OJcYqwWzAG" role="37wK5m">
-                  <node concept="37vLTw" id="7OJcYqwWzAH" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7OJcYqw9N$5" resolve="attributeLc" />
-                  </node>
-                  <node concept="3TrcHB" id="7OJcYqwWzAI" role="2OqNvi">
-                    <ref role="3TsBF5" to="h3y3:2chztJeDvZC" resolve="version" />
-                  </node>
+                <node concept="37vLTw" id="6jbF0Boq2y6" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Boq2y2" resolve="mpsSpecificVersion" />
                 </node>
                 <node concept="2OqwBi" id="7OJcYqwWzAJ" role="37wK5m">
                   <node concept="37vLTw" id="7OJcYqwWzAK" role="2Oq$k0">
@@ -751,6 +792,9 @@
                     </node>
                   </node>
                 </node>
+                <node concept="37vLTw" id="6jbF0Boq2y7" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Boq2y2" resolve="mpsSpecificVersion" />
+                </node>
               </node>
             </node>
           </node>
@@ -868,6 +912,9 @@
                     </node>
                   </node>
                 </node>
+                <node concept="37vLTw" id="6jbF0Boq2y8" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Boq2y2" resolve="mpsSpecificVersion" />
+                </node>
               </node>
             </node>
           </node>
@@ -888,6 +935,16 @@
                   <node concept="2V$Bhx" id="7OJcYqwuwtI" role="2V$M_3">
                     <property role="2V$B1T" value="c72da2b9-7cce-4447-8389-f407dc1158b7" />
                     <property role="2V$B1Q" value="jetbrains.mps.lang.structure" />
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="6jbF0Boy2Nt" role="37wK5m">
+                  <ref role="37wK5l" node="34Q84zMXVAC" resolve="getLanguageVersionString" />
+                  <ref role="1Pybhc" node="6jTTMHD72IS" resolve="MpsLanguageUtil" />
+                  <node concept="pHN19" id="6jbF0Boy3Q$" role="37wK5m">
+                    <node concept="2V$Bhx" id="6jbF0Boy3Q_" role="2V$M_3">
+                      <property role="2V$B1T" value="c72da2b9-7cce-4447-8389-f407dc1158b7" />
+                      <property role="2V$B1Q" value="jetbrains.mps.lang.structure" />
+                    </node>
                   </node>
                 </node>
               </node>
@@ -936,6 +993,414 @@
           </node>
         </node>
         <node concept="3clFbH" id="34Q84zNQEPO" role="3cqZAp" />
+        <node concept="3cpWs8" id="6LPkCA$4XA_" role="3cqZAp">
+          <node concept="3cpWsn" id="6LPkCA$4XAC" role="3cpWs9">
+            <property role="TrG5h" value="mpsDeprecated" />
+            <node concept="3Tqbb2" id="6LPkCA$4XAz" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="6LPkCA$55_c" role="33vP2m">
+              <node concept="2tJFMh" id="6LPkCA$530O" role="2Oq$k0">
+                <node concept="ZC_QK" id="6LPkCA$54dt" role="2tJFKM">
+                  <ref role="2aWVGs" to="tpce:hOasaTk" resolve="DeprecatedNodeAnnotation" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="6LPkCA$56uH" role="2OqNvi">
+                <node concept="37vLTw" id="6LPkCA$57it" role="Vysub">
+                  <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA$59e5" role="3cqZAp">
+          <node concept="37vLTI" id="6LPkCA$5dal" role="3clFbG">
+            <node concept="2ShNRf" id="6LPkCA$5el7" role="37vLTx">
+              <node concept="1pGfFk" id="6LPkCA$5ek$" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqwqLmd" resolve="AnnotationConceptStaple" />
+                <node concept="2OqwBi" id="6LPkCA$5m4Q" role="37wK5m">
+                  <node concept="2tJFMh" id="6LPkCA$5fZq" role="2Oq$k0">
+                    <node concept="ZC_QK" id="6LPkCA$5gNI" role="2tJFKM">
+                      <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
+                      <node concept="ZC_QK" id="6LPkCA$5gNJ" role="2aWVGa">
+                        <ref role="2aWVGs" to="4xw4:6LPkCA$5hYZ" resolve="Deprecated" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="6LPkCA$5mVp" role="2OqNvi">
+                    <node concept="37vLTw" id="6LPkCA$5nJ_" role="Vysub">
+                      <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="6LPkCA$5oUu" role="37wK5m">
+                  <ref role="3cqZAo" node="6LPkCA$4XAC" resolve="mpsDeprecated" />
+                </node>
+                <node concept="2YIFZM" id="6LPkCA$5so4" role="37wK5m">
+                  <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                  <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getConcept(long,long,long,java.lang.String)" resolve="getConcept" />
+                  <node concept="37vLTw" id="6LPkCA$5tEc" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+                  </node>
+                  <node concept="37vLTw" id="6LPkCA$5tEd" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+                  </node>
+                  <node concept="2YIFZM" id="6LPkCA$5tEe" role="37wK5m">
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <node concept="2OqwBi" id="6LPkCA$5tEf" role="37wK5m">
+                      <node concept="37vLTw" id="6LPkCA$5tEg" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6LPkCA$4XAC" resolve="mpsDeprecated" />
+                      </node>
+                      <node concept="3TrcHB" id="6LPkCA$5tEh" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="6LPkCA$5tEi" role="37wK5m">
+                    <node concept="37vLTw" id="6LPkCA$5tEj" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6LPkCA$4XAC" resolve="mpsDeprecated" />
+                    </node>
+                    <node concept="3TrcHB" id="6LPkCA$5tEk" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="6jbF0Boq2y9" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Boq2y2" resolve="mpsSpecificVersion" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6LPkCA$5a0J" role="37vLTJ">
+              <node concept="Xjq3P" id="6LPkCA$59e3" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6LPkCA$5bxa" role="2OqNvi">
+                <ref role="2Oxat5" node="6LPkCA$4PdD" resolve="DEPRECATED" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA$4Wl7" role="3cqZAp" />
+        <node concept="3cpWs8" id="6LPkCA$AHUH" role="3cqZAp">
+          <node concept="3cpWsn" id="6LPkCA$AHUI" role="3cpWs9">
+            <property role="TrG5h" value="mpsDeprecatedComment" />
+            <node concept="3Tqbb2" id="6LPkCA$AHgk" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="6LPkCA$AHUJ" role="33vP2m">
+              <node concept="2tJFMh" id="6LPkCA$AHUK" role="2Oq$k0">
+                <node concept="ZC_QK" id="6LPkCA$AHUL" role="2tJFKM">
+                  <ref role="2aWVGs" to="tpce:hOasaTk" resolve="DeprecatedNodeAnnotation" />
+                  <node concept="ZC_QK" id="6LPkCA$AHUM" role="2aWVGa">
+                    <ref role="2aWVGs" to="tpce:hOYLQ3C" resolve="comment" />
+                  </node>
+                </node>
+              </node>
+              <node concept="Vyspw" id="6LPkCA$AHUN" role="2OqNvi">
+                <node concept="37vLTw" id="6LPkCA$AHUO" role="Vysub">
+                  <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA$AOgq" role="3cqZAp">
+          <node concept="37vLTI" id="6LPkCA$ASdN" role="3clFbG">
+            <node concept="2ShNRf" id="6LPkCA$ATAN" role="37vLTx">
+              <node concept="1pGfFk" id="6LPkCA$ATAg" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvRxYF" resolve="PropertyStaple" />
+                <node concept="2OqwBi" id="6LPkCA$B1OE" role="37wK5m">
+                  <node concept="2tJFMh" id="6LPkCA$AUZa" role="2Oq$k0">
+                    <node concept="ZC_QK" id="6LPkCA$AVKT" role="2tJFKM">
+                      <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
+                      <node concept="ZC_QK" id="6LPkCA$AX9U" role="2aWVGa">
+                        <ref role="2aWVGs" to="4xw4:6LPkCA$5hYZ" resolve="Deprecated" />
+                        <node concept="ZC_QK" id="6LPkCA$AZjj" role="2aWVGa">
+                          <ref role="2aWVGs" to="4xw4:6LPkCA$5hZ9" resolve="comment" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="6LPkCA$B3mZ" role="2OqNvi">
+                    <node concept="37vLTw" id="6LPkCA$B4h7" role="Vysub">
+                      <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="6LPkCA$B6qP" role="37wK5m">
+                  <ref role="3cqZAo" node="6LPkCA$AHUI" resolve="mpsDeprecatedComment" />
+                </node>
+                <node concept="2YIFZM" id="6LPkCA$B99t" role="37wK5m">
+                  <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
+                  <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                  <node concept="37vLTw" id="6LPkCA$B99u" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+                  </node>
+                  <node concept="37vLTw" id="6LPkCA$B99v" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+                  </node>
+                  <node concept="2YIFZM" id="6LPkCA$B99w" role="37wK5m">
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <node concept="2OqwBi" id="6LPkCA$B99x" role="37wK5m">
+                      <node concept="37vLTw" id="6LPkCA$B99y" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6LPkCA$4XAC" resolve="mpsDeprecated" />
+                      </node>
+                      <node concept="3TrcHB" id="6LPkCA$B99z" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="6LPkCA$B99$" role="37wK5m">
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <node concept="2OqwBi" id="6LPkCA$B99_" role="37wK5m">
+                      <node concept="37vLTw" id="6LPkCA$B99A" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6LPkCA$AHUI" resolve="mpsDeprecatedComment" />
+                      </node>
+                      <node concept="3TrcHB" id="6LPkCA$B99B" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="6LPkCA$B99C" role="37wK5m">
+                    <node concept="37vLTw" id="6LPkCA$B99D" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6LPkCA$AHUI" resolve="mpsDeprecatedComment" />
+                    </node>
+                    <node concept="3TrcHB" id="6LPkCA$B99E" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="6jbF0Boq9oX" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Boq2y2" resolve="mpsSpecificVersion" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6LPkCA$APap" role="37vLTJ">
+              <node concept="Xjq3P" id="6LPkCA$AOgn" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6LPkCA$AQQ3" role="2OqNvi">
+                <ref role="2Oxat5" node="6LPkCA$_MBG" resolve="DEPRECATED_COMMENT" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA$AzG5" role="3cqZAp" />
+        <node concept="3cpWs8" id="6LPkCA$BenR" role="3cqZAp">
+          <node concept="3cpWsn" id="6LPkCA$BenS" role="3cpWs9">
+            <property role="TrG5h" value="mpsDeprecatedBuild" />
+            <node concept="3Tqbb2" id="6LPkCA$BenT" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="6LPkCA$BenU" role="33vP2m">
+              <node concept="2tJFMh" id="6LPkCA$BenV" role="2Oq$k0">
+                <node concept="ZC_QK" id="6LPkCA$BenW" role="2tJFKM">
+                  <ref role="2aWVGs" to="tpce:hOasaTk" resolve="DeprecatedNodeAnnotation" />
+                  <node concept="ZC_QK" id="6LPkCA$BenX" role="2aWVGa">
+                    <ref role="2aWVGs" to="tpce:hOYLP83" resolve="build" />
+                  </node>
+                </node>
+              </node>
+              <node concept="Vyspw" id="6LPkCA$BenY" role="2OqNvi">
+                <node concept="37vLTw" id="6LPkCA$BenZ" role="Vysub">
+                  <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA$Benq" role="3cqZAp">
+          <node concept="37vLTI" id="6LPkCA$Benr" role="3clFbG">
+            <node concept="2ShNRf" id="6LPkCA$Bens" role="37vLTx">
+              <node concept="1pGfFk" id="6LPkCA$Bent" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvRxYF" resolve="PropertyStaple" />
+                <node concept="2OqwBi" id="6LPkCA$Benu" role="37wK5m">
+                  <node concept="2tJFMh" id="6LPkCA$Benv" role="2Oq$k0">
+                    <node concept="ZC_QK" id="6LPkCA$Benw" role="2tJFKM">
+                      <ref role="2aWVGs" to="4xw4:5JNiskir1pX" resolve="MPS-specific annotations" />
+                      <node concept="ZC_QK" id="6LPkCA$Benx" role="2aWVGa">
+                        <ref role="2aWVGs" to="4xw4:6LPkCA$5hYZ" resolve="Deprecated" />
+                        <node concept="ZC_QK" id="6LPkCA$Beny" role="2aWVGa">
+                          <ref role="2aWVGs" to="4xw4:6LPkCA$5hZe" resolve="build" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="6LPkCA$Benz" role="2OqNvi">
+                    <node concept="37vLTw" id="6LPkCA$Ben$" role="Vysub">
+                      <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="6LPkCA$Ben_" role="37wK5m">
+                  <ref role="3cqZAo" node="6LPkCA$BenS" resolve="mpsDeprecatedBuild" />
+                </node>
+                <node concept="2YIFZM" id="6LPkCA$BenA" role="37wK5m">
+                  <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getProperty(long,long,long,long,java.lang.String)" resolve="getProperty" />
+                  <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                  <node concept="37vLTw" id="6LPkCA$BenB" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+                  </node>
+                  <node concept="37vLTw" id="6LPkCA$BenC" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+                  </node>
+                  <node concept="2YIFZM" id="6LPkCA$BenD" role="37wK5m">
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <node concept="2OqwBi" id="6LPkCA$BenE" role="37wK5m">
+                      <node concept="37vLTw" id="6LPkCA$BenF" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6LPkCA$4XAC" resolve="mpsDeprecated" />
+                      </node>
+                      <node concept="3TrcHB" id="6LPkCA$BenG" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="6LPkCA$BenH" role="37wK5m">
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <node concept="2OqwBi" id="6LPkCA$BenI" role="37wK5m">
+                      <node concept="37vLTw" id="6LPkCA$BenJ" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6LPkCA$BenS" resolve="mpsDeprecatedBuild" />
+                      </node>
+                      <node concept="3TrcHB" id="6LPkCA$BenK" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:dqwjwHwEjp" resolve="propertyId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="6LPkCA$BenL" role="37wK5m">
+                    <node concept="37vLTw" id="6LPkCA$BenM" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6LPkCA$BenS" resolve="mpsDeprecatedBuild" />
+                    </node>
+                    <node concept="3TrcHB" id="6LPkCA$BenN" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="6jbF0Boqc8F" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Boq2y2" resolve="mpsSpecificVersion" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6LPkCA$BenO" role="37vLTJ">
+              <node concept="Xjq3P" id="6LPkCA$BenP" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6LPkCA$BenQ" role="2OqNvi">
+                <ref role="2Oxat5" node="6LPkCA$_ODm" resolve="DEPRECATED_BUILD" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA$Benp" role="3cqZAp" />
+        <node concept="3cpWs8" id="6jbF0Boqq3j" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0Boqq3k" role="3cpWs9">
+            <property role="TrG5h" value="m3Version" />
+            <node concept="17QB3L" id="6jbF0BoqpsN" role="1tU5fm" />
+            <node concept="2OqwBi" id="6jbF0Boqq3l" role="33vP2m">
+              <node concept="2OqwBi" id="6jbF0Boqq3m" role="2Oq$k0">
+                <node concept="2tJFMh" id="6jbF0Boqq3n" role="2Oq$k0">
+                  <node concept="ZC_QK" id="6jbF0Boqq3o" role="2tJFKM">
+                    <ref role="2aWVGs" to="i2js:5sACIIs$PgG" resolve="LionCore_M3" />
+                  </node>
+                </node>
+                <node concept="Vyspw" id="6jbF0Boqq3p" role="2OqNvi">
+                  <node concept="37vLTw" id="6jbF0Boqq3q" role="Vysub">
+                    <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3TrcHB" id="6jbF0Boqq3r" role="2OqNvi">
+                <ref role="3TsBF5" to="h3y3:2chztJeDvZC" resolve="version" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6jbF0BoqdYh" role="3cqZAp" />
+        <node concept="3cpWs8" id="6LPkCA_3hhi" role="3cqZAp">
+          <node concept="3cpWsn" id="6LPkCA_3hhj" role="3cpWs9">
+            <property role="TrG5h" value="mpsIKeyed" />
+            <node concept="3Tqbb2" id="6LPkCA_3gAb" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="6LPkCA_3hhk" role="33vP2m">
+              <node concept="2tJFMh" id="6LPkCA_3hhl" role="2Oq$k0">
+                <node concept="ZC_QK" id="6LPkCA_3hhm" role="2tJFKM">
+                  <ref role="2aWVGs" to="tpce:1ob16QT2yIl" resolve="INamedStructureElement" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="6LPkCA_3hhn" role="2OqNvi">
+                <node concept="37vLTw" id="6LPkCA_3hho" role="Vysub">
+                  <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LPkCA_3aLj" role="3cqZAp">
+          <node concept="37vLTI" id="6LPkCA_3qoV" role="3clFbG">
+            <node concept="2ShNRf" id="6LPkCA_3rQg" role="37vLTx">
+              <node concept="1pGfFk" id="6LPkCA_3tLE" role="2ShVmc">
+                <ref role="37wK5l" node="7OJcYqvXZ91" resolve="InterfaceStaple" />
+                <node concept="2OqwBi" id="6LPkCA_3_tt" role="37wK5m">
+                  <node concept="2tJFMh" id="6LPkCA_3vfh" role="2Oq$k0">
+                    <node concept="ZC_QK" id="6LPkCA_3w_7" role="2tJFKM">
+                      <ref role="2aWVGs" to="i2js:5sACIIs$PgG" resolve="LionCore_M3" />
+                      <node concept="ZC_QK" id="6LPkCA_3y3p" role="2aWVGa">
+                        <ref role="2aWVGs" to="i2js:19nRYgR_pax" resolve="IKeyed" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="6LPkCA_3Bgp" role="2OqNvi">
+                    <node concept="37vLTw" id="6LPkCA_3CCh" role="Vysub">
+                      <ref role="3cqZAo" node="DUXtGZOlyn" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="6LPkCA_3DBF" role="37wK5m">
+                  <ref role="3cqZAo" node="6LPkCA_3hhj" resolve="mpsIKeyed" />
+                </node>
+                <node concept="2YIFZM" id="6LPkCA_3Pro" role="37wK5m">
+                  <ref role="37wK5l" to="2k9e:~MetaAdapterFactory.getInterfaceConcept(long,long,long,java.lang.String)" resolve="getInterfaceConcept" />
+                  <ref role="1Pybhc" to="2k9e:~MetaAdapterFactory" resolve="MetaAdapterFactory" />
+                  <node concept="37vLTw" id="6LPkCA_3Prp" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETD" resolve="structureLangHighBits" />
+                  </node>
+                  <node concept="37vLTw" id="6LPkCA_3Prq" role="37wK5m">
+                    <ref role="3cqZAo" node="34Q84zNQETJ" resolve="structureLangLowBits" />
+                  </node>
+                  <node concept="2YIFZM" id="6LPkCA_3Prr" role="37wK5m">
+                    <ref role="1Pybhc" to="wyt6:~Long" resolve="Long" />
+                    <ref role="37wK5l" to="wyt6:~Long.parseLong(java.lang.String)" resolve="parseLong" />
+                    <node concept="2OqwBi" id="6LPkCA_3Prs" role="37wK5m">
+                      <node concept="37vLTw" id="6LPkCA_3Prt" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6LPkCA_3hhj" resolve="mpsIKeyed" />
+                      </node>
+                      <node concept="3TrcHB" id="6LPkCA_3Pru" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpce:5OIo7_R7SN0" resolve="conceptId" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="6LPkCA_3Prv" role="37wK5m">
+                    <node concept="37vLTw" id="6LPkCA_3Prw" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6LPkCA_3hhj" resolve="mpsIKeyed" />
+                    </node>
+                    <node concept="3TrcHB" id="6LPkCA_3Prx" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="6jbF0BoqwPz" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Boqq3k" resolve="m3Version" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6LPkCA_3n33" role="37vLTJ">
+              <node concept="Xjq3P" id="6LPkCA_3m5r" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6LPkCA_3oH0" role="2OqNvi">
+                <ref role="2Oxat5" node="6LPkCA_30CM" resolve="IKEYED" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6LPkCA_39d6" role="3cqZAp" />
         <node concept="3cpWs8" id="7OJcYqwt4hL" role="3cqZAp">
           <node concept="3cpWsn" id="7OJcYqwt4hM" role="3cpWs9">
             <property role="TrG5h" value="mpsClassifier" />
@@ -1014,6 +1479,9 @@
                       <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                     </node>
                   </node>
+                </node>
+                <node concept="37vLTw" id="6jbF0Boqzq$" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Boqq3k" resolve="m3Version" />
                 </node>
               </node>
             </node>
@@ -1099,6 +1567,9 @@
                     </node>
                   </node>
                 </node>
+                <node concept="37vLTw" id="6jbF0Boq_LX" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Boqq3k" resolve="m3Version" />
+                </node>
               </node>
             </node>
           </node>
@@ -1182,6 +1653,9 @@
                       <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                     </node>
                   </node>
+                </node>
+                <node concept="37vLTw" id="6jbF0BoqCgz" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Boqq3k" resolve="m3Version" />
                 </node>
               </node>
             </node>
@@ -1285,6 +1759,9 @@
                     </node>
                   </node>
                 </node>
+                <node concept="37vLTw" id="6jbF0BoqEJW" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Boq2y2" resolve="mpsSpecificVersion" />
+                </node>
               </node>
             </node>
           </node>
@@ -1386,6 +1863,9 @@
                       <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                     </node>
                   </node>
+                </node>
+                <node concept="37vLTw" id="6jbF0BoqHob" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Boq2y2" resolve="mpsSpecificVersion" />
                 </node>
               </node>
             </node>
@@ -1492,6 +1972,12 @@
               <node concept="1rXfSq" id="7OJcYqxsoBg" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqwv4tE" resolve="getConceptShortDescription" />
               </node>
+              <node concept="1rXfSq" id="6LPkCA$BrxE" role="HW$Y0">
+                <ref role="37wK5l" node="6LPkCA$_CYy" resolve="getDeprecated_comment" />
+              </node>
+              <node concept="1rXfSq" id="6LPkCA$BuAQ" role="HW$Y0">
+                <ref role="37wK5l" node="6LPkCA$_CZ1" resolve="getDeprecated_build" />
+              </node>
             </node>
           </node>
         </node>
@@ -1501,6 +1987,33 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5M8g5cSYLiu" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA$5EIU" role="jymVt">
+      <property role="TrG5h" value="listMpsM2Annotations" />
+      <node concept="3Tm1VV" id="6LPkCA$5EIW" role="1B3o_S" />
+      <node concept="_YKpA" id="6LPkCA$5EIX" role="3clF45">
+        <node concept="3uibUv" id="6LPkCA$5EIY" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6LPkCA$5EJ3" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA$5IRi" role="3cqZAp">
+          <node concept="2ShNRf" id="6LPkCA$5IRg" role="3clFbG">
+            <node concept="Tc6Ow" id="6LPkCA$5MFP" role="2ShVmc">
+              <node concept="3uibUv" id="6LPkCA$5QHU" role="HW$YZ">
+                <ref role="3uigEE" node="7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
+              </node>
+              <node concept="1rXfSq" id="6LPkCA$5SRC" role="HW$Y0">
+                <ref role="37wK5l" node="6LPkCA$4HpE" resolve="getDeprecated" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6LPkCA$5EJ4" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA$5GYl" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqx$xY7" role="jymVt">
       <property role="TrG5h" value="listLcLanguages" />
       <node concept="3Tm1VV" id="7OJcYqx$xY8" role="1B3o_S" />
@@ -1582,6 +2095,12 @@
               <node concept="1rXfSq" id="7OJcYqx$uEK" role="HW$Y0">
                 <ref role="37wK5l" node="7OJcYqwir$e" resolve="getINamed" />
               </node>
+              <node concept="1rXfSq" id="6LPkCA_3YwJ" role="HW$Y0">
+                <ref role="37wK5l" node="6LPkCA_2W49" resolve="getIKeyed" />
+              </node>
+              <node concept="1rXfSq" id="6LPkCA$sfmB" role="HW$Y0">
+                <ref role="37wK5l" node="6LPkCA$4HpE" resolve="getDeprecated" />
+              </node>
             </node>
           </node>
         </node>
@@ -1627,6 +2146,66 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="3clFb_" id="6LPkCA$4HpE" role="jymVt">
+      <property role="TrG5h" value="getDeprecated" />
+      <node concept="3uibUv" id="6LPkCA$4HpF" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
+      </node>
+      <node concept="3Tm1VV" id="6LPkCA$4HpG" role="1B3o_S" />
+      <node concept="3clFbS" id="6LPkCA$4Hq1" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA$4Hq4" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA$4Tnc" role="3clFbG">
+            <node concept="Xjq3P" id="6LPkCA$4Rxy" role="2Oq$k0" />
+            <node concept="2OwXpG" id="6LPkCA$4V8j" role="2OqNvi">
+              <ref role="2Oxat5" node="6LPkCA$4PdD" resolve="DEPRECATED" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6LPkCA$4Hq2" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="6LPkCA$_CYy" role="jymVt">
+      <property role="TrG5h" value="getDeprecated_comment" />
+      <node concept="3uibUv" id="6LPkCA$_CYz" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
+      </node>
+      <node concept="3Tm1VV" id="6LPkCA$_CY$" role="1B3o_S" />
+      <node concept="3clFbS" id="6LPkCA$_CYX" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA$_CZ0" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA$_UOi" role="3clFbG">
+            <node concept="Xjq3P" id="6LPkCA$_Tqb" role="2Oq$k0" />
+            <node concept="2OwXpG" id="6LPkCA$_WZd" role="2OqNvi">
+              <ref role="2Oxat5" node="6LPkCA$_MBG" resolve="DEPRECATED_COMMENT" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6LPkCA$_CYY" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="6LPkCA$_CZ1" role="jymVt">
+      <property role="TrG5h" value="getDeprecated_build" />
+      <node concept="3uibUv" id="6LPkCA$_CZ2" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
+      </node>
+      <node concept="3Tm1VV" id="6LPkCA$_CZ3" role="1B3o_S" />
+      <node concept="3clFbS" id="6LPkCA$_CZs" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA$_CZv" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA$A0TZ" role="3clFbG">
+            <node concept="Xjq3P" id="6LPkCA$_YME" role="2Oq$k0" />
+            <node concept="2OwXpG" id="6LPkCA$A33h" role="2OqNvi">
+              <ref role="2Oxat5" node="6LPkCA$_ODm" resolve="DEPRECATED_BUILD" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6LPkCA$_CZt" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="3clFb_" id="7OJcYqwv4t2" role="jymVt">
       <property role="TrG5h" value="getStructureLanguage" />
       <node concept="3uibUv" id="7OJcYqwv4t3" role="3clF45">
@@ -1644,6 +2223,26 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYq$v6r0" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="6LPkCA_2W49" role="jymVt">
+      <property role="TrG5h" value="getIKeyed" />
+      <node concept="3uibUv" id="6LPkCA_2W4a" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvXZ8V" resolve="InterfaceStaple" />
+      </node>
+      <node concept="3Tm1VV" id="6LPkCA_2W4b" role="1B3o_S" />
+      <node concept="3clFbS" id="6LPkCA_2W4w" role="3clF47">
+        <node concept="3clFbF" id="6LPkCA_2W4z" role="3cqZAp">
+          <node concept="2OqwBi" id="6LPkCA_34LE" role="3clFbG">
+            <node concept="Xjq3P" id="6LPkCA_33jy" role="2Oq$k0" />
+            <node concept="2OwXpG" id="6LPkCA_373d" role="2OqNvi">
+              <ref role="2Oxat5" node="6LPkCA_30CM" resolve="IKEYED" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6LPkCA_2W4x" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -3064,16 +3663,6 @@
             <property role="1dT_AB" value="Tries to find custom LionWeb language key via `LionWebLanguageKey`." />
           </node>
         </node>
-        <node concept="TZ5HA" id="3M8YG$9B2$v" role="TZ5H$">
-          <node concept="1dT_AC" id="3M8YG$9B2$w" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="3M8YG$9AWM2" role="TZ5H$">
-          <node concept="1dT_AC" id="3M8YG$9AWM3" role="1dT_Ay">
-            <property role="1dT_AB" value="Transparently maps LionCore language keys." />
-          </node>
-        </node>
         <node concept="TUZQ0" id="3M8YG$9AU47" role="3nqlJM">
           <property role="TUZQ4" value="Language to inspect for an instance of `LionWebLanguageKey` in structure aspect." />
           <node concept="zr_55" id="3M8YG$9AU49" role="zr_5Q">
@@ -3135,7 +3724,7 @@
                 <node concept="liA8E" id="5M3rB6_W0yT" role="2OqNvi">
                   <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
                   <node concept="35c_gC" id="5M3rB6_W0yU" role="37wK5m">
-                    <ref role="35c_gD" to="234s:6fYiNFad_9U" resolve="LionWebLanguageKey" />
+                    <ref role="35c_gD" to="234s:6fYiNFad_9U" resolve="LionWebLanguage" />
                   </node>
                 </node>
               </node>
@@ -3180,16 +3769,6 @@
             <property role="1dT_AB" value="Tries to find custom LionWeb language key via `LionWebLanguageKey`." />
           </node>
         </node>
-        <node concept="TZ5HA" id="3M8YG$9Bay8" role="TZ5H$">
-          <node concept="1dT_AC" id="3M8YG$9Bay9" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="3M8YG$9Baya" role="TZ5H$">
-          <node concept="1dT_AC" id="3M8YG$9Bayb" role="1dT_Ay">
-            <property role="1dT_AB" value="Transparently maps LionCore language keys." />
-          </node>
-        </node>
         <node concept="TUZQ0" id="3M8YG$9AY8i" role="3nqlJM">
           <property role="TUZQ4" value="Language structure aspect to inspect for an instance of `LionWebLanguageKey`." />
           <node concept="zr_55" id="3M8YG$9AY8k" role="zr_5Q">
@@ -3198,6 +3777,200 @@
         </node>
         <node concept="x79VA" id="3M8YG$9AY8l" role="3nqlJM">
           <property role="x79VB" value="Custom LionWeb key of `structure`, if available." />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6jbF0BnU3si" role="jymVt" />
+    <node concept="3clFb_" id="6jbF0BnTYl$" role="jymVt">
+      <property role="TrG5h" value="findVersionFromLanguage" />
+      <node concept="3clFbS" id="6jbF0BnTYl_" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BnTYlA" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BnTYlB" role="3cpWs9">
+            <property role="TrG5h" value="converter" />
+            <node concept="3uibUv" id="6jbF0BnTYlC" role="1tU5fm">
+              <ref role="3uigEE" node="39$JcGGnjRO" resolve="MpsLanguageConverter" />
+            </node>
+            <node concept="2YIFZM" id="6jbF0BnTYlD" role="33vP2m">
+              <ref role="37wK5l" node="39$JcGGnzni" resolve="getInstance" />
+              <ref role="1Pybhc" node="39$JcGGnjRO" resolve="MpsLanguageConverter" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6jbF0BnTYlE" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BnTYlF" role="3cpWs9">
+            <property role="TrG5h" value="structure" />
+            <node concept="3uibUv" id="6jbF0BnTYlG" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+            </node>
+            <node concept="2OqwBi" id="6jbF0BnTYlH" role="33vP2m">
+              <node concept="37vLTw" id="6jbF0BnTYlI" role="2Oq$k0">
+                <ref role="3cqZAo" node="6jbF0BnTYlB" resolve="converter" />
+              </node>
+              <node concept="liA8E" id="6jbF0BnTYlJ" role="2OqNvi">
+                <ref role="37wK5l" node="39$JcGGsLhM" resolve="toStructureModel" />
+                <node concept="37vLTw" id="6jbF0BnTYlK" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0BnTYlX" resolve="sLanguage" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6jbF0BnTYlL" role="3cqZAp">
+          <node concept="3clFbS" id="6jbF0BnTYlM" role="3clFbx">
+            <node concept="3cpWs6" id="6jbF0BnTYlN" role="3cqZAp">
+              <node concept="10Nm6u" id="6jbF0BnTYlO" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3clFbC" id="6jbF0BnTYlP" role="3clFbw">
+            <node concept="10Nm6u" id="6jbF0BnTYlQ" role="3uHU7w" />
+            <node concept="37vLTw" id="6jbF0BnTYlR" role="3uHU7B">
+              <ref role="3cqZAo" node="6jbF0BnTYlF" resolve="structure" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6jbF0BnTYlS" role="3cqZAp">
+          <node concept="1rXfSq" id="6jbF0BnTYlT" role="3cqZAk">
+            <ref role="37wK5l" node="6jbF0BnTYkP" resolve="findVersionFromLanguage" />
+            <node concept="37vLTw" id="6jbF0BnTYlU" role="37wK5m">
+              <ref role="3cqZAo" node="6jbF0BnTYlF" resolve="structure" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6jbF0BnTYlV" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0BnTYlW" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0BnTYlX" role="3clF46">
+        <property role="TrG5h" value="sLanguage" />
+        <node concept="3uibUv" id="6jbF0BnTYlY" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0BnTYlZ" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BnTYm0" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="P$JXv" id="6jbF0BnTYm1" role="lGtFl">
+        <node concept="TZ5HA" id="6jbF0BnTYm2" role="TZ5H$">
+          <node concept="1dT_AC" id="6jbF0BnTYm3" role="1dT_Ay">
+            <property role="1dT_AB" value="Tries to find custom LionWeb language version via `LionWebLanguage`." />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="6jbF0BnTYm8" role="3nqlJM">
+          <property role="TUZQ4" value="Language to inspect for an instance of `LionWebLanguage` in structure aspect." />
+          <node concept="zr_55" id="6jbF0BnTYm9" role="zr_5Q">
+            <ref role="zr_51" node="6jbF0BnTYlX" resolve="sLanguage" />
+          </node>
+        </node>
+        <node concept="x79VA" id="6jbF0BnTYma" role="3nqlJM">
+          <property role="x79VB" value="Custom LionWeb version of `sLanguage`, if available." />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6jbF0BnTYlz" role="jymVt" />
+    <node concept="3clFb_" id="6jbF0BnTYkP" role="jymVt">
+      <property role="TrG5h" value="findVersionFromLanguage" />
+      <node concept="3Tm1VV" id="6jbF0BnTYkQ" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0BnTYkR" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0BnTYkS" role="3clF46">
+        <property role="TrG5h" value="structure" />
+        <node concept="3uibUv" id="6jbF0BnTYkT" role="1tU5fm">
+          <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0BnTYkU" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6jbF0BnTYkV" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0BnTYkW" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0BnTYkX" role="3cpWs9">
+            <property role="TrG5h" value="rootNodes" />
+            <node concept="3uibUv" id="6jbF0BnTYkY" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Iterable" resolve="Iterable" />
+              <node concept="3uibUv" id="6jbF0BnTYkZ" role="11_B2D">
+                <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6jbF0BnTYl0" role="33vP2m">
+              <node concept="37vLTw" id="6jbF0BnTYl1" role="2Oq$k0">
+                <ref role="3cqZAo" node="6jbF0BnTYkS" resolve="structure" />
+              </node>
+              <node concept="liA8E" id="6jbF0BnTYl2" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRootNodes()" resolve="getRootNodes" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="6jbF0BnTYl3" role="3cqZAp">
+          <node concept="2GrKxI" id="6jbF0BnTYl4" role="2Gsz3X">
+            <property role="TrG5h" value="rootNode" />
+          </node>
+          <node concept="37vLTw" id="6jbF0BnTYl5" role="2GsD0m">
+            <ref role="3cqZAo" node="6jbF0BnTYkX" resolve="rootNodes" />
+          </node>
+          <node concept="3clFbS" id="6jbF0BnTYl6" role="2LFqv$">
+            <node concept="3clFbJ" id="6jbF0BnTYl7" role="3cqZAp">
+              <node concept="2OqwBi" id="6jbF0BnTYl8" role="3clFbw">
+                <node concept="2GrUjf" id="6jbF0BnTYl9" role="2Oq$k0">
+                  <ref role="2Gs0qQ" node="6jbF0BnTYl4" resolve="rootNode" />
+                </node>
+                <node concept="liA8E" id="6jbF0BnTYla" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+                  <node concept="35c_gC" id="6jbF0BnTYlb" role="37wK5m">
+                    <ref role="35c_gD" to="234s:6fYiNFad_9U" resolve="LionWebLanguage" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="6jbF0BnTYlc" role="3clFbx">
+                <node concept="3cpWs8" id="6jbF0BnTYld" role="3cqZAp">
+                  <node concept="3cpWsn" id="6jbF0BnTYle" role="3cpWs9">
+                    <property role="TrG5h" value="version" />
+                    <node concept="17QB3L" id="6jbF0BnTYlf" role="1tU5fm" />
+                    <node concept="2OqwBi" id="6jbF0BnTYlg" role="33vP2m">
+                      <node concept="2GrUjf" id="6jbF0BnTYlh" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="6jbF0BnTYl4" resolve="rootNode" />
+                      </node>
+                      <node concept="liA8E" id="6jbF0BnTYli" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SNode.getProperty(org.jetbrains.mps.openapi.language.SProperty)" resolve="getProperty" />
+                        <node concept="355D3s" id="6jbF0BnTYlj" role="37wK5m">
+                          <ref role="355D3t" to="234s:6fYiNFad_9U" resolve="LionWebLanguage" />
+                          <ref role="355D3u" to="234s:6jbF0BnT6Ct" resolve="version" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="6jbF0BnTYlk" role="3cqZAp">
+                  <node concept="37vLTw" id="6jbF0BnTYll" role="3cqZAk">
+                    <ref role="3cqZAo" node="6jbF0BnTYle" resolve="version" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6jbF0BnTYlm" role="3cqZAp">
+          <node concept="10Nm6u" id="6jbF0BnTYln" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0BnTYlo" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="P$JXv" id="6jbF0BnTYlp" role="lGtFl">
+        <node concept="TZ5HA" id="6jbF0BnTYlq" role="TZ5H$">
+          <node concept="1dT_AC" id="6jbF0BnTYlr" role="1dT_Ay">
+            <property role="1dT_AB" value="Tries to find custom LionWeb language version via `LionWebLanguage.version`." />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="6jbF0BnTYlw" role="3nqlJM">
+          <property role="TUZQ4" value="Language structure aspect to inspect for an instance of `LionWebLanguage`." />
+          <node concept="zr_55" id="6jbF0BnTYlx" role="zr_5Q">
+            <ref role="zr_51" node="6jbF0BnTYkS" resolve="structure" />
+          </node>
+        </node>
+        <node concept="x79VA" id="6jbF0BnTYly" role="3nqlJM">
+          <property role="x79VB" value="Custom LionWeb version of `structure`, if available." />
         </node>
       </node>
     </node>
@@ -5894,7 +6667,162 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="6LPkCA$4CHT" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA$4Crf" role="jymVt">
+      <property role="TrG5h" value="getDeprecated" />
+      <node concept="3uibUv" id="6LPkCA$4Crg" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
+      </node>
+      <node concept="3Tm1VV" id="6LPkCA$4Crh" role="1B3o_S" />
+      <node concept="3clFbS" id="6LPkCA$4Cri" role="3clF47" />
+      <node concept="P$JXv" id="6LPkCA$4Crj" role="lGtFl">
+        <node concept="TZ5HA" id="6LPkCA$4Crk" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$4Crl" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.specific.lang.MPS-specific annotations.Deprecated" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA$4Crm" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$4Crn" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA$4Cro" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$4Crp" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA$4E6e" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$4E6f" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation as " />
+          </node>
+          <node concept="1dT_AA" id="6LPkCA$4E6g" role="1dT_Ay">
+            <node concept="92FcH" id="6LPkCA$4E6h" role="qph3F">
+              <node concept="TZ5HA" id="6LPkCA$4E6i" role="2XjZqd" />
+              <node concept="VXe08" id="6LPkCA$4E6j" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SConcept" resolve="SConcept" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="6LPkCA$4E6k" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA$4Crx" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$4Cry" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: Deprecated" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA$4Crz" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$4Cr$" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: c72da2b9-7cce-4447-8389-f407dc1158b7/1224240836180" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="5JNiskirdbC" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA$_zmH" role="jymVt">
+      <property role="TrG5h" value="getDeprecated_comment" />
+      <node concept="3uibUv" id="6LPkCA$_zmI" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
+      </node>
+      <node concept="3Tm1VV" id="6LPkCA$_zmJ" role="1B3o_S" />
+      <node concept="3clFbS" id="6LPkCA$_zmK" role="3clF47" />
+      <node concept="P$JXv" id="6LPkCA$_zmL" role="lGtFl">
+        <node concept="TZ5HA" id="6LPkCA$_zmM" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$_zmN" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.specific.lang.MPS-specific annotations.Deprecated.comment" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA$_zmO" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$_zmP" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation.comment" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA$_zmQ" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$_zmR" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA$_zmS" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$_zmT" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation.comment as " />
+          </node>
+          <node concept="1dT_AA" id="6LPkCA$_zmU" role="1dT_Ay">
+            <node concept="92FcH" id="6LPkCA$_zmV" role="qph3F">
+              <node concept="TZ5HA" id="6LPkCA$_zmW" role="2XjZqd" />
+              <node concept="VXe08" id="6LPkCA$_zmX" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SProperty" resolve="SProperty" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="6LPkCA$_zmY" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA$_zmZ" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$_zn0" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: Deprecated-comment" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA$_zn1" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$_zn2" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: c72da2b9-7cce-4447-8389-f407dc1158b7/1224240836180/1225118933224" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA$_AwP" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA$_AgU" role="jymVt">
+      <property role="TrG5h" value="getDeprecated_build" />
+      <node concept="3uibUv" id="6LPkCA$_AgV" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvRt75" resolve="PropertyStaple" />
+      </node>
+      <node concept="3Tm1VV" id="6LPkCA$_AgW" role="1B3o_S" />
+      <node concept="3clFbS" id="6LPkCA$_AgX" role="3clF47" />
+      <node concept="P$JXv" id="6LPkCA$_AgY" role="lGtFl">
+        <node concept="TZ5HA" id="6LPkCA$_AgZ" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$_Ah0" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.specific.lang.MPS-specific annotations.Deprecated.build" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA$_Ah1" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$_Ah2" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation.build" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA$_Ah3" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$_Ah4" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA$_Ah5" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$_Ah6" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation.build as " />
+          </node>
+          <node concept="1dT_AA" id="6LPkCA$_Ah7" role="1dT_Ay">
+            <node concept="92FcH" id="6LPkCA$_Ah8" role="qph3F">
+              <node concept="TZ5HA" id="6LPkCA$_Ah9" role="2XjZqd" />
+              <node concept="VXe08" id="6LPkCA$_Aha" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SProperty" resolve="SProperty" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="6LPkCA$_Ahb" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA$_Ahc" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$_Ahd" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: Deprecated-comment" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA$_Ahe" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$_Ahf" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: c72da2b9-7cce-4447-8389-f407dc1158b7/1224240836180/1225118929411" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="5JNiskipPPH" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwUzr1" role="jymVt">
       <property role="TrG5h" value="getSpecificLanguage" />
@@ -6048,6 +6976,58 @@
       </node>
     </node>
     <node concept="2tJIrI" id="34Q84zNODKa" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA_2RQ$" role="jymVt">
+      <property role="TrG5h" value="getIKeyed" />
+      <node concept="3uibUv" id="6LPkCA_2RQ_" role="3clF45">
+        <ref role="3uigEE" node="7OJcYqvXZ8V" resolve="InterfaceStaple" />
+      </node>
+      <node concept="3Tm1VV" id="6LPkCA_2RQA" role="1B3o_S" />
+      <node concept="3clFbS" id="6LPkCA_2RQB" role="3clF47" />
+      <node concept="P$JXv" id="6LPkCA_2RQC" role="lGtFl">
+        <node concept="TZ5HA" id="6LPkCA_2RQD" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA_2RQE" role="1dT_Ay">
+            <property role="1dT_AB" value="lc: io.lionweb.mps.m3.core.LionCore_M3.IKeyed" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA_2RQF" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA_2RQG" role="1dT_Ay">
+            <property role="1dT_AB" value="mps: jetbrains.mps.lang.structure.structure.INamedStructureElement" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA_2RQH" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA_2RQI" role="1dT_Ay">
+            <property role="1dT_AB" value="slang: " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA_2RQJ" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA_2RQK" role="1dT_Ay">
+            <property role="1dT_AB" value="jetbrains.mps.lang.structure.structure.INamedStructureElement as " />
+          </node>
+          <node concept="1dT_AA" id="6LPkCA_2RQL" role="1dT_Ay">
+            <node concept="92FcH" id="6LPkCA_2RQM" role="qph3F">
+              <node concept="TZ5HA" id="6LPkCA_2RQN" role="2XjZqd" />
+              <node concept="VXe08" id="6LPkCA_2RQO" role="92FcQ">
+                <ref role="VXe09" to="c17a:~SInterfaceConcept" resolve="SInterfaceConcept" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="6LPkCA_2RQP" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA_2RQQ" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA_2RQR" role="1dT_Ay">
+            <property role="1dT_AB" value="lcKey: IKeyed" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6LPkCA_2RQS" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA_2RQT" role="1dT_Ay">
+            <property role="1dT_AB" value="mpsId: c72da2b9-7cce-4447-8389-f407dc1158b7/1588368162880629653" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6LPkCA_2Sim" role="jymVt" />
     <node concept="3clFb_" id="7OJcYqwQy$m" role="jymVt">
       <property role="TrG5h" value="getClassifier" />
       <node concept="3uibUv" id="7OJcYqwQy$n" role="3clF45">
@@ -6333,6 +7313,24 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="6LPkCA$5By3" role="jymVt" />
+    <node concept="3clFb_" id="6LPkCA$5BOW" role="jymVt">
+      <property role="TrG5h" value="listMpsM2Annotations" />
+      <node concept="3clFbS" id="6LPkCA$5BOZ" role="3clF47" />
+      <node concept="3Tm1VV" id="6LPkCA$5BP0" role="1B3o_S" />
+      <node concept="_YKpA" id="6LPkCA$5BIu" role="3clF45">
+        <node concept="3uibUv" id="6LPkCA$5BOS" role="_ZDj9">
+          <ref role="3uigEE" node="7OJcYqwqLm4" resolve="AnnotationConceptStaple" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="6LPkCA$5CdK" role="lGtFl">
+        <node concept="TZ5HA" id="6LPkCA$5CdL" role="TZ5H$">
+          <node concept="1dT_AC" id="6LPkCA$5CdM" role="1dT_Ay">
+            <property role="1dT_AB" value="All MPS structure attributes that are converted to different LionWeb M2 annotations." />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="3Tm1VV" id="5JNiskhxHcY" role="1B3o_S" />
     <node concept="3uibUv" id="5JNiski3mfI" role="3HQHJm">
       <ref role="3uigEE" node="5JNiski3jVc" resolve="ILionCoreConstants_2023_1" />
@@ -6545,6 +7543,16 @@
                     <property role="2V$B1Q" value="io.lionweb.mps.structure.attribute" />
                   </node>
                 </node>
+                <node concept="2YIFZM" id="6jbF0BoycSB" role="37wK5m">
+                  <ref role="37wK5l" node="34Q84zMXVAC" resolve="getLanguageVersionString" />
+                  <ref role="1Pybhc" node="6jTTMHD72IS" resolve="MpsLanguageUtil" />
+                  <node concept="pHN19" id="6jbF0BoydNa" role="37wK5m">
+                    <node concept="2V$Bhx" id="6jbF0BoyfFG" role="2V$M_3">
+                      <property role="2V$B1T" value="411e5b27-8a76-482e-8af8-1704262b4468" />
+                      <property role="2V$B1Q" value="io.lionweb.mps.structure.attribute" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -6624,6 +7632,16 @@
                     <property role="2V$B1Q" value="jetbrains.mps.lang.core" />
                   </node>
                 </node>
+                <node concept="2YIFZM" id="6jbF0BoygE$" role="37wK5m">
+                  <ref role="37wK5l" node="34Q84zMXVAC" resolve="getLanguageVersionString" />
+                  <ref role="1Pybhc" node="6jTTMHD72IS" resolve="MpsLanguageUtil" />
+                  <node concept="pHN19" id="6jbF0BoygE_" role="37wK5m">
+                    <node concept="2V$Bhx" id="6jbF0BoyiuI" role="2V$M_3">
+                      <property role="2V$B1T" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c" />
+                      <property role="2V$B1Q" value="jetbrains.mps.lang.core" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
             <node concept="2OqwBi" id="7OJcYqxKYbm" role="37vLTJ">
@@ -6677,6 +7695,9 @@
                   <ref role="1PxDUh" to="xx25:~SPrimitiveTypes" resolve="SPrimitiveTypes" />
                   <ref role="3cqZAo" to="xx25:~SPrimitiveTypes.STRING" resolve="STRING" />
                 </node>
+                <node concept="37vLTw" id="6jbF0BoqUAU" role="37wK5m">
+                  <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
+                </node>
               </node>
             </node>
           </node>
@@ -6724,6 +7745,9 @@
                   <ref role="3cqZAo" to="xx25:~SPrimitiveTypes.BOOLEAN" resolve="BOOLEAN" />
                   <ref role="1PxDUh" to="xx25:~SPrimitiveTypes" resolve="SPrimitiveTypes" />
                 </node>
+                <node concept="37vLTw" id="6jbF0BoqX5D" role="37wK5m">
+                  <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
+                </node>
               </node>
             </node>
           </node>
@@ -6770,6 +7794,9 @@
                 <node concept="10M0yZ" id="7OJcYqvSxpN" role="37wK5m">
                   <ref role="3cqZAo" to="xx25:~SPrimitiveTypes.INTEGER" resolve="INTEGER" />
                   <ref role="1PxDUh" to="xx25:~SPrimitiveTypes" resolve="SPrimitiveTypes" />
+                </node>
+                <node concept="37vLTw" id="6jbF0BoqZLW" role="37wK5m">
+                  <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
                 </node>
               </node>
             </node>
@@ -6895,6 +7922,9 @@
                     </node>
                   </node>
                 </node>
+                <node concept="37vLTw" id="6jbF0Bor2_Q" role="37wK5m">
+                  <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
+                </node>
               </node>
             </node>
           </node>
@@ -6990,6 +8020,9 @@
                 <node concept="37vLTw" id="7OJcYqwdP1Q" role="37wK5m">
                   <ref role="3cqZAo" node="7OJcYqwdP1F" resolve="slangNode" />
                 </node>
+                <node concept="37vLTw" id="6jbF0Bor4_M" role="37wK5m">
+                  <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
+                </node>
               </node>
             </node>
           </node>
@@ -7074,6 +8107,9 @@
                     </node>
                   </node>
                 </node>
+                <node concept="37vLTw" id="6jbF0Bor75x" role="37wK5m">
+                  <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
+                </node>
               </node>
             </node>
           </node>
@@ -7123,6 +8159,9 @@
                   <node concept="liA8E" id="7OJcYqvT593" role="2OqNvi">
                     <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
                   </node>
+                </node>
+                <node concept="37vLTw" id="6jbF0Bor9MU" role="37wK5m">
+                  <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
                 </node>
               </node>
             </node>
@@ -7207,6 +8246,9 @@
                       <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                     </node>
                   </node>
+                </node>
+                <node concept="37vLTw" id="6jbF0Borcwz" role="37wK5m">
+                  <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
                 </node>
               </node>
             </node>
@@ -7309,6 +8351,9 @@
                       <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                     </node>
                   </node>
+                </node>
+                <node concept="37vLTw" id="6jbF0Boreq_" role="37wK5m">
+                  <ref role="3cqZAo" node="3M8YG$9w5jG" resolve="LION_CORE_VERSION" />
                 </node>
               </node>
             </node>
@@ -9488,6 +10533,84 @@
         <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
     </node>
+    <node concept="2tJIrI" id="6jbF0Bo0wtH" role="jymVt" />
+    <node concept="2YIFZL" id="6jbF0Bo0uK5" role="jymVt">
+      <property role="TrG5h" value="getLanguageVersionString" />
+      <node concept="3clFbS" id="6jbF0Bo0uK6" role="3clF47">
+        <node concept="3cpWs8" id="6jbF0Bo0vdZ" role="3cqZAp">
+          <node concept="3cpWsn" id="6jbF0Bo0ve0" role="3cpWs9">
+            <property role="TrG5h" value="version" />
+            <node concept="17QB3L" id="6jbF0Bo0v8b" role="1tU5fm" />
+            <node concept="2OqwBi" id="6jbF0Bo0ve1" role="33vP2m">
+              <node concept="37vLTw" id="6jbF0Bo0ve2" role="2Oq$k0">
+                <ref role="3cqZAo" node="6jbF0Bo0uNq" resolve="attributeFinder" />
+              </node>
+              <node concept="liA8E" id="6jbF0Bo0ve3" role="2OqNvi">
+                <ref role="37wK5l" node="6jbF0BnTYl$" resolve="findVersionFromLanguage" />
+                <node concept="37vLTw" id="6jbF0Bo0ve4" role="37wK5m">
+                  <ref role="3cqZAo" node="6jbF0Bo0uKd" resolve="language" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6jbF0Bo0vhK" role="3cqZAp" />
+        <node concept="3clFbJ" id="6jbF0Bo0vlw" role="3cqZAp">
+          <node concept="3clFbS" id="6jbF0Bo0vly" role="3clFbx">
+            <node concept="3clFbF" id="6jbF0Bo0vVQ" role="3cqZAp">
+              <node concept="37vLTI" id="6jbF0Bo0wc2" role="3clFbG">
+                <node concept="37vLTw" id="6jbF0Bo0vVO" role="37vLTJ">
+                  <ref role="3cqZAo" node="6jbF0Bo0ve0" resolve="version" />
+                </node>
+                <node concept="1rXfSq" id="6jbF0BoxTZr" role="37vLTx">
+                  <ref role="37wK5l" node="34Q84zMXVAC" resolve="getLanguageVersionString" />
+                  <node concept="37vLTw" id="6jbF0BoxU27" role="37wK5m">
+                    <ref role="3cqZAo" node="6jbF0Bo0uKd" resolve="language" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="6jbF0Bo0vEl" role="3clFbw">
+            <node concept="10Nm6u" id="6jbF0Bo0vT3" role="3uHU7w" />
+            <node concept="37vLTw" id="6jbF0Bo0vm7" role="3uHU7B">
+              <ref role="3cqZAo" node="6jbF0Bo0ve0" resolve="version" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6jbF0Bo0wle" role="3cqZAp" />
+        <node concept="3cpWs6" id="6jbF0Bo0wnS" role="3cqZAp">
+          <node concept="37vLTw" id="6jbF0Bo0woy" role="3cqZAk">
+            <ref role="3cqZAo" node="6jbF0Bo0ve0" resolve="version" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6jbF0Bo0uKb" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0Bo0uKc" role="3clF45" />
+      <node concept="37vLTG" id="6jbF0Bo0uKd" role="3clF46">
+        <property role="TrG5h" value="language" />
+        <node concept="3uibUv" id="6jbF0Bo0uKe" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0Bo0uKf" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6jbF0Bo0uNq" role="3clF46">
+        <property role="TrG5h" value="attributeFinder" />
+        <node concept="3uibUv" id="6jbF0Bo0uOp" role="1tU5fm">
+          <ref role="3uigEE" node="pPZz6cPvUw" resolve="LionWebAttributeFinder" />
+        </node>
+        <node concept="2AHcQZ" id="6jbF0Bo0zUM" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0Bo0uKg" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6jbF0Bo0uIK" role="jymVt" />
+    <node concept="2tJIrI" id="6jbF0Bo0uJh" role="jymVt" />
     <node concept="3Tm1VV" id="6jTTMHD72IT" role="1B3o_S" />
     <node concept="3UR2Jj" id="6jTTMHD72JM" role="lGtFl">
       <node concept="TZ5HA" id="6jTTMHD72JN" role="TZ5H$">
@@ -9570,6 +10693,15 @@
       <node concept="3Tm1VV" id="7OJcYq_s$7E" role="1B3o_S" />
       <node concept="17QB3L" id="7OJcYq_syTs" role="3clF45" />
       <node concept="2AHcQZ" id="7OJcYq_s_6d" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="6jbF0Boix1I" role="jymVt">
+      <property role="TrG5h" value="getLcLanguageVersion" />
+      <node concept="17QB3L" id="6jbF0Boix1J" role="3clF45" />
+      <node concept="3Tm1VV" id="6jbF0Boix1K" role="1B3o_S" />
+      <node concept="3clFbS" id="6jbF0Boix1L" role="3clF47" />
+      <node concept="2AHcQZ" id="6jbF0Boix1Q" role="2AJF6D">
         <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
     </node>
@@ -9699,6 +10831,12 @@
       <node concept="3Tm6S6" id="7OJcYq_sAXf" role="1B3o_S" />
       <node concept="17QB3L" id="7OJcYq_sAXh" role="1tU5fm" />
     </node>
+    <node concept="312cEg" id="6jbF0BoizmN" role="jymVt">
+      <property role="TrG5h" value="lcLanguageVersion" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="6jbF0BoizmO" role="1B3o_S" />
+      <node concept="17QB3L" id="6jbF0BoizmQ" role="1tU5fm" />
+    </node>
     <node concept="2tJIrI" id="7OJcYq_sC1m" role="jymVt" />
     <node concept="3clFbW" id="7OJcYqvKqOn" role="jymVt">
       <node concept="3cqZAl" id="7OJcYqvKqOo" role="3clF45" />
@@ -9795,6 +10933,19 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbF" id="6jbF0BoizmR" role="3cqZAp">
+          <node concept="37vLTI" id="6jbF0BoizmT" role="3clFbG">
+            <node concept="2OqwBi" id="6jbF0BoizLn" role="37vLTJ">
+              <node concept="Xjq3P" id="6jbF0BoizUz" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6jbF0BoizLq" role="2OqNvi">
+                <ref role="2Oxat5" node="6jbF0BoizmN" resolve="lcLanguageVersion" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="6jbF0BoizmX" role="37vLTx">
+              <ref role="3cqZAo" node="6jbF0BoiyL_" resolve="lcLanguageVersion" />
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="37vLTG" id="7OJcYqvKqXW" role="3clF46">
         <property role="TrG5h" value="lc" />
@@ -9848,6 +10999,13 @@
         <property role="TrG5h" value="lcLanguageKey" />
         <node concept="17QB3L" id="7OJcYq_sAy7" role="1tU5fm" />
         <node concept="2AHcQZ" id="7OJcYq_sAJj" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6jbF0BoiyL_" role="3clF46">
+        <property role="TrG5h" value="lcLanguageVersion" />
+        <node concept="17QB3L" id="6jbF0Boiz3k" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0Boiz8y" role="2AJF6D">
           <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
         </node>
       </node>
@@ -9996,6 +11154,24 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="7OJcYq_sCwg" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="6jbF0Boi_gF" role="jymVt">
+      <property role="TrG5h" value="getLcLanguageVersion" />
+      <node concept="17QB3L" id="6jbF0Boi_gG" role="3clF45" />
+      <node concept="3Tm1VV" id="6jbF0Boi_gH" role="1B3o_S" />
+      <node concept="2AHcQZ" id="6jbF0Boi_gJ" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3clFbS" id="6jbF0Boi_gK" role="3clF47">
+        <node concept="3clFbF" id="6jbF0BoiAAF" role="3cqZAp">
+          <node concept="37vLTw" id="6jbF0BoiAAC" role="3clFbG">
+            <ref role="3cqZAo" node="6jbF0BoizmN" resolve="lcLanguageVersion" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6jbF0Boi_gL" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
@@ -10188,6 +11364,9 @@
               </node>
             </node>
           </node>
+          <node concept="37vLTw" id="6jbF0BoiF_Q" role="37wK5m">
+            <ref role="3cqZAo" node="6jbF0BoiFf3" resolve="lcLanguageVersion" />
+          </node>
         </node>
       </node>
       <node concept="37vLTG" id="7OJcYqvKXdF" role="3clF46">
@@ -10215,6 +11394,13 @@
         </node>
         <node concept="2AHcQZ" id="7OJcYqwL_IU" role="2AJF6D">
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6jbF0BoiFf3" role="3clF46">
+        <property role="TrG5h" value="lcLanguageVersion" />
+        <node concept="17QB3L" id="6jbF0BoiFf4" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0BoiFf5" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
         </node>
       </node>
     </node>
@@ -10311,6 +11497,9 @@
               </node>
             </node>
           </node>
+          <node concept="37vLTw" id="6jbF0BoiMJ2" role="37wK5m">
+            <ref role="3cqZAo" node="6jbF0BoiMkh" resolve="lcLanguageVersion" />
+          </node>
         </node>
         <node concept="3clFbH" id="7OJcYq_mndi" role="3cqZAp" />
         <node concept="3clFbF" id="7OJcYq_mnyF" role="3cqZAp">
@@ -10358,6 +11547,13 @@
         </node>
         <node concept="2AHcQZ" id="7OJcYqwNt$J" role="2AJF6D">
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6jbF0BoiMkh" role="3clF46">
+        <property role="TrG5h" value="lcLanguageVersion" />
+        <node concept="17QB3L" id="6jbF0BoiMki" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0BoiMkj" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
         </node>
       </node>
     </node>
@@ -10459,12 +11655,6 @@
       <node concept="3Tm6S6" id="7OJcYqwopVI" role="1B3o_S" />
       <node concept="10Oyi0" id="7OJcYqwoq8T" role="1tU5fm" />
     </node>
-    <node concept="312cEg" id="7OJcYqxRpgA" role="jymVt">
-      <property role="TrG5h" value="lcVersion" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tm6S6" id="7OJcYqxRoR8" role="1B3o_S" />
-      <node concept="17QB3L" id="7OJcYqxRpbY" role="1tU5fm" />
-    </node>
     <node concept="3clFbW" id="7OJcYqvMRo3" role="jymVt">
       <node concept="3cqZAl" id="7OJcYqvMRo4" role="3clF45" />
       <node concept="3Tm1VV" id="7OJcYqvMRo5" role="1B3o_S" />
@@ -10498,6 +11688,9 @@
           </node>
           <node concept="37vLTw" id="7OJcYq_sMfc" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqvMRoP" resolve="lcKey" />
+          </node>
+          <node concept="37vLTw" id="6jbF0BoiLdQ" role="37wK5m">
+            <ref role="3cqZAo" node="7OJcYqvO4y8" resolve="lcLanguageVersion" />
           </node>
         </node>
         <node concept="3clFbF" id="7OJcYqvNTvz" role="3cqZAp">
@@ -10534,19 +11727,6 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="7OJcYqvMZyu" role="3cqZAp">
-          <node concept="37vLTI" id="7OJcYqvN09E" role="3clFbG">
-            <node concept="37vLTw" id="7OJcYqvN0fj" role="37vLTx">
-              <ref role="3cqZAo" node="7OJcYqvO4y8" resolve="lcVersion" />
-            </node>
-            <node concept="2OqwBi" id="7OJcYqvMZEN" role="37vLTJ">
-              <node concept="Xjq3P" id="7OJcYqvMZys" role="2Oq$k0" />
-              <node concept="2OwXpG" id="7OJcYqvMZNH" role="2OqNvi">
-                <ref role="2Oxat5" node="7OJcYqxRpgA" resolve="lcVersion" />
-              </node>
-            </node>
-          </node>
-        </node>
       </node>
       <node concept="37vLTG" id="7OJcYqxRdhz" role="3clF46">
         <property role="TrG5h" value="lc" />
@@ -10567,7 +11747,7 @@
         </node>
       </node>
       <node concept="37vLTG" id="7OJcYqvO4y8" role="3clF46">
-        <property role="TrG5h" value="lcVersion" />
+        <property role="TrG5h" value="lcLanguageVersion" />
         <node concept="17QB3L" id="7OJcYqvO6KI" role="1tU5fm" />
         <node concept="2AHcQZ" id="7OJcYqwMwUp" role="2AJF6D">
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
@@ -10598,12 +11778,8 @@
           <node concept="37vLTw" id="7OJcYqwqr1O" role="37wK5m">
             <ref role="3cqZAo" node="7OJcYqwqm4H" resolve="slang" />
           </node>
-          <node concept="2YIFZM" id="7OJcYqwqrGk" role="37wK5m">
-            <ref role="37wK5l" node="34Q84zMXVAC" resolve="getLanguageVersionString" />
-            <ref role="1Pybhc" node="6jTTMHD72IS" resolve="MpsLanguageUtil" />
-            <node concept="37vLTw" id="7OJcYqwqrGl" role="37wK5m">
-              <ref role="3cqZAo" node="7OJcYqwqm4H" resolve="slang" />
-            </node>
+          <node concept="37vLTw" id="6jbF0BoxX9l" role="37wK5m">
+            <ref role="3cqZAo" node="6jbF0BoxWZK" resolve="lcLanguageVersion" />
           </node>
           <node concept="2OqwBi" id="7OJcYqwqwht" role="37wK5m">
             <node concept="2YIFZM" id="7OJcYqwquaC" role="2Oq$k0">
@@ -10635,6 +11811,13 @@
         <property role="TrG5h" value="slang" />
         <node concept="3uibUv" id="7OJcYqwqm4I" role="1tU5fm">
           <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6jbF0BoxWZK" role="3clF46">
+        <property role="TrG5h" value="lcLanguageVersion" />
+        <node concept="17QB3L" id="6jbF0BoxWZL" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0BoxWZM" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
     </node>
@@ -10672,24 +11855,6 @@
             </node>
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="3clFb_" id="7OJcYqvN0Qp" role="jymVt">
-      <property role="TrG5h" value="getLcVersion" />
-      <node concept="17QB3L" id="7OJcYqvN0Qq" role="3clF45" />
-      <node concept="3Tm1VV" id="7OJcYqvN0Qr" role="1B3o_S" />
-      <node concept="3clFbS" id="7OJcYqvN0Qs" role="3clF47">
-        <node concept="3clFbF" id="7OJcYqvN0Qt" role="3cqZAp">
-          <node concept="2OqwBi" id="7OJcYqvN0Qm" role="3clFbG">
-            <node concept="Xjq3P" id="7OJcYqvN0Qn" role="2Oq$k0" />
-            <node concept="2OwXpG" id="7OJcYqvN0Qo" role="2OqNvi">
-              <ref role="2Oxat5" node="7OJcYqxRpgA" resolve="lcVersion" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="7OJcYqwMZw2" role="2AJF6D">
-        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
       </node>
     </node>
     <node concept="3uibUv" id="7OJcYqxR8Gt" role="1zkMxy">
@@ -10778,6 +11943,9 @@
               </node>
             </node>
           </node>
+          <node concept="37vLTw" id="6jbF0BoiHQ$" role="37wK5m">
+            <ref role="3cqZAo" node="6jbF0BoiHyh" resolve="lcLanguageVersion" />
+          </node>
         </node>
       </node>
       <node concept="37vLTG" id="7OJcYqvQc4_" role="3clF46">
@@ -10805,6 +11973,13 @@
         </node>
         <node concept="2AHcQZ" id="7OJcYqwMcj$" role="2AJF6D">
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6jbF0BoiHyh" role="3clF46">
+        <property role="TrG5h" value="lcLanguageVersion" />
+        <node concept="17QB3L" id="6jbF0BoiHyi" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0BoiHyj" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
         </node>
       </node>
     </node>
@@ -10894,6 +12069,9 @@
               </node>
             </node>
           </node>
+          <node concept="37vLTw" id="6jbF0BoiNek" role="37wK5m">
+            <ref role="3cqZAo" node="6jbF0BoiMZ7" resolve="lcLanguageVersion" />
+          </node>
         </node>
       </node>
       <node concept="37vLTG" id="7OJcYqvRxYM" role="3clF46">
@@ -10921,6 +12099,13 @@
         </node>
         <node concept="2AHcQZ" id="7OJcYqwNIIE" role="2AJF6D">
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6jbF0BoiMZ7" role="3clF46">
+        <property role="TrG5h" value="lcLanguageVersion" />
+        <node concept="17QB3L" id="6jbF0BoiMZ8" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0BoiMZ9" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
         </node>
       </node>
     </node>
@@ -11001,6 +12186,9 @@
               </node>
             </node>
           </node>
+          <node concept="37vLTw" id="6jbF0BoiKie" role="37wK5m">
+            <ref role="3cqZAo" node="6jbF0BoiIxK" resolve="lcLanguageVersion" />
+          </node>
         </node>
       </node>
       <node concept="37vLTG" id="7OJcYqvXZ9h" role="3clF46">
@@ -11028,6 +12216,13 @@
         </node>
         <node concept="2AHcQZ" id="7OJcYqwMnwX" role="2AJF6D">
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6jbF0BoiIxK" role="3clF46">
+        <property role="TrG5h" value="lcLanguageVersion" />
+        <node concept="17QB3L" id="6jbF0BoiIxL" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0BoiIxM" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
         </node>
       </node>
     </node>
@@ -11180,6 +12375,9 @@
               </node>
             </node>
           </node>
+          <node concept="37vLTw" id="6jbF0BoiGJ1" role="37wK5m">
+            <ref role="3cqZAo" node="6jbF0BoiG6y" resolve="lcLanguageVersion" />
+          </node>
         </node>
         <node concept="3clFbH" id="7OJcYq_muor" role="3cqZAp" />
         <node concept="3clFbF" id="7OJcYq_muos" role="3cqZAp">
@@ -11227,6 +12425,13 @@
         </node>
         <node concept="2AHcQZ" id="7OJcYqwLYCE" role="2AJF6D">
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6jbF0BoiG6y" role="3clF46">
+        <property role="TrG5h" value="lcLanguageVersion" />
+        <node concept="17QB3L" id="6jbF0BoiG6z" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0BoiG6$" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
         </node>
       </node>
     </node>
@@ -11398,6 +12603,9 @@
               </node>
             </node>
           </node>
+          <node concept="37vLTw" id="6jbF0BoiEXR" role="37wK5m">
+            <ref role="3cqZAo" node="6jbF0BoiEoX" resolve="lcLanguageVersion" />
+          </node>
         </node>
         <node concept="3clFbF" id="7OJcYqwpbTR" role="3cqZAp">
           <node concept="37vLTI" id="7OJcYqwpbTT" role="3clFbG">
@@ -11464,6 +12672,13 @@
         </node>
         <node concept="2AHcQZ" id="7OJcYqwLpiQ" role="2AJF6D">
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6jbF0BoiEoX" role="3clF46">
+        <property role="TrG5h" value="lcLanguageVersion" />
+        <node concept="17QB3L" id="6jbF0BoiEoY" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0BoiEoZ" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
         </node>
       </node>
     </node>
@@ -11638,6 +12853,9 @@
               </node>
             </node>
           </node>
+          <node concept="37vLTw" id="6jbF0BoiDvG" role="37wK5m">
+            <ref role="3cqZAo" node="6jbF0BoiBVS" resolve="lcLanguageVersion" />
+          </node>
         </node>
       </node>
       <node concept="37vLTG" id="7OJcYqwqLmz" role="3clF46">
@@ -11665,6 +12883,13 @@
         </node>
         <node concept="2AHcQZ" id="7OJcYqwLh1w" role="2AJF6D">
           <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6jbF0BoiBVS" role="3clF46">
+        <property role="TrG5h" value="lcLanguageVersion" />
+        <node concept="17QB3L" id="6jbF0BoiCqp" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6jbF0BoiCss" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
         </node>
       </node>
     </node>

--- a/solutions/io.lionweb.mps.m3.selfdescription/models/io.lionweb.mps.m3.selfdescription.converted.mps
+++ b/solutions/io.lionweb.mps.m3.selfdescription/models/io.lionweb.mps.m3.selfdescription.converted.mps
@@ -3325,7 +3325,7 @@
   <node concept="2RzRRF" id="4R9posqf3NK">
     <property role="2RzON1" value="My-TestLang3" />
     <property role="TrG5h" value="io.lionweb.mps.converter.TestLang3" />
-    <property role="3HH78N" value="0" />
+    <property role="3HH78N" value="00 my! VERSION 😀" />
     <node concept="2RzPWn" id="4R9posqf3NL" role="2RzR6B">
       <property role="2RzP46" value="false" />
       <property role="TrG5h" value="TestConceptPlain" />

--- a/solutions/io.lionweb.mps.m3.selfdescription/models/io.lionweb.mps.m3.selfdescription.imported.mps
+++ b/solutions/io.lionweb.mps.m3.selfdescription/models/io.lionweb.mps.m3.selfdescription.imported.mps
@@ -73,7 +73,7 @@
   </node>
   <node concept="2RzRRF" id="7pLZNi2wTGx">
     <property role="TrG5h" value="LionCore.M3" />
-    <property role="3HH78N" value="1" />
+    <property role="3HH78N" value="2023.1" />
     <property role="2RzON1" value="LionCore_M3" />
     <node concept="2RzPWn" id="7pLZNi2wTGy" role="2RzR6B">
       <property role="2RzP46" value="true" />
@@ -301,7 +301,7 @@
   </node>
   <node concept="2RzRRF" id="5sACIIs$PgG">
     <property role="TrG5h" value="LionCore.M3" />
-    <property role="3HH78N" value="1" />
+    <property role="3HH78N" value="2023.1" />
     <property role="2RzON1" value="LionCore_M3" />
     <node concept="2RzPWn" id="5sACIIs$PgH" role="2RzR6B">
       <property role="2RzP46" value="true" />

--- a/test-project-externalLib/gradle.properties
+++ b/test-project-externalLib/gradle.properties
@@ -1,4 +1,4 @@
-lionwebVersion=0.2.9-SNAPSHOT
+lionwebVersion=0.2.10-SNAPSHOT
 lionwebRelease=2023.1
 mpsVersionSuffix=2021.1
 mpsVersion=2021.1.4

--- a/test-project/gradle.properties
+++ b/test-project/gradle.properties
@@ -1,4 +1,4 @@
-lionwebVersion=0.2.9-SNAPSHOT
+lionwebVersion=0.2.10-SNAPSHOT
 lionwebRelease=2023.1
 mpsVersionSuffix=2021.1
 mpsVersion=2021.1.4


### PR DESCRIPTION
Merged `mps2021.1` into `meinte/extend-export-tests-2021.1` as a separate branch, and then made some small fixes — most importantly I fixed stated LionWeb-mps versions so that build on GitHub works.