### PR TITLE
Add a field to Json2LionCore converter for the dependsOn languages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
 * Ensure JSON is always exported with UTF8 encoding
 * Optionally export concept helpUrl and language element @docs attribute as lionweb annotation
 * Use `mps-gradle-plugin` v2 to build lionweb-mps
-* * Added `depends on` field to the ImportLanguageFromJson converter, to import languages dependent on other (LionCore) languages 
+* Add `depends on` field to the ImportLanguageFromJson converter, to import languages dependent on other (LionCore) languages 
 
 ## 0.2.10-2023.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelog for LionWeb-MPS
 
+* Added `depends on` field to the ImportLanguageFromJson converter, to import languages dependent on other (LionCore) languages 
+
 ## 0.2.10-2023.1
 
 * Added optional `version` to LionWeb Language root in structure aspect.

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.behavior.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.behavior.mps
@@ -2698,6 +2698,9 @@
                 <node concept="2ShNRf" id="5YadkJSxSkl" role="33vP2m">
                   <node concept="1pGfFk" id="5YadkJSxSkk" role="2ShVmc">
                     <ref role="37wK5l" to="9pi3:5sACIIsA0tB" resolve="LionCore2JsonConverter" />
+                    <node concept="37vLTw" id="488yEreU7el" role="37wK5m">
+                      <ref role="3cqZAo" node="1KsTggJhA$U" resolve="lionwebVersion" />
+                    </node>
                     <node concept="37vLTw" id="5YadkJSxSTD" role="37wK5m">
                       <ref role="3cqZAo" node="5M3rB6C9CRl" resolve="constants" />
                     </node>
@@ -2707,6 +2710,14 @@
                     <node concept="2ShNRf" id="5YadkJSxXCj" role="37wK5m">
                       <node concept="1pGfFk" id="5YadkJSxZF9" role="2ShVmc">
                         <ref role="37wK5l" to="t47h:5M3rB6AxjLI" resolve="LionCoreLanguageGuaranteedMapper" />
+                      </node>
+                    </node>
+                    <node concept="2ShNRf" id="488yEreU860" role="37wK5m">
+                      <node concept="1pGfFk" id="488yEreU8zp" role="2ShVmc">
+                        <ref role="37wK5l" to="6peh:4ZQFfbQ9DSn" resolve="LionCoreFactory" />
+                        <node concept="37vLTw" id="488yEreU98w" role="37wK5m">
+                          <ref role="3cqZAo" node="1KsTggJhA$U" resolve="lionwebVersion" />
+                        </node>
                       </node>
                     </node>
                     <node concept="2OqwBi" id="5YadkJSy2Wq" role="37wK5m">

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.behavior.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.behavior.mps
@@ -309,6 +309,9 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
+      <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
+        <child id="1176906787974" name="rightExpression" index="576Qk" />
+      </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
@@ -345,6 +348,7 @@
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
+      <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
     </language>
   </registry>
   <node concept="13h7C7" id="4na9S9Ya_m_">
@@ -2735,27 +2739,60 @@
                 </node>
               </node>
             </node>
-            <node concept="3cpWs8" id="z1IqfFSQk$" role="3cqZAp">
-              <node concept="3cpWsn" id="z1IqfFSQk_" role="3cpWs9">
-                <property role="TrG5h" value="jsonLanguages" />
-                <node concept="_YKpA" id="z1IqfFSQiz" role="1tU5fm">
-                  <node concept="3uibUv" id="z1IqfFSQiA" role="_ZDj9">
+            <node concept="3cpWs8" id="6NZwk6fibKN" role="3cqZAp">
+              <node concept="3cpWsn" id="6NZwk6fibKO" role="3cpWs9">
+                <property role="TrG5h" value="usedLanguagesAsJson" />
+                <node concept="A3Dl8" id="6NZwk6fibKP" role="1tU5fm">
+                  <node concept="3uibUv" id="6NZwk6fibKQ" role="A3Ik2">
                     <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
                   </node>
                 </node>
-                <node concept="2OqwBi" id="z1IqfFSQkA" role="33vP2m">
-                  <node concept="37vLTw" id="z1IqfFSQkB" role="2Oq$k0">
+                <node concept="2OqwBi" id="6NZwk6fibKR" role="33vP2m">
+                  <node concept="37vLTw" id="6NZwk6fibKS" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5YadkJSxRul" resolve="lionMPS2lionJavaConverter" />
+                  </node>
+                  <node concept="liA8E" id="6NZwk6fibKT" role="2OqNvi">
+                    <ref role="37wK5l" to="9pi3:5sACIIsA0ut" resolve="convert" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="TXaBS0BhVq" role="3cqZAp">
+              <node concept="3cpWsn" id="TXaBS0BhVt" role="3cpWs9">
+                <property role="TrG5h" value="importedLanguages" />
+                <node concept="A3Dl8" id="TXaBS0BhVn" role="1tU5fm">
+                  <node concept="3uibUv" id="TXaBS0BiDn" role="A3Ik2">
+                    <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="TXaBS0BkQf" role="33vP2m">
+                  <node concept="37vLTw" id="TXaBS0BkQg" role="2Oq$k0">
                     <ref role="3cqZAo" node="z1IqfFSPZE" resolve="deserializer" />
                   </node>
-                  <node concept="liA8E" id="z1IqfFSQkC" role="2OqNvi">
+                  <node concept="liA8E" id="TXaBS0BkQh" role="2OqNvi">
                     <ref role="37wK5l" to="6peh:5wsogBc3YTv" resolve="deserializeLanguages" />
-                    <node concept="2OqwBi" id="5YadkJSy9ks" role="37wK5m">
-                      <node concept="37vLTw" id="5YadkJSy8TA" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5YadkJSxRul" resolve="lionMPS2lionJavaConverter" />
-                      </node>
-                      <node concept="liA8E" id="5YadkJSyade" role="2OqNvi">
-                        <ref role="37wK5l" to="9pi3:5sACIIsA0ut" resolve="convert" />
-                      </node>
+                    <node concept="37vLTw" id="TXaBS0BmbC" role="37wK5m">
+                      <ref role="3cqZAo" node="6NZwk6fibKO" resolve="usedLanguagesAsJson" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="TXaBS0Bohh" role="3cqZAp">
+              <node concept="3cpWsn" id="TXaBS0Bohk" role="3cpWs9">
+                <property role="TrG5h" value="jsonLanguages" />
+                <node concept="A3Dl8" id="TXaBS0Bohe" role="1tU5fm">
+                  <node concept="3uibUv" id="TXaBS0BoEV" role="A3Ik2">
+                    <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="TXaBS0Brod" role="33vP2m">
+                  <node concept="37vLTw" id="TXaBS0BqSN" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6NZwk6fibKO" resolve="usedLanguagesAsJson" />
+                  </node>
+                  <node concept="3QWeyG" id="TXaBS0Bs$i" role="2OqNvi">
+                    <node concept="37vLTw" id="TXaBS0Bt10" role="576Qk">
+                      <ref role="3cqZAo" node="TXaBS0BhVt" resolve="importedLanguages" />
                     </node>
                   </node>
                 </node>
@@ -2794,7 +2831,7 @@
                       <ref role="3cqZAo" node="5M3rB6C9D6x" resolve="mapper" />
                     </node>
                     <node concept="37vLTw" id="z1IqfFSTuV" role="37wK5m">
-                      <ref role="3cqZAo" node="z1IqfFSQk_" resolve="jsonLanguages" />
+                      <ref role="3cqZAo" node="TXaBS0Bohk" resolve="jsonLanguages" />
                     </node>
                   </node>
                 </node>

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.behavior.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.behavior.mps
@@ -2670,28 +2670,6 @@
                 </node>
               </node>
             </node>
-            <node concept="3cpWs8" id="z1IqfFSPZD" role="3cqZAp">
-              <node concept="3cpWsn" id="z1IqfFSPZE" role="3cpWs9">
-                <property role="TrG5h" value="deserializer" />
-                <node concept="3uibUv" id="z1IqfFSPWh" role="1tU5fm">
-                  <ref role="3uigEE" to="6peh:z1IqfFwqda" resolve="Deserializer" />
-                </node>
-                <node concept="2ShNRf" id="z1IqfFSPZF" role="33vP2m">
-                  <node concept="1pGfFk" id="z1IqfFSPZG" role="2ShVmc">
-                    <ref role="37wK5l" to="6peh:z1IqfFwqeg" resolve="Deserializer" />
-                    <node concept="37vLTw" id="1KsTggJhE7E" role="37wK5m">
-                      <ref role="3cqZAo" node="1KsTggJhA$U" resolve="lionwebVersion" />
-                    </node>
-                    <node concept="37vLTw" id="z1IqfFSPZH" role="37wK5m">
-                      <ref role="3cqZAo" node="z1IqfFSMnI" resolve="inputStream" />
-                    </node>
-                    <node concept="37vLTw" id="7OJcYqxWMqb" role="37wK5m">
-                      <ref role="3cqZAo" node="7OJcYqxWMq4" resolve="jsonConstants" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="3clFbH" id="5hsSXrmD5g8" role="3cqZAp" />
             <node concept="3cpWs8" id="5YadkJSxRuk" role="3cqZAp">
               <node concept="3cpWsn" id="5YadkJSxRul" role="3cpWs9">
@@ -2757,6 +2735,32 @@
                 </node>
               </node>
             </node>
+            <node concept="3clFbH" id="TXaBS0H4Ys" role="3cqZAp" />
+            <node concept="3cpWs8" id="z1IqfFSPZD" role="3cqZAp">
+              <node concept="3cpWsn" id="z1IqfFSPZE" role="3cpWs9">
+                <property role="TrG5h" value="deserializer" />
+                <node concept="3uibUv" id="z1IqfFSPWh" role="1tU5fm">
+                  <ref role="3uigEE" to="6peh:z1IqfFwqda" resolve="Deserializer" />
+                </node>
+                <node concept="2ShNRf" id="z1IqfFSPZF" role="33vP2m">
+                  <node concept="1pGfFk" id="z1IqfFSPZG" role="2ShVmc">
+                    <ref role="37wK5l" to="6peh:TXaBS0HMk6" resolve="Deserializer" />
+                    <node concept="37vLTw" id="1KsTggJhE7E" role="37wK5m">
+                      <ref role="3cqZAo" node="1KsTggJhA$U" resolve="lionwebVersion" />
+                    </node>
+                    <node concept="37vLTw" id="z1IqfFSPZH" role="37wK5m">
+                      <ref role="3cqZAo" node="z1IqfFSMnI" resolve="inputStream" />
+                    </node>
+                    <node concept="37vLTw" id="7OJcYqxWMqb" role="37wK5m">
+                      <ref role="3cqZAo" node="7OJcYqxWMq4" resolve="jsonConstants" />
+                    </node>
+                    <node concept="37vLTw" id="TXaBS0HepT" role="37wK5m">
+                      <ref role="3cqZAo" node="6NZwk6fibKO" resolve="usedLanguagesAsJson" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
             <node concept="3cpWs8" id="TXaBS0BhVq" role="3cqZAp">
               <node concept="3cpWsn" id="TXaBS0BhVt" role="3cpWs9">
                 <property role="TrG5h" value="importedLanguages" />
@@ -2771,9 +2775,6 @@
                   </node>
                   <node concept="liA8E" id="TXaBS0BkQh" role="2OqNvi">
                     <ref role="37wK5l" to="6peh:5wsogBc3YTv" resolve="deserializeLanguages" />
-                    <node concept="37vLTw" id="TXaBS0BmbC" role="37wK5m">
-                      <ref role="3cqZAo" node="6NZwk6fibKO" resolve="usedLanguagesAsJson" />
-                    </node>
                   </node>
                 </node>
               </node>

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.behavior.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.behavior.mps
@@ -2547,7 +2547,6 @@
     <node concept="13i0hz" id="5N2LjD7MP48" role="13h7CS">
       <property role="TrG5h" value="importt" />
       <node concept="3Tm1VV" id="5N2LjD7MP49" role="1B3o_S" />
-      <node concept="3cqZAl" id="5N2LjD7MP4o" role="3clF45" />
       <node concept="3clFbS" id="5N2LjD7MP4b" role="3clF47">
         <node concept="3cpWs8" id="z1IqfFSG9t" role="3cqZAp">
           <node concept="3cpWsn" id="z1IqfFSG9u" role="3cpWs9">
@@ -2566,7 +2565,9 @@
         </node>
         <node concept="3clFbJ" id="5N2LjD7MPPw" role="3cqZAp">
           <node concept="3clFbS" id="5N2LjD7MPPx" role="3clFbx">
-            <node concept="3cpWs6" id="5N2LjD7MPPy" role="3cqZAp" />
+            <node concept="3cpWs6" id="5N2LjD7MPPy" role="3cqZAp">
+              <node concept="10Nm6u" id="TXaBS0PxBy" role="3cqZAk" />
+            </node>
           </node>
           <node concept="3clFbC" id="1apSfP9EIEm" role="3clFbw">
             <node concept="10Nm6u" id="1apSfP9EIW6" role="3uHU7w" />
@@ -2944,7 +2945,12 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbH" id="z1IqfFSRto" role="3cqZAp" />
+            <node concept="3clFbH" id="TXaBS0P_iO" role="3cqZAp" />
+            <node concept="3cpWs6" id="TXaBS0Py$z" role="3cqZAp">
+              <node concept="37vLTw" id="TXaBS0Pzer" role="3cqZAk">
+                <ref role="3cqZAo" node="z1IqfFSTRe" resolve="lcLanguages" />
+              </node>
+            </node>
           </node>
           <node concept="3uVAMA" id="z1IqfFSMTf" role="1zxBo5">
             <node concept="3clFbS" id="z1IqfFSMTi" role="1zc67A">
@@ -2966,6 +2972,9 @@
                 <node concept="37vLTw" id="z1IqfFSUY1" role="9lYJj">
                   <ref role="3cqZAo" node="z1IqfFSMTj" resolve="e" />
                 </node>
+              </node>
+              <node concept="3cpWs6" id="TXaBS0P$tf" role="3cqZAp">
+                <node concept="10Nm6u" id="TXaBS0P$Fj" role="3cqZAk" />
               </node>
             </node>
             <node concept="XOnhg" id="z1IqfFSMTj" role="1zc67B">
@@ -2999,6 +3008,11 @@
           <node concept="1dT_AC" id="5N2LjD7MSI5" role="1dT_Ay">
             <property role="1dT_AB" value="second &quot;t&quot; because `import` is a reserved keyword." />
           </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="TXaBS0PwZX" role="3clF45">
+        <node concept="3Tqbb2" id="TXaBS0PwZY" role="A3Ik2">
+          <ref role="ehGHo" to="h3y3:2ju2syjkngz" resolve="Language" />
         </node>
       </node>
     </node>

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.behavior.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.behavior.mps
@@ -2689,6 +2689,41 @@
               </node>
             </node>
             <node concept="3clFbH" id="5hsSXrmD5g8" role="3cqZAp" />
+            <node concept="3cpWs8" id="5YadkJSxRuk" role="3cqZAp">
+              <node concept="3cpWsn" id="5YadkJSxRul" role="3cpWs9">
+                <property role="TrG5h" value="lionMPS2lionJavaConverter" />
+                <node concept="3uibUv" id="5YadkJSxRum" role="1tU5fm">
+                  <ref role="3uigEE" to="9pi3:5sACIIsA0s2" resolve="LionCore2JsonConverter" />
+                </node>
+                <node concept="2ShNRf" id="5YadkJSxSkl" role="33vP2m">
+                  <node concept="1pGfFk" id="5YadkJSxSkk" role="2ShVmc">
+                    <ref role="37wK5l" to="9pi3:5sACIIsA0tB" resolve="LionCore2JsonConverter" />
+                    <node concept="37vLTw" id="5YadkJSxSTD" role="37wK5m">
+                      <ref role="3cqZAo" node="5M3rB6C9CRl" resolve="constants" />
+                    </node>
+                    <node concept="37vLTw" id="5YadkJSxTrP" role="37wK5m">
+                      <ref role="3cqZAo" node="7OJcYqxWMq4" resolve="jsonConstants" />
+                    </node>
+                    <node concept="2ShNRf" id="5YadkJSxXCj" role="37wK5m">
+                      <node concept="1pGfFk" id="5YadkJSxZF9" role="2ShVmc">
+                        <ref role="37wK5l" to="t47h:5M3rB6AxjLI" resolve="LionCoreLanguageGuaranteedMapper" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="5YadkJSy2Wq" role="37wK5m">
+                      <node concept="2OqwBi" id="5YadkJSy0yx" role="2Oq$k0">
+                        <node concept="13iPFW" id="5YadkJSxZY1" role="2Oq$k0" />
+                        <node concept="3Tsc0h" id="5YadkJSy1iu" role="2OqNvi">
+                          <ref role="3TtcxE" to="d0tf:DUXtH0uZbo" resolve="languages" />
+                        </node>
+                      </node>
+                      <node concept="13MTOL" id="5YadkJSy6Ka" role="2OqNvi">
+                        <ref role="13MTZf" to="h3y3:2ju2syjknNj" resolve="language" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
             <node concept="3cpWs8" id="z1IqfFSQk$" role="3cqZAp">
               <node concept="3cpWsn" id="z1IqfFSQk_" role="3cpWs9">
                 <property role="TrG5h" value="jsonLanguages" />
@@ -2703,6 +2738,14 @@
                   </node>
                   <node concept="liA8E" id="z1IqfFSQkC" role="2OqNvi">
                     <ref role="37wK5l" to="6peh:5wsogBc3YTv" resolve="deserializeLanguages" />
