### PR TITLE
Automatic cascading merges

### DIFF
--- a/.github/workflows/PR-into-next-version.yml
+++ b/.github/workflows/PR-into-next-version.yml
@@ -1,0 +1,10 @@
+name: PR to merge into the next version
+
+on:
+  push:
+    branches:
+      - 'mps*'
+
+jobs:
+  create-pr:
+    uses: specificlanguages/cascading-merge/.github/workflows/workflow.yml@v1


### PR DESCRIPTION
This PR ensures that on push into one of the "mps" branches, a new PR is automatically created by the github actions bot for the next branch that contains all the changes from the current push: mps2021.1 → mps2021.2 → mps2021.3.

More information: https://github.com/specificlanguages/cascading-merge
Example from a different repository: https://github.com/IETS3/iets3.opensource/pull/1301