+                    <node concept="2OqwBi" id="5YadkJSy9ks" role="37wK5m">
+                      <node concept="37vLTw" id="5YadkJSy8TA" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5YadkJSxRul" resolve="lionMPS2lionJavaConverter" />
+                      </node>
+                      <node concept="liA8E" id="5YadkJSyade" role="2OqNvi">
+                        <ref role="37wK5l" to="9pi3:5sACIIsA0ut" resolve="convert" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.behavior.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.behavior.mps
@@ -28,6 +28,8 @@
     <import index="j5yh" ref="r:137003c8-aa9f-4bda-ae9b-f5d7ec2da82c(io.lionweb.mps.json.idmapper)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="7x5y" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.nio.charset(JDK/)" />
+    <import index="i290" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.java.stub(MPS.Core/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" implicit="true" />
   </imports>
@@ -2566,7 +2568,10 @@
         <node concept="3clFbJ" id="5N2LjD7MPPw" role="3cqZAp">
           <node concept="3clFbS" id="5N2LjD7MPPx" role="3clFbx">
             <node concept="3cpWs6" id="5N2LjD7MPPy" role="3cqZAp">
-              <node concept="10Nm6u" id="TXaBS0PxBy" role="3cqZAk" />
+              <node concept="2YIFZM" id="59fw59O50Yp" role="3cqZAk">
+                <ref role="37wK5l" to="33ny:~Collections.emptyList()" resolve="emptyList" />
+                <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+              </node>
             </node>
           </node>
           <node concept="3clFbC" id="1apSfP9EIEm" role="3clFbw">
@@ -2974,7 +2979,10 @@
                 </node>
               </node>
               <node concept="3cpWs6" id="TXaBS0P$tf" role="3cqZAp">
-                <node concept="10Nm6u" id="TXaBS0P$Fj" role="3cqZAk" />
+                <node concept="2YIFZM" id="59fw59O525F" role="3cqZAk">
+                  <ref role="37wK5l" to="33ny:~Collections.emptyList()" resolve="emptyList" />
+                  <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+                </node>
               </node>
             </node>
             <node concept="XOnhg" id="z1IqfFSMTj" role="1zc67B">

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.editor.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.editor.mps
@@ -385,5 +385,38 @@
       <node concept="2iRfu4" id="5N2LjD7OIVR" role="2iSdaV" />
     </node>
   </node>
+  <node concept="24kQdi" id="5YadkJSwkb9">
+    <ref role="1XX52x" to="d0tf:z1IqfFSzDB" resolve="ImportLanguageFromJson" />
+    <node concept="3EZMnI" id="5YadkJSwkff" role="2wV5jI">
+      <node concept="3EZMnI" id="5YadkJSwkfy" role="3EZMnx">
+        <node concept="VPM3Z" id="5YadkJSwkf$" role="3F10Kt" />
+        <node concept="PMmxH" id="5YadkJSwkfH" role="3EZMnx">
+          <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+        </node>
+        <node concept="3F0A7n" id="5YadkJSwkfM" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+        <node concept="2iRfu4" id="5YadkJSwkfB" role="2iSdaV" />
+      </node>
+      <node concept="3F0ifn" id="5YadkJSwkfp" role="3EZMnx" />
+      <node concept="3F0A7n" id="5YadkJSwkfY" role="3EZMnx">
+        <ref role="1NtTu8" to="d0tf:4na9S9Ya_fn" resolve="path" />
+      </node>
+      <node concept="3F0ifn" id="5YadkJSwkmd" role="3EZMnx" />
+      <node concept="3EZMnI" id="5YadkJSwkpp" role="3EZMnx">
+        <node concept="VPM3Z" id="5YadkJSwkpr" role="3F10Kt" />
+        <node concept="3F0ifn" id="5YadkJSwkpt" role="3EZMnx">
+          <property role="3F0ifm" value="depends on" />
+        </node>
+        <node concept="3F2HdR" id="5YadkJSwkpL" role="3EZMnx">
+          <ref role="1NtTu8" to="d0tf:DUXtH0uZbo" resolve="languages" />
+          <node concept="2iRkQZ" id="5YadkJSwkpO" role="2czzBx" />
+          <node concept="VPM3Z" id="5YadkJSwkpP" role="3F10Kt" />
+        </node>
+        <node concept="2iRfu4" id="5YadkJSwkpu" role="2iSdaV" />
+      </node>
+      <node concept="2iRkQZ" id="5YadkJSwkfi" role="2iSdaV" />
+    </node>
+  </node>
 </model>
 

--- a/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.structure.mps
+++ b/languages/io.lionweb.mps.converter.lang/models/io.lionweb.mps.converter.lang.structure.mps
@@ -103,6 +103,9 @@
     <node concept="1QGGSu" id="5glO5qL6ePs" role="rwd14">
       <property role="1iqoE4" value="${module}/icons/json2language.png" />
     </node>
+    <node concept="PrWs8" id="5YadkJSwhWu" role="PzmwI">
+      <ref role="PrY4T" node="7qGUpN3Cils" resolve="ILanguageReferenceContainer" />
+    </node>
   </node>
   <node concept="1TIwiD" id="7qGUpN3ChNP">
     <property role="EcuMT" value="8551466651976015093" />

--- a/solutions/io.lionweb.mps.build.test/models/io.lionweb.mps.build.test.mps
+++ b/solutions/io.lionweb.mps.build.test/models/io.lionweb.mps.build.test.mps
@@ -2705,6 +2705,11 @@
           <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
         </node>
       </node>
+      <node concept="1SiIV0" id="6KZ0V$Rukn9" role="3bR37C">
+        <node concept="3bR9La" id="6KZ0V$Rukna" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:6aIAM_Qd5ki" resolve="jetbrains.mps.lang.test.matcher" />
+        </node>
+      </node>
     </node>
     <node concept="1E1JtA" id="2_4dqAZFOPK" role="3989C9">
       <property role="BnDLt" value="true" />

--- a/solutions/io.lionweb.mps.build.test/models/io.lionweb.mps.build.test.mps
+++ b/solutions/io.lionweb.mps.build.test/models/io.lionweb.mps.build.test.mps
@@ -2867,6 +2867,16 @@
           <ref role="3bR37D" to="e6nc:6jI_U5e9kIC" resolve="io.lionweb.mps.m3.runtime" />
         </node>
       </node>
+      <node concept="1SiIV0" id="59fw59O3Exq" role="3bR37C">
+        <node concept="3bR9La" id="59fw59O3Exr" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1TaHNgiIbJ$" resolve="jetbrains.mps.ide.editor" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="59fw59O3Exs" role="3bR37C">
+        <node concept="3bR9La" id="59fw59O3Ext" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:6aIAM_Qd5ki" resolve="jetbrains.mps.lang.test.matcher" />
+        </node>
+      </node>
     </node>
     <node concept="1E1JtA" id="3fg6BaZxW07" role="3989C9">
       <property role="BnDLt" value="true" />

--- a/solutions/io.lionweb.mps.converter.test/io.lionweb.mps.converter.test.msd
+++ b/solutions/io.lionweb.mps.converter.test/io.lionweb.mps.converter.test.msd
@@ -33,6 +33,8 @@
     <dependency reexport="false">f2801650-65d5-424e-bb1b-463a8781b786(jetbrains.mps.baseLanguage.javadoc)</dependency>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
     <dependency reexport="false">1f02557f-ee3b-4ebc-bcea-ff6ec30a2c3e(io.lionweb.mps.converter.test.support)</dependency>
+    <dependency reexport="false">5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)</dependency>
+    <dependency reexport="false">e55e6749-03cb-4ea7-9695-2322bab791c1(jetbrains.mps.lang.test.matcher)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:97ef2b8d-23e1-433e-8d23-48f916dd314d:io.lionweb.mps.converter.lang" version="0" />
@@ -56,6 +58,7 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="76d927fd-3a5a-4e40-865b-7c2d329ca675(MultiRefLang)" version="0" />
     <module reference="4d96f781-5fa4-4d94-817a-c51f74fdf43f(io.lionweb.mps.converter)" version="0" />
@@ -74,11 +77,13 @@
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="f2801650-65d5-424e-bb1b-463a8781b786(jetbrains.mps.baseLanguage.javadoc)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="e55e6749-03cb-4ea7-9695-2322bab791c1(jetbrains.mps.lang.test.matcher)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="537f9cb0-0f25-3c76-8b86-308f45010100(library)" version="0" />
   </dependencyVersions>

--- a/solutions/io.lionweb.mps.converter.test/models/io.lionweb.mps.converter.test.converter@tests.mps
+++ b/solutions/io.lionweb.mps.converter.test/models/io.lionweb.mps.converter.test.converter@tests.mps
@@ -20,6 +20,11 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="apzt" ref="r:ea3bdd37-0680-4524-8252-d8093e3b6903(io.lionweb.mps.converter.util)" />
     <import index="jfqc" ref="r:6e560006-b8bd-4479-9a0e-1c215f48423a(io.lionweb.mps.converter.test.support)" />
+    <import index="aoz0" ref="r:d60048c8-25ba-4e49-bf73-bc4371af9b2e(io.lionweb.mps.converter.lang.behavior)" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="y5e1" ref="r:4464540a-9650-433f-b716-ed95bbac5a69(jetbrains.mps.lang.test.matcher)" />
     <import index="2pzz" ref="r:74e14b22-3b4a-45ce-940b-9bdca99c102f(io.lionweb.mps.m3.builtin)" implicit="true" />
   </imports>
   <registry>
@@ -51,6 +56,7 @@
       <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1732176556423009631" name="jetbrains.mps.baseLanguage.structure.MultiLineComment" flags="ng" index="2lOVwT">
         <child id="1732176556423038857" name="lines" index="2lOMFJ" />
@@ -95,6 +101,7 @@
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
@@ -105,6 +112,14 @@
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
@@ -145,9 +160,13 @@
       <concept id="2656571587264865491" name="io.lionweb.mps.m3.structure.InterfaceReference" flags="ng" index="2RzQOr">
         <reference id="2656571587264865492" name="interface" index="2RzQOs" />
       </concept>
+      <concept id="2656571587264871634" name="io.lionweb.mps.m3.structure.LanguageReference" flags="ng" index="2RzRkq">
+        <reference id="2656571587264871635" name="language" index="2RzRkr" />
+      </concept>
       <concept id="2656571587264869411" name="io.lionweb.mps.m3.structure.Language" flags="ng" index="2RzRRF">
         <property id="2526956841135898600" name="version" index="3HH78N" />
         <child id="2656571587264870511" name="entities" index="2RzR6B" />
+        <child id="2656571587264871163" name="dependsOn" index="2RzRcN" />
       </concept>
       <concept id="2656571587264873280" name="io.lionweb.mps.m3.structure.Enumeration" flags="ng" index="2RzSE8">
         <child id="2656571587264874244" name="literals" index="2RzSVc" />
@@ -155,11 +174,21 @@
       <concept id="2656571587264872967" name="io.lionweb.mps.m3.structure.PrimitiveType" flags="ng" index="2RzSJf" />
       <concept id="2656571587264873619" name="io.lionweb.mps.m3.structure.EnumerationLiteral" flags="ng" index="2RzSPr" />
     </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
     <language id="97ef2b8d-23e1-433e-8d23-48f916dd314d" name="io.lionweb.mps.converter.lang">
       <concept id="5066961138993480707" name="io.lionweb.mps.converter.lang.structure.ConvertLanguageToLionCore" flags="ng" index="qeN9c" />
+      <concept id="8551466651976017244" name="io.lionweb.mps.converter.lang.structure.ILanguageReferenceContainer" flags="ng" index="2P3sN0">
+        <child id="755186209566487256" name="languages" index="1a0gs3" />
+      </concept>
       <concept id="5028875375328515028" name="io.lionweb.mps.converter.lang.structure.APathConverter" flags="ng" index="VS7hm">
         <property id="5028875375328515031" name="path" index="VS7hl" />
       </concept>
+      <concept id="630989536496859751" name="io.lionweb.mps.converter.lang.structure.ImportLanguageFromJson" flags="ng" index="3z8Sf4" />
       <concept id="1622443184644647655" name="io.lionweb.mps.converter.lang.structure.ILanguageIdentityContainer" flags="ng" index="3IuRAt">
         <child id="5066961138993587939" name="languages" index="qeD2G" />
       </concept>
@@ -176,13 +205,26 @@
       </concept>
     </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="7080278351417106679" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertIsNotNull" flags="nn" index="2Hmddi">
+        <child id="7080278351417106681" name="expression" index="2Hmdds" />
+      </concept>
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
         <child id="8427750732757990724" name="expected" index="3tpDZB" />
       </concept>
       <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1172073500303" name="jetbrains.mps.baseLanguage.unitTest.structure.Message" flags="ng" index="3_1$Yv">
+        <child id="1172073511101" name="message" index="3_1BAH" />
+      </concept>
+      <concept id="1172075514136" name="jetbrains.mps.baseLanguage.unitTest.structure.MessageHolder" flags="ng" index="3_9gw8">
+        <child id="1172075534298" name="message" index="3_9lra" />
+      </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="7400021826774799413" name="jetbrains.mps.lang.smodel.structure.NodePointerExpression" flags="ng" index="2tJFMh">
         <child id="7400021826774799510" name="ref" index="2tJFKM" />
       </concept>
@@ -227,6 +269,12 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
@@ -235,9 +283,19 @@
         <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="4611582986551314327" name="jetbrains.mps.baseLanguage.collections.structure.OfTypeOperation" flags="nn" index="UnYns">
+        <child id="4611582986551314344" name="requestedType" index="UnYnz" />
+      </concept>
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+        <child id="1240687658305" name="delimiter" index="3uJOhx" />
+      </concept>
+      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
+      <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
   </registry>
   <node concept="1lH9Xt" id="48csSBOnu1D">
@@ -3744,6 +3802,357 @@
         <node concept="7CXmI" id="6LPkCA_eaP9" role="lGtFl">
           <node concept="7OXhh" id="6LPkCA_eaPb" role="7EUXB">
             <property role="GvXf4" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="TXaBS0Opfe">
+    <property role="TrG5h" value="ImportLanguageFromJson" />
+    <node concept="1qefOq" id="5sACIIszZSy" role="1SKRRt">
+      <node concept="2RzRRF" id="5ocQ9W1u7kH" role="1qenE9">
+        <property role="TrG5h" value="library" />
+        <property role="3HH78N" value="0" />
+        <property role="2RzON1" value="NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAw" />
+        <node concept="3xLA65" id="5ocQ9W1u7kV" role="lGtFl">
+          <property role="TrG5h" value="library" />
+        </node>
+        <node concept="2RzPWn" id="5ocQ9W1u7kI" role="2RzR6B">
+          <property role="2RzP46" value="false" />
+          <property role="2RzON1" value="NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLy0yNTg2Mzk4OTU5MDM1MjUwMjYx" />
+          <property role="TrG5h" value="Book" />
+          <ref role="2RzPfO" to="2pzz:39$JcGFBN1$" resolve="Node" />
+          <node concept="2RzOpR" id="5ocQ9W1u7kL" role="2RzPPN">
+            <property role="2RzON1" value="NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLy0yNTg2Mzk4OTU5MDM1MjUwMjYxLzI3MDkyODE3OTA0MDA0MDk2OTQ" />
+            <property role="TrG5h" value="author" />
+            <property role="2RzO1C" value="false" />
+            <ref role="2RzQvY" node="5ocQ9W1u7kT" resolve="Writer" />
+          </node>
+          <node concept="2RzOeU" id="5ocQ9W1u7kK" role="2RzPPN">
+            <property role="2RzON1" value="NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLy0yNTg2Mzk4OTU5MDM1MjUwMjYxLy00Mzg2MTUwNjczNDI5OTQ5NTUy" />
+            <property role="TrG5h" value="pages" />
+            <property role="2RzO1C" value="true" />
+            <ref role="2Rx9Fl" to="2pzz:48csSBPfMBo" resolve="Integer" />
+          </node>
+          <node concept="2RzOeU" id="5ocQ9W1u7kJ" role="2RzPPN">
+            <property role="2RzON1" value="NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLy0yNTg2Mzk4OTU5MDM1MjUwMjYxLy02NDc2MDE3NTAyOTM2MDY4MTk5" />
+            <property role="TrG5h" value="title" />
+            <property role="2RzO1C" value="true" />
+            <ref role="2Rx9Fl" to="2pzz:2ju2syjnJjX" resolve="String" />
+          </node>
+        </node>
+        <node concept="2RzPWn" id="5ocQ9W1u7kM" role="2RzR6B">
+          <property role="2RzP46" value="false" />
+          <property role="2RzON1" value="NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLzU1ODIwOTMzOTQ1NTE3NDM0MTc" />
+          <property role="TrG5h" value="GuideBookWriter" />
+          <ref role="2RzPfO" node="5ocQ9W1u7kT" resolve="Writer" />
+          <node concept="2RzOeU" id="5ocQ9W1u7kN" role="2RzPPN">
+            <property role="2RzON1" value="NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLzU1ODIwOTMzOTQ1NTE3NDM0MTcvLTQ0MDQ1Mzk3MTU3MTg0MzkyNjM" />
+            <property role="TrG5h" value="countries" />
+            <property role="2RzO1C" value="true" />
+            <ref role="2Rx9Fl" to="2pzz:2ju2syjnJjX" resolve="String" />
+          </node>
+        </node>
+        <node concept="2RzPWn" id="5ocQ9W1u7kO" role="2RzR6B">
+          <property role="2RzP46" value="false" />
+          <property role="2RzON1" value="NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLzg2OTkxNDExNTA2MzkyMDA3NzE" />
+          <property role="TrG5h" value="Library" />
+          <ref role="2RzPfO" to="2pzz:39$JcGFBN1$" resolve="Node" />
+          <node concept="2RzOte" id="5ocQ9W1u7kQ" role="2RzPPN">
+            <property role="2RzON1" value="NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLzg2OTkxNDExNTA2MzkyMDA3NzEvLTYzOTI0NjgyNTk0NDA3MjQ1MzE" />
+            <property role="TrG5h" value="books" />
+            <property role="2RzO1C" value="false" />
+            <property role="2RzOhW" value="true" />
+            <ref role="2RzQvY" node="5ocQ9W1u7kI" resolve="Book" />
+          </node>
+          <node concept="2RzOeU" id="5ocQ9W1u7kP" role="2RzPPN">
+            <property role="2RzON1" value="NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLzg2OTkxNDExNTA2MzkyMDA3NzEvMTY2MzE2NjUzNTM4OTU1NjUwNw" />
+            <property role="TrG5h" value="name" />
+            <property role="2RzO1C" value="true" />
+            <ref role="2Rx9Fl" to="2pzz:2ju2syjnJjX" resolve="String" />
+          </node>
+        </node>
+        <node concept="2RzPWn" id="5ocQ9W1u7kR" role="2RzR6B">
+          <property role="2RzP46" value="false" />
+          <property role="2RzON1" value="NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLy02MTY0NzkwMTUxMTcxMTQxMzE5" />
+          <property role="TrG5h" value="SpecialistBookWriter" />
+          <ref role="2RzPfO" node="5ocQ9W1u7kT" resolve="Writer" />
+          <node concept="2RzOeU" id="5ocQ9W1u7kS" role="2RzPPN">
+            <property role="2RzON1" value="NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLy02MTY0NzkwMTUxMTcxMTQxMzE5Ly0xMDU4NzUxMzAyMDYwOTg0NjEy" />
+            <property role="TrG5h" value="subject" />
+            <property role="2RzO1C" value="true" />
+            <ref role="2Rx9Fl" to="2pzz:2ju2syjnJjX" resolve="String" />
+          </node>
+        </node>
+        <node concept="2RzPWn" id="5ocQ9W1u7kT" role="2RzR6B">
+          <property role="2RzP46" value="false" />
+          <property role="2RzON1" value="NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLy02MzA4OTk2OTY0NjI5MTg1MTYz" />
+          <property role="TrG5h" value="Writer" />
+          <ref role="2RzPfO" to="2pzz:39$JcGFBN1$" resolve="Node" />
+          <node concept="2RzOeU" id="5ocQ9W1u7kU" role="2RzPPN">
+            <property role="2RzON1" value="NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLy02MzA4OTk2OTY0NjI5MTg1MTYzLzY0Njg3ODM4NDUzODY0MzUxNjY" />
+            <property role="TrG5h" value="name" />
+            <property role="2RzO1C" value="true" />
+            <ref role="2Rx9Fl" to="2pzz:2ju2syjnJjX" resolve="String" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="TXaBS0WWIX" role="1SKRRt">
+      <node concept="2RzRRF" id="5YadkJSARSk" role="1qenE9">
+        <property role="2RzON1" value="extendedlibrary" />
+        <property role="TrG5h" value="extendedlibrary" />
+        <property role="3HH78N" value="1" />
+        <node concept="3xLA65" id="5YadkJSARSm" role="lGtFl">
+          <property role="TrG5h" value="extendedlibrary" />
+        </node>
+        <node concept="2RzRkq" id="5YadkJSARSo" role="2RzRcN">
+          <ref role="2RzRkr" node="5ocQ9W1u7kH" resolve="library" />
+        </node>
+        <node concept="2RzPWn" id="1IvYv3E_dwX" role="2RzR6B">
+          <property role="2RzON1" value="extendedlibrary-CopyRight" />
+          <property role="TrG5h" value="CopyRight" />
+          <node concept="2RzOte" id="1IvYv3E_dBi" role="2RzPPN">
+            <property role="2RzON1" value="extendedlibrary-CopyRight-countries" />
+            <property role="TrG5h" value="countries" />
+            <property role="2RzO1C" value="true" />
+            <property role="2RzOhW" value="true" />
+            <ref role="2RzQvY" node="1IvYv3E_dzr" resolve="CountriesContainer" />
+          </node>
+          <node concept="2RzOpR" id="1IvYv3E_dBn" role="2RzPPN">
+            <property role="2RzON1" value="extendedlibrary-CopyRight-writer" />
+            <property role="TrG5h" value="writer" />
+            <ref role="2RzQvY" node="5ocQ9W1u7kT" resolve="Writer" />
+          </node>
+        </node>
+        <node concept="2RzPWn" id="1IvYv3E_dzr" role="2RzR6B">
+          <property role="2RzON1" value="extendedlibrary-CountriesContainer" />
+          <property role="TrG5h" value="CountriesContainer" />
+          <node concept="2RzOeU" id="1IvYv3E_dBg" role="2RzPPN">
+            <property role="2RzON1" value="extendedlibrary-CountriesContainer-content" />
+            <property role="TrG5h" value="content" />
+            <ref role="2Rx9Fl" to="2pzz:2ju2syjnJjX" resolve="String" />
+          </node>
+        </node>
+        <node concept="2RzPWn" id="5YadkJSARSq" role="2RzR6B">
+          <property role="2RzON1" value="extendedlibrary-LocalLibrary" />
+          <property role="TrG5h" value="LocalLibrary" />
+          <ref role="2RzPfO" node="5ocQ9W1u7kO" resolve="Library" />
+          <node concept="2RzOeU" id="1IvYv3E_dBe" role="2RzPPN">
+            <property role="2RzON1" value="extendedlibrary-LocalLibrary-country" />
+            <property role="TrG5h" value="country" />
+            <ref role="2Rx9Fl" to="2pzz:2ju2syjnJjX" resolve="String" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="TXaBS0Ozs9" role="1SKRRt">
+      <node concept="3z8Sf4" id="TXaBS0Ozs8" role="1qenE9">
+        <property role="TrG5h" value="bla" />
+        <property role="VS7hl" value="${lionweb-mps.home}/solutions/io.lionweb.mps.converter.test/resources/extendedlibrary-metamodel.json" />
+        <node concept="7CXmI" id="TXaBS0Ozsc" role="lGtFl">
+          <node concept="7OXhh" id="TXaBS0Ozse" role="7EUXB">
+            <property role="GvXf4" value="true" />
+          </node>
+        </node>
+        <node concept="2RzRkq" id="TXaBS0OA8h" role="1a0gs3">
+          <ref role="2RzRkr" node="5ocQ9W1u7kH" resolve="library" />
+        </node>
+        <node concept="3xLA65" id="TXaBS0P0yO" role="lGtFl">
+          <property role="TrG5h" value="importLangFromJson" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="TXaBS0OYWm" role="1SL9yI">
+      <property role="TrG5h" value="TestBehavior" />
+      <node concept="3cqZAl" id="TXaBS0OYWn" role="3clF45" />
+      <node concept="3clFbS" id="TXaBS0OYWo" role="3clF47">
+        <node concept="3cpWs8" id="TXaBS0PADp" role="3cqZAp">
+          <node concept="3cpWsn" id="TXaBS0PADs" role="3cpWs9">
+            <property role="TrG5h" value="lcLanguages" />
+            <node concept="A3Dl8" id="TXaBS0PADm" role="1tU5fm">
+              <node concept="3Tqbb2" id="TXaBS0PALx" role="A3Ik2">
+                <ref role="ehGHo" to="h3y3:2ju2syjkngz" resolve="Language" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="TXaBS0PB52" role="33vP2m">
+              <node concept="3xONca" id="TXaBS0PAUF" role="2Oq$k0">
+                <ref role="3xOPvv" node="TXaBS0P0yO" resolve="importLangFromJson" />
+              </node>
+              <node concept="2qgKlT" id="TXaBS0PBlh" role="2OqNvi">
+                <ref role="37wK5l" to="aoz0:5N2LjD7MP48" resolve="importt" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Hmddi" id="TXaBS0PCiS" role="3cqZAp">
+          <node concept="37vLTw" id="TXaBS0PCk9" role="2Hmdds">
+            <ref role="3cqZAo" node="TXaBS0PADs" resolve="lcLanguages" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="TXaBS0PBqx" role="3cqZAp">
+          <node concept="3cmrfG" id="TXaBS0PBCC" role="3tpDZB">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="2OqwBi" id="TXaBS0PBRT" role="3tpDZA">
+            <node concept="37vLTw" id="TXaBS0PBIa" role="2Oq$k0">
+              <ref role="3cqZAo" node="TXaBS0PADs" resolve="lcLanguages" />
+            </node>
+            <node concept="34oBXx" id="TXaBS0PC9e" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="TXaBS14Rku" role="3cqZAp" />
+        <node concept="3clFbF" id="TXaBS14RI$" role="3cqZAp">
+          <node concept="2YIFZM" id="TXaBS14SgN" role="3clFbG">
+            <ref role="1Pybhc" to="jfqc:48csSBPyj1E" resolve="LanguageSorter" />
+            <ref role="37wK5l" to="jfqc:48csSBPyH5b" resolve="sort" />
+            <node concept="2OqwBi" id="TXaBS14SPA" role="37wK5m">
+              <node concept="37vLTw" id="TXaBS14SrI" role="2Oq$k0">
+                <ref role="3cqZAo" node="TXaBS0PADs" resolve="lcLanguages" />
+              </node>
+              <node concept="1yVyf7" id="TXaBS14Tpm" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3KvkLt3BeA_" role="3cqZAp">
+          <node concept="3cpWsn" id="3KvkLt3BeAA" role="3cpWs9">
+            <property role="TrG5h" value="expected" />
+            <node concept="3uibUv" id="3KvkLt3BeAz" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~List" resolve="List" />
+              <node concept="3uibUv" id="3KvkLt3Bgyc" role="11_B2D">
+                <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="2LEXDCdQB9g" role="33vP2m">
+              <node concept="Tc6Ow" id="2LEXDCdQB9h" role="2ShVmc">
+                <node concept="3uibUv" id="2LEXDCdQB9i" role="HW$YZ">
+                  <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                </node>
+                <node concept="3xONca" id="TXaBS0X2jg" role="HW$Y0">
+                  <ref role="3xOPvv" node="5ocQ9W1u7kV" resolve="library" />
+                </node>
+                <node concept="3xONca" id="TXaBS0X2SW" role="HW$Y0">
+                  <ref role="3xOPvv" node="5YadkJSARSm" resolve="extendedlibrary" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3KvkLt3B_CA" role="3cqZAp">
+          <node concept="3cpWsn" id="3KvkLt3B_CB" role="3cpWs9">
+            <property role="TrG5h" value="actual" />
+            <node concept="3uibUv" id="3KvkLt3B_C$" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~List" resolve="List" />
+              <node concept="3uibUv" id="3KvkLt3BBlL" role="11_B2D">
+                <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6NZwk6fh_L7" role="33vP2m">
+              <node concept="2OqwBi" id="6NZwk6fhzlX" role="2Oq$k0">
+                <node concept="UnYns" id="6NZwk6fh$78" role="2OqNvi">
+                  <node concept="3uibUv" id="6NZwk6fh$BT" role="UnYnz">
+                    <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="TXaBS0WZjF" role="2Oq$k0">
+                  <ref role="3cqZAo" node="TXaBS0PADs" resolve="lcLanguages" />
+                </node>
+              </node>
+              <node concept="ANE8D" id="6NZwk6fhA_W" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="GfTf1YP944" role="3cqZAp">
+          <node concept="3cpWsn" id="GfTf1YP945" role="3cpWs9">
+            <property role="TrG5h" value="diff" />
+            <node concept="_YKpA" id="GfTf1YPbFe" role="1tU5fm">
+              <node concept="3uibUv" id="GfTf1YPbFg" role="_ZDj9">
+                <ref role="3uigEE" to="y5e1:7MIYyntDZEK" resolve="NodeDifference" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="GfTf1YP946" role="33vP2m">
+              <node concept="2ShNRf" id="GfTf1YP947" role="2Oq$k0">
+                <node concept="1pGfFk" id="GfTf1YP948" role="2ShVmc">
+                  <ref role="37wK5l" to="y5e1:39D1ywqVAMq" resolve="NodesMatcher" />
+                  <node concept="37vLTw" id="GfTf1YP94a" role="37wK5m">
+                    <ref role="3cqZAo" node="3KvkLt3B_CB" resolve="actual" />
+                  </node>
+                  <node concept="37vLTw" id="GfTf1YP949" role="37wK5m">
+                    <ref role="3cqZAo" node="3KvkLt3BeAA" resolve="expected" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="GfTf1YP94b" role="2OqNvi">
+                <ref role="37wK5l" to="y5e1:39D1ywqVH_i" resolve="diff" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="5wEVZcC3ck3" role="3cqZAp">
+          <node concept="3_1$Yv" id="5wEVZcC3dpu" role="3_9lra">
+            <node concept="3cpWs3" id="GfTf1YPak6" role="3_1BAH">
+              <node concept="2OqwBi" id="GfTf1YPegS" role="3uHU7w">
+                <node concept="2OqwBi" id="GfTf1YPcCb" role="2Oq$k0">
+                  <node concept="37vLTw" id="GfTf1YPakq" role="2Oq$k0">
+                    <ref role="3cqZAo" node="GfTf1YP945" resolve="diff" />
+                  </node>
+                  <node concept="3$u5V9" id="GfTf1YPdw5" role="2OqNvi">
+                    <node concept="1bVj0M" id="GfTf1YPdw7" role="23t8la">
+                      <node concept="3clFbS" id="GfTf1YPdw8" role="1bW5cS">
+                        <node concept="3clFbF" id="GfTf1YPdwh" role="3cqZAp">
+                          <node concept="2OqwBi" id="GfTf1YPdEj" role="3clFbG">
+                            <node concept="37vLTw" id="GfTf1YPdwg" role="2Oq$k0">
+                              <ref role="3cqZAo" node="GfTf1YPdw9" resolve="it" />
+                            </node>
+                            <node concept="liA8E" id="GfTf1YPdRj" role="2OqNvi">
+                              <ref role="37wK5l" to="y5e1:39D1ywqUtCH" resolve="print" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="GfTf1YPdw9" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="GfTf1YPdwa" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3uJxvA" id="GfTf1YPeE1" role="2OqNvi">
+                  <node concept="Xl_RD" id="GfTf1YPfkO" role="3uJOhx">
+                    <property role="Xl_RC" value="\n" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs3" id="GfTf1YPg5N" role="3uHU7B">
+                <node concept="3cpWs3" id="2LEXDCdQHOj" role="3uHU7B">
+                  <node concept="3cpWs3" id="2LEXDCdQFjN" role="3uHU7B">
+                    <node concept="3cpWs3" id="2LEXDCdQEqA" role="3uHU7B">
+                      <node concept="Xl_RD" id="2LEXDCdQDWo" role="3uHU7B">
+                        <property role="Xl_RC" value="The nodes '" />
+                      </node>
+                      <node concept="37vLTw" id="3KvkLt3C0iQ" role="3uHU7w">
+                        <ref role="3cqZAo" node="3KvkLt3BeAA" resolve="expected" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="2LEXDCdQFjX" role="3uHU7w">
+                      <property role="Xl_RC" value="' and '" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="3KvkLt3C3gl" role="3uHU7w">
+                    <ref role="3cqZAo" node="3KvkLt3B_CB" resolve="actual" />
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="2LEXDCdQJlK" role="3uHU7w">
+                  <property role="Xl_RC" value="' do not match!\n" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5wEVZcC3eI2" role="3vwVQn">
+            <node concept="37vLTw" id="GfTf1YP94c" role="2Oq$k0">
+              <ref role="3cqZAo" node="GfTf1YP945" resolve="diff" />
+            </node>
+            <node concept="1v1jN8" id="GfTf1YP$_w" role="2OqNvi" />
           </node>
         </node>
       </node>

--- a/solutions/io.lionweb.mps.converter.test/resources/extendedlibrary-metamodel.json
+++ b/solutions/io.lionweb.mps.converter.test/resources/extendedlibrary-metamodel.json
@@ -1,0 +1,532 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-M3",
+      "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "extendedlibrary",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Language"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-version"
+          },
+          "value": "1"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "extendedlibrary"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "extendedlibrary"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-entities"
+          },
+          "children": [
+            "extendedlibrary-LocalLibrary",
+            "extendedlibrary-CopyRight",
+            "extendedlibrary-CountriesContainer"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-dependsOn"
+          },
+          "targets": [
+            {
+              "resolveInfo": "library",
+              "reference": "NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAw"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": null
+    },
+    {
+      "id": "extendedlibrary-LocalLibrary",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "extendedlibrary-LocalLibrary"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "LocalLibrary"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "extendedlibrary-LocalLibrary-country"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Library",
+              "reference": "NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLzg2OTkxNDExNTA2MzkyMDA3NzE"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "extendedlibrary"
+    },
+    {
+      "id": "extendedlibrary-LocalLibrary-country",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "extendedlibrary-LocalLibrary-country"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "country"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "extendedlibrary-LocalLibrary"
+    },
+    {
+      "id": "extendedlibrary-CopyRight",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "extendedlibrary-CopyRight"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "CopyRight"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "extendedlibrary-CopyRight-writer",
+            "extendedlibrary-CopyRight-countries"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "extendedlibrary"
+    },
+    {
+      "id": "extendedlibrary-CopyRight-writer",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "extendedlibrary-CopyRight-writer"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "writer"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Writer",
+              "reference": "NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLy02MzA4OTk2OTY0NjI5MTg1MTYz"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "extendedlibrary-CopyRight"
+    },
+    {
+      "id": "extendedlibrary-CopyRight-countries",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "extendedlibrary-CopyRight-countries"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "countries"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "CountriesContainer",
+              "reference": "extendedlibrary-CountriesContainer"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "extendedlibrary-CopyRight"
+    },
+    {
+      "id": "extendedlibrary-CountriesContainer",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "extendedlibrary-CountriesContainer"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "CountriesContainer"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "extendedlibrary-CountriesContainer-content"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "extendedlibrary"
+    },
+    {
+      "id": "extendedlibrary-CountriesContainer-content",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "extendedlibrary-CountriesContainer-content"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "content"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "extendedlibrary-CountriesContainer"
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json.test/io.lionweb.mps.json.test.msd
+++ b/solutions/io.lionweb.mps.json.test/io.lionweb.mps.json.test.msd
@@ -36,6 +36,7 @@
     <dependency reexport="false">60791ea2-7a1d-4862-a1ef-f87878cc3b6e(io.lionweb.mps.converter.TestComputedProperty)</dependency>
     <dependency reexport="false">1ec6d5e7-6402-4c18-95d0-6e0906eb1ff1(io.lionweb.mps.converter.TestEnum)</dependency>
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+    <dependency reexport="false">e55e6749-03cb-4ea7-9695-2322bab791c1(jetbrains.mps.lang.test.matcher)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:76d927fd-3a5a-4e40-865b-7c2d329ca675:MultiRefLang" version="1" />
@@ -48,7 +49,7 @@
     <language slang="l:48d0f6eb-6186-4cec-83d1-7caedb05a494:io.lionweb.mps.converter.TestLang2" version="0" />
     <language slang="l:099490a3-1e39-4ed1-bebc-8027665cecf9:io.lionweb.mps.converter.TestLang3" version="0" />
     <language slang="l:a95063a5-27eb-4ae8-894e-ea20f8b3d6a2:io.lionweb.mps.converter.TestRefs" version="0" />
-    <language slang="l:63c09674-565f-4cbb-add6-f15c4e540c84:io.lionweb.mps.converter.Utf8" version="0" />
+    <language slang="l:63c09674-565f-4cbb-add6-f15c4e540c84:io.lionweb.mps.converter.TestUtf8" version="0" />
     <language slang="l:97ef2b8d-23e1-433e-8d23-48f916dd314d:io.lionweb.mps.converter.lang" version="0" />
     <language slang="l:01cf0d82-8d29-4fc4-be96-28abaf4ad33d:io.lionweb.mps.m3" version="0" />
     <language slang="l:4a963078-62c4-4f96-9b52-198a0c63da4b:io.lionweb.mps.testsupport" version="0" />
@@ -97,6 +98,7 @@
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)" version="0" />
+    <module reference="e55e6749-03cb-4ea7-9695-2322bab791c1(jetbrains.mps.lang.test.matcher)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="537f9cb0-0f25-3c76-8b86-308f45010100(library)" version="0" />
   </dependencyVersions>

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2lioncore@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2lioncore@tests.mps
@@ -50,6 +50,13 @@
       <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
@@ -86,6 +93,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -100,6 +108,11 @@
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
@@ -114,6 +127,13 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1154542696413" name="jetbrains.mps.baseLanguage.structure.ArrayCreatorWithInitializer" flags="nn" index="3g6Rrh">
+        <child id="1154542793668" name="componentType" index="3g7fb8" />
+        <child id="1154542803372" name="initValue" index="3g7hyw" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -173,9 +193,13 @@
       <concept id="2656571587264865491" name="io.lionweb.mps.m3.structure.InterfaceReference" flags="ng" index="2RzQOr">
         <reference id="2656571587264865492" name="interface" index="2RzQOs" />
       </concept>
+      <concept id="2656571587264871634" name="io.lionweb.mps.m3.structure.LanguageReference" flags="ng" index="2RzRkq">
+        <reference id="2656571587264871635" name="language" index="2RzRkr" />
+      </concept>
       <concept id="2656571587264869411" name="io.lionweb.mps.m3.structure.Language" flags="ng" index="2RzRRF">
         <property id="2526956841135898600" name="version" index="3HH78N" />
         <child id="2656571587264870511" name="entities" index="2RzR6B" />
+        <child id="2656571587264871163" name="dependsOn" index="2RzRcN" />
       </concept>
       <concept id="2656571587264873280" name="io.lionweb.mps.m3.structure.Enumeration" flags="ng" index="2RzSE8">
         <child id="2656571587264874244" name="literals" index="2RzSVc" />
@@ -224,6 +248,9 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1224414427926" name="jetbrains.mps.baseLanguage.collections.structure.SequenceCreator" flags="nn" index="kMnCb">
+        <child id="1224414456414" name="elementType" index="kMuH3" />
+      </concept>
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -235,7 +262,9 @@
         <child id="1235573187520" name="singletonValue" index="2HTEbv" />
       </concept>
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
   <node concept="2XOHcx" id="3ePT3MiXrx5">
@@ -243,6 +272,356 @@
   </node>
   <node concept="1lH9Xt" id="5sACIIszZSx">
     <property role="TrG5h" value="json2LionCore" />
+    <node concept="2XrIbr" id="5YadkJSAW$i" role="1qtyYc">
+      <property role="TrG5h" value="toLionCoreExtended" />
+      <node concept="3Tqbb2" id="5YadkJSAWIc" role="3clF45">
+        <ref role="ehGHo" to="h3y3:2ju2syjkngz" resolve="Language" />
+      </node>
+      <node concept="3clFbS" id="5YadkJSAW$k" role="3clF47">
+        <node concept="3cpWs8" id="5YadkJSAWSf" role="3cqZAp">
+          <node concept="3cpWsn" id="5YadkJSAWSg" role="3cpWs9">
+            <property role="TrG5h" value="file" />
+            <node concept="3uibUv" id="5YadkJSAWSh" role="1tU5fm">
+              <ref role="3uigEE" to="guwi:~File" resolve="File" />
+            </node>
+            <node concept="2YIFZM" id="5YadkJSAWSi" role="33vP2m">
+              <ref role="1Pybhc" to="kte7:5wsogBcvCwV" resolve="TestPathExpander" />
+              <ref role="37wK5l" to="kte7:5wsogBcvCyw" resolve="expandTestFile" />
+              <node concept="37vLTw" id="5YadkJSAWSj" role="37wK5m">
+                <ref role="3cqZAo" node="5YadkJSAWKL" resolve="fileName" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3J1_TO" id="5YadkJSAWSk" role="3cqZAp">
+          <node concept="3clFbS" id="5YadkJSAWSl" role="1zxBo7">
+            <node concept="3cpWs8" id="5YadkJSAWSm" role="3cqZAp">
+              <node concept="3cpWsn" id="5YadkJSAWSn" role="3cpWs9">
+                <property role="TrG5h" value="repository" />
+                <node concept="3uibUv" id="5YadkJSAWSo" role="1tU5fm">
+                  <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+                </node>
+                <node concept="2OqwBi" id="5YadkJSAWSp" role="33vP2m">
+                  <node concept="1jGwE1" id="5YadkJSAWSq" role="2Oq$k0" />
+                  <node concept="liA8E" id="5YadkJSAWSr" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="5YadkJSAWSs" role="3cqZAp">
+              <node concept="3cpWsn" id="5YadkJSAWSt" role="3cpWs9">
+                <property role="TrG5h" value="constants" />
+                <node concept="3uibUv" id="5YadkJSAWSu" role="1tU5fm">
+                  <ref role="3uigEE" to="y7p:DUXtGZOlwJ" resolve="LionCoreConstants" />
+                </node>
+                <node concept="2ShNRf" id="5YadkJSAWSv" role="33vP2m">
+                  <node concept="1pGfFk" id="5YadkJSAWSw" role="2ShVmc">
+                    <ref role="37wK5l" to="y7p:DUXtGZOlxP" resolve="LionCoreConstants" />
+                    <node concept="37vLTw" id="5YadkJSAWSx" role="37wK5m">
+                      <ref role="3cqZAo" node="5YadkJSAWSn" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="5YadkJSAWSy" role="3cqZAp">
+              <node concept="3cpWsn" id="5YadkJSAWSz" role="3cpWs9">
+                <property role="TrG5h" value="jsonConstants" />
+                <node concept="3uibUv" id="5YadkJSAWS$" role="1tU5fm">
+                  <ref role="3uigEE" to="6peh:5JNiskj4S1d" resolve="JsonConstants" />
+                </node>
+                <node concept="2ShNRf" id="5YadkJSAWS_" role="33vP2m">
+                  <node concept="1pGfFk" id="5YadkJSAWSA" role="2ShVmc">
+                    <ref role="37wK5l" to="6peh:5JNiskj4SJa" resolve="JsonConstants" />
+                    <node concept="2YIFZM" id="5YadkJSAWSB" role="37wK5m">
+                      <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
+                      <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
+                    </node>
+                    <node concept="2ShNRf" id="5YadkJSAWSC" role="37wK5m">
+                      <node concept="HV5vD" id="5YadkJSAWSD" role="2ShVmc">
+                        <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="5YadkJSAWSE" role="37wK5m">
+                      <ref role="3cqZAo" node="5YadkJSAWSt" resolve="constants" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="5YadkJSAWSF" role="3cqZAp">
+              <node concept="3cpWsn" id="5YadkJSAWSG" role="3cpWs9">
+                <property role="TrG5h" value="deserializer" />
+                <node concept="3uibUv" id="5YadkJSAWSH" role="1tU5fm">
+                  <ref role="3uigEE" to="6peh:z1IqfFwqda" resolve="Deserializer" />
+                </node>
+                <node concept="2ShNRf" id="5YadkJSAWSI" role="33vP2m">
+                  <node concept="1pGfFk" id="5YadkJSAWSJ" role="2ShVmc">
+                    <ref role="37wK5l" to="6peh:z1IqfFwqeg" resolve="Deserializer" />
+                    <node concept="2ShNRf" id="5YadkJSAWSK" role="37wK5m">
+                      <node concept="1pGfFk" id="5YadkJSAWSL" role="2ShVmc">
+                        <ref role="37wK5l" to="guwi:~BufferedInputStream.&lt;init&gt;(java.io.InputStream)" resolve="BufferedInputStream" />
+                        <node concept="37vLTw" id="5YadkJSAWSM" role="37wK5m">
+                          <ref role="3cqZAo" node="5YadkJSAWTH" resolve="inputStream" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="5YadkJSAWSN" role="37wK5m">
+                      <ref role="3cqZAo" node="5YadkJSAWSz" resolve="jsonConstants" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="5YadkJSBiXn" role="3cqZAp" />
+            <node concept="3cpWs8" id="5YadkJSBjD2" role="3cqZAp">
+              <node concept="3cpWsn" id="5YadkJSBjD3" role="3cpWs9">
+                <property role="TrG5h" value="languages" />
+                <node concept="_YKpA" id="5YadkJSBjD4" role="1tU5fm">
+                  <node concept="3uibUv" id="5YadkJSBjD5" role="_ZDj9">
+                    <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="5YadkJSBata" role="3cqZAp">
+              <node concept="3clFbS" id="5YadkJSBatc" role="3clFbx">
+                <node concept="3cpWs8" id="5YadkJSBdGJ" role="3cqZAp">
+                  <node concept="3cpWsn" id="5YadkJSBdGK" role="3cpWs9">
+                    <property role="TrG5h" value="lionMPS2lionJavaConverter" />
+                    <node concept="3uibUv" id="5YadkJSBdGL" role="1tU5fm">
+                      <ref role="3uigEE" to="9pi3:5sACIIsA0s2" resolve="LionCore2JsonConverter" />
+                    </node>
+                    <node concept="2ShNRf" id="5YadkJSBfyN" role="33vP2m">
+                      <node concept="1pGfFk" id="5YadkJSBg0f" role="2ShVmc">
+                        <ref role="37wK5l" to="9pi3:5sACIIsA0tB" resolve="LionCore2JsonConverter" />
+                        <node concept="37vLTw" id="5YadkJSBggr" role="37wK5m">
+                          <ref role="3cqZAo" node="5YadkJSAWSt" resolve="constants" />
+                        </node>
+                        <node concept="37vLTw" id="5YadkJSBgQ_" role="37wK5m">
+                          <ref role="3cqZAo" node="5YadkJSAWSz" resolve="jsonConstants" />
+                        </node>
+                        <node concept="2ShNRf" id="5YadkJSBhkK" role="37wK5m">
+                          <node concept="1pGfFk" id="5YadkJSBi4b" role="2ShVmc">
+                            <ref role="37wK5l" to="t47h:5M3rB6AxjLI" resolve="LionCoreLanguageGuaranteedMapper" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="5YadkJSBiH1" role="37wK5m">
+                          <ref role="3cqZAo" node="5YadkJSAWNM" resolve="usedLangs" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="5YadkJSBs6D" role="3cqZAp">
+                  <node concept="37vLTI" id="5YadkJSBsvV" role="3clFbG">
+                    <node concept="2OqwBi" id="5YadkJSBtfl" role="37vLTx">
+                      <node concept="37vLTw" id="5YadkJSBsSK" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5YadkJSAWSG" resolve="deserializer" />
+                      </node>
+                      <node concept="liA8E" id="5YadkJSBtKZ" role="2OqNvi">
+                        <ref role="37wK5l" to="6peh:5wsogBc3YTv" resolve="deserializeLanguages" />
+                        <node concept="2OqwBi" id="5YadkJSBuCF" role="37wK5m">
+                          <node concept="37vLTw" id="5YadkJSBu5i" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5YadkJSBdGK" resolve="lionMPS2lionJavaConverter" />
+                          </node>
+                          <node concept="liA8E" id="5YadkJSBveB" role="2OqNvi">
+                            <ref role="37wK5l" to="9pi3:5sACIIsA0ut" resolve="convert" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="5YadkJSBs6B" role="37vLTJ">
+                      <ref role="3cqZAo" node="5YadkJSBjD3" resolve="languages" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5YadkJSBb52" role="3clFbw">
+                <node concept="37vLTw" id="5YadkJSBaG3" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5YadkJSAWNM" resolve="usedLangs" />
+                </node>
+                <node concept="3GX2aA" id="5YadkJSBbvB" role="2OqNvi" />
+              </node>
+              <node concept="9aQIb" id="5YadkJSBlyK" role="9aQIa">
+                <node concept="3clFbS" id="5YadkJSBlyL" role="9aQI4">
+                  <node concept="3clFbF" id="5YadkJSBnZ6" role="3cqZAp">
+                    <node concept="37vLTI" id="5YadkJSBoxq" role="3clFbG">
+                      <node concept="37vLTw" id="5YadkJSBnZ4" role="37vLTJ">
+                        <ref role="3cqZAo" node="5YadkJSBjD3" resolve="languages" />
+                      </node>
+                      <node concept="2OqwBi" id="5YadkJSAWSS" role="37vLTx">
+                        <node concept="37vLTw" id="5YadkJSAWST" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5YadkJSAWSG" resolve="deserializer" />
+                        </node>
+                        <node concept="liA8E" id="5YadkJSAWSU" role="2OqNvi">
+                          <ref role="37wK5l" to="6peh:5wsogBc3YTv" resolve="deserializeLanguages" />
+                          <node concept="2ShNRf" id="5YadkJSBq$G" role="37wK5m">
+                            <node concept="kMnCb" id="5YadkJSBr5d" role="2ShVmc">
+                              <node concept="3uibUv" id="5YadkJSBrpe" role="kMuH3">
+                                <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="5YadkJSAWSY" role="3cqZAp" />
+            <node concept="3cpWs8" id="5YadkJSAWSZ" role="3cqZAp">
+              <node concept="3cpWsn" id="5YadkJSAWT0" role="3cpWs9">
+                <property role="TrG5h" value="converter" />
+                <node concept="3uibUv" id="5YadkJSAWT1" role="1tU5fm">
+                  <ref role="3uigEE" to="9pi3:z1IqfFwV_H" resolve="Json2LionCoreConverter" />
+                </node>
+                <node concept="2ShNRf" id="5YadkJSAWT2" role="33vP2m">
+                  <node concept="1pGfFk" id="5YadkJSAWT3" role="2ShVmc">
+                    <ref role="37wK5l" to="9pi3:z1IqfFwVBn" resolve="Json2LionCoreConverter" />
+                    <node concept="37vLTw" id="5YadkJSAWT4" role="37wK5m">
+                      <ref role="3cqZAo" node="5YadkJSAWSt" resolve="constants" />
+                    </node>
+                    <node concept="37vLTw" id="5YadkJSAWT5" role="37wK5m">
+                      <ref role="3cqZAo" node="5YadkJSAWSz" resolve="jsonConstants" />
+                    </node>
+                    <node concept="2ShNRf" id="5YadkJSAWT6" role="37wK5m">
+                      <node concept="1pGfFk" id="5YadkJSAWT7" role="2ShVmc">
+                        <ref role="37wK5l" to="j5yh:5M3rB6Aw8DZ" resolve="JsonDirectLanguageGuaranteedMapper" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="5YadkJSAWT8" role="37wK5m">
+                      <ref role="3cqZAo" node="5YadkJSBjD3" resolve="languages" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="5YadkJSAWT9" role="3cqZAp">
+              <node concept="3cpWsn" id="5YadkJSAWTa" role="3cpWs9">
+                <property role="TrG5h" value="converted" />
+                <node concept="A3Dl8" id="5YadkJSAWTb" role="1tU5fm">
+                  <node concept="3Tqbb2" id="5YadkJSAWTc" role="A3Ik2">
+                    <ref role="ehGHo" to="h3y3:2ju2syjkngz" resolve="Language" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5YadkJSAWTd" role="33vP2m">
+                  <node concept="37vLTw" id="5YadkJSAWTe" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5YadkJSAWT0" resolve="converter" />
+                  </node>
+                  <node concept="liA8E" id="5YadkJSAWTf" role="2OqNvi">
+                    <ref role="37wK5l" to="9pi3:z1IqfFwZOY" resolve="convert" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="5YadkJSAWTg" role="3cqZAp" />
+            <node concept="3vlDli" id="5YadkJSAWTh" role="3cqZAp">
+              <node concept="3cmrfG" id="5YadkJSAWTi" role="3tpDZB">
+                <property role="3cmrfH" value="1" />
+              </node>
+              <node concept="2OqwBi" id="5YadkJSAWTj" role="3tpDZA">
+                <node concept="37vLTw" id="5YadkJSAWTk" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5YadkJSAWTa" resolve="converted" />
+                </node>
+                <node concept="34oBXx" id="5YadkJSAWTl" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="3clFbH" id="5YadkJSAWTm" role="3cqZAp" />
+            <node concept="3cpWs8" id="5YadkJSAWTn" role="3cqZAp">
+              <node concept="3cpWsn" id="5YadkJSAWTo" role="3cpWs9">
+                <property role="TrG5h" value="actual" />
+                <node concept="3Tqbb2" id="5YadkJSAWTp" role="1tU5fm">
+                  <ref role="ehGHo" to="h3y3:2ju2syjkngz" resolve="Language" />
+                </node>
+                <node concept="2YIFZM" id="5YadkJSAWTq" role="33vP2m">
+                  <ref role="37wK5l" to="jfqc:48csSBPyH5b" resolve="sort" />
+                  <ref role="1Pybhc" to="jfqc:48csSBPyj1E" resolve="LanguageSorter" />
+                  <node concept="2OqwBi" id="5YadkJSAWTr" role="37wK5m">
+                    <node concept="37vLTw" id="5YadkJSAWTs" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5YadkJSAWTa" resolve="converted" />
+                    </node>
+                    <node concept="1uHKPH" id="5YadkJSAWTt" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1PQTyP" id="5YadkJSAWTu" role="3cqZAp">
+              <node concept="37vLTw" id="5YadkJSAWTv" role="JAdkl">
+                <ref role="3cqZAo" node="5YadkJSAWTo" resolve="actual" />
+              </node>
+              <node concept="37vLTw" id="5YadkJSAWTw" role="JA92f">
+                <ref role="3cqZAo" node="5YadkJSAWKX" resolve="expected" />
+              </node>
+            </node>
+            <node concept="3clFbH" id="5YadkJSAWTx" role="3cqZAp" />
+            <node concept="3cpWs6" id="5YadkJSAWTy" role="3cqZAp">
+              <node concept="37vLTw" id="5YadkJSAWTz" role="3cqZAk">
+                <ref role="3cqZAo" node="5YadkJSAWTo" resolve="actual" />
+              </node>
+            </node>
+          </node>
+          <node concept="3uVAMA" id="5YadkJSAWT$" role="1zxBo5">
+            <node concept="3clFbS" id="5YadkJSAWT_" role="1zc67A">
+              <node concept="YS8fn" id="5YadkJSAWTA" role="3cqZAp">
+                <node concept="2ShNRf" id="5YadkJSAWTB" role="YScLw">
+                  <node concept="1pGfFk" id="5YadkJSAWTC" role="2ShVmc">
+                    <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.Throwable)" resolve="RuntimeException" />
+                    <node concept="37vLTw" id="5YadkJSAWTD" role="37wK5m">
+                      <ref role="3cqZAo" node="5YadkJSAWTE" resolve="e" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="XOnhg" id="5YadkJSAWTE" role="1zc67B">
+              <property role="TrG5h" value="e" />
+              <node concept="nSUau" id="5YadkJSAWTF" role="1tU5fm">
+                <node concept="3uibUv" id="5YadkJSAWTG" role="nSUat">
+                  <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3J1hQo" id="5YadkJSAWTH" role="3J1_TS">
+            <property role="3TUv4t" value="true" />
+            <property role="TrG5h" value="inputStream" />
+            <node concept="3uibUv" id="5YadkJSAWTI" role="1tU5fm">
+              <ref role="3uigEE" to="guwi:~InputStream" resolve="InputStream" />
+            </node>
+            <node concept="2ShNRf" id="5YadkJSAWTJ" role="33vP2m">
+              <node concept="1pGfFk" id="5YadkJSAWTK" role="2ShVmc">
+                <ref role="37wK5l" to="guwi:~FileInputStream.&lt;init&gt;(java.io.File)" resolve="FileInputStream" />
+                <node concept="37vLTw" id="5YadkJSAWTL" role="37wK5m">
+                  <ref role="3cqZAo" node="5YadkJSAWSg" resolve="file" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="5YadkJSAWKE" role="1B3o_S" />
+      <node concept="37vLTG" id="5YadkJSAWKL" role="3clF46">
+        <property role="TrG5h" value="fileName" />
+        <node concept="17QB3L" id="5YadkJSAWKK" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="5YadkJSAWKX" role="3clF46">
+        <property role="TrG5h" value="expected" />
+        <node concept="3Tqbb2" id="5YadkJSAWLf" role="1tU5fm">
+          <ref role="ehGHo" to="h3y3:2ju2syjkngz" resolve="Language" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5YadkJSAWNM" role="3clF46">
+        <property role="TrG5h" value="usedLangs" />
+        <node concept="A3Dl8" id="5YadkJSAWNY" role="1tU5fm">
+          <node concept="3Tqbb2" id="5YadkJSB8cz" role="A3Ik2">
+            <ref role="ehGHo" to="h3y3:2ju2syjkngz" resolve="Language" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2XrIbr" id="5ocQ9W1xKFG" role="1qtyYc">
       <property role="TrG5h" value="toLionCore" />
       <node concept="3Tqbb2" id="5ocQ9W1xKJD" role="3clF45">
@@ -377,6 +756,13 @@
                   </node>
                   <node concept="liA8E" id="5ocQ9W1xKK$" role="2OqNvi">
                     <ref role="37wK5l" to="6peh:5wsogBc3YTv" resolve="deserializeLanguages" />
+                    <node concept="2ShNRf" id="5YadkJSyts$" role="37wK5m">
+                      <node concept="kMnCb" id="5YadkJSywRc" role="2ShVmc">
+                        <node concept="3uibUv" id="5YadkJSyxg_" role="kMuH3">
+                          <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+                        </node>
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -1034,6 +1420,41 @@
         <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
       </node>
     </node>
+    <node concept="1LZb2c" id="5YadkJSASo5" role="1SL9yI">
+      <property role="TrG5h" value="extendedLibrary_LC" />
+      <node concept="3cqZAl" id="5YadkJSASo6" role="3clF45" />
+      <node concept="3clFbS" id="5YadkJSASoa" role="3clF47">
+        <node concept="3clFbF" id="5YadkJSASw8" role="3cqZAp">
+          <node concept="2OqwBi" id="5YadkJSASz2" role="3clFbG">
+            <node concept="2WthIp" id="5YadkJSASw7" role="2Oq$k0" />
+            <node concept="2XshWL" id="5YadkJSASBb" role="2OqNvi">
+              <ref role="2WH_rO" node="5YadkJSAW$i" resolve="toLionCoreExtended" />
+              <node concept="Xl_RD" id="5YadkJSASHu" role="2XxRq1">
+                <property role="Xl_RC" value="extendedlibrary-metamodel.json" />
+              </node>
+              <node concept="3xONca" id="5YadkJSASMO" role="2XxRq1">
+                <ref role="3xOPvv" node="5YadkJSARSm" resolve="extendedlibrary" />
+              </node>
+              <node concept="2OqwBi" id="5YadkJSB63A" role="2XxRq1">
+                <node concept="1eOMI4" id="5YadkJSB5NM" role="2Oq$k0">
+                  <node concept="2ShNRf" id="5YadkJSB5iN" role="1eOMHV">
+                    <node concept="3g6Rrh" id="5YadkJSB5ug" role="2ShVmc">
+                      <node concept="3Tqbb2" id="5YadkJSB99_" role="3g7fb8">
+                        <ref role="ehGHo" to="h3y3:2ju2syjkngz" resolve="Language" />
+                      </node>
+                      <node concept="3xONca" id="5YadkJSB5Fz" role="3g7hyw">
+                        <ref role="3xOPvv" node="5ocQ9W1u7kV" resolve="library" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="39bAoz" id="5YadkJSB6xi" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="1LZb2c" id="5ocQ9W1xRiD" role="1SL9yI">
       <property role="TrG5h" value="lionCore_LC" />
       <node concept="3cqZAl" id="5ocQ9W1xRiE" role="3clF45" />
@@ -1556,6 +1977,24 @@
             <property role="2RzO1C" value="true" />
             <ref role="2Rx9Fl" to="2pzz:2ju2syjnJjX" resolve="String" />
           </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="5YadkJSARAd" role="1SKRRt">
+      <node concept="2RzRRF" id="5YadkJSARSk" role="1qenE9">
+        <property role="2RzON1" value="bdf20e91-513f-4957-918d-b901e3cf0227" />
+        <property role="TrG5h" value="extendedLibrary" />
+        <property role="3HH78N" value="1" />
+        <node concept="3xLA65" id="5YadkJSARSm" role="lGtFl">
+          <property role="TrG5h" value="extendedlibrary" />
+        </node>
+        <node concept="2RzRkq" id="5YadkJSARSo" role="2RzRcN">
+          <ref role="2RzRkr" node="5ocQ9W1u7kH" resolve="library" />
+        </node>
+        <node concept="2RzPWn" id="5YadkJSARSq" role="2RzR6B">
+          <property role="2RzON1" value="2b601bd7-0f50-4fec-adbc-555acd5c4de7" />
+          <property role="TrG5h" value="LocalLibrary" />
+          <ref role="2RzPfO" node="5ocQ9W1u7kO" resolve="Library" />
         </node>
       </node>
     </node>

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2lioncore@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2lioncore@tests.mps
@@ -262,9 +262,6 @@
       <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
         <child id="1176906787974" name="rightExpression" index="576Qk" />
       </concept>
-      <concept id="1224414427926" name="jetbrains.mps.baseLanguage.collections.structure.SequenceCreator" flags="nn" index="kMnCb">
-        <child id="1224414456414" name="elementType" index="kMuH3" />
-      </concept>
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -395,33 +392,6 @@
                 </node>
               </node>
             </node>
-            <node concept="3cpWs8" id="5YadkJSAWSF" role="3cqZAp">
-              <node concept="3cpWsn" id="5YadkJSAWSG" role="3cpWs9">
-                <property role="TrG5h" value="deserializer" />
-                <node concept="3uibUv" id="5YadkJSAWSH" role="1tU5fm">
-                  <ref role="3uigEE" to="6peh:z1IqfFwqda" resolve="Deserializer" />
-                </node>
-                <node concept="2ShNRf" id="5YadkJSAWSI" role="33vP2m">
-                  <node concept="1pGfFk" id="5YadkJSAWSJ" role="2ShVmc">
-                    <ref role="37wK5l" to="6peh:z1IqfFwqeg" resolve="Deserializer" />
-                    <node concept="37vLTw" id="488yErfah8o" role="37wK5m">
-                      <ref role="3cqZAo" node="488yErfadH4" resolve="lionwebVersion" />
-                    </node>
-                    <node concept="2ShNRf" id="5YadkJSAWSK" role="37wK5m">
-                      <node concept="1pGfFk" id="5YadkJSAWSL" role="2ShVmc">
-                        <ref role="37wK5l" to="guwi:~BufferedInputStream.&lt;init&gt;(java.io.InputStream)" resolve="BufferedInputStream" />
-                        <node concept="37vLTw" id="5YadkJSAWSM" role="37wK5m">
-                          <ref role="3cqZAo" node="5YadkJSAWTH" resolve="inputStream" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="37vLTw" id="5YadkJSAWSN" role="37wK5m">
-                      <ref role="3cqZAo" node="5YadkJSAWSz" resolve="jsonConstants" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="3clFbH" id="5YadkJSBiXn" role="3cqZAp" />
             <node concept="3cpWs8" id="6NZwk6fibK_" role="3cqZAp">
               <node concept="3cpWsn" id="6NZwk6fibKA" role="3cpWs9">
@@ -479,6 +449,37 @@
                 </node>
               </node>
             </node>
+            <node concept="3clFbH" id="TXaBS0HigT" role="3cqZAp" />
+            <node concept="3cpWs8" id="5YadkJSAWSF" role="3cqZAp">
+              <node concept="3cpWsn" id="5YadkJSAWSG" role="3cpWs9">
+                <property role="TrG5h" value="deserializer" />
+                <node concept="3uibUv" id="5YadkJSAWSH" role="1tU5fm">
+                  <ref role="3uigEE" to="6peh:z1IqfFwqda" resolve="Deserializer" />
+                </node>
+                <node concept="2ShNRf" id="5YadkJSAWSI" role="33vP2m">
+                  <node concept="1pGfFk" id="5YadkJSAWSJ" role="2ShVmc">
+                    <ref role="37wK5l" to="6peh:TXaBS0HMk6" resolve="Deserializer" />
+                    <node concept="37vLTw" id="488yErfah8o" role="37wK5m">
+                      <ref role="3cqZAo" node="488yErfadH4" resolve="lionwebVersion" />
+                    </node>
+                    <node concept="2ShNRf" id="5YadkJSAWSK" role="37wK5m">
+                      <node concept="1pGfFk" id="5YadkJSAWSL" role="2ShVmc">
+                        <ref role="37wK5l" to="guwi:~BufferedInputStream.&lt;init&gt;(java.io.InputStream)" resolve="BufferedInputStream" />
+                        <node concept="37vLTw" id="5YadkJSAWSM" role="37wK5m">
+                          <ref role="3cqZAo" node="5YadkJSAWTH" resolve="inputStream" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="5YadkJSAWSN" role="37wK5m">
+                      <ref role="3cqZAo" node="5YadkJSAWSz" resolve="jsonConstants" />
+                    </node>
+                    <node concept="37vLTw" id="TXaBS0Hjhq" role="37wK5m">
+                      <ref role="3cqZAo" node="6NZwk6fibKO" resolve="usedLanguagesAsJson" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
             <node concept="3cpWs8" id="6NZwk6fi_RS" role="3cqZAp">
               <node concept="3cpWsn" id="6NZwk6fi_RV" role="3cpWs9">
                 <property role="TrG5h" value="languages" />
@@ -498,9 +499,6 @@
                       </node>
                       <node concept="liA8E" id="6NZwk6fiffY" role="2OqNvi">
                         <ref role="37wK5l" to="6peh:5wsogBc3YTv" resolve="deserializeLanguages" />
-                        <node concept="37vLTw" id="6NZwk6fiffZ" role="37wK5m">
-                          <ref role="3cqZAo" node="6NZwk6fibKO" resolve="usedLanguagesAsJson" />
-                        </node>
                       </node>
                     </node>
                   </node>
@@ -929,13 +927,6 @@
                   </node>
                   <node concept="liA8E" id="5ocQ9W1xKK$" role="2OqNvi">
                     <ref role="37wK5l" to="6peh:5wsogBc3YTv" resolve="deserializeLanguages" />
-                    <node concept="2ShNRf" id="5YadkJSyts$" role="37wK5m">
-                      <node concept="kMnCb" id="5YadkJSywRc" role="2ShVmc">
-                        <node concept="3uibUv" id="5YadkJSyxg_" role="kMuH3">
-                          <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
-                        </node>
-                      </node>
-                    </node>
                   </node>
                 </node>
               </node>

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2lioncore@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2lioncore@tests.mps
@@ -23,6 +23,8 @@
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="jfqc" ref="r:6e560006-b8bd-4479-9a0e-1c215f48423a(io.lionweb.mps.converter.test.support)" />
     <import index="kte7" ref="r:2b2fbaa9-e628-460c-aea7-59a3006590c9(io.lionweb.mps.json.test.support)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="y5e1" ref="r:4464540a-9650-433f-b716-ed95bbac5a69(jetbrains.mps.lang.test.matcher)" />
     <import index="2pzz" ref="r:74e14b22-3b4a-45ce-940b-9bdca99c102f(io.lionweb.mps.m3.builtin)" implicit="true" />
   </imports>
   <registry>
@@ -50,13 +52,7 @@
       <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
-        <child id="1082485599096" name="statements" index="9aQI4" />
-      </concept>
-      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
-        <child id="1068498886297" name="rValue" index="37vLTx" />
-        <child id="1068498886295" name="lValue" index="37vLTJ" />
-      </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
@@ -93,7 +89,6 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
-      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -108,17 +103,13 @@
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
-      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
-        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
-        <child id="1068580123160" name="condition" index="3clFbw" />
-        <child id="1068580123161" name="ifTrue" index="3clFbx" />
-      </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -141,6 +132,11 @@
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
         <child id="8276990574895933173" name="catchBody" index="1zc67A" />
@@ -207,6 +203,12 @@
       <concept id="2656571587264872967" name="io.lionweb.mps.m3.structure.PrimitiveType" flags="ng" index="2RzSJf" />
       <concept id="2656571587264873619" name="io.lionweb.mps.m3.structure.EnumerationLiteral" flags="ng" index="2RzSPr" />
     </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
     <language id="4a963078-62c4-4f96-9b52-198a0c63da4b" name="io.lionweb.mps.testsupport">
       <concept id="797107380639005765" name="io.lionweb.mps.testsupport.structure.AssertMatchVerbose" flags="ng" index="1PQTyP" />
     </language>
@@ -229,6 +231,12 @@
       <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
         <child id="1171981057159" name="condition" index="3vwVQn" />
       </concept>
+      <concept id="1172073500303" name="jetbrains.mps.baseLanguage.unitTest.structure.Message" flags="ng" index="3_1$Yv">
+        <child id="1172073511101" name="message" index="3_1BAH" />
+      </concept>
+      <concept id="1172075514136" name="jetbrains.mps.baseLanguage.unitTest.structure.MessageHolder" flags="ng" index="3_9gw8">
+        <child id="1172075534298" name="message" index="3_9lra" />
+      </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
@@ -248,6 +256,12 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
+        <child id="1176906787974" name="rightExpression" index="576Qk" />
+      </concept>
       <concept id="1224414427926" name="jetbrains.mps.baseLanguage.collections.structure.SequenceCreator" flags="nn" index="kMnCb">
         <child id="1224414456414" name="elementType" index="kMuH3" />
       </concept>
@@ -257,14 +271,30 @@
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
       <concept id="1235573135402" name="jetbrains.mps.baseLanguage.collections.structure.SingletonSequenceCreator" flags="nn" index="2HTt$P">
         <child id="1235573175711" name="elementType" index="2HTBi0" />
         <child id="1235573187520" name="singletonValue" index="2HTEbv" />
       </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="4611582986551314327" name="jetbrains.mps.baseLanguage.collections.structure.OfTypeOperation" flags="nn" index="UnYns">
+        <child id="4611582986551314344" name="requestedType" index="UnYnz" />
+      </concept>
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
-      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+        <child id="1240687658305" name="delimiter" index="3uJOhx" />
+      </concept>
+      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
+      <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
+      <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
     </language>
   </registry>
   <node concept="2XOHcx" id="3ePT3MiXrx5">
@@ -325,6 +355,19 @@
                 </node>
               </node>
             </node>
+            <node concept="3cpWs8" id="488yErfadH3" role="3cqZAp">
+              <node concept="3cpWsn" id="488yErfadH4" role="3cpWs9">
+                <property role="TrG5h" value="lionwebVersion" />
+                <node concept="3uibUv" id="488yErfadH5" role="1tU5fm">
+                  <ref role="3uigEE" to="6peh:1KsTggJdySE" resolve="ILionWebVersionAdapter" />
+                </node>
+                <node concept="2ShNRf" id="488yErfadH6" role="33vP2m">
+                  <node concept="HV5vD" id="488yErfadH7" role="2ShVmc">
+                    <ref role="HV5vE" to="6peh:1KsTggJeQM5" resolve="LionWebVersionAdapter" />
+                  </node>
+                </node>
+              </node>
+            </node>
             <node concept="3cpWs8" id="5YadkJSAWSy" role="3cqZAp">
               <node concept="3cpWsn" id="5YadkJSAWSz" role="3cpWs9">
                 <property role="TrG5h" value="jsonConstants" />
@@ -334,13 +377,15 @@
                 <node concept="2ShNRf" id="5YadkJSAWS_" role="33vP2m">
                   <node concept="1pGfFk" id="5YadkJSAWSA" role="2ShVmc">
                     <ref role="37wK5l" to="6peh:5JNiskj4SJa" resolve="JsonConstants" />
-                    <node concept="2YIFZM" id="5YadkJSAWSB" role="37wK5m">
-                      <ref role="1Pybhc" to="imb3:~LionCoreBuiltins" resolve="LionCoreBuiltins" />
-                      <ref role="37wK5l" to="imb3:~LionCoreBuiltins.getInstance()" resolve="getInstance" />
+                    <node concept="37vLTw" id="488yErfaeV6" role="37wK5m">
+                      <ref role="3cqZAo" node="488yErfadH4" resolve="lionwebVersion" />
                     </node>
                     <node concept="2ShNRf" id="5YadkJSAWSC" role="37wK5m">
-                      <node concept="HV5vD" id="5YadkJSAWSD" role="2ShVmc">
-                        <ref role="HV5vE" to="6peh:7weWCFlyxlE" resolve="LionCoreAdapter" />
+                      <node concept="1pGfFk" id="488yErfagdm" role="2ShVmc">
+                        <ref role="37wK5l" to="6peh:1KsTggJeQkZ" resolve="LionCoreAdapter" />
+                        <node concept="37vLTw" id="488yErfagdl" role="37wK5m">
+                          <ref role="3cqZAo" node="488yErfadH4" resolve="lionwebVersion" />
+                        </node>
                       </node>
                     </node>
                     <node concept="37vLTw" id="5YadkJSAWSE" role="37wK5m">
@@ -359,6 +404,9 @@
                 <node concept="2ShNRf" id="5YadkJSAWSI" role="33vP2m">
                   <node concept="1pGfFk" id="5YadkJSAWSJ" role="2ShVmc">
                     <ref role="37wK5l" to="6peh:z1IqfFwqeg" resolve="Deserializer" />
+                    <node concept="37vLTw" id="488yErfah8o" role="37wK5m">
+                      <ref role="3cqZAo" node="488yErfadH4" resolve="lionwebVersion" />
+                    </node>
                     <node concept="2ShNRf" id="5YadkJSAWSK" role="37wK5m">
                       <node concept="1pGfFk" id="5YadkJSAWSL" role="2ShVmc">
                         <ref role="37wK5l" to="guwi:~BufferedInputStream.&lt;init&gt;(java.io.InputStream)" resolve="BufferedInputStream" />
@@ -375,95 +423,83 @@
               </node>
             </node>
             <node concept="3clFbH" id="5YadkJSBiXn" role="3cqZAp" />
-            <node concept="3cpWs8" id="5YadkJSBjD2" role="3cqZAp">
-              <node concept="3cpWsn" id="5YadkJSBjD3" role="3cpWs9">
-                <property role="TrG5h" value="languages" />
-                <node concept="_YKpA" id="5YadkJSBjD4" role="1tU5fm">
-                  <node concept="3uibUv" id="5YadkJSBjD5" role="_ZDj9">
-                    <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+            <node concept="3cpWs8" id="6NZwk6fibK_" role="3cqZAp">
+              <node concept="3cpWsn" id="6NZwk6fibKA" role="3cpWs9">
+                <property role="TrG5h" value="lionMPS2lionJavaConverter" />
+                <node concept="3uibUv" id="6NZwk6fibKB" role="1tU5fm">
+                  <ref role="3uigEE" to="9pi3:5sACIIsA0s2" resolve="LionCore2JsonConverter" />
+                </node>
+                <node concept="2ShNRf" id="6NZwk6fibKC" role="33vP2m">
+                  <node concept="1pGfFk" id="6NZwk6fibKD" role="2ShVmc">
+                    <ref role="37wK5l" to="9pi3:5sACIIsA0tB" resolve="LionCore2JsonConverter" />
+                    <node concept="37vLTw" id="6NZwk6fibKE" role="37wK5m">
+                      <ref role="3cqZAo" node="488yErfadH4" resolve="lionwebVersion" />
+                    </node>
+                    <node concept="37vLTw" id="6NZwk6fibKF" role="37wK5m">
+                      <ref role="3cqZAo" node="5YadkJSAWSt" resolve="constants" />
+                    </node>
+                    <node concept="37vLTw" id="6NZwk6fibKG" role="37wK5m">
+                      <ref role="3cqZAo" node="5YadkJSAWSz" resolve="jsonConstants" />
+                    </node>
+                    <node concept="2ShNRf" id="6NZwk6fibKH" role="37wK5m">
+                      <node concept="1pGfFk" id="6NZwk6fibKI" role="2ShVmc">
+                        <ref role="37wK5l" to="t47h:5M3rB6AxjLI" resolve="LionCoreLanguageGuaranteedMapper" />
+                      </node>
+                    </node>
+                    <node concept="2ShNRf" id="6NZwk6fibKJ" role="37wK5m">
+                      <node concept="1pGfFk" id="6NZwk6fibKK" role="2ShVmc">
+                        <ref role="37wK5l" to="6peh:4ZQFfbQ9DSn" resolve="LionCoreFactory" />
+                        <node concept="37vLTw" id="6NZwk6fibKL" role="37wK5m">
+                          <ref role="3cqZAo" node="488yErfadH4" resolve="lionwebVersion" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="6NZwk6fibKM" role="37wK5m">
+                      <ref role="3cqZAo" node="5YadkJSAWNM" resolve="usedLangs" />
+                    </node>
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="3clFbJ" id="5YadkJSBata" role="3cqZAp">
-              <node concept="3clFbS" id="5YadkJSBatc" role="3clFbx">
-                <node concept="3cpWs8" id="5YadkJSBdGJ" role="3cqZAp">
-                  <node concept="3cpWsn" id="5YadkJSBdGK" role="3cpWs9">
-                    <property role="TrG5h" value="lionMPS2lionJavaConverter" />
-                    <node concept="3uibUv" id="5YadkJSBdGL" role="1tU5fm">
-                      <ref role="3uigEE" to="9pi3:5sACIIsA0s2" resolve="LionCore2JsonConverter" />
-                    </node>
-                    <node concept="2ShNRf" id="5YadkJSBfyN" role="33vP2m">
-                      <node concept="1pGfFk" id="5YadkJSBg0f" role="2ShVmc">
-                        <ref role="37wK5l" to="9pi3:5sACIIsA0tB" resolve="LionCore2JsonConverter" />
-                        <node concept="37vLTw" id="5YadkJSBggr" role="37wK5m">
-                          <ref role="3cqZAo" node="5YadkJSAWSt" resolve="constants" />
-                        </node>
-                        <node concept="37vLTw" id="5YadkJSBgQ_" role="37wK5m">
-                          <ref role="3cqZAo" node="5YadkJSAWSz" resolve="jsonConstants" />
-                        </node>
-                        <node concept="2ShNRf" id="5YadkJSBhkK" role="37wK5m">
-                          <node concept="1pGfFk" id="5YadkJSBi4b" role="2ShVmc">
-                            <ref role="37wK5l" to="t47h:5M3rB6AxjLI" resolve="LionCoreLanguageGuaranteedMapper" />
-                          </node>
-                        </node>
-                        <node concept="37vLTw" id="5YadkJSBiH1" role="37wK5m">
-                          <ref role="3cqZAo" node="5YadkJSAWNM" resolve="usedLangs" />
-                        </node>
-                      </node>
-                    </node>
+            <node concept="3cpWs8" id="6NZwk6fibKN" role="3cqZAp">
+              <node concept="3cpWsn" id="6NZwk6fibKO" role="3cpWs9">
+                <property role="TrG5h" value="usedLanguagesAsJson" />
+                <node concept="A3Dl8" id="6NZwk6fibKP" role="1tU5fm">
+                  <node concept="3uibUv" id="6NZwk6fibKQ" role="A3Ik2">
+                    <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
                   </node>
                 </node>
-                <node concept="3clFbF" id="5YadkJSBs6D" role="3cqZAp">
-                  <node concept="37vLTI" id="5YadkJSBsvV" role="3clFbG">
-                    <node concept="2OqwBi" id="5YadkJSBtfl" role="37vLTx">
-                      <node concept="37vLTw" id="5YadkJSBsSK" role="2Oq$k0">
+                <node concept="2OqwBi" id="6NZwk6fibKR" role="33vP2m">
+                  <node concept="37vLTw" id="6NZwk6fibKS" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6NZwk6fibKA" resolve="lionMPS2lionJavaConverter" />
+                  </node>
+                  <node concept="liA8E" id="6NZwk6fibKT" role="2OqNvi">
+                    <ref role="37wK5l" to="9pi3:5sACIIsA0ut" resolve="convert" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="6NZwk6fi_RS" role="3cqZAp">
+              <node concept="3cpWsn" id="6NZwk6fi_RV" role="3cpWs9">
+                <property role="TrG5h" value="languages" />
+                <node concept="A3Dl8" id="6NZwk6fi_RP" role="1tU5fm">
+                  <node concept="3uibUv" id="6NZwk6fiAAq" role="A3Ik2">
+                    <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="6NZwk6figFk" role="33vP2m">
+                  <node concept="37vLTw" id="6NZwk6figFl" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6NZwk6fibKO" resolve="usedLanguagesAsJson" />
+                  </node>
+                  <node concept="3QWeyG" id="6NZwk6figFm" role="2OqNvi">
+                    <node concept="2OqwBi" id="6NZwk6fiffW" role="576Qk">
+                      <node concept="37vLTw" id="6NZwk6fiffX" role="2Oq$k0">
                         <ref role="3cqZAo" node="5YadkJSAWSG" resolve="deserializer" />
                       </node>
-                      <node concept="liA8E" id="5YadkJSBtKZ" role="2OqNvi">
+                      <node concept="liA8E" id="6NZwk6fiffY" role="2OqNvi">
                         <ref role="37wK5l" to="6peh:5wsogBc3YTv" resolve="deserializeLanguages" />
-                        <node concept="2OqwBi" id="5YadkJSBuCF" role="37wK5m">
-                          <node concept="37vLTw" id="5YadkJSBu5i" role="2Oq$k0">
-                            <ref role="3cqZAo" node="5YadkJSBdGK" resolve="lionMPS2lionJavaConverter" />
-                          </node>
-                          <node concept="liA8E" id="5YadkJSBveB" role="2OqNvi">
-                            <ref role="37wK5l" to="9pi3:5sACIIsA0ut" resolve="convert" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="37vLTw" id="5YadkJSBs6B" role="37vLTJ">
-                      <ref role="3cqZAo" node="5YadkJSBjD3" resolve="languages" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="5YadkJSBb52" role="3clFbw">
-                <node concept="37vLTw" id="5YadkJSBaG3" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5YadkJSAWNM" resolve="usedLangs" />
-                </node>
-                <node concept="3GX2aA" id="5YadkJSBbvB" role="2OqNvi" />
-              </node>
-              <node concept="9aQIb" id="5YadkJSBlyK" role="9aQIa">
-                <node concept="3clFbS" id="5YadkJSBlyL" role="9aQI4">
-                  <node concept="3clFbF" id="5YadkJSBnZ6" role="3cqZAp">
-                    <node concept="37vLTI" id="5YadkJSBoxq" role="3clFbG">
-                      <node concept="37vLTw" id="5YadkJSBnZ4" role="37vLTJ">
-                        <ref role="3cqZAo" node="5YadkJSBjD3" resolve="languages" />
-                      </node>
-                      <node concept="2OqwBi" id="5YadkJSAWSS" role="37vLTx">
-                        <node concept="37vLTw" id="5YadkJSAWST" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5YadkJSAWSG" resolve="deserializer" />
-                        </node>
-                        <node concept="liA8E" id="5YadkJSAWSU" role="2OqNvi">
-                          <ref role="37wK5l" to="6peh:5wsogBc3YTv" resolve="deserializeLanguages" />
-                          <node concept="2ShNRf" id="5YadkJSBq$G" role="37wK5m">
-                            <node concept="kMnCb" id="5YadkJSBr5d" role="2ShVmc">
-                              <node concept="3uibUv" id="5YadkJSBrpe" role="kMuH3">
-                                <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
-                              </node>
-                            </node>
-                          </node>
+                        <node concept="37vLTw" id="6NZwk6fiffZ" role="37wK5m">
+                          <ref role="3cqZAo" node="6NZwk6fibKO" resolve="usedLanguagesAsJson" />
                         </node>
                       </node>
                     </node>
@@ -493,7 +529,7 @@
                       </node>
                     </node>
                     <node concept="37vLTw" id="5YadkJSAWT8" role="37wK5m">
-                      <ref role="3cqZAo" node="5YadkJSBjD3" resolve="languages" />
+                      <ref role="3cqZAo" node="6NZwk6fi_RV" resolve="languages" />
                     </node>
                   </node>
                 </node>
@@ -519,20 +555,20 @@
             </node>
             <node concept="3clFbH" id="5YadkJSAWTg" role="3cqZAp" />
             <node concept="3vlDli" id="5YadkJSAWTh" role="3cqZAp">
-              <node concept="3cmrfG" id="5YadkJSAWTi" role="3tpDZB">
-                <property role="3cmrfH" value="1" />
-              </node>
               <node concept="2OqwBi" id="5YadkJSAWTj" role="3tpDZA">
                 <node concept="37vLTw" id="5YadkJSAWTk" role="2Oq$k0">
                   <ref role="3cqZAo" node="5YadkJSAWTa" resolve="converted" />
                 </node>
                 <node concept="34oBXx" id="5YadkJSAWTl" role="2OqNvi" />
               </node>
+              <node concept="3cmrfG" id="1IvYv3EA_Wc" role="3tpDZB">
+                <property role="3cmrfH" value="2" />
+              </node>
             </node>
             <node concept="3clFbH" id="5YadkJSAWTm" role="3cqZAp" />
             <node concept="3cpWs8" id="5YadkJSAWTn" role="3cqZAp">
               <node concept="3cpWsn" id="5YadkJSAWTo" role="3cpWs9">
-                <property role="TrG5h" value="actual" />
+                <property role="TrG5h" value="actualLanguage" />
                 <node concept="3Tqbb2" id="5YadkJSAWTp" role="1tU5fm">
                   <ref role="ehGHo" to="h3y3:2ju2syjkngz" resolve="Language" />
                 </node>
@@ -543,23 +579,160 @@
                     <node concept="37vLTw" id="5YadkJSAWTs" role="2Oq$k0">
                       <ref role="3cqZAo" node="5YadkJSAWTa" resolve="converted" />
                     </node>
-                    <node concept="1uHKPH" id="5YadkJSAWTt" role="2OqNvi" />
+                    <node concept="1yVyf7" id="1IvYv3EDMQ0" role="2OqNvi" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="1PQTyP" id="5YadkJSAWTu" role="3cqZAp">
-              <node concept="37vLTw" id="5YadkJSAWTv" role="JAdkl">
-                <ref role="3cqZAo" node="5YadkJSAWTo" resolve="actual" />
+            <node concept="3clFbH" id="6NZwk6fgPco" role="3cqZAp" />
+            <node concept="3cpWs8" id="3KvkLt3BeA_" role="3cqZAp">
+              <node concept="3cpWsn" id="3KvkLt3BeAA" role="3cpWs9">
+                <property role="TrG5h" value="expected" />
+                <node concept="3uibUv" id="3KvkLt3BeAz" role="1tU5fm">
+                  <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                  <node concept="3uibUv" id="3KvkLt3Bgyc" role="11_B2D">
+                    <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="2LEXDCdQB9g" role="33vP2m">
+                  <node concept="Tc6Ow" id="2LEXDCdQB9h" role="2ShVmc">
+                    <node concept="3uibUv" id="2LEXDCdQB9i" role="HW$YZ">
+                      <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                    </node>
+                    <node concept="2OqwBi" id="6NZwk6fgWvl" role="HW$Y0">
+                      <node concept="37vLTw" id="6NZwk6fgVrI" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5YadkJSAWNM" resolve="usedLangs" />
+                      </node>
+                      <node concept="1uHKPH" id="6NZwk6fgXjx" role="2OqNvi" />
+                    </node>
+                    <node concept="37vLTw" id="6NZwk6fgYDV" role="HW$Y0">
+                      <ref role="3cqZAo" node="5YadkJSAWKX" resolve="expectedLanguage" />
+                    </node>
+                  </node>
+                </node>
               </node>
-              <node concept="37vLTw" id="5YadkJSAWTw" role="JA92f">
-                <ref role="3cqZAo" node="5YadkJSAWKX" resolve="expected" />
+            </node>
+            <node concept="3cpWs8" id="3KvkLt3B_CA" role="3cqZAp">
+              <node concept="3cpWsn" id="3KvkLt3B_CB" role="3cpWs9">
+                <property role="TrG5h" value="actual" />
+                <node concept="3uibUv" id="3KvkLt3B_C$" role="1tU5fm">
+                  <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                  <node concept="3uibUv" id="3KvkLt3BBlL" role="11_B2D">
+                    <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="6NZwk6fh_L7" role="33vP2m">
+                  <node concept="2OqwBi" id="6NZwk6fhzlX" role="2Oq$k0">
+                    <node concept="37vLTw" id="6NZwk6fhyht" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5YadkJSAWTa" resolve="converted" />
+                    </node>
+                    <node concept="UnYns" id="6NZwk6fh$78" role="2OqNvi">
+                      <node concept="3uibUv" id="6NZwk6fh$BT" role="UnYnz">
+                        <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="ANE8D" id="6NZwk6fhA_W" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="GfTf1YP944" role="3cqZAp">
+              <node concept="3cpWsn" id="GfTf1YP945" role="3cpWs9">
+                <property role="TrG5h" value="diff" />
+                <node concept="_YKpA" id="GfTf1YPbFe" role="1tU5fm">
+                  <node concept="3uibUv" id="GfTf1YPbFg" role="_ZDj9">
+                    <ref role="3uigEE" to="y5e1:7MIYyntDZEK" resolve="NodeDifference" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="GfTf1YP946" role="33vP2m">
+                  <node concept="2ShNRf" id="GfTf1YP947" role="2Oq$k0">
+                    <node concept="1pGfFk" id="GfTf1YP948" role="2ShVmc">
+                      <ref role="37wK5l" to="y5e1:39D1ywqVAMq" resolve="NodesMatcher" />
+                      <node concept="37vLTw" id="GfTf1YP94a" role="37wK5m">
+                        <ref role="3cqZAo" node="3KvkLt3B_CB" resolve="actual" />
+                      </node>
+                      <node concept="37vLTw" id="GfTf1YP949" role="37wK5m">
+                        <ref role="3cqZAo" node="3KvkLt3BeAA" resolve="expected" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="GfTf1YP94b" role="2OqNvi">
+                    <ref role="37wK5l" to="y5e1:39D1ywqVH_i" resolve="diff" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3vwNmj" id="5wEVZcC3ck3" role="3cqZAp">
+              <node concept="3_1$Yv" id="5wEVZcC3dpu" role="3_9lra">
+                <node concept="3cpWs3" id="GfTf1YPak6" role="3_1BAH">
+                  <node concept="2OqwBi" id="GfTf1YPegS" role="3uHU7w">
+                    <node concept="2OqwBi" id="GfTf1YPcCb" role="2Oq$k0">
+                      <node concept="37vLTw" id="GfTf1YPakq" role="2Oq$k0">
+                        <ref role="3cqZAo" node="GfTf1YP945" resolve="diff" />
+                      </node>
+                      <node concept="3$u5V9" id="GfTf1YPdw5" role="2OqNvi">
+                        <node concept="1bVj0M" id="GfTf1YPdw7" role="23t8la">
+                          <node concept="3clFbS" id="GfTf1YPdw8" role="1bW5cS">
+                            <node concept="3clFbF" id="GfTf1YPdwh" role="3cqZAp">
+                              <node concept="2OqwBi" id="GfTf1YPdEj" role="3clFbG">
+                                <node concept="37vLTw" id="GfTf1YPdwg" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="GfTf1YPdw9" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="GfTf1YPdRj" role="2OqNvi">
+                                  <ref role="37wK5l" to="y5e1:39D1ywqUtCH" resolve="print" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="GfTf1YPdw9" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="GfTf1YPdwa" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3uJxvA" id="GfTf1YPeE1" role="2OqNvi">
+                      <node concept="Xl_RD" id="GfTf1YPfkO" role="3uJOhx">
+                        <property role="Xl_RC" value="\n" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs3" id="GfTf1YPg5N" role="3uHU7B">
+                    <node concept="3cpWs3" id="2LEXDCdQHOj" role="3uHU7B">
+                      <node concept="3cpWs3" id="2LEXDCdQFjN" role="3uHU7B">
+                        <node concept="3cpWs3" id="2LEXDCdQEqA" role="3uHU7B">
+                          <node concept="Xl_RD" id="2LEXDCdQDWo" role="3uHU7B">
+                            <property role="Xl_RC" value="The nodes '" />
+                          </node>
+                          <node concept="37vLTw" id="3KvkLt3C0iQ" role="3uHU7w">
+                            <ref role="3cqZAo" node="3KvkLt3BeAA" resolve="expected" />
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="2LEXDCdQFjX" role="3uHU7w">
+                          <property role="Xl_RC" value="' and '" />
+                        </node>
+                      </node>
+                      <node concept="37vLTw" id="3KvkLt3C3gl" role="3uHU7w">
+                        <ref role="3cqZAo" node="3KvkLt3B_CB" resolve="actual" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="2LEXDCdQJlK" role="3uHU7w">
+                      <property role="Xl_RC" value="' do not match!\n" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5wEVZcC3eI2" role="3vwVQn">
+                <node concept="37vLTw" id="GfTf1YP94c" role="2Oq$k0">
+                  <ref role="3cqZAo" node="GfTf1YP945" resolve="diff" />
+                </node>
+                <node concept="1v1jN8" id="GfTf1YP$_w" role="2OqNvi" />
               </node>
             </node>
             <node concept="3clFbH" id="5YadkJSAWTx" role="3cqZAp" />
             <node concept="3cpWs6" id="5YadkJSAWTy" role="3cqZAp">
               <node concept="37vLTw" id="5YadkJSAWTz" role="3cqZAk">
-                <ref role="3cqZAo" node="5YadkJSAWTo" resolve="actual" />
+                <ref role="3cqZAo" node="5YadkJSAWTo" resolve="actualLanguage" />
               </node>
             </node>
           </node>
@@ -608,7 +781,7 @@
         <node concept="17QB3L" id="5YadkJSAWKK" role="1tU5fm" />
       </node>
       <node concept="37vLTG" id="5YadkJSAWKX" role="3clF46">
-        <property role="TrG5h" value="expected" />
+        <property role="TrG5h" value="expectedLanguage" />
         <node concept="3Tqbb2" id="5YadkJSAWLf" role="1tU5fm">
           <ref role="ehGHo" to="h3y3:2ju2syjkngz" resolve="Language" />
         </node>
@@ -1982,8 +2155,8 @@
     </node>
     <node concept="1qefOq" id="5YadkJSARAd" role="1SKRRt">
       <node concept="2RzRRF" id="5YadkJSARSk" role="1qenE9">
-        <property role="2RzON1" value="bdf20e91-513f-4957-918d-b901e3cf0227" />
-        <property role="TrG5h" value="extendedLibrary" />
+        <property role="2RzON1" value="extendedlibrary" />
+        <property role="TrG5h" value="extendedlibrary" />
         <property role="3HH78N" value="1" />
         <node concept="3xLA65" id="5YadkJSARSm" role="lGtFl">
           <property role="TrG5h" value="extendedlibrary" />
@@ -1991,10 +2164,40 @@
         <node concept="2RzRkq" id="5YadkJSARSo" role="2RzRcN">
           <ref role="2RzRkr" node="5ocQ9W1u7kH" resolve="library" />
         </node>
+        <node concept="2RzPWn" id="1IvYv3E_dwX" role="2RzR6B">
+          <property role="2RzON1" value="extendedlibrary-CopyRight" />
+          <property role="TrG5h" value="CopyRight" />
+          <node concept="2RzOte" id="1IvYv3E_dBi" role="2RzPPN">
+            <property role="2RzON1" value="extendedlibrary-CopyRight-countries" />
+            <property role="TrG5h" value="countries" />
+            <property role="2RzO1C" value="true" />
+            <property role="2RzOhW" value="true" />
+            <ref role="2RzQvY" node="1IvYv3E_dzr" resolve="CountriesContainer" />
+          </node>
+          <node concept="2RzOpR" id="1IvYv3E_dBn" role="2RzPPN">
+            <property role="2RzON1" value="extendedlibrary-CopyRight-writer" />
+            <property role="TrG5h" value="writer" />
+            <ref role="2RzQvY" node="5ocQ9W1u7kT" resolve="Writer" />
+          </node>
+        </node>
+        <node concept="2RzPWn" id="1IvYv3E_dzr" role="2RzR6B">
+          <property role="2RzON1" value="extendedlibrary-CountriesContainer" />
+          <property role="TrG5h" value="CountriesContainer" />
+          <node concept="2RzOeU" id="1IvYv3E_dBg" role="2RzPPN">
+            <property role="2RzON1" value="extendedlibrary-CountriesContainer-content" />
+            <property role="TrG5h" value="content" />
+            <ref role="2Rx9Fl" to="2pzz:2ju2syjnJjX" resolve="String" />
+          </node>
+        </node>
         <node concept="2RzPWn" id="5YadkJSARSq" role="2RzR6B">
-          <property role="2RzON1" value="2b601bd7-0f50-4fec-adbc-555acd5c4de7" />
+          <property role="2RzON1" value="extendedlibrary-LocalLibrary" />
           <property role="TrG5h" value="LocalLibrary" />
           <ref role="2RzPfO" node="5ocQ9W1u7kO" resolve="Library" />
+          <node concept="2RzOeU" id="1IvYv3E_dBe" role="2RzPPN">
+            <property role="2RzON1" value="extendedlibrary-LocalLibrary-country" />
+            <property role="TrG5h" value="country" />
+            <ref role="2Rx9Fl" to="2pzz:2ju2syjnJjX" resolve="String" />
+          </node>
         </node>
       </node>
     </node>

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2slanguage@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2slanguage@tests.mps
@@ -177,9 +177,6 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
-      <concept id="1224414427926" name="jetbrains.mps.baseLanguage.collections.structure.SequenceCreator" flags="nn" index="kMnCb">
-        <child id="1224414456414" name="elementType" index="kMuH3" />
-      </concept>
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -1794,13 +1791,6 @@
                   </node>
                   <node concept="liA8E" id="5ocQ9W1vI8N" role="2OqNvi">
                     <ref role="37wK5l" to="6peh:5wsogBc3YTv" resolve="deserializeLanguages" />
-                    <node concept="2ShNRf" id="5YadkJSyy6I" role="37wK5m">
-                      <node concept="kMnCb" id="5YadkJSyz10" role="2ShVmc">
-                        <node concept="3uibUv" id="5YadkJSyzwn" role="kMuH3">
-                          <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
-                        </node>
-                      </node>
-                    </node>
                   </node>
                 </node>
               </node>

--- a/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2slanguage@tests.mps
+++ b/solutions/io.lionweb.mps.json.test/models/io.lionweb.mps.json.test.json2slanguage@tests.mps
@@ -177,6 +177,9 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1224414427926" name="jetbrains.mps.baseLanguage.collections.structure.SequenceCreator" flags="nn" index="kMnCb">
+        <child id="1224414456414" name="elementType" index="kMuH3" />
+      </concept>
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -1791,6 +1794,13 @@
                   </node>
                   <node concept="liA8E" id="5ocQ9W1vI8N" role="2OqNvi">
                     <ref role="37wK5l" to="6peh:5wsogBc3YTv" resolve="deserializeLanguages" />
+                    <node concept="2ShNRf" id="5YadkJSyy6I" role="37wK5m">
+                      <node concept="kMnCb" id="5YadkJSyz10" role="2ShVmc">
+                        <node concept="3uibUv" id="5YadkJSyzwn" role="kMuH3">
+                          <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+                        </node>
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>

--- a/solutions/io.lionweb.mps.json.test/resources/extendedlibrary-metamodel.json
+++ b/solutions/io.lionweb.mps.json.test/resources/extendedlibrary-metamodel.json
@@ -1,0 +1,532 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-M3",
+      "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "extendedlibrary",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Language"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-version"
+          },
+          "value": "1"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "extendedlibrary"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "extendedlibrary"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-entities"
+          },
+          "children": [
+            "extendedlibrary-LocalLibrary",
+            "extendedlibrary-CopyRight",
+            "extendedlibrary-CountriesContainer"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-dependsOn"
+          },
+          "targets": [
+            {
+              "resolveInfo": "library",
+              "reference": "NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAw"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": null
+    },
+    {
+      "id": "extendedlibrary-LocalLibrary",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "extendedlibrary-LocalLibrary"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "LocalLibrary"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "extendedlibrary-LocalLibrary-country"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Library",
+              "reference": "NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLzg2OTkxNDExNTA2MzkyMDA3NzE"
+            }
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "extendedlibrary"
+    },
+    {
+      "id": "extendedlibrary-LocalLibrary-country",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "extendedlibrary-LocalLibrary-country"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "country"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "extendedlibrary-LocalLibrary"
+    },
+    {
+      "id": "extendedlibrary-CopyRight",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "extendedlibrary-CopyRight"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "CopyRight"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "extendedlibrary-CopyRight-writer",
+            "extendedlibrary-CopyRight-countries"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "extendedlibrary"
+    },
+    {
+      "id": "extendedlibrary-CopyRight-writer",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "extendedlibrary-CopyRight-writer"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "writer"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Writer",
+              "reference": "NTM3ZjljYjAtMGYyNS0zYzc2LThiODYtMzA4ZjQ1MDEwMTAwLy02MzA4OTk2OTY0NjI5MTg1MTYz"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "extendedlibrary-CopyRight"
+    },
+    {
+      "id": "extendedlibrary-CopyRight-countries",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "extendedlibrary-CopyRight-countries"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "countries"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "CountriesContainer",
+              "reference": "extendedlibrary-CountriesContainer"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "extendedlibrary-CopyRight"
+    },
+    {
+      "id": "extendedlibrary-CountriesContainer",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "extendedlibrary-CountriesContainer"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "CountriesContainer"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "extendedlibrary-CountriesContainer-content"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "extendedlibrary"
+    },
+    {
+      "id": "extendedlibrary-CountriesContainer-content",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "extendedlibrary-CountriesContainer-content"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "content"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "extendedlibrary-CountriesContainer"
+    }
+  ]
+}

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
@@ -311,6 +311,7 @@
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
       <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
         <child id="1226511765987" name="elementType" index="2hN53Y" />
       </concept>
@@ -660,6 +661,36 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbF" id="5YadkJSwqPE" role="3cqZAp">
+          <node concept="2OqwBi" id="5YadkJSwrIg" role="3clFbG">
+            <node concept="37vLTw" id="5YadkJSwqPC" role="2Oq$k0">
+              <ref role="3cqZAo" node="5YadkJSwpB9" resolve="usedLanguages" />
+            </node>
+            <node concept="2es0OD" id="5YadkJSwscA" role="2OqNvi">
+              <node concept="1bVj0M" id="5YadkJSwscC" role="23t8la">
+                <node concept="3clFbS" id="5YadkJSwscD" role="1bW5cS">
+                  <node concept="3clFbF" id="5YadkJSwstL" role="3cqZAp">
+                    <node concept="2OqwBi" id="5YadkJSwt1S" role="3clFbG">
+                      <node concept="37vLTw" id="5YadkJSwstK" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5wsogBc40MM" resolve="standardSerialization" />
+                      </node>
+                      <node concept="liA8E" id="5YadkJSwtwY" role="2OqNvi">
+                        <ref role="37wK5l" to="jxh5:~JsonSerialization.registerLanguage(io.lionweb.lioncore.java.language.Language)" resolve="registerLanguage" />
+                        <node concept="37vLTw" id="5YadkJSwtKI" role="37wK5m">
+                          <ref role="3cqZAo" node="5YadkJSwscE" resolve="it" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="5YadkJSwscE" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="5YadkJSwscF" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="5hsSXrmF8GB" role="3cqZAp">
           <node concept="2OqwBi" id="5hsSXrmF90w" role="3clFbG">
             <node concept="37vLTw" id="5hsSXrmF8G_" role="2Oq$k0">
@@ -711,6 +742,14 @@
       <node concept="_YKpA" id="5wsogBc3YT9" role="3clF45">
         <node concept="3uibUv" id="5wsogBc3YTs" role="_ZDj9">
           <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5YadkJSwpB9" role="3clF46">
+        <property role="TrG5h" value="usedLanguages" />
+        <node concept="A3Dl8" id="5YadkJSypmI" role="1tU5fm">
+          <node concept="3uibUv" id="5YadkJSypDA" role="A3Ik2">
+            <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+          </node>
         </node>
       </node>
     </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
@@ -675,7 +675,7 @@
                         <ref role="3cqZAo" node="5wsogBc40MM" resolve="standardSerialization" />
                       </node>
                       <node concept="liA8E" id="5YadkJSwtwY" role="2OqNvi">
-                        <ref role="37wK5l" to="jxh5:~JsonSerialization.registerLanguage(io.lionweb.lioncore.java.language.Language)" resolve="registerLanguage" />
+                        <ref role="37wK5l" to="jxh5:~AbstractSerialization.registerLanguage(io.lionweb.lioncore.java.language.Language)" resolve="registerLanguage" />
                         <node concept="37vLTw" id="5YadkJSwtKI" role="37wK5m">
                           <ref role="3cqZAo" node="5YadkJSwscE" resolve="it" />
                         </node>

--- a/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
+++ b/solutions/io.lionweb.mps.json/models/io.lionweb.mps.json.mps
@@ -315,6 +315,9 @@
       <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
         <child id="1226511765987" name="elementType" index="2hN53Y" />
       </concept>
+      <concept id="1224414427926" name="jetbrains.mps.baseLanguage.collections.structure.SequenceCreator" flags="nn" index="kMnCb">
+        <child id="1224414456414" name="elementType" index="kMuH3" />
+      </concept>
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -380,11 +383,37 @@
         <ref role="3uigEE" node="1KsTggJdySE" resolve="ILionWebVersionAdapter" />
       </node>
     </node>
+    <node concept="312cEg" id="TXaBS0FWSy" role="jymVt">
+      <property role="TrG5h" value="usedLanguages" />
+      <node concept="3Tm6S6" id="TXaBS0FWSv" role="1B3o_S" />
+      <node concept="A3Dl8" id="TXaBS0FWSw" role="1tU5fm">
+        <node concept="3uibUv" id="TXaBS0FWSx" role="A3Ik2">
+          <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="z1IqfFwqqe" role="jymVt" />
     <node concept="3clFbW" id="z1IqfFwqeg" role="jymVt">
       <node concept="3cqZAl" id="z1IqfFwqei" role="3clF45" />
       <node concept="3Tm1VV" id="z1IqfFwqej" role="1B3o_S" />
       <node concept="3clFbS" id="z1IqfFwqek" role="3clF47">
+        <node concept="3clFbF" id="TXaBS0FWSD" role="3cqZAp">
+          <node concept="37vLTI" id="TXaBS0FWSE" role="3clFbG">
+            <node concept="2OqwBi" id="TXaBS0FWSF" role="37vLTJ">
+              <node concept="Xjq3P" id="TXaBS0FWSG" role="2Oq$k0" />
+              <node concept="2OwXpG" id="TXaBS0FWSH" role="2OqNvi">
+                <ref role="2Oxat5" node="TXaBS0FWSy" resolve="usedLanguages" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="TXaBS0I7bd" role="37vLTx">
+              <node concept="kMnCb" id="TXaBS0I7Dj" role="2ShVmc">
+                <node concept="3uibUv" id="TXaBS0I7KY" role="kMuH3">
+                  <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="5hsSXrmCA_d" role="3cqZAp">
           <node concept="37vLTI" id="5hsSXrmCA_e" role="3clFbG">
             <node concept="2OqwBi" id="5hsSXrmCA_f" role="37vLTJ">
@@ -455,11 +484,128 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="TXaBS0HKlJ" role="jymVt" />
+    <node concept="3clFbW" id="TXaBS0HMk6" role="jymVt">
+      <node concept="3cqZAl" id="TXaBS0HMk7" role="3clF45" />
+      <node concept="3Tm1VV" id="TXaBS0HMk8" role="1B3o_S" />
+      <node concept="3clFbS" id="TXaBS0HMk9" role="3clF47">
+        <node concept="3clFbF" id="TXaBS0HMka" role="3cqZAp">
+          <node concept="37vLTI" id="TXaBS0HMkb" role="3clFbG">
+            <node concept="2OqwBi" id="TXaBS0HMkc" role="37vLTJ">
+              <node concept="Xjq3P" id="TXaBS0HMkd" role="2Oq$k0" />
+              <node concept="2OwXpG" id="TXaBS0HMke" role="2OqNvi">
+                <ref role="2Oxat5" node="TXaBS0FWSy" resolve="usedLanguages" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="TXaBS0HMkf" role="37vLTx">
+              <ref role="3cqZAo" node="TXaBS0HMkG" resolve="usedLanguages" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="TXaBS0HMkg" role="3cqZAp">
+          <node concept="37vLTI" id="TXaBS0HMkh" role="3clFbG">
+            <node concept="2OqwBi" id="TXaBS0HMki" role="37vLTJ">
+              <node concept="Xjq3P" id="TXaBS0HMkj" role="2Oq$k0" />
+              <node concept="2OwXpG" id="TXaBS0HMkk" role="2OqNvi">
+                <ref role="2Oxat5" node="5hsSXrmC_NE" resolve="jsonConstants" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="TXaBS0HMkl" role="37vLTx">
+              <ref role="3cqZAo" node="TXaBS0HMkE" resolve="jsonConstants" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="TXaBS0HMkm" role="3cqZAp">
+          <node concept="37vLTI" id="TXaBS0HMkn" role="3clFbG">
+            <node concept="2OqwBi" id="TXaBS0HMko" role="37vLTJ">
+              <node concept="Xjq3P" id="TXaBS0HMkp" role="2Oq$k0" />
+              <node concept="2OwXpG" id="TXaBS0HMkq" role="2OqNvi">
+                <ref role="2Oxat5" node="z1IqfFwqjR" resolve="input" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="TXaBS0HMkr" role="37vLTx">
+              <node concept="1pGfFk" id="TXaBS0HMks" role="2ShVmc">
+                <ref role="37wK5l" to="guwi:~InputStreamReader.&lt;init&gt;(java.io.InputStream)" resolve="InputStreamReader" />
+                <node concept="37vLTw" id="TXaBS0HMkt" role="37wK5m">
+                  <ref role="3cqZAo" node="TXaBS0HMkB" resolve="input" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="TXaBS0HMku" role="3cqZAp">
+          <node concept="37vLTI" id="TXaBS0HMkv" role="3clFbG">
+            <node concept="2OqwBi" id="TXaBS0HMkw" role="37vLTJ">
+              <node concept="Xjq3P" id="TXaBS0HMkx" role="2Oq$k0" />
+              <node concept="2OwXpG" id="TXaBS0HMky" role="2OqNvi">
+                <ref role="2Oxat5" node="1KsTggJgXxA" resolve="lionwebVersion" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="TXaBS0HMkz" role="37vLTx">
+              <ref role="3cqZAo" node="TXaBS0HMk$" resolve="lionwebVersion" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="TXaBS0HMk$" role="3clF46">
+        <property role="TrG5h" value="lionwebVersion" />
+        <node concept="3uibUv" id="TXaBS0HMk_" role="1tU5fm">
+          <ref role="3uigEE" node="1KsTggJdySE" resolve="ILionWebVersionAdapter" />
+        </node>
+        <node concept="2AHcQZ" id="TXaBS0HMkA" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="TXaBS0HMkB" role="3clF46">
+        <property role="TrG5h" value="input" />
+        <node concept="3uibUv" id="TXaBS0HMkC" role="1tU5fm">
+          <ref role="3uigEE" to="guwi:~InputStream" resolve="InputStream" />
+        </node>
+        <node concept="2AHcQZ" id="TXaBS0HMkD" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="TXaBS0HMkE" role="3clF46">
+        <property role="TrG5h" value="jsonConstants" />
+        <node concept="3uibUv" id="TXaBS0HMkF" role="1tU5fm">
+          <ref role="3uigEE" node="5JNiskj4R_R" resolve="IJsonConstants" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="TXaBS0HMkG" role="3clF46">
+        <property role="TrG5h" value="usedLanguages" />
+        <node concept="A3Dl8" id="TXaBS0HMkH" role="1tU5fm">
+          <node concept="3uibUv" id="TXaBS0HMkI" role="A3Ik2">
+            <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="TXaBS0HQZu" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="TXaBS0HLtO" role="jymVt" />
     <node concept="2tJIrI" id="5wsogBcth7p" role="jymVt" />
     <node concept="3clFbW" id="5wsogBctgVc" role="jymVt">
       <node concept="3cqZAl" id="5wsogBctgVd" role="3clF45" />
       <node concept="3Tm1VV" id="5wsogBctgVe" role="1B3o_S" />
       <node concept="3clFbS" id="5wsogBctgVf" role="3clF47">
+        <node concept="3clFbF" id="TXaBS0FWSJ" role="3cqZAp">
+          <node concept="37vLTI" id="TXaBS0FWSK" role="3clFbG">
+            <node concept="2OqwBi" id="TXaBS0FWSL" role="37vLTJ">
+              <node concept="Xjq3P" id="TXaBS0FWSM" role="2Oq$k0" />
+              <node concept="2OwXpG" id="TXaBS0FWSN" role="2OqNvi">
+                <ref role="2Oxat5" node="TXaBS0FWSy" resolve="usedLanguages" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="TXaBS0HJCS" role="37vLTx">
+              <node concept="kMnCb" id="TXaBS0HKb6" role="2ShVmc">
+                <node concept="3uibUv" id="TXaBS0HKhZ" role="kMuH3">
+                  <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="5hsSXrmCALt" role="3cqZAp">
           <node concept="37vLTI" id="5hsSXrmCALu" role="3clFbG">
             <node concept="2OqwBi" id="5hsSXrmCALv" role="37vLTJ">
@@ -525,6 +671,101 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="TXaBS0HGTU" role="jymVt" />
+    <node concept="3clFbW" id="TXaBS0HIBe" role="jymVt">
+      <node concept="3cqZAl" id="TXaBS0HIBf" role="3clF45" />
+      <node concept="3Tm1VV" id="TXaBS0HIBg" role="1B3o_S" />
+      <node concept="3clFbS" id="TXaBS0HIBh" role="3clF47">
+        <node concept="3clFbF" id="TXaBS0HIBi" role="3cqZAp">
+          <node concept="37vLTI" id="TXaBS0HIBj" role="3clFbG">
+            <node concept="2OqwBi" id="TXaBS0HIBk" role="37vLTJ">
+              <node concept="Xjq3P" id="TXaBS0HIBl" role="2Oq$k0" />
+              <node concept="2OwXpG" id="TXaBS0HIBm" role="2OqNvi">
+                <ref role="2Oxat5" node="TXaBS0FWSy" resolve="usedLanguages" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="TXaBS0HIBn" role="37vLTx">
+              <ref role="3cqZAo" node="TXaBS0HIBM" resolve="usedLanguages" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="TXaBS0HIBo" role="3cqZAp">
+          <node concept="37vLTI" id="TXaBS0HIBp" role="3clFbG">
+            <node concept="2OqwBi" id="TXaBS0HIBq" role="37vLTJ">
+              <node concept="Xjq3P" id="TXaBS0HIBr" role="2Oq$k0" />
+              <node concept="2OwXpG" id="TXaBS0HIBs" role="2OqNvi">
+                <ref role="2Oxat5" node="5hsSXrmC_NE" resolve="jsonConstants" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="TXaBS0HIBt" role="37vLTx">
+              <ref role="3cqZAo" node="TXaBS0HIBK" resolve="jsonConstants" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="TXaBS0HIBu" role="3cqZAp">
+          <node concept="37vLTI" id="TXaBS0HIBv" role="3clFbG">
+            <node concept="2OqwBi" id="TXaBS0HIBw" role="37vLTJ">
+              <node concept="Xjq3P" id="TXaBS0HIBx" role="2Oq$k0" />
+              <node concept="2OwXpG" id="TXaBS0HIBy" role="2OqNvi">
+                <ref role="2Oxat5" node="z1IqfFwqjR" resolve="input" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="TXaBS0HIBz" role="37vLTx">
+              <ref role="3cqZAo" node="TXaBS0HIBH" resolve="input" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="TXaBS0HIB$" role="3cqZAp">
+          <node concept="37vLTI" id="TXaBS0HIB_" role="3clFbG">
+            <node concept="2OqwBi" id="TXaBS0HIBA" role="37vLTJ">
+              <node concept="Xjq3P" id="TXaBS0HIBB" role="2Oq$k0" />
+              <node concept="2OwXpG" id="TXaBS0HIBC" role="2OqNvi">
+                <ref role="2Oxat5" node="1KsTggJgXxA" resolve="lionwebVersion" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="TXaBS0HIBD" role="37vLTx">
+              <ref role="3cqZAo" node="TXaBS0HIBE" resolve="lionwebVersion" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="TXaBS0HIBE" role="3clF46">
+        <property role="TrG5h" value="lionwebVersion" />
+        <node concept="3uibUv" id="TXaBS0HIBF" role="1tU5fm">
+          <ref role="3uigEE" node="1KsTggJdySE" resolve="ILionWebVersionAdapter" />
+        </node>
+        <node concept="2AHcQZ" id="TXaBS0HIBG" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="TXaBS0HIBH" role="3clF46">
+        <property role="TrG5h" value="input" />
+        <node concept="3uibUv" id="TXaBS0HIBI" role="1tU5fm">
+          <ref role="3uigEE" to="guwi:~Reader" resolve="Reader" />
+        </node>
+        <node concept="2AHcQZ" id="TXaBS0HIBJ" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="TXaBS0HIBK" role="3clF46">
+        <property role="TrG5h" value="jsonConstants" />
+        <node concept="3uibUv" id="TXaBS0HIBL" role="1tU5fm">
+          <ref role="3uigEE" node="5JNiskj4R_R" resolve="IJsonConstants" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="TXaBS0HIBM" role="3clF46">
+        <property role="TrG5h" value="usedLanguages" />
+        <node concept="A3Dl8" id="TXaBS0HIBN" role="1tU5fm">
+          <node concept="3uibUv" id="TXaBS0HIBO" role="A3Ik2">
+            <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="TXaBS0HQHl" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="TXaBS0HHZq" role="jymVt" />
     <node concept="2tJIrI" id="z1IqfFwqsp" role="jymVt" />
     <node concept="3clFb_" id="z1IqfFwqy3" role="jymVt">
       <property role="TrG5h" value="deserialize" />
@@ -661,31 +902,31 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5YadkJSwqPE" role="3cqZAp">
-          <node concept="2OqwBi" id="5YadkJSwrIg" role="3clFbG">
-            <node concept="37vLTw" id="5YadkJSwqPC" role="2Oq$k0">
-              <ref role="3cqZAo" node="5YadkJSwpB9" resolve="usedLanguages" />
+        <node concept="3clFbF" id="TXaBS0G0cr" role="3cqZAp">
+          <node concept="2OqwBi" id="TXaBS0G0z9" role="3clFbG">
+            <node concept="37vLTw" id="TXaBS0G0cp" role="2Oq$k0">
+              <ref role="3cqZAo" node="TXaBS0FWSy" resolve="usedLanguages" />
             </node>
-            <node concept="2es0OD" id="5YadkJSwscA" role="2OqNvi">
-              <node concept="1bVj0M" id="5YadkJSwscC" role="23t8la">
-                <node concept="3clFbS" id="5YadkJSwscD" role="1bW5cS">
-                  <node concept="3clFbF" id="5YadkJSwstL" role="3cqZAp">
-                    <node concept="2OqwBi" id="5YadkJSwt1S" role="3clFbG">
-                      <node concept="37vLTw" id="5YadkJSwstK" role="2Oq$k0">
+            <node concept="2es0OD" id="TXaBS0G1al" role="2OqNvi">
+              <node concept="1bVj0M" id="TXaBS0G1an" role="23t8la">
+                <node concept="3clFbS" id="TXaBS0G1ao" role="1bW5cS">
+                  <node concept="3clFbF" id="TXaBS0G1wY" role="3cqZAp">
+                    <node concept="2OqwBi" id="TXaBS0G1x0" role="3clFbG">
+                      <node concept="37vLTw" id="TXaBS0G1x1" role="2Oq$k0">
                         <ref role="3cqZAo" node="5wsogBc40MM" resolve="standardSerialization" />
                       </node>
-                      <node concept="liA8E" id="5YadkJSwtwY" role="2OqNvi">
+                      <node concept="liA8E" id="TXaBS0G1x2" role="2OqNvi">
                         <ref role="37wK5l" to="jxh5:~AbstractSerialization.registerLanguage(io.lionweb.lioncore.java.language.Language)" resolve="registerLanguage" />
-                        <node concept="37vLTw" id="5YadkJSwtKI" role="37wK5m">
-                          <ref role="3cqZAo" node="5YadkJSwscE" resolve="it" />
+                        <node concept="37vLTw" id="TXaBS0G1x3" role="37wK5m">
+                          <ref role="3cqZAo" node="TXaBS0G1ap" resolve="it" />
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="Rh6nW" id="5YadkJSwscE" role="1bW2Oz">
+                <node concept="Rh6nW" id="TXaBS0G1ap" role="1bW2Oz">
                   <property role="TrG5h" value="it" />
-                  <node concept="2jxLKc" id="5YadkJSwscF" role="1tU5fm" />
+                  <node concept="2jxLKc" id="TXaBS0G1aq" role="1tU5fm" />
                 </node>
               </node>
             </node>
@@ -742,14 +983,6 @@
       <node concept="_YKpA" id="5wsogBc3YT9" role="3clF45">
         <node concept="3uibUv" id="5wsogBc3YTs" role="_ZDj9">
           <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="5YadkJSwpB9" role="3clF46">
-        <property role="TrG5h" value="usedLanguages" />
-        <node concept="A3Dl8" id="5YadkJSypmI" role="1tU5fm">
-          <node concept="3uibUv" id="5YadkJSypDA" role="A3Ik2">
-            <ref role="3uigEE" to="imb3:~Language" resolve="Language" />
-          </node>
         </node>
       </node>
     </node>


### PR DESCRIPTION
To import into MPS a LionWeb language that depends on other languages, we need to explicitly specify these dependencies in our converter. This change allows to specify dependencies as (existing) LionCore languages